### PR TITLE
feat(studio): add Kling Elements + Motion Control video endpoints

### DIFF
--- a/ee/pocketpaw_ee/cloud/studio/__init__.py
+++ b/ee/pocketpaw_ee/cloud/studio/__init__.py
@@ -15,6 +15,10 @@
 # official fal-client SDK), and their outputs persist through the same media
 # storage so the gallery + flow grow on every edit.
 #
+# The "Edit video" panel drives Kling Elements (``fal_elements``) directly
+# against fal the same way — a source video + element/reference images + a
+# prompt, dispatched through ``POST /studio/video-elements``.
+#
 # Wire shapes match paw-enterprise ``src/lib/core/studio/types.ts`` exactly
 # (models/styles/generations/GenerateRequest/EditRequest/PromptSuggestion), so
 # flipping the frontend's ``USE_MOCK`` flag is the only change needed there.

--- a/ee/pocketpaw_ee/cloud/studio/__init__.py
+++ b/ee/pocketpaw_ee/cloud/studio/__init__.py
@@ -17,7 +17,10 @@
 #
 # The "Edit video" panel drives Kling Elements (``fal_elements``) directly
 # against fal the same way — a source video + element/reference images + a
-# prompt, dispatched through ``POST /studio/video-elements``.
+# prompt, dispatched through ``POST /studio/video-elements``. The "Motion
+# control" panel drives Kling Motion Control (``fal_motion``) — a character image
+# + reference motion video, dispatched through
+# ``POST /studio/video-motion-control``.
 #
 # Wire shapes match paw-enterprise ``src/lib/core/studio/types.ts`` exactly
 # (models/styles/generations/GenerateRequest/EditRequest/PromptSuggestion), so

