### PR TITLE
Keep CORS headers on a 500 so crashes stop reading as CORS errors

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/http.py
+++ b/ee/pocketpaw_ee/cloud/_core/http.py
@@ -9,14 +9,31 @@ Subsequent phases extend this module with: a request-id middleware that
 propagates `RequestContext.request_id` from the response back to the
 client (so frontends can echo it in bug reports), and any HTTP-shape
 helpers that emerge during chat refactor.
+
+Updated 2026-08-24 (fix/cors-headers-on-unhandled-500): also maps
+`SmokeGateFailed` — the sites generator's build/install/smoke failure, a plain
+`RuntimeError` subclass, NOT a `CloudError`. The service layer deliberately lets
+it propagate raw on the preview/arm path so `edit_svelte_component` can roll the
+component source back and re-raise; nothing above that re-raise mapped it, so
+`POST /sites/by-pocket/{id}/editable` answered a failed build with an opaque 500
+(and, being unhandled, a 500 with no CORS headers — the browser then reported a
+CORS failure and the real reason never reached anyone). Mapping it HERE, at the
+HTTP boundary, leaves every service-layer rollback contract untouched: the
+exception still propagates exactly as before, only its final wire shape changes
+— to the same `sites.generator_failed` envelope the LIVE publish path already
+returns.
 """
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud._core.errors import CloudError, Internal
+
+logger = logging.getLogger(__name__)
 
 
 async def cloud_error_handler(request: Request, exc: CloudError) -> JSONResponse:
@@ -29,6 +46,35 @@ async def cloud_error_handler(request: Request, exc: CloudError) -> JSONResponse
     return JSONResponse(status_code=exc.status_code, content=exc.to_dict())
 
 
+async def smoke_gate_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Map a raw `SmokeGateFailed` to the `sites.generator_failed` envelope.
+
+    Same code/message the live publish path produces via
+    `_build_or_cloud_error`, so a failed build reads identically whether it was
+    a live publish or an arm-for-editing preview. The cause is logged, never
+    leaked: a build log can carry paths and env details.
+    """
+    logger.error(
+        "sites: generator build failed on %s %s",
+        request.method,
+        request.url.path,
+        exc_info=exc,
+    )
+    return JSONResponse(
+        status_code=500,
+        content={
+            **Internal(
+                "sites.generator_failed",
+                "Site generation failed — the publishing toolchain is unavailable "
+                "or the build did not complete. See server logs for details.",
+            ).to_dict(),
+            # friendlyErrorMessage (paw-enterprise) reads `detail`, not `error`.
+            "detail": "Site generation failed — the build did not complete. "
+            "See server logs for details.",
+        },
+    )
+
+
 def add_error_handler(app: FastAPI) -> None:
     """Register `cloud_error_handler` on `app`. Safe to call more than once;
     the latter call wins (FastAPI overwrites by exception class)."""
@@ -36,5 +82,15 @@ def add_error_handler(app: FastAPI) -> None:
     # narrowing to CloudError is the whole point — suppress the variance.
     app.add_exception_handler(CloudError, cloud_error_handler)  # type: ignore[arg-type]
 
+    # Imported lazily: `_core` must not pull the sites package (and its
+    # generator toolchain imports) in at module import time. An install without
+    # the sites module simply has nothing to map.
+    try:
+        from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+    except Exception:  # noqa: BLE001 - sites layer absent/unimportable
+        logger.debug("sites.generator_client unavailable — SmokeGateFailed unmapped")
+        return
+    app.add_exception_handler(SmokeGateFailed, smoke_gate_handler)
 
-__all__ = ["add_error_handler", "cloud_error_handler"]
+
+__all__ = ["add_error_handler", "cloud_error_handler", "smoke_gate_handler"]