--- a/ee/pocketpaw_ee/cloud/studio/fal_elements.py
+++ b/ee/pocketpaw_ee/cloud/studio/fal_elements.py
@@ -1,0 +1,263 @@
+# ee/pocketpaw_ee/cloud/studio/fal_elements.py — direct fal.ai Kling ELEMENTS client.
+#
+# The /studio "Edit video" panel drives Kling's Elements model
+# (``fal-ai/kling-video/v1.6/standard/elements``) DIRECTLY against fal here, the
+# same decision as the canvas edit ops (``fal_edit``) and text/image-to-video
+# (``fal_video``): the LiteLLM gateway serves generation models only and has no
+# route for Kling's element-based video editing. One credential path
+# (``FAL_AI_API_KEY``), one SDK, and the output persists through media storage.
+#
+# The Elements model takes a prompt plus a set of reference images
+# (``input_image_urls`` — the "elements" the edit is conditioned on) and,
+# optionally, a source video (``video_url``) to edit in place. The studio
+# service resolves local media paths / http URLs / data URLs to ``data:`` URLs
+# before calling here (mirroring ``fal_video``'s image-to-video path), so fal
+# never needs a route back into the deployment's private media storage.
+#
+# Argument building + result extraction are pure so they unit-test without the
+# SDK; ``_run_fal`` / ``_download`` are the seams tests monkeypatch (exactly like
+# ``fal_edit`` / ``fal_video``).
+#
+# Created 2026-08-24 (studio-video-elements): Kling Elements dispatch.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# The Kling Elements endpoint. Its contract is ``{prompt, input_image_urls?,
+# video_url?, duration?, aspect_ratio?}`` — prompt + element images compose the
+# scene, and an optional ``video_url`` switches it to edit-an-existing-video.
+DEFAULT_ELEMENTS_MODEL = "fal-ai/kling-video/v1.6/standard/elements"
+
+# The studio "Edit video" panel caps reference/element images at 20 (the user's
+# spec). fal's own per-request cap may be lower for a given model version, but we
+# enforce the product limit here and let fal surface anything stricter.
+MAX_ELEMENT_IMAGES = 20
+
+# Durations the composer offers (mirrors the rail's 2s / 5s / 10s picker). fal
+# endpoints enforce their own accepted set; a duration the chosen model doesn't
+# accept surfaces as a clear upstream validation error rather than a silent clamp.
+SUPPORTED_DURATIONS: tuple[int, ...] = (2, 5, 10)
+
+# Client + server-side deadlines for the fal call. Video jobs queue and render
+# for seconds to minutes, so these are generous but bounded so a hung upstream
+# fails fast instead of pinning a worker forever.
+_CLIENT_TIMEOUT = 600.0
+_START_TIMEOUT = 180.0
+_DOWNLOAD_TIMEOUT = 300.0
+
+
+class FalElementsError(Exception):
+    """A fal.ai Kling Elements call failed (missing SDK, upstream error,
+    malformed result, or no output video). The studio service maps this to 502."""
+
+
+# ── Endpoint + argument building ─────────────────────────────────────────────
+
+
+def resolve_endpoint(model_id: str | None) -> str:
+    """Map a requested model id onto a real fal endpoint.
+
+    ``fal-ai/...`` ids pass straight through (the caller already picked an
+    endpoint); anything else — including None — falls back to the Kling Elements
+    default.
+    """
+    m = (model_id or "").strip()
+    if m.startswith("fal-ai/"):
+        return m
+    return DEFAULT_ELEMENTS_MODEL
+
+
+def build_arguments(
+    *,
+    prompt: str,
+    input_image_urls: list[str] | None = None,
+    video_url: str | None = None,
+    duration_sec: int | None = None,
+    aspect_ratio: str | None = None,
+) -> dict[str, Any]:
+    """Build the fal ``arguments`` dict for one Kling Elements call.
+
+    Pure + side-effect free so it is unit-testable in isolation. Kling standard
+    takes ``duration`` as a string ("5" / "10") and ``aspect_ratio`` as one of
+    "16:9" / "9:16" / "1:1". ``input_image_urls`` is the list of element/reference
+    images; ``video_url`` switches the call to edit-an-existing-video. Both are
+    omitted when absent so a bare prompt-only call is still valid.
+    """
+    args: dict[str, Any] = {"prompt": prompt}
+    urls = [u for u in (input_image_urls or []) if u and u.strip()]
+    if urls:
+        args["input_image_urls"] = urls
+    if video_url and video_url.strip():
+        args["video_url"] = video_url.strip()
+    if duration_sec and duration_sec > 0:
+        args["duration"] = str(int(duration_sec))
+    if aspect_ratio:
+        args["aspect_ratio"] = aspect_ratio
+    return args
+
+
+# ── Result handling ──────────────────────────────────────────────────────────
+
+
+def _extract_video_url(result: dict[str, Any]) -> str | None:
+    """Pull the output video URL from a fal video result.
+
+    Handles the common shapes: ``video: {url, …}`` (kling / wan / minimax /
+    veo), ``videos: [{url, …}]`` (rare multi-output), or a bare top-level
+    ``url``.
+    """
+    video = result.get("video")
+    if isinstance(video, dict) and isinstance(video.get("url"), str):
+        return video["url"]
+    videos = result.get("videos")
+    if isinstance(videos, list):
+        for v in videos:
+            if isinstance(v, dict) and isinstance(v.get("url"), str):
+                return v["url"]
+    if isinstance(result.get("url"), str):
+        return result["url"]
+    return None
+
+
+def _extract_poster_url(result: dict[str, Any]) -> str | None:
+    """Pull a poster/thumbnail URL when the endpoint returns one (some models
+    return ``poster: {url}`` or ``thumbnails: [{url}]``); None when absent."""
+    poster = result.get("poster")
+    if isinstance(poster, dict) and isinstance(poster.get("url"), str):
+        return poster["url"]
+    thumbs = result.get("thumbnails")
+    if isinstance(thumbs, list):
+        for t in thumbs:
+            if isinstance(t, dict) and isinstance(t.get("url"), str):
+                return t["url"]
+    return None
+
+
+async def _download(url: str) -> tuple[bytes, str]:
+    """Download one fal-hosted result file and return ``(bytes, content_type)``.
+
+    fal media URLs are publicly accessible (no auth header needed) but expire per
+    the account's media-expiration setting, so the service persists the bytes
+    into media storage before the URL goes stale.
+    """
+    async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+    mime = resp.headers.get("content-type", "video/mp4").split(";")[0].strip() or "video/mp4"
+    return resp.content, mime
+
+
+# ── The fal SDK seam (tests inject _run_fal) ────────────────────────────────
+
+
+async def _run_fal(
+    endpoint: str,
+    arguments: dict[str, Any],
+    *,
+    key: str,
+    client_timeout: float = _CLIENT_TIMEOUT,
+    start_timeout: float = _START_TIMEOUT,
+) -> dict[str, Any]:
+    """Run a fal endpoint via the official SDK. Lazy-imports fal_client so the
+    module imports even before the dep is installed (EE lazy-import pattern)."""
+    try:
+        import fal_client  # noqa: PLC0415 — lazy: SDK is an optional runtime dep
+    except ImportError as exc:  # pragma: no cover — env with the dep installed
+        raise FalElementsError(
+            "fal-client is not installed — run `pip install fal-client` (pocketpaw-ee dep)"
+        ) from exc
+    try:
+        client = fal_client.AsyncClient(key=key, default_timeout=client_timeout)
+        result = await client.run(
+            endpoint,
+            arguments=arguments,
+            timeout=client_timeout,
+            start_timeout=start_timeout,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface the upstream reason to the user
+        logger.warning("studio: fal elements '%s' failed", endpoint, exc_info=True)
+        raise FalElementsError(f"fal elements '{endpoint}' failed: {exc}") from exc
+    if not isinstance(result, dict):
+        raise FalElementsError(f"fal elements '{endpoint}' returned an unexpected result")
+    return result
+
+
+# ── Public entry point ───────────────────────────────────────────────────────
+
+
+async def run_fal_elements(
+    *,
+    prompt: str,
+    input_image_urls: list[str] | None = None,
+    video_url: str | None = None,
+    duration_sec: int | None = None,
+    aspect_ratio: str | None = None,
+    model: str | None = None,
+    key: str | None = None,
+) -> tuple[bytes, str, bytes | None, str | None]:
+    """Run one Kling Elements call against fal and return the result.
+
+    ``input_image_urls`` (one or more ``data:`` image URLs) are the element/
+    reference images; ``video_url`` (a ``data:`` video URL) switches the call to
+    edit-an-existing-video. At least one of them OR a non-empty prompt is
+    required — a bare prompt-only call is a valid text-to-video through Elements.
+
+    Returns ``(video_bytes, video_mime, poster_bytes, poster_mime)`` — the
+    poster pair is ``(None, None)`` when the endpoint didn't return one. Raises
+    ValueError (missing key / empty prompt + no inputs) and FalElementsError
+    (upstream failure / no output).
+    """
+    from . import fal_edit
+
+    text = (prompt or "").strip()
+    urls = [u for u in (input_image_urls or []) if u and u.strip()]
+    if not text and not urls and not (video_url or "").strip():
+        raise ValueError("prompt or element images are required for video editing")
+
+    endpoint = resolve_endpoint(model)
+    arguments = build_arguments(
+        prompt=text or "edit the video with these elements",
+        input_image_urls=urls or None,
+        video_url=video_url,
+        duration_sec=duration_sec,
+        aspect_ratio=aspect_ratio,
+    )
+
+    api_key = key if key is not None else fal_edit.fal_api_key()
+    if not api_key:
+        raise FalElementsError("fal.ai API key is not configured (set FAL_AI_API_KEY)")
+
+    result = await _run_fal(endpoint, arguments, key=api_key)
+    video_url_out = _extract_video_url(result)
+    if not video_url_out:
+        raise FalElementsError(f"fal elements '{endpoint}' returned no video data")
+
+    video_bytes, video_mime = await _download(video_url_out)
+
+    poster_bytes: bytes | None = None
+    poster_mime: str | None = None
+    poster_url = _extract_poster_url(result)
+    if poster_url:
+        try:
+            poster_bytes, poster_mime = await _download(poster_url)
+        except Exception:  # noqa: BLE001 — a poster is cosmetic; never fail the video
+            logger.warning("studio: fal elements poster download failed (non-fatal)", exc_info=True)
+            poster_bytes, poster_mime = None, None
+    return video_bytes, video_mime, poster_bytes, poster_mime
+
+
+__all__ = [
+    "DEFAULT_ELEMENTS_MODEL",
+    "MAX_ELEMENT_IMAGES",
+    "SUPPORTED_DURATIONS",
+    "FalElementsError",
+    "resolve_endpoint",
+    "build_arguments",
+    "run_fal_elements",
+]

--- a/ee/pocketpaw_ee/cloud/studio/fal_motion.py
+++ b/ee/pocketpaw_ee/cloud/studio/fal_motion.py
@@ -1,0 +1,272 @@
+# ee/pocketpaw_ee/cloud/studio/fal_motion.py — direct fal.ai Kling MOTION CONTROL client.
+#
+# The /studio "Motion control" panel drives Kling's Motion Control model
+# (``fal-ai/kling-video/v2.6/standard/motion-control``) DIRECTLY against fal,
+# the same decision as the canvas edit ops (``fal_edit``), text/image-to-video
+# (``fal_video``) and the "Edit video" panel (``fal_elements``): the LiteLLM
+# gateway serves generation models only and has no route for Kling's motion
+# control. One credential path (``FAL_AI_API_KEY``), one SDK, and the output
+# persists through media storage.
+#
+# Motion control animates a character image (``image_url`` — a subject whose
+# face and body are visible) to follow a reference motion clip (``video_url`` —
+# a "motion preset" whose camera/body motion is transferred). The
+# ``character_orientation`` flag controls whether the character keeps the motion
+# video's orientation ("video") or its own source orientation ("image"). The
+# studio service resolves local media paths / http URLs / data URLs to ``data:``
+# URLs before calling here (mirroring ``fal_elements``), so fal never needs a
+# route back into the deployment's private media storage.
+#
+# Argument building + result extraction are pure so they unit-test without the
+# SDK; ``_run_fal`` / ``_download`` are the seams tests monkeypatch (exactly like
+# ``fal_edit`` / ``fal_video`` / ``fal_elements``).
+#
+# Created 2026-08-24 (studio-motion-control): Kling Motion Control dispatch.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# The Kling Motion Control endpoint. Its contract is ``{image_url, video_url,
+# character_orientation?}`` — a character image is animated to follow the
+# reference motion video.
+DEFAULT_MOTION_MODEL = "fal-ai/kling-video/v2.6/standard/motion-control"
+
+# ``character_orientation``: "video" keeps the character's orientation in sync
+# with the motion clip; "image" keeps the character's original orientation.
+CHARACTER_ORIENTATIONS: tuple[str, ...] = ("video", "image")
+DEFAULT_CHARACTER_ORIENTATION = "video"
+
+# Client + server-side deadlines for the fal call. Video jobs queue and render
+# for seconds to minutes, so these are generous but bounded so a hung upstream
+# fails fast instead of pinning a worker forever.
+_CLIENT_TIMEOUT = 600.0
+_START_TIMEOUT = 180.0
+_DOWNLOAD_TIMEOUT = 300.0
+
+
+class FalMotionError(Exception):
+    """A fal.ai Kling Motion Control call failed (missing SDK, upstream error,
+    malformed result, or no output video). The studio service maps this to 502."""
+
+
+class FalMotionValidationError(FalMotionError):
+    """fal rejected the request as invalid input (a 4xx from the endpoint —
+    e.g. image too small / bad character_orientation / video too long). The
+    studio service maps this to a 400 so the user sees the exact reason."""
+
+
+# ── Endpoint + argument building ─────────────────────────────────────────────
+
+
+def resolve_endpoint(model_id: str | None) -> str:
+    """Map a requested model id onto a real fal endpoint.
+
+    ``fal-ai/...`` ids pass straight through (the caller already picked an
+    endpoint); anything else — including None — falls back to the Kling Motion
+    Control default.
+    """
+    m = (model_id or "").strip()
+    if m.startswith("fal-ai/"):
+        return m
+    return DEFAULT_MOTION_MODEL
+
+
+def build_arguments(
+    *,
+    image_url: str,
+    video_url: str,
+    character_orientation: str | None = None,
+) -> dict[str, Any]:
+    """Build the fal ``arguments`` dict for one Kling Motion Control call.
+
+    Pure + side-effect free so it is unit-testable in isolation. The character
+    image (``image_url``) is animated to follow the reference motion video
+    (``video_url``); ``character_orientation`` defaults to "video" (follow the
+    motion clip's orientation).
+    """
+    args: dict[str, Any] = {
+        "image_url": image_url.strip(),
+        "video_url": video_url.strip(),
+    }
+    orientation = (character_orientation or "").strip() or DEFAULT_CHARACTER_ORIENTATION
+    args["character_orientation"] = orientation
+    return args
+
+
+# ── Result handling ──────────────────────────────────────────────────────────
+
+
+def _extract_video_url(result: dict[str, Any]) -> str | None:
+    """Pull the output video URL from a fal video result.
+
+    Handles the common shapes: ``video: {url, …}`` (kling / wan / minimax /
+    veo), ``videos: [{url, …}]`` (rare multi-output), or a bare top-level
+    ``url``.
+    """
+    video = result.get("video")
+    if isinstance(video, dict) and isinstance(video.get("url"), str):
+        return video["url"]
+    videos = result.get("videos")
+    if isinstance(videos, list):
+        for v in videos:
+            if isinstance(v, dict) and isinstance(v.get("url"), str):
+                return v["url"]
+    if isinstance(result.get("url"), str):
+        return result["url"]
+    return None
+
+
+def _extract_poster_url(result: dict[str, Any]) -> str | None:
+    """Pull a poster/thumbnail URL when the endpoint returns one (some models
+    return ``poster: {url}`` or ``thumbnails: [{url}]``); None when absent."""
+    poster = result.get("poster")
+    if isinstance(poster, dict) and isinstance(poster.get("url"), str):
+        return poster["url"]
+    thumbs = result.get("thumbnails")
+    if isinstance(thumbs, list):
+        for t in thumbs:
+            if isinstance(t, dict) and isinstance(t.get("url"), str):
+                return t["url"]
+    return None
+
+
+async def _download(url: str) -> tuple[bytes, str]:
+    """Download one fal-hosted result file and return ``(bytes, content_type)``.
+
+    fal media URLs are publicly accessible (no auth header needed) but expire per
+    the account's media-expiration setting, so the service persists the bytes
+    into media storage before the URL goes stale.
+    """
+    async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+    mime = resp.headers.get("content-type", "video/mp4").split(";")[0].strip() or "video/mp4"
+    return resp.content, mime
+
+
+# ── The fal SDK seam (tests inject _run_fal) ────────────────────────────────
+
+
+async def _run_fal(
+    endpoint: str,
+    arguments: dict[str, Any],
+    *,
+    key: str,
+    client_timeout: float = _CLIENT_TIMEOUT,
+    start_timeout: float = _START_TIMEOUT,
+) -> dict[str, Any]:
+    """Run a fal endpoint via the official SDK. Lazy-imports fal_client so the
+    module imports even before the dep is installed (EE lazy-import pattern)."""
+    try:
+        import fal_client  # noqa: PLC0415 — lazy: SDK is an optional runtime dep
+    except ImportError as exc:  # pragma: no cover — env with the dep installed
+        raise FalMotionError(
+            "fal-client is not installed — run `pip install fal-client` (pocketpaw-ee dep)"
+        ) from exc
+    try:
+        client = fal_client.AsyncClient(key=key, default_timeout=client_timeout)
+        result = await client.run(
+            endpoint,
+            arguments=arguments,
+            timeout=client_timeout,
+            start_timeout=start_timeout,
+        )
+    except fal_client.FalClientHTTPError as exc:
+        # A 4xx means fal REJECTED the inputs (image/video/character_orientation
+        # validation) — surface it as a client error (→ 400), not a 502.
+        if exc.status_code is not None and 400 <= exc.status_code < 500:
+            raise FalMotionValidationError(
+                f"fal motion-control rejected the request: {exc}"
+            ) from exc
+        raise FalMotionError(f"fal motion-control '{endpoint}' failed: {exc}") from exc
+    except Exception as exc:  # noqa: BLE001 — surface the upstream reason to the user
+        logger.warning("studio: fal motion-control '%s' failed", endpoint, exc_info=True)
+        raise FalMotionError(f"fal motion-control '{endpoint}' failed: {exc}") from exc
+    if not isinstance(result, dict):
+        raise FalMotionError(f"fal motion-control '{endpoint}' returned an unexpected result")
+    return result
+
+
+# ── Public entry point ───────────────────────────────────────────────────────
+
+
+async def run_fal_motion(
+    *,
+    image_url: str,
+    video_url: str,
+    character_orientation: str | None = None,
+    model: str | None = None,
+    key: str | None = None,
+) -> tuple[bytes, str, bytes | None, str | None]:
+    """Run one Kling Motion Control call against fal and return the result.
+
+    ``image_url`` (a ``data:`` image URL) is the character to animate (visible
+    face and body); ``video_url`` (a ``data:`` video URL) is the reference motion
+    preset. Both are required. Returns
+    ``(video_bytes, video_mime, poster_bytes, poster_mime)`` — the poster pair is
+    ``(None, None)`` when the endpoint didn't return one. Raises ValueError
+    (missing image/video/key) and FalMotionError (upstream failure / no output).
+    """
+    from . import fal_edit
+
+    img = (image_url or "").strip()
+    vid = (video_url or "").strip()
+    if not img:
+        raise ValueError("a character image is required for motion control")
+    if not vid:
+        raise ValueError("a motion reference video is required for motion control")
+
+    orientation = (character_orientation or "").strip() or DEFAULT_CHARACTER_ORIENTATION
+    if orientation not in CHARACTER_ORIENTATIONS:
+        raise ValueError(
+            f"character_orientation must be one of {', '.join(CHARACTER_ORIENTATIONS)}"
+        )
+
+    endpoint = resolve_endpoint(model)
+    arguments = build_arguments(
+        image_url=img,
+        video_url=vid,
+        character_orientation=orientation,
+    )
+
+    api_key = key if key is not None else fal_edit.fal_api_key()
+    if not api_key:
+        raise FalMotionError("fal.ai API key is not configured (set FAL_AI_API_KEY)")
+
+    result = await _run_fal(endpoint, arguments, key=api_key)
+    video_url_out = _extract_video_url(result)
+    if not video_url_out:
+        raise FalMotionError(f"fal motion-control '{endpoint}' returned no video data")
+
+    video_bytes, video_mime = await _download(video_url_out)
+
+    poster_bytes: bytes | None = None
+    poster_mime: str | None = None
+    poster_url = _extract_poster_url(result)
+    if poster_url:
+        try:
+            poster_bytes, poster_mime = await _download(poster_url)
+        except Exception:  # noqa: BLE001 — a poster is cosmetic; never fail the video
+            logger.warning(
+                "studio: fal motion-control poster download failed (non-fatal)", exc_info=True
+            )
+            poster_bytes, poster_mime = None, None
+    return video_bytes, video_mime, poster_bytes, poster_mime
+
+
+__all__ = [
+    "DEFAULT_MOTION_MODEL",
+    "CHARACTER_ORIENTATIONS",
+    "DEFAULT_CHARACTER_ORIENTATION",
+    "FalMotionError",
+    "FalMotionValidationError",
+    "resolve_endpoint",
+    "build_arguments",
+    "run_fal_motion",
+]

--- a/ee/pocketpaw_ee/cloud/studio/router.py
+++ b/ee/pocketpaw_ee/cloud/studio/router.py
@@ -11,6 +11,7 @@
 #   POST /studio/generate        → Generation             (LiteLLM + fal.ai)
 #   GET  /studio/generations/{id}→ Generation
 #   POST /studio/edit            → Generation             (fal.ai edit endpoints)
+#   POST /studio/video-elements  → Generation             (fal.ai Kling Elements)
 #   POST /studio/suggest-prompt  → PromptSuggestion       (heuristic, no LLM)
 #
 # The tenant is attached per-request via ``current_workspace_id`` (the frontend
@@ -112,6 +113,25 @@ async def edit(
         raise HTTPException(501, str(exc)) from exc
     except service.StudioUpstreamError as exc:
         raise HTTPException(502, f"Image edit failed: {exc}") from exc
+
+
+@router.post("/video-elements", response_model=schemas.Generation)
+async def video_elements(
+    req: schemas.VideoElementsRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> schemas.Generation:
+    """Run the "Edit video" panel's Kling Elements call directly against fal.ai.
+
+    Accepts a source video (≤30s), up to 20 element/reference images, and a
+    prompt; the result video is persisted as a NEW generation. Bad input (too
+    many images / source over 30s / missing everything) returns 400; a fal
+    upstream failure 502."""
+    try:
+        return await service.generate_video_elements(req, workspace_id=workspace_id)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    except service.StudioUpstreamError as exc:
+        raise HTTPException(502, f"Video edit failed: {exc}") from exc
 
 
 @router.post("/suggest-prompt", response_model=schemas.PromptSuggestion)

--- a/ee/pocketpaw_ee/cloud/studio/router.py
+++ b/ee/pocketpaw_ee/cloud/studio/router.py
@@ -12,6 +12,7 @@
 #   GET  /studio/generations/{id}→ Generation
 #   POST /studio/edit            → Generation             (fal.ai edit endpoints)
 #   POST /studio/video-elements  → Generation             (fal.ai Kling Elements)
+#   POST /studio/video-motion-control → Generation        (fal.ai Kling Motion Control)
 #   POST /studio/suggest-prompt  → PromptSuggestion       (heuristic, no LLM)
 #
 # The tenant is attached per-request via ``current_workspace_id`` (the frontend
@@ -132,6 +133,25 @@ async def video_elements(
         raise HTTPException(400, str(exc)) from exc
     except service.StudioUpstreamError as exc:
         raise HTTPException(502, f"Video edit failed: {exc}") from exc
+
+
+@router.post("/video-motion-control", response_model=schemas.Generation)
+async def video_motion_control(
+    req: schemas.VideoMotionRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> schemas.Generation:
+    """Run the "Motion control" panel's Kling Motion Control call directly
+    against fal.ai.
+
+    Accepts a character image (visible face and body) and a reference motion
+    video; the result video is persisted as a NEW generation. Bad input (missing
+    character image / motion video) returns 400; a fal upstream failure 502."""
+    try:
+        return await service.generate_video_motion(req, workspace_id=workspace_id)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    except service.StudioUpstreamError as exc:
+        raise HTTPException(502, f"Motion control failed: {exc}") from exc
 
 
 @router.post("/suggest-prompt", response_model=schemas.PromptSuggestion)

--- a/ee/pocketpaw_ee/cloud/studio/schemas.py
+++ b/ee/pocketpaw_ee/cloud/studio/schemas.py
@@ -127,6 +127,24 @@ class EditRequest(BaseModel):
     model: str | None = None
 
 
+class VideoElementsRequest(BaseModel):
+    """Body of ``POST /studio/video-elements`` — the "Edit video" panel.
+
+    Drives Kling Elements (``fal-ai/kling-video/v1.6/standard/elements``): a
+    prompt plus up to 20 element/reference images, and optionally a source video
+    to edit. ``sourceDurationSec`` is echoed by the frontend so the backend can
+    enforce the 30-second source cap defensively (the frontend already reads the
+    real duration from the video element, but never trust the client)."""
+
+    prompt: str
+    videoUrl: str | None = None
+    inputImageUrls: list[str] | None = None
+    aspectRatio: str = "16:9"
+    durationSec: int | None = None
+    sourceDurationSec: float | None = None
+    model: str | None = None
+
+
 class PromptSuggestion(BaseModel):
     """Response of ``POST /studio/suggest-prompt``: a sentence in, an enriched
     prompt + the media kind it implies (powers the flow editor's Text node)."""
@@ -233,6 +251,7 @@ __all__ = [
     "Generation",
     "GenerateRequest",
     "EditRequest",
+    "VideoElementsRequest",
     "PromptSuggestion",
     "SuggestPromptRequest",
     "StudioModelsResponse",

--- a/ee/pocketpaw_ee/cloud/studio/schemas.py
+++ b/ee/pocketpaw_ee/cloud/studio/schemas.py
@@ -145,6 +145,22 @@ class VideoElementsRequest(BaseModel):
     model: str | None = None
 
 
+class VideoMotionRequest(BaseModel):
+    """Body of ``POST /studio/video-motion-control`` — the "Motion control" panel.
+
+    Drives Kling Motion Control (``fal-ai/kling-video/v2.6/standard/motion-control``):
+    a character image (visible face and body) is animated to follow a reference
+    motion video. ``characterOrientation`` controls whether the character keeps
+    the motion clip's orientation ("video") or its own ("image")."""
+
+    imageUrl: str
+    videoUrl: str
+    characterOrientation: str = "video"
+    aspectRatio: str = "16:9"
+    durationSec: int | None = None
+    model: str | None = None
+
+
 class PromptSuggestion(BaseModel):
     """Response of ``POST /studio/suggest-prompt``: a sentence in, an enriched
     prompt + the media kind it implies (powers the flow editor's Text node)."""
@@ -252,6 +268,7 @@ __all__ = [
     "GenerateRequest",
     "EditRequest",
     "VideoElementsRequest",
+    "VideoMotionRequest",
     "PromptSuggestion",
     "SuggestPromptRequest",
     "StudioModelsResponse",

--- a/ee/pocketpaw_ee/cloud/studio/service.py
+++ b/ee/pocketpaw_ee/cloud/studio/service.py
@@ -38,6 +38,7 @@
 from __future__ import annotations
 
 import base64
+import io
 import json
 import logging
 import re
@@ -53,7 +54,7 @@ from pocketpaw_ee.catalog import service as catalog_service
 from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry
 from pocketpaw_ee.cloud.media import storage as media_storage
 
-from . import fal_edit, fal_elements, fal_video, schemas
+from . import fal_edit, fal_elements, fal_motion, fal_video, schemas
 
 logger = logging.getLogger(__name__)
 
@@ -869,6 +870,57 @@ async def _resolve_source_data_url(source_url: str) -> tuple[str, str]:
     return fal_edit.encode_bytes(data, mime), mime
 
 
+# fal's motion-control image cap (from the endpoint schema): images up to
+# 3850×3850px are accepted. Oversized uploads (e.g. a ~12K×18K photo) would be
+# rejected, so we downscale the long side to fit before dispatch. We never
+# upscale — a too-small image is left for fal to flag with a clear 400.
+FAL_IMAGE_MAX_DIM = 3850
+
+
+def _fit_character_image(data_url: str, mime: str) -> tuple[str, str]:
+    """Downscale an oversized character image to fal's 3850px cap (aspect
+    preserving), re-encoding as JPEG. Images already within the cap pass through
+    untouched. A non-decoding image also passes through (fal's own validation
+    then reports it) rather than turning into a 500."""
+    header, sep, b64 = data_url.partition(",")
+    if not sep:
+        return data_url, mime
+    try:
+        raw = base64.b64decode(b64)
+    except ValueError as exc:
+        raise ValueError("could not decode the character image") from exc
+
+    try:
+        from PIL import Image
+    except ImportError:  # pragma: no cover — Pillow is a pocketpaw dep
+        return data_url, mime
+
+    try:
+        with Image.open(io.BytesIO(raw)) as img:
+            width, height = img.size
+            if width <= FAL_IMAGE_MAX_DIM and height <= FAL_IMAGE_MAX_DIM:
+                return data_url, mime
+            scale = FAL_IMAGE_MAX_DIM / max(width, height)
+            new_size = (max(1, round(width * scale)), max(1, round(height * scale)))
+            if img.mode in ("RGBA", "LA", "P"):
+                rgba = img.convert("RGBA")
+                flattened = Image.new("RGB", rgba.size, (255, 255, 255))
+                flattened.paste(rgba, mask=rgba.split()[-1])
+                img = flattened
+            else:
+                img = img.convert("RGB")
+            img = img.resize(new_size, Image.LANCZOS)
+            buf = io.BytesIO()
+            img.save(buf, format="JPEG", quality=90)
+    except Exception:  # noqa: BLE001 — never 500 the request over image processing
+        logger.warning("character image downscale failed (serving original)", exc_info=True)
+        return data_url, mime
+    return (
+        f"data:image/jpeg;base64,{base64.b64encode(buf.getvalue()).decode('ascii')}",
+        "image/jpeg",
+    )
+
+
 async def edit(req: schemas.EditRequest, *, workspace_id: str) -> schemas.Generation:
     """Run a canvas edit op (inpaint/expand/upscale/variations/remove-bg/edit/
     sketch-to-image) DIRECTLY against fal.ai — the LiteLLM gateway serves
@@ -1028,6 +1080,94 @@ async def generate_video_elements(
     return record
 
 
+# ── Motion control (Kling Motion Control) ───────────────────────────────────
+# The /studio "Motion control" panel: a character image (visible face and body)
+# is animated to follow a reference motion clip, dispatched DIRECTLY against
+# fal's Kling Motion Control endpoint (``fal_motion``). Inputs resolve to
+# ``data:`` URLs (media path / http / data pass through via
+# ``_resolve_source_data_url``) so fal never needs a route back into the
+# deployment's private media storage. The produced video (+ optional poster)
+# persists through media storage like every other generation.
+
+
+async def generate_video_motion(
+    req: schemas.VideoMotionRequest, *, workspace_id: str
+) -> schemas.Generation:
+    """Run a Kling Motion Control call and return a NEW ``succeeded`` Generation.
+
+    The character image and reference motion video are resolved to ``data:`` URLs
+    and passed to fal_motion; the returned video is saved through media storage
+    (with a poster frame when the endpoint produced one) and the record lands in
+    the workspace history. A missing character image / motion video is a
+    ValueError (router → 400); a fal upstream failure surfaces as
+    StudioUpstreamError (router → 502).
+    """
+    image_url = (req.imageUrl or "").strip()
+    video_url = (req.videoUrl or "").strip()
+    if not image_url:
+        raise ValueError("a character image is required for motion control")
+    if not video_url:
+        raise ValueError("a motion reference video is required for motion control")
+
+    image_data_url, image_mime = await _resolve_source_data_url(image_url)
+    image_data_url, _ = _fit_character_image(image_data_url, image_mime)
+
+    # The reference motion video is typically a PUBLIC URL (the hardcoded preset).
+    # fal fetches public URLs directly (and re-encoding a multi-MB clip into a
+    # base64 data URI both wastes bandwidth and risks hitting request limits), so
+    # pass a hosted URL straight through. Private media paths still resolve to
+    # data URLs so fal never needs a route back into our storage.
+    if video_url.startswith(("http://", "https://")):
+        video_arg = video_url
+    else:
+        video_arg, _ = await _resolve_source_data_url(video_url)
+
+    model = (req.model or "").strip() or fal_motion.DEFAULT_MOTION_MODEL
+    try:
+        video_bytes, video_mime, poster_bytes, poster_mime = await fal_motion.run_fal_motion(
+            image_url=image_data_url,
+            video_url=video_arg,
+            character_orientation=req.characterOrientation,
+            model=model,
+        )
+    except fal_motion.FalMotionValidationError as exc:
+        raise ValueError(str(exc)) from exc
+    except fal_motion.FalMotionError as exc:
+        raise StudioUpstreamError(str(exc)) from exc
+
+    if not video_bytes:
+        raise StudioUpstreamError("fal motion-control returned no video data")
+
+    mime = video_mime or "video/mp4"
+    video_url_out = await _save_image_bytes(video_bytes, mime=mime, ext=_video_ext(mime))
+    assets: list[dict[str, Any]] = [{"id": _seq_id("asset"), "url": video_url_out, "mime": mime}]
+    if poster_bytes:
+        poster_mime_val = poster_mime or "image/jpeg"
+        poster_url_out = await _save_image_bytes(
+            poster_bytes, mime=poster_mime_val, ext=_video_poster_ext(poster_mime_val)
+        )
+        assets[0]["posterUrl"] = poster_url_out
+
+    params: dict[str, Any] = {
+        "kind": "video",
+        "model": model,
+        "aspectRatio": req.aspectRatio,
+        "count": 1,
+        "durationSec": req.durationSec,
+    }
+    record = _new_generation(
+        gen_id=_seq_id("gen"),
+        prompt="Motion control",
+        kind="video",
+        model=model,
+        params=params,
+        assets=assets,
+        status="succeeded",
+    )
+    _append_history({**record.model_dump(), "_workspace": workspace_id})
+    return record
+
+
 def suggest_prompt(sentence: str) -> schemas.PromptSuggestion:
     """Enrich a plain sentence into a generation prompt + inferred media kind.
     Heuristic mirror of the mock (no LLM call): a motion/reel vocabulary implies
@@ -1057,5 +1197,6 @@ __all__ = [
     "generate",
     "edit",
     "generate_video_elements",
+    "generate_video_motion",
     "suggest_prompt",
 ]

--- a/ee/pocketpaw_ee/cloud/studio/service.py
+++ b/ee/pocketpaw_ee/cloud/studio/service.py
@@ -53,7 +53,7 @@ from pocketpaw_ee.catalog import service as catalog_service
 from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry
 from pocketpaw_ee.cloud.media import storage as media_storage
 
-from . import fal_edit, fal_video, schemas
+from . import fal_edit, fal_elements, fal_video, schemas
 
 logger = logging.getLogger(__name__)
 
@@ -933,6 +933,101 @@ async def edit(req: schemas.EditRequest, *, workspace_id: str) -> schemas.Genera
     return record
 
 
+# ── Video editing (Kling Elements) ───────────────────────────────────────────
+# The /studio "Edit video" panel: a source video (≤30s) + up to 20 element/
+# reference images + a prompt, dispatched DIRECTLY against fal's Kling Elements
+# endpoint (``fal_elements``). Inputs resolve to ``data:`` URLs (media path /
+# http / data pass through via ``_resolve_source_data_url``) so fal never needs
+# a route back into the deployment's private media storage. The produced video
+# (+ optional poster) persists through media storage like every other generation.
+
+
+async def generate_video_elements(
+    req: schemas.VideoElementsRequest, *, workspace_id: str
+) -> schemas.Generation:
+    """Run a Kling Elements video edit and return a NEW ``succeeded`` Generation.
+
+    The source video (optional) and each element image (max 20) are resolved to
+    ``data:`` URLs and passed to fal_elements; the returned video is saved through
+    media storage (with a poster frame when the endpoint produced one) and the
+    record lands in the workspace history. A source video longer than 30s or more
+    than 20 element images is a ValueError (router → 400); a fal upstream failure
+    surfaces as StudioUpstreamError (router → 502).
+    """
+    prompt = (req.prompt or "").strip()
+    image_urls = [u for u in (req.inputImageUrls or []) if u and u.strip()]
+    video_url = (req.videoUrl or "").strip()
+
+    if not prompt and not video_url and not image_urls:
+        raise ValueError("prompt, a source video, or element images are required")
+    if len(image_urls) > fal_elements.MAX_ELEMENT_IMAGES:
+        raise ValueError(f"at most {fal_elements.MAX_ELEMENT_IMAGES} element images are allowed")
+    if req.sourceDurationSec is not None and req.sourceDurationSec > 30:
+        raise ValueError("source video must be 30 seconds or less")
+
+    # Kling Elements needs a prompt to describe the edit; fall back to a default
+    # motion instruction when the user edited a video without typing one.
+    effective_prompt = prompt or "edit the video with the provided elements"
+    final_prompt = await _apply_style(effective_prompt, None)
+
+    input_data_urls: list[str] | None = None
+    if image_urls:
+        input_data_urls = []
+        for url in image_urls:
+            data_url, _ = await _resolve_source_data_url(url)
+            input_data_urls.append(data_url)
+
+    video_data_url: str | None = None
+    if video_url:
+        video_data_url, _ = await _resolve_source_data_url(video_url)
+
+    model = (req.model or "").strip() or fal_elements.DEFAULT_ELEMENTS_MODEL
+    try:
+        video_bytes, video_mime, poster_bytes, poster_mime = await fal_elements.run_fal_elements(
+            prompt=final_prompt,
+            input_image_urls=input_data_urls,
+            video_url=video_data_url,
+            duration_sec=req.durationSec,
+            aspect_ratio=req.aspectRatio,
+            model=model,
+        )
+    except fal_elements.FalElementsError as exc:
+        raise StudioUpstreamError(str(exc)) from exc
+
+    if not video_bytes:
+        raise StudioUpstreamError("fal elements returned no video data")
+
+    mime = video_mime or "video/mp4"
+    video_url_out = await _save_image_bytes(video_bytes, mime=mime, ext=_video_ext(mime))
+    assets: list[dict[str, Any]] = [{"id": _seq_id("asset"), "url": video_url_out, "mime": mime}]
+    if poster_bytes:
+        poster_mime_val = poster_mime or "image/jpeg"
+        poster_url_out = await _save_image_bytes(
+            poster_bytes, mime=poster_mime_val, ext=_video_poster_ext(poster_mime_val)
+        )
+        assets[0]["posterUrl"] = poster_url_out
+
+    params: dict[str, Any] = {
+        "kind": "video",
+        "model": model,
+        "aspectRatio": req.aspectRatio,
+        "count": 1,
+        "durationSec": req.durationSec,
+        "inputImageCount": len(input_data_urls) if input_data_urls else None,
+    }
+    record = _new_generation(
+        gen_id=_seq_id("gen"),
+        prompt=final_prompt,
+        kind="video",
+        model=model,
+        params=params,
+        assets=assets,
+        status="succeeded",
+    )
+    _append_history({**record.model_dump(), "_workspace": workspace_id})
+    return record
+
+
 def suggest_prompt(sentence: str) -> schemas.PromptSuggestion:
     """Enrich a plain sentence into a generation prompt + inferred media kind.
     Heuristic mirror of the mock (no LLM call): a motion/reel vocabulary implies
@@ -961,5 +1056,6 @@ __all__ = [
     "tracked_generation_filenames",
     "generate",
     "edit",
+    "generate_video_elements",
     "suggest_prompt",
 ]

--- a/tests/cloud/studio/test_fal_elements.py
+++ b/tests/cloud/studio/test_fal_elements.py
@@ -1,0 +1,170 @@
+# tests/cloud/studio/test_fal_elements.py — the direct fal.ai Kling ELEMENTS client.
+#
+# fal_elements is the seam that makes the /studio "Edit video" panel work: it
+# resolves the model id → fal endpoint, builds the arguments (prompt /
+# input_image_urls / video_url / duration / aspect_ratio), runs the endpoint
+# through the fal-client SDK, and downloads the result video (+ optional poster).
+# These tests keep the fal HTTP layer OUT of the picture — ``_run_fal`` and
+# ``_download`` are monkeypatched — so argument building + dispatch + error
+# mapping are asserted precisely.
+#
+# Created 2026-08-24 (studio-video-elements): Kling Elements dispatch tests.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.studio import fal_edit, fal_elements
+
+
+@pytest.fixture(autouse=True)
+def _no_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep fal_api_key's env resolution deterministic (same as test_fal_edit)."""
+    import dotenv
+
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda *a, **kw: False)
+
+
+# ── Endpoint resolution ──────────────────────────────────────────────────────
+
+
+def test_resolve_endpoint_passes_fal_ai_through() -> None:
+    assert fal_elements.resolve_endpoint("fal-ai/foo/v1/elements") == "fal-ai/foo/v1/elements"
+
+
+def test_resolve_endpoint_falls_back_to_default() -> None:
+    assert fal_elements.resolve_endpoint("kling-elements") == fal_elements.DEFAULT_ELEMENTS_MODEL
+    assert fal_elements.resolve_endpoint(None) == fal_elements.DEFAULT_ELEMENTS_MODEL
+    assert fal_elements.resolve_endpoint("  ") == fal_elements.DEFAULT_ELEMENTS_MODEL
+
+
+# ── Argument building ────────────────────────────────────────────────────────
+
+
+def test_build_arguments_prompt_only() -> None:
+    assert fal_elements.build_arguments(prompt="a scene") == {"prompt": "a scene"}
+
+
+def test_build_arguments_full() -> None:
+    args = fal_elements.build_arguments(
+        prompt="add a cow",
+        input_image_urls=["data:image/png;base64,aaa", "  ", "data:image/png;base64,bbb"],
+        video_url="data:video/mp4;base64,vvv",
+        duration_sec=5,
+        aspect_ratio="16:9",
+    )
+    assert args == {
+        "prompt": "add a cow",
+        "input_image_urls": ["data:image/png;base64,aaa", "data:image/png;base64,bbb"],
+        "video_url": "data:video/mp4;base64,vvv",
+        "duration": "5",
+        "aspect_ratio": "16:9",
+    }
+
+
+def test_build_arguments_omits_blanks() -> None:
+    args = fal_elements.build_arguments(
+        prompt="p", input_image_urls=["  "], video_url="  ", duration_sec=0, aspect_ratio=None
+    )
+    assert args == {"prompt": "p"}
+
+
+# ── Result extraction ────────────────────────────────────────────────────────
+
+
+def test_extract_video_url_shapes() -> None:
+    assert fal_elements._extract_video_url({"video": {"url": "https://fal.test/v.mp4"}}) == (
+        "https://fal.test/v.mp4"
+    )
+    assert (
+        fal_elements._extract_video_url({"videos": [{"url": "https://fal.test/a.mp4"}]})
+        == "https://fal.test/a.mp4"
+    )
+    assert fal_elements._extract_video_url({"url": "https://fal.test/b.mp4"}) == (
+        "https://fal.test/b.mp4"
+    )
+    assert fal_elements._extract_video_url({}) is None
+
+
+def test_extract_poster_url_shapes() -> None:
+    assert fal_elements._extract_poster_url({"poster": {"url": "https://fal.test/p.jpg"}}) == (
+        "https://fal.test/p.jpg"
+    )
+    assert (
+        fal_elements._extract_poster_url({"thumbnails": [{"url": "https://fal.test/t.jpg"}]})
+        == "https://fal.test/t.jpg"
+    )
+    assert fal_elements._extract_poster_url({}) is None
+
+
+# ── Dispatch ─────────────────────────────────────────────────────────────────
+
+
+async def test_run_fal_elements_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fal result → downloaded mp4 (+ poster) is returned; the endpoint,
+    arguments, and resolved key are asserted."""
+    seen: dict = {}
+
+    async def _fake_run(endpoint, arguments, *, key, client_timeout=None, start_timeout=None):
+        seen.update(endpoint=endpoint, arguments=arguments, key=key)
+        return {
+            "video": {"url": "https://fal.test/out.mp4"},
+            "poster": {"url": "https://fal.test/p.jpg"},
+        }
+
+    async def _fake_download(url):
+        if url.endswith("p.jpg"):
+            return b"poster", "image/jpeg"
+        return b"mp4", "video/mp4"
+
+    monkeypatch.setattr(fal_elements, "_run_fal", _fake_run)
+    monkeypatch.setattr(fal_elements, "_download", _fake_download)
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+
+    out = await fal_elements.run_fal_elements(
+        prompt="add a cow",
+        input_image_urls=["data:image/png;base64,aaa"],
+        video_url="data:video/mp4;base64,vvv",
+        duration_sec=5,
+        aspect_ratio="16:9",
+    )
+
+    assert out == (b"mp4", "video/mp4", b"poster", "image/jpeg")
+    assert seen["key"] == "sk-fal"
+    assert seen["endpoint"] == fal_elements.DEFAULT_ELEMENTS_MODEL
+    assert seen["arguments"]["input_image_urls"] == ["data:image/png;base64,aaa"]
+    assert seen["arguments"]["video_url"] == "data:video/mp4;base64,vvv"
+
+
+async def test_run_fal_elements_requires_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+    with pytest.raises(ValueError):
+        await fal_elements.run_fal_elements(prompt="  ", input_image_urls=[], video_url=None)
+
+
+async def test_run_fal_elements_missing_key_is_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: None)
+    with pytest.raises(fal_elements.FalElementsError, match="API key"):
+        await fal_elements.run_fal_elements(prompt="a scene")
+
+
+async def test_run_fal_elements_no_video_is_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_run(endpoint, arguments, *, key, client_timeout=None, start_timeout=None):
+        return {"status": "done"}
+
+    monkeypatch.setattr(fal_elements, "_run_fal", _fake_run)
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+    with pytest.raises(fal_elements.FalElementsError, match="no video"):
+        await fal_elements.run_fal_elements(prompt="a scene")
+
+
+async def test_run_fal_elements_upstream_failure_is_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A FalElementsError raised by the SDK seam propagates (run_fal_elements
+    doesn't swallow it — the real `_run_fal` wraps raw upstream errors)."""
+
+    async def _boom(endpoint, arguments, *, key, client_timeout=None, start_timeout=None):
+        raise fal_elements.FalElementsError("fal elements 'x' failed: upstream 500")
+
+    monkeypatch.setattr(fal_elements, "_run_fal", _boom)
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+    with pytest.raises(fal_elements.FalElementsError, match="upstream 500"):
+        await fal_elements.run_fal_elements(prompt="a scene")

--- a/tests/cloud/studio/test_fal_motion.py
+++ b/tests/cloud/studio/test_fal_motion.py
@@ -1,0 +1,198 @@
+# tests/cloud/studio/test_fal_motion.py — the direct fal.ai Kling MOTION CONTROL client.
+#
+# fal_motion is the seam that makes the /studio "Motion control" panel work: it
+# resolves the model id → fal endpoint, builds the arguments (image_url /
+# video_url / character_orientation), runs the endpoint through the fal-client
+# SDK, and downloads the result video (+ optional poster). These tests keep the
+# fal HTTP layer OUT of the picture — ``_run_fal`` and ``_download`` are
+# monkeypatched — so argument building + dispatch + error mapping are asserted
+# precisely.
+#
+# Created 2026-08-24 (studio-motion-control): Kling Motion Control dispatch tests.
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud.studio import fal_edit, fal_motion
+
+
+@pytest.fixture(autouse=True)
+def _no_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep fal_api_key's env resolution deterministic (same as test_fal_edit)."""
+    import dotenv
+
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda *a, **kw: False)
+
+
+# ── Endpoint resolution ──────────────────────────────────────────────────────
+
+
+def test_resolve_endpoint_passes_fal_ai_through() -> None:
+    assert fal_motion.resolve_endpoint("fal-ai/foo/v2.6/motion-control") == (
+        "fal-ai/foo/v2.6/motion-control"
+    )
+
+
+def test_resolve_endpoint_falls_back_to_default() -> None:
+    assert fal_motion.resolve_endpoint("kling-motion") == fal_motion.DEFAULT_MOTION_MODEL
+    assert fal_motion.resolve_endpoint(None) == fal_motion.DEFAULT_MOTION_MODEL
+    assert fal_motion.resolve_endpoint("  ") == fal_motion.DEFAULT_MOTION_MODEL
+
+
+# ── Argument building ────────────────────────────────────────────────────────
+
+
+def test_build_arguments_defaults_orientation_to_video() -> None:
+    args = fal_motion.build_arguments(
+        image_url="data:image/png;base64,aaa", video_url="data:video/mp4;base64,vvv"
+    )
+    assert args == {
+        "image_url": "data:image/png;base64,aaa",
+        "video_url": "data:video/mp4;base64,vvv",
+        "character_orientation": "video",
+    }
+
+
+def test_build_arguments_explicit_orientation() -> None:
+    args = fal_motion.build_arguments(image_url="i", video_url="v", character_orientation="image")
+    assert args["character_orientation"] == "image"
+
+
+# ── Result extraction ────────────────────────────────────────────────────────
+
+
+def test_extract_video_url_shapes() -> None:
+    assert fal_motion._extract_video_url({"video": {"url": "https://fal.test/v.mp4"}}) == (
+        "https://fal.test/v.mp4"
+    )
+    assert fal_motion._extract_video_url({"videos": [{"url": "https://fal.test/a.mp4"}]}) == (
+        "https://fal.test/a.mp4"
+    )
+    assert fal_motion._extract_video_url({"url": "https://fal.test/b.mp4"}) == (
+        "https://fal.test/b.mp4"
+    )
+    assert fal_motion._extract_video_url({}) is None
+
+
+def test_extract_poster_url_shapes() -> None:
+    assert fal_motion._extract_poster_url({"poster": {"url": "https://fal.test/p.jpg"}}) == (
+        "https://fal.test/p.jpg"
+    )
+    assert fal_motion._extract_poster_url({"thumbnails": [{"url": "https://fal.test/t.jpg"}]}) == (
+        "https://fal.test/t.jpg"
+    )
+    assert fal_motion._extract_poster_url({}) is None
+
+
+# ── Dispatch ─────────────────────────────────────────────────────────────────
+
+
+async def test_run_fal_motion_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fal result → downloaded mp4 (+ poster) is returned; the endpoint,
+    arguments, and resolved key are asserted."""
+    seen: dict = {}
+
+    async def _fake_run(endpoint, arguments, *, key, client_timeout=None, start_timeout=None):
+        seen.update(endpoint=endpoint, arguments=arguments, key=key)
+        return {
+            "video": {"url": "https://fal.test/out.mp4"},
+            "poster": {"url": "https://fal.test/p.jpg"},
+        }
+
+    async def _fake_download(url):
+        if url.endswith("p.jpg"):
+            return b"poster", "image/jpeg"
+        return b"mp4", "video/mp4"
+
+    monkeypatch.setattr(fal_motion, "_run_fal", _fake_run)
+    monkeypatch.setattr(fal_motion, "_download", _fake_download)
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+
+    out = await fal_motion.run_fal_motion(
+        image_url="data:image/png;base64,aaa",
+        video_url="data:video/mp4;base64,vvv",
+        character_orientation="video",
+    )
+
+    assert out == (b"mp4", "video/mp4", b"poster", "image/jpeg")
+    assert seen["key"] == "sk-fal"
+    assert seen["endpoint"] == fal_motion.DEFAULT_MOTION_MODEL
+    assert seen["arguments"]["image_url"] == "data:image/png;base64,aaa"
+    assert seen["arguments"]["video_url"] == "data:video/mp4;base64,vvv"
+    assert seen["arguments"]["character_orientation"] == "video"
+
+
+async def test_run_fal_motion_requires_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+    with pytest.raises(ValueError, match="character image"):
+        await fal_motion.run_fal_motion(image_url="  ", video_url="v")
+
+
+async def test_run_fal_motion_requires_video(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+    with pytest.raises(ValueError, match="motion reference video"):
+        await fal_motion.run_fal_motion(image_url="i", video_url="  ")
+
+
+async def test_run_fal_motion_rejects_bad_orientation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+    with pytest.raises(ValueError, match="character_orientation"):
+        await fal_motion.run_fal_motion(
+            image_url="i", video_url="v", character_orientation="diagonal"
+        )
+
+
+async def test_run_fal_motion_missing_key_is_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: None)
+    with pytest.raises(fal_motion.FalMotionError, match="API key"):
+        await fal_motion.run_fal_motion(image_url="i", video_url="v")
+
+
+async def test_run_fal_motion_no_video_is_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_run(endpoint, arguments, *, key, client_timeout=None, start_timeout=None):
+        return {"status": "done"}
+
+    monkeypatch.setattr(fal_motion, "_run_fal", _fake_run)
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+    with pytest.raises(fal_motion.FalMotionError, match="no video"):
+        await fal_motion.run_fal_motion(image_url="i", video_url="v")
+
+
+async def test_run_fal_motion_upstream_failure_is_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A FalMotionError raised by the SDK seam propagates (run_fal_motion
+    doesn't swallow it — the real `_run_fal` wraps raw upstream errors)."""
+
+    async def _boom(endpoint, arguments, *, key, client_timeout=None, start_timeout=None):
+        raise fal_motion.FalMotionError("fal motion-control 'x' failed: upstream 500")
+
+    monkeypatch.setattr(fal_motion, "_run_fal", _boom)
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+    with pytest.raises(fal_motion.FalMotionError, match="upstream 500"):
+        await fal_motion.run_fal_motion(image_url="i", video_url="v")
+
+
+async def test_run_fal_maps_4xx_to_validation_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 4xx FalClientHTTPError from the SDK (fal rejected the inputs) maps to
+    FalMotionValidationError, which the service turns into a 400."""
+    import fal_client
+
+    def _http_422() -> fal_client.FalClientHTTPError:
+        request = httpx.Request("POST", "https://fal.run/x")
+        response = httpx.Response(
+            422,
+            request=request,
+            json=[{"msg": "Image dimensions are too small. Minimum 340x340."}],
+        )
+        return fal_client.FalClientHTTPError(str(response.json()), 422, {}, response)
+
+    class _FakeAsyncClient:
+        def __init__(self, *, key, default_timeout): ...
+
+        async def run(self, *args, **kwargs):
+            raise _http_422()
+
+    monkeypatch.setattr(fal_client, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(fal_edit, "fal_api_key", lambda: "sk-fal")
+    with pytest.raises(fal_motion.FalMotionValidationError, match="rejected"):
+        await fal_motion.run_fal_motion(image_url="i", video_url="v")

--- a/tests/cloud/studio/test_router.py
+++ b/tests/cloud/studio/test_router.py
@@ -256,6 +256,56 @@ def test_post_edit_upstream_failure_is_502(client, monkeypatch):
     assert "Image edit failed" in resp.json()["detail"]
 
 
+def test_post_video_elements_returns_generation(client, monkeypatch):
+    async def _elements(req, *, workspace_id):
+        assert req.prompt == "add a cow"
+        assert req.inputImageUrls == ["/api/v1/media/a.png", "/api/v1/media/b.png"]
+        assert req.videoUrl == "/api/v1/media/src.mp4"
+        assert req.sourceDurationSec == 4.5
+        assert workspace_id == "ws-1"
+        return _generation()
+
+    monkeypatch.setattr(studio_service, "generate_video_elements", _elements)
+    resp = client.post(
+        "/api/v1/studio/video-elements",
+        json={
+            "prompt": "add a cow",
+            "videoUrl": "/api/v1/media/src.mp4",
+            "inputImageUrls": ["/api/v1/media/a.png", "/api/v1/media/b.png"],
+            "sourceDurationSec": 4.5,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "gen_abc"
+    assert resp.json()["status"] == "succeeded"
+
+
+def test_post_video_elements_bad_input_is_400(client, monkeypatch):
+    async def _elements(req, *, workspace_id):
+        raise ValueError("source video must be 30 seconds or less")
+
+    monkeypatch.setattr(studio_service, "generate_video_elements", _elements)
+    resp = client.post(
+        "/api/v1/studio/video-elements",
+        json={"prompt": "x", "sourceDurationSec": 31},
+    )
+    assert resp.status_code == 400
+    assert "30 seconds" in resp.json()["detail"]
+
+
+def test_post_video_elements_upstream_failure_is_502(client, monkeypatch):
+    async def _elements(req, *, workspace_id):
+        raise studio_service.StudioUpstreamError("fal elements failed: timeout")
+
+    monkeypatch.setattr(studio_service, "generate_video_elements", _elements)
+    resp = client.post(
+        "/api/v1/studio/video-elements",
+        json={"prompt": "x"},
+    )
+    assert resp.status_code == 502
+    assert "Video edit failed" in resp.json()["detail"]
+
+
 def test_post_suggest_prompt(client):
     resp = client.post("/api/v1/studio/suggest-prompt", json={"sentence": "a lighthouse"})
     assert resp.status_code == 200

--- a/tests/cloud/studio/test_router.py
+++ b/tests/cloud/studio/test_router.py
@@ -306,6 +306,54 @@ def test_post_video_elements_upstream_failure_is_502(client, monkeypatch):
     assert "Video edit failed" in resp.json()["detail"]
 
 
+def test_post_video_motion_control_returns_generation(client, monkeypatch):
+    async def _motion(req, *, workspace_id):
+        assert req.imageUrl == "/api/v1/media/char.png"
+        assert req.videoUrl == "https://cdn.test/motion.mp4"
+        assert req.characterOrientation == "video"
+        assert workspace_id == "ws-1"
+        return _generation()
+
+    monkeypatch.setattr(studio_service, "generate_video_motion", _motion)
+    resp = client.post(
+        "/api/v1/studio/video-motion-control",
+        json={
+            "imageUrl": "/api/v1/media/char.png",
+            "videoUrl": "https://cdn.test/motion.mp4",
+            "characterOrientation": "video",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "gen_abc"
+    assert resp.json()["status"] == "succeeded"
+
+
+def test_post_video_motion_control_bad_input_is_400(client, monkeypatch):
+    async def _motion(req, *, workspace_id):
+        raise ValueError("a character image is required for motion control")
+
+    monkeypatch.setattr(studio_service, "generate_video_motion", _motion)
+    resp = client.post(
+        "/api/v1/studio/video-motion-control",
+        json={"imageUrl": "", "videoUrl": "https://cdn.test/motion.mp4"},
+    )
+    assert resp.status_code == 400
+    assert "character image" in resp.json()["detail"]
+
+
+def test_post_video_motion_control_upstream_failure_is_502(client, monkeypatch):
+    async def _motion(req, *, workspace_id):
+        raise studio_service.StudioUpstreamError("fal motion-control failed: timeout")
+
+    monkeypatch.setattr(studio_service, "generate_video_motion", _motion)
+    resp = client.post(
+        "/api/v1/studio/video-motion-control",
+        json={"imageUrl": "/api/v1/media/char.png", "videoUrl": "https://cdn.test/motion.mp4"},
+    )
+    assert resp.status_code == 502
+    assert "Motion control failed" in resp.json()["detail"]
+
+
 def test_post_suggest_prompt(client):
     resp = client.post("/api/v1/studio/suggest-prompt", json={"sentence": "a lighthouse"})
     assert resp.status_code == 200

--- a/tests/cloud/studio/test_service.py
+++ b/tests/cloud/studio/test_service.py
@@ -37,7 +37,7 @@ from pocketpaw_ee.catalog import service as catalog_service
 from pocketpaw_ee.catalog.litellm_client import CatalogUpstreamError
 from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry, Pricing
 from pocketpaw_ee.cloud.media import storage as media_storage
-from pocketpaw_ee.cloud.studio import fal_edit, fal_elements, fal_video, schemas
+from pocketpaw_ee.cloud.studio import fal_edit, fal_elements, fal_motion, fal_video, schemas
 
 from pocketpaw.uploads.local import LocalStorageAdapter
 
@@ -695,6 +695,140 @@ async def test_generate_video_elements_fal_failure_is_upstream_error(
     with pytest.raises(service.StudioUpstreamError, match="bad key"):
         await service.generate_video_elements(req, workspace_id="ws-1")
     assert service._load_history() == []
+
+
+# ── motion control (direct fal.ai Kling Motion Control dispatch) ─────────────
+
+
+async def test_generate_video_motion_happy_path(monkeypatch, studio_env) -> None:
+    """A fal motion-control result → the mp4 (+ poster) is saved, a succeeded
+    video Generation is returned, and both inputs are forwarded."""
+    generated, history = studio_env
+    seen: dict = {}
+
+    async def _fake_motion(*, image_url, video_url, character_orientation, model, key=None):
+        seen.update(
+            image_url=image_url,
+            video_url=video_url,
+            character_orientation=character_orientation,
+            model=model,
+        )
+        return b"mp4", "video/mp4", b"png-poster", "image/png"
+
+    monkeypatch.setattr(fal_motion, "run_fal_motion", _fake_motion)
+
+    req = schemas.VideoMotionRequest(
+        imageUrl=_DATA_URL,
+        videoUrl=_DATA_URL,
+        characterOrientation="video",
+        aspectRatio="16:9",
+    )
+    gen = await service.generate_video_motion(req, workspace_id="ws-1")
+
+    assert gen.status == "succeeded"
+    assert gen.kind == "video"
+    assert gen.assets[0].mime == "video/mp4"
+    assert gen.assets[0].url.startswith("/api/v1/media/")
+    assert gen.assets[0].posterUrl.startswith("/api/v1/media/")
+    assert seen["image_url"] == _DATA_URL
+    assert seen["video_url"] == _DATA_URL
+    assert seen["character_orientation"] == "video"
+    assert service.list_generations("ws-1")[0].id == gen.id
+
+
+async def test_generate_video_motion_requires_image(monkeypatch, studio_env) -> None:
+    req = schemas.VideoMotionRequest(imageUrl="  ", videoUrl=_DATA_URL)
+    with pytest.raises(ValueError, match="character image"):
+        await service.generate_video_motion(req, workspace_id="ws-1")
+
+
+async def test_generate_video_motion_requires_video(monkeypatch, studio_env) -> None:
+    req = schemas.VideoMotionRequest(imageUrl=_DATA_URL, videoUrl="  ")
+    with pytest.raises(ValueError, match="motion reference video"):
+        await service.generate_video_motion(req, workspace_id="ws-1")
+
+
+async def test_generate_video_motion_fal_failure_is_upstream_error(monkeypatch, studio_env) -> None:
+    async def _boom(**kwargs):
+        raise fal_motion.FalMotionError("fal motion-control 'x' failed: bad key")
+
+    monkeypatch.setattr(fal_motion, "run_fal_motion", _boom)
+    req = schemas.VideoMotionRequest(imageUrl=_DATA_URL, videoUrl=_DATA_URL)
+    with pytest.raises(service.StudioUpstreamError, match="bad key"):
+        await service.generate_video_motion(req, workspace_id="ws-1")
+    assert service._load_history() == []
+
+
+async def test_generate_video_motion_validation_error_is_value_error(
+    monkeypatch, studio_env
+) -> None:
+    """fal rejecting the inputs (a 4xx) surfaces as ValueError (→ 400), not 502."""
+
+    async def _invalid(**kwargs):
+        raise fal_motion.FalMotionValidationError(
+            "fal motion-control rejected the request: Image dimensions are too small"
+        )
+
+    monkeypatch.setattr(fal_motion, "run_fal_motion", _invalid)
+    req = schemas.VideoMotionRequest(imageUrl=_DATA_URL, videoUrl=_DATA_URL)
+    with pytest.raises(ValueError, match="dimensions are too small"):
+        await service.generate_video_motion(req, workspace_id="ws-1")
+    assert service._load_history() == []
+
+
+async def test_generate_video_motion_passes_public_video_url_through(
+    monkeypatch, studio_env
+) -> None:
+    """A hosted http(s) video URL is forwarded to fal AS-IS (not re-encoded to a
+    data URL), while the character image is still resolved to a data URL."""
+    seen: dict = {}
+    public_video = "https://cdn.higgsfield.ai/kling_motion_control_preset/x.mp4"
+
+    async def _fake_motion(*, image_url, video_url, character_orientation, model, key=None):
+        seen.update(image_url=image_url, video_url=video_url)
+        return b"mp4", "video/mp4", None, None
+
+    monkeypatch.setattr(fal_motion, "run_fal_motion", _fake_motion)
+    req = schemas.VideoMotionRequest(imageUrl=_DATA_URL, videoUrl=public_video)
+    await service.generate_video_motion(req, workspace_id="ws-1")
+
+    assert seen["image_url"] == _DATA_URL
+    assert seen["video_url"] == public_video
+
+
+def test_fit_character_image_downscales_oversized() -> None:
+    """An image over fal's 3850px cap is downscaled (aspect preserved) to a JPEG
+    whose long side equals the cap."""
+    from io import BytesIO
+
+    from PIL import Image
+
+    im = Image.new("RGB", (5000, 2000), (10, 20, 30))
+    buf = BytesIO()
+    im.save(buf, format="JPEG")
+    data_url = "data:image/jpeg;base64," + base64.b64encode(buf.getvalue()).decode()
+
+    out_url, out_mime = service._fit_character_image(data_url, "image/jpeg")
+
+    assert out_mime == "image/jpeg"
+    out = Image.open(BytesIO(base64.b64decode(out_url.split(",", 1)[1])))
+    width, height = out.size
+    assert max(width, height) == service.FAL_IMAGE_MAX_DIM
+    assert min(width, height) == round(2000 * service.FAL_IMAGE_MAX_DIM / 5000)
+
+
+def test_fit_character_image_passes_through_within_limit() -> None:
+    """An image already within the cap is returned unchanged."""
+    from io import BytesIO
+
+    from PIL import Image
+
+    im = Image.new("RGB", (512, 512), (200, 100, 50))
+    buf = BytesIO()
+    im.save(buf, format="JPEG")
+    data_url = "data:image/jpeg;base64," + base64.b64encode(buf.getvalue()).decode()
+
+    assert service._fit_character_image(data_url, "image/jpeg") == (data_url, "image/jpeg")
 
 
 # ── styles + suggest ─────────────────────────────────────────────────────────

--- a/tests/cloud/studio/test_service.py
+++ b/tests/cloud/studio/test_service.py
@@ -37,7 +37,7 @@ from pocketpaw_ee.catalog import service as catalog_service
 from pocketpaw_ee.catalog.litellm_client import CatalogUpstreamError
 from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry, Pricing
 from pocketpaw_ee.cloud.media import storage as media_storage
-from pocketpaw_ee.cloud.studio import fal_edit, fal_video, schemas
+from pocketpaw_ee.cloud.studio import fal_edit, fal_elements, fal_video, schemas
 
 from pocketpaw.uploads.local import LocalStorageAdapter
 
@@ -598,6 +598,102 @@ async def test_edit_no_output_is_upstream_error(monkeypatch, studio_env) -> None
     req = schemas.EditRequest(op="upscale", sourceUrl=_DATA_URL)
     with pytest.raises(service.StudioUpstreamError, match="no output images"):
         await service.edit(req, workspace_id="ws-1")
+    assert service._load_history() == []
+
+
+# ── video elements (direct fal.ai Kling Elements dispatch) ───────────────────
+
+
+async def test_generate_video_elements_happy_path(monkeypatch, studio_env) -> None:
+    """A fal elements result → the mp4 (+ poster) is saved, a succeeded video
+    Generation is returned, and every input (video + elements) is forwarded."""
+    generated, history = studio_env
+    seen: dict = {}
+
+    async def _fake_elements(
+        *, prompt, input_image_urls, video_url, duration_sec, aspect_ratio, model, key=None
+    ):
+        seen.update(
+            prompt=prompt,
+            input_image_urls=input_image_urls,
+            video_url=video_url,
+            duration_sec=duration_sec,
+            aspect_ratio=aspect_ratio,
+            model=model,
+        )
+        return b"mp4", "video/mp4", b"png-poster", "image/png"
+
+    monkeypatch.setattr(fal_elements, "run_fal_elements", _fake_elements)
+
+    req = schemas.VideoElementsRequest(
+        prompt="add a cow",
+        videoUrl=_DATA_URL,
+        inputImageUrls=[_DATA_URL, _DATA_URL],
+        aspectRatio="16:9",
+        durationSec=5,
+        sourceDurationSec=4.2,
+    )
+    gen = await service.generate_video_elements(req, workspace_id="ws-1")
+
+    assert gen.status == "succeeded"
+    assert gen.kind == "video"
+    assert gen.params.inputImageCount == 2
+    assert gen.assets[0].mime == "video/mp4"
+    assert gen.assets[0].url.startswith("/api/v1/media/")
+    assert gen.assets[0].posterUrl.startswith("/api/v1/media/")
+    assert seen["input_image_urls"] == [_DATA_URL, _DATA_URL]
+    assert seen["video_url"] == _DATA_URL
+    assert seen["duration_sec"] == 5
+    assert service.list_generations("ws-1")[0].id == gen.id
+
+
+async def test_generate_video_elements_prompt_only(monkeypatch, studio_env) -> None:
+    """A prompt-only request is valid (text-to-video through Elements)."""
+    seen: dict = {}
+
+    async def _fake_elements(
+        *, prompt, input_image_urls, video_url, duration_sec, aspect_ratio, model, key=None
+    ):
+        seen["prompt"] = prompt
+        return b"mp4", "video/mp4", None, None
+
+    monkeypatch.setattr(fal_elements, "run_fal_elements", _fake_elements)
+    req = schemas.VideoElementsRequest(prompt="a wave", aspectRatio="1:1")
+    gen = await service.generate_video_elements(req, workspace_id="ws-1")
+    assert gen.status == "succeeded"
+    assert seen["prompt"] == "a wave"
+
+
+async def test_generate_video_elements_rejects_too_many_images(monkeypatch, studio_env) -> None:
+    req = schemas.VideoElementsRequest(
+        prompt="x", inputImageUrls=[_DATA_URL] * (fal_elements.MAX_ELEMENT_IMAGES + 1)
+    )
+    with pytest.raises(ValueError, match="at most 20"):
+        await service.generate_video_elements(req, workspace_id="ws-1")
+
+
+async def test_generate_video_elements_rejects_overlong_source(monkeypatch, studio_env) -> None:
+    req = schemas.VideoElementsRequest(prompt="x", videoUrl=_DATA_URL, sourceDurationSec=30.1)
+    with pytest.raises(ValueError, match="30 seconds or less"):
+        await service.generate_video_elements(req, workspace_id="ws-1")
+
+
+async def test_generate_video_elements_requires_something(monkeypatch, studio_env) -> None:
+    req = schemas.VideoElementsRequest(prompt="  ")
+    with pytest.raises(ValueError, match="required"):
+        await service.generate_video_elements(req, workspace_id="ws-1")
+
+
+async def test_generate_video_elements_fal_failure_is_upstream_error(
+    monkeypatch, studio_env
+) -> None:
+    async def _boom(**kwargs):
+        raise fal_elements.FalElementsError("fal elements 'x' failed: bad key")
+
+    monkeypatch.setattr(fal_elements, "run_fal_elements", _boom)
+    req = schemas.VideoElementsRequest(prompt="a scene")
+    with pytest.raises(service.StudioUpstreamError, match="bad key"):
+        await service.generate_video_elements(req, workspace_id="ws-1")
     assert service._load_history() == []
 
 


### PR DESCRIPTION
## Summary
Backend for the /studio canvas video tools: two fal-direct endpoints that power the two-tab video panel.

1. **Edit video** — `POST /studio/video-elements` → fal **Kling Elements** (`fal-ai/kling-video/v1.6/standard/elements`).
2. **Motion control** — `POST /studio/video-motion-control` → fal **Kling Motion Control** (`fal-ai/kling-video/v2.6/standard/motion-control`).

Both return a persisted video `Generation`, mirroring the existing `fal_edit` / `fal_video` seams.

## Changes
- **`fal_elements.py`** (new) — direct fal client for Kling Elements; `build_arguments` / `_run_fal` / result extraction, capped at 20 element images.
- **`fal_motion.py`** (new) — direct fal client for Kling Motion Control; builds `{image_url, video_url, character_orientation}`, and distinguishes fal 4xx validation errors (`FalMotionValidationError`) from upstream failures.
- **`schemas.py`** — `VideoElementsRequest` + `VideoMotionRequest`.
- **`service.py`** —
  - `generate_video_elements`: validates (≤20 images, source ≤30s), resolves inputs to data URLs, persists video + poster.
  - `generate_video_motion`: resolves the character image to a data URL, **auto-downscales oversized images to fal's 3850px cap**, passes a public motion video URL straight through, persists video + poster.
- **`router.py`** — `POST /video-elements` and `POST /video-motion-control` with 400/502 mapping (fal validation → 400, upstream → 502).
- Tests for both fal clients, service dispatch + validation mapping + downscale + video-URL pass-through, and the router.

## Validation
- `uv run ruff check` — clean
- `uv run ruff format` — clean
- `uv run pytest tests/cloud/studio/` — 178 passed