--- a/src/pocketpaw/api/cors.py
+++ b/src/pocketpaw/api/cors.py
@@ -1,0 +1,153 @@
+"""Shared CORS policy for the two app factories (``api/serve.py``, ``dashboard.py``).
+
+Created: 2026-08-24 (fix/cors-headers-on-unhandled-500).
+
+Why this module exists — the bug it closes:
+
+``CORSMiddleware`` only attaches ``Access-Control-Allow-Origin`` to responses that
+travel back out *through* it. Starlette builds its stack as
+
+    ServerErrorMiddleware
+      -> [user middleware, incl. CORSMiddleware]
+        -> ExceptionMiddleware -> router
+
+so an exception with no registered handler propagates PAST ``CORSMiddleware``
+(nothing was sent through it) and ``ServerErrorMiddleware`` — which sits OUTSIDE
+it — mints the 500 itself. That 500 carries no CORS headers, and a browser
+reports the result as::
+
+    Access to fetch at '<url>' from origin '<origin>' has been blocked by CORS
+    policy: No 'Access-Control-Allow-Origin' header is present on the requested
+    resource.
+
+which is a lie: the CORS config is fine, the request 500'd. Every server-side
+crash on a cross-origin call was being reported to the user as a CORS
+misconfiguration, hiding the real failure. Reproduced against the deployed
+backend on ``POST /api/v1/sites/by-pocket/{id}/editable``.
+
+The fix: register an ``Exception`` handler. FastAPI hands that handler to
+``ServerErrorMiddleware``, so we mint the 500 ourselves and attach the CORS
+headers by hand (the middleware cannot do it for us at that point). Starlette
+still re-raises the original exception afterwards, so logging, ``TestClient``'s
+``raise_server_exceptions``, and every existing traceback path are unchanged.
+
+The response body carries BOTH shapes the frontend understands: ``error`` (the
+machine-readable cloud envelope) and ``detail`` (the key ``friendlyErrorMessage``
+in paw-enterprise actually reads).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "BUILTIN_ORIGINS",
+    "ORIGIN_REGEX",
+    "allowed_origins",
+    "install_cors",
+    "origin_allowed",
+]
+
+# Desktop/dev origins that are always allowed; deployments add their own via
+# ``POCKETPAW_API_CORS_ALLOWED_ORIGINS`` (Settings.api_cors_allowed_origins).
+BUILTIN_ORIGINS = [
+    "tauri://localhost",
+    "https://tauri.localhost",  # Tauri v2
+    "http://localhost:1420",  # Tauri dev server
+]
+
+# Any localhost / 127.0.0.1 origin on any port or scheme.
+ORIGIN_REGEX = r"^https?://([a-z]+\.)?localhost(:\d+)?$|^https?://127\.0\.0\.1(:\d+)?$"
+
+_ORIGIN_RE = re.compile(ORIGIN_REGEX)
+
+
+def allowed_origins() -> list[str]:
+    """Builtin origins plus the deployment's configured extras.
+
+    Settings load failures are non-fatal — a misconfigured settings file must
+    not take the whole app down at import time, it just means no extra origins.
+    """
+    from pocketpaw.config import Settings
+
+    try:
+        custom = Settings.load().api_cors_allowed_origins
+    except Exception as exc:  # noqa: BLE001 - never block app construction
+        logger.debug("Failed to load custom CORS origins: %s", exc)
+        custom = []
+    return list(set(BUILTIN_ORIGINS + list(custom or [])))
+
+
+def origin_allowed(origin: str, origins: list[str]) -> bool:
+    """Mirror Starlette's own check: exact match, wildcard, or the regex.
+
+    Starlette uses ``fullmatch`` for ``allow_origin_regex``; match that exactly
+    so the 500 path can never be more permissive than the middleware.
+    """
+    if not origin:
+        return False
+    return "*" in origins or origin in origins or _ORIGIN_RE.fullmatch(origin) is not None
+
+
+def install_cors(app: FastAPI) -> None:
+    """Add ``CORSMiddleware`` and the CORS-aware unhandled-error handler.
+
+    Call this LAST among ``add_middleware`` calls so CORS is the outermost user
+    middleware — every inner rejection (auth 401, CSRF 403, a mapped
+    ``CloudError``) then ships its ``Access-Control-Allow-Origin`` on the way
+    out. The error handler covers the one case the middleware structurally
+    cannot: the unhandled 500 minted above it.
+    """
+    from fastapi.middleware.cors import CORSMiddleware
+
+    origins = allowed_origins()
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_origin_regex=ORIGIN_REGEX,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    add_cors_aware_error_handler(app, origins)
+
+
+def add_cors_aware_error_handler(app: FastAPI, origins: list[str]) -> None:
+    """Register the ``Exception`` handler that keeps CORS headers on a 500."""
+    from fastapi import Request
+    from fastapi.responses import JSONResponse
+
+    async def unhandled_error_handler(request: Request, exc: Exception) -> JSONResponse:
+        logger.error(
+            "Unhandled error on %s %s",
+            request.method,
+            request.url.path,
+            exc_info=exc,
+        )
+        response = JSONResponse(
+            status_code=500,
+            content={
+                "error": {
+                    "code": "internal_error",
+                    "message": "Internal server error — see server logs for details.",
+                },
+                # friendlyErrorMessage (paw-enterprise) reads `detail`, not `error`.
+                "detail": "Internal server error — see server logs for details.",
+            },
+        )
+        origin = request.headers.get("origin") or ""
+        if origin_allowed(origin, origins):
+            response.headers["Access-Control-Allow-Origin"] = origin
+            response.headers["Access-Control-Allow-Credentials"] = "true"
+            response.headers["Vary"] = "Origin"
+        return response
+
+    app.add_exception_handler(Exception, unhandled_error_handler)  # type: ignore[arg-type]

--- a/src/pocketpaw/api/serve.py
+++ b/src/pocketpaw/api/serve.py
@@ -32,10 +32,10 @@ def create_api_app():
     from contextlib import asynccontextmanager
 
     from fastapi import FastAPI, Query, WebSocket
-    from fastapi.middleware.cors import CORSMiddleware
 
+    from pocketpaw.api.cors import install_cors
     from pocketpaw.api.v1 import mount_v1_routers
-    from pocketpaw.config import Settings, get_access_token
+    from pocketpaw.config import get_access_token
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -93,25 +93,11 @@ def create_api_app():
     # CSRFMiddleware added inside `mount_cloud()`. Without this, a CSRF
     # 403 short-circuits before CORS can attach Access-Control-Allow-
     # Origin and the browser reports a misleading CORS error.
-    _BUILTIN_ORIGINS = [
-        "tauri://localhost",
-        "https://tauri.localhost",
-        "http://localhost:1420",
-    ]
-    try:
-        _custom = Settings.load().api_cors_allowed_origins
-    except Exception:
-        _custom = []
-    _ORIGINS = list(set(_BUILTIN_ORIGINS + _custom))
-
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=_ORIGINS,
-        allow_origin_regex=r"^https?://([a-z]+\.)?localhost(:\d+)?$|^https?://127\.0\.0\.1(:\d+)?$",
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    # `install_cors` also registers the CORS-aware unhandled-error handler: a 500
+    # is minted by ServerErrorMiddleware, which sits OUTSIDE this middleware, so
+    # without that handler every crash comes back header-less and the browser
+    # blames CORS instead of showing the real failure. See api/cors.py.
+    install_cors(app)
 
     # --- WebSocket handler helper ----------------------------------------
     async def _handle_ws(

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -37,7 +37,6 @@ try:
     import qrcode
     import uvicorn
     from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
-    from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import Response
     from fastapi.staticfiles import StaticFiles
     from fastapi.templating import Jinja2Templates
@@ -48,6 +47,7 @@ except ImportError as _exc:
     ) from _exc
 
 import pocketpaw.dashboard_state as _state
+from pocketpaw.api.cors import install_cors
 from pocketpaw.api.v1 import mount_v1_routers
 from pocketpaw.bootstrap import DefaultBootstrapProvider
 from pocketpaw.config import Settings, get_access_token, get_config_path
@@ -146,20 +146,11 @@ app = FastAPI(
     openapi_url="/api/v1/openapi.json",
 )
 
-# CORS — localhost + Cloudflare tunnel + Tauri desktop + custom origins from config
-_BUILTIN_ORIGINS = [
-    "tauri://localhost",
-    "https://tauri.localhost",  # Tauri v2
-    "http://localhost:1420",  # Tauri dev server
-]
-try:
-    _custom_origins = Settings.load().api_cors_allowed_origins
-except Exception as e:
-    logger.debug("Failed to load custom CORS origins: %s", e)
-    _custom_origins = []
-_EXTRA_ORIGINS = list(set(_BUILTIN_ORIGINS + _custom_origins))
-
-# NOTE: CORSMiddleware is registered AFTER AuthMiddleware below so that CORS
+# CORS — localhost + Cloudflare tunnel + Tauri desktop + custom origins from
+# config. The policy (and the CORS-aware 500 handler that goes with it) lives in
+# api/cors.py so this app and `pocketpaw serve` cannot drift apart.
+#
+# NOTE: install_cors() is called AFTER AuthMiddleware below so that CORS
 # is outermost (Starlette processes last-added first) and handles OPTIONS
 # preflight before auth can reject them.  See line ~193.
 
@@ -249,14 +240,10 @@ app.include_router(auth_router)
 # Auth must be registered BEFORE CORS so CORS is outermost and handles
 # OPTIONS preflight requests before auth can reject them.
 app.add_middleware(AuthMiddleware)
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=_EXTRA_ORIGINS,
-    allow_origin_regex=r"^https?://([a-z]+\.)?localhost(:\d+)?$|^https?://127\.0\.0\.1(:\d+)?$",
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# Also registers the CORS-aware unhandled-error handler — a 500 is minted by
+# ServerErrorMiddleware, which sits OUTSIDE CORSMiddleware, so without it every
+# crash returns header-less and the browser blames CORS. See api/cors.py.
+install_cors(app)
 
 
 # ==================== MCP Server API ====================

--- a/tests/cloud/_core/test_http.py
+++ b/tests/cloud/_core/test_http.py
@@ -111,3 +111,70 @@ async def test_cloud_error_handler_returns_envelope_directly() -> None:
     assert response.status_code == 404
     body = bytes(response.body).decode("utf-8")
     assert '"workspace.not_found"' in body
+
+
+# ---------------------------------------------------------------------------
+# SmokeGateFailed — the sites build failure that used to escape as a bare 500
+# ---------------------------------------------------------------------------
+#
+# `SmokeGateFailed` is a plain RuntimeError subclass, not a CloudError, and the
+# service layer deliberately re-raises it raw on the preview/arm path so
+# `edit_svelte_component` can roll the component source back. Nothing above that
+# mapped it, so `POST /sites/by-pocket/{id}/editable` answered a failed build
+# with an opaque, unhandled 500 — which additionally lost its CORS headers and
+# reached the browser as a bogus CORS error.
+#
+# Mutation that must break these: drop the `add_exception_handler(SmokeGateFailed,
+# ...)` line in `_core/http.py::add_error_handler`.
+
+
+def _build_smoke_app(*, with_cors: bool = False) -> FastAPI:
+    from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+    app = FastAPI()
+    add_error_handler(app)
+
+    @app.get("/arm")
+    def _arm() -> dict:
+        raise SmokeGateFailed("build failed (exit 1)")
+
+    if with_cors:
+        from fastapi.middleware.cors import CORSMiddleware
+
+        # Added last = outermost, exactly as the real app factories install it.
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["https://paw.example.com"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+    return app
+
+
+def test_smoke_gate_failed_maps_to_generator_failed_envelope() -> None:
+    client = TestClient(_build_smoke_app(), raise_server_exceptions=False)
+    resp = client.get("/arm")
+    assert resp.status_code == 500
+    assert resp.json()["error"]["code"] == "sites.generator_failed"
+
+
+def test_smoke_gate_failed_carries_a_detail_the_frontend_reads() -> None:
+    """friendlyErrorMessage (paw-enterprise) reads `detail`, not `error`."""
+    client = TestClient(_build_smoke_app(), raise_server_exceptions=False)
+    assert client.get("/arm").json()["detail"]
+
+
+def test_smoke_gate_failed_does_not_leak_the_build_log() -> None:
+    """Build output can carry paths and env details — logs only."""
+    client = TestClient(_build_smoke_app(), raise_server_exceptions=False)
+    assert "exit 1" not in client.get("/arm").text
+
+
+def test_smoke_gate_failed_response_keeps_cors_headers() -> None:
+    """The whole point: a mapped handler runs INSIDE CORSMiddleware, so the
+    browser sees the real error instead of a fabricated CORS failure."""
+    client = TestClient(_build_smoke_app(with_cors=True), raise_server_exceptions=False)
+    resp = client.get("/arm", headers={"Origin": "https://paw.example.com"})
+    assert resp.status_code == 500
+    assert resp.headers.get("access-control-allow-origin") == "https://paw.example.com"

--- a/tests/test_api_cors.py
+++ b/tests/test_api_cors.py
@@ -1,5 +1,9 @@
 # Tests for API CORS configuration.
 # Created: 2026-02-20
+# Updated 2026-08-24 (fix/cors-headers-on-unhandled-500): the origin policy moved
+# out of dashboard.py into the shared pocketpaw.api.cors module (dashboard.py and
+# api/serve.py carried byte-identical copies), so these read it from there. The
+# behaviour these assert is unchanged.
 
 from pocketpaw.api.v1 import _V1_ROUTERS, mount_v1_routers
 
@@ -45,10 +49,23 @@ class TestCORSConfig:
 
     def test_cors_origins_include_tauri(self):
         """Tauri origins should be in the CORS config."""
-        from pocketpaw.dashboard import _BUILTIN_ORIGINS
+        from pocketpaw.api.cors import BUILTIN_ORIGINS
 
-        assert "tauri://localhost" in _BUILTIN_ORIGINS
-        assert "http://localhost:1420" in _BUILTIN_ORIGINS
+        assert "tauri://localhost" in BUILTIN_ORIGINS
+        assert "http://localhost:1420" in BUILTIN_ORIGINS
+
+    def test_localhost_origins_match_the_middleware_regex(self):
+        """The 500 path reuses `origin_allowed`; it must not be looser than the
+        regex handed to CORSMiddleware, or a crash would answer origins the
+        happy path refuses."""
+        from pocketpaw.api.cors import origin_allowed
+
+        assert origin_allowed("http://localhost:5173", [])
+        assert origin_allowed("https://127.0.0.1", [])
+        assert origin_allowed("https://paw.example.com", ["https://paw.example.com"])
+        assert not origin_allowed("https://evil.example.com", [])
+        assert not origin_allowed("https://localhost.evil.example.com", [])
+        assert not origin_allowed("", [])
 
     def test_api_cors_allowed_origins_in_settings(self):
         """api_cors_allowed_origins field exists in Settings."""

--- a/tests/test_api_serve.py
+++ b/tests/test_api_serve.py
@@ -341,3 +341,73 @@ class TestSocketResourceSafety:
             run_dashboard(host="0.0.0.0", port=9999, open_browser=False)
 
         mock_sock.__exit__.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CORS survives an unhandled 500
+# ---------------------------------------------------------------------------
+#
+# Regression: Starlette mints the 500 for an unhandled exception in
+# ServerErrorMiddleware, which sits OUTSIDE CORSMiddleware, so that response
+# carried no Access-Control-Allow-Origin. A browser reports the result as
+#
+#   "...has been blocked by CORS policy: No 'Access-Control-Allow-Origin'
+#    header is present on the requested resource."
+#
+# which points at a CORS misconfiguration that isn't there and hides the real
+# crash. Reproduced against the deployed backend on
+# POST /api/v1/sites/by-pocket/{id}/editable.
+#
+# Mutation that must break these: delete the `install_cors` call's error-handler
+# registration (api/cors.py::add_cors_aware_error_handler) — the 500 then comes
+# back header-less again.
+
+
+class TestCorsOnUnhandledError:
+    @pytest.fixture
+    def boom_client(self, api_app):
+        @api_app.get("/api/v1/_test_boom")
+        async def _boom():
+            raise RuntimeError("kaboom")
+
+        # raise_server_exceptions=False so the wire response is asserted rather
+        # than the exception re-raised into the test (Starlette re-raises after
+        # sending, which is unchanged by this fix).
+        return TestClient(api_app, raise_server_exceptions=False)
+
+    def test_unhandled_500_keeps_cors_headers(self, boom_client):
+        with patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=True):
+            resp = boom_client.get(
+                "/api/v1/_test_boom", headers={"Origin": "http://localhost:1420"}
+            )
+        assert resp.status_code == 500
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost:1420"
+        assert resp.headers.get("access-control-allow-credentials") == "true"
+
+    def test_unhandled_500_body_is_readable_by_the_frontend(self, boom_client):
+        """Both envelope shapes: `error.code` (machine) and `detail` (the key
+        paw-enterprise's friendlyErrorMessage actually reads)."""
+        with patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=True):
+            resp = boom_client.get(
+                "/api/v1/_test_boom", headers={"Origin": "http://localhost:1420"}
+            )
+        body = resp.json()
+        assert body["error"]["code"] == "internal_error"
+        assert body["detail"]
+
+    def test_unhandled_500_does_not_leak_the_exception_message(self, boom_client):
+        """The traceback goes to the logs; the client gets a generic sentence."""
+        with patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=True):
+            resp = boom_client.get(
+                "/api/v1/_test_boom", headers={"Origin": "http://localhost:1420"}
+            )
+        assert "kaboom" not in resp.text
+
+    def test_disallowed_origin_still_gets_no_cors_header_on_500(self, boom_client):
+        """The 500 path must not be more permissive than CORSMiddleware itself."""
+        with patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=True):
+            resp = boom_client.get(
+                "/api/v1/_test_boom", headers={"Origin": "https://evil.example.com"}
+            )
+        assert resp.status_code == 500
+        assert "access-control-allow-origin" not in resp.headers


### PR DESCRIPTION
## What the browser reported

```
Access to fetch at 'https://backend.../api/v1/sites/by-pocket/{id}/editable'
from origin 'https://paw...' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

## What was actually happening

The CORS config is fine. Against the deployed backend the header comes back on
the preflight, on a 401, and on a 404:

```
$ curl -si -X OPTIONS .../editable -H "Origin: https://paw..." \
       -H "Access-Control-Request-Method: POST"
HTTP/1.1 200 OK
Access-Control-Allow-Origin: https://paw...
```

The 500 is the problem. Starlette's stack is

```
ServerErrorMiddleware -> [user middleware, incl. CORSMiddleware] -> ExceptionMiddleware -> router
```

so an exception with no registered handler propagates past CORSMiddleware
(nothing was ever sent through it), and ServerErrorMiddleware, which sits
outside it, mints the 500 itself. That response has no CORS headers, so the
browser reports a CORS failure and the actual crash never reaches anyone. Every
server-side error on a cross-origin call has been arriving this way, which is
why the reason for this one was invisible.

Reproduced locally: an unhandled route on the serve app returns 500 with
`access-control-allow-origin: None`.

## The two changes

`src/pocketpaw/api/cors.py` now holds the origin policy (dashboard.py and
api/serve.py carried byte-identical copies of it) and registers an `Exception`
handler. FastAPI hands that handler to ServerErrorMiddleware, so we mint the 500
ourselves and attach the headers by hand, which is the one thing the middleware
cannot do from where it sits. Starlette still re-raises afterwards, so logging
and TestClient's `raise_server_exceptions` behave exactly as before. The handler
reuses the same allow-check as the middleware (same regex, same `fullmatch`), so
the crash path can never answer an origin the happy path refuses.

`SmokeGateFailed` now maps to the `sites.generator_failed` envelope at the HTTP
boundary. It is a plain RuntimeError, and the service layer deliberately
re-raises it raw on the preview/arm path so `edit_svelte_component` can roll the
component source back. Nothing above that re-raise mapped it, so a failed build
answered `/editable` with an opaque 500. Handling it at the boundary leaves every
rollback contract untouched: the exception still propagates identically, only its
final wire shape changes, to the same envelope a live publish already returns via
`_build_or_cloud_error`.

Both bodies carry `error.code` and `detail`, because `friendlyErrorMessage` in
paw-enterprise reads `detail`.

## Verification

Both gates were mutation-checked, since a passing test only proves the code and
the test agree:

- delete the `add_cors_aware_error_handler` call, and 2 of the 4 CORS tests fail
- delete `add_exception_handler(SmokeGateFailed, ...)`, and 3 of the 4 mapping
  tests fail

Sweep over test_api_serve, test_api_cors, test_dashboard_security,
test_dashboard_starlette_compat, test_api_rate_limits, test_api_events_sse,
test_auth_exception_logging, test_remote_access, tests/cloud/_core and
tests/ee/sites: 1541 passed, 4 failed. Those same 4 fail identically on dev with
this branch's changes stashed. Two of them need a live cloud DB, one needs fcntl
(Linux only), and one is an xdist ordering artifact that passes when its file
runs alone. None are related to this change.

## What this does not fix

The `/editable` call still 500s. This makes the reason visible instead of hiding
it behind a CORS message. The likely cause is the sites toolchain failing its
build inside the deployed container; the response will now say
`sites.generator_failed` and the traceback will be in the backend logs. Working
out why is a separate job, and it needed this fix to be possible at all.