### PR TITLE
The inbox froze the moment a human took over

### DIFF
--- a/ee/pocketpaw_ee/cloud/auth/domain.py
+++ b/ee/pocketpaw_ee/cloud/auth/domain.py
@@ -41,4 +41,23 @@ class AuthUser:
     mfa_enabled: bool = False
 
 
-__all__ = ["AuthUser", "WorkspaceMembershipRef"]
+@dataclass(frozen=True)
+class UserIdentity:
+    """The presentational half of a user — what a message header shows.
+
+    Deliberately three fields and no more. It is handed to surfaces that attribute
+    something to a person (a Paw Bar takeover reply, an audit line) and is meant to
+    be safe to serialize outward to anyone already authorized to see WHO acted, so
+    it carries no email, no membership, no status and no auth state.
+
+    ``name`` is empty when the user has neither a full name nor an email, and the
+    whole object is simply absent when the id resolves to nobody — an unresolvable
+    author renders as anonymous rather than as a raw id.
+    """
+
+    id: str
+    name: str
+    avatar: str
+
+
+__all__ = ["AuthUser", "UserIdentity", "WorkspaceMembershipRef"]

--- a/ee/pocketpaw_ee/cloud/auth/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/service.py
@@ -10,6 +10,14 @@ Public API is module-level ``async def`` functions:
 - ``set_active_workspace(ctx, workspace_id)``
 - ``set_avatar_path(ctx, avatar_path)``
 - ``get_home_pocket_id(user_id)`` / ``claim_home_pocket_id(user_id, id, *, expected)``
+- ``resolve_display_names(user_ids)`` / ``resolve_identities(user_ids)``
+
+Updated: 2026-08-24 — added ``resolve_identities``, the name-AND-avatar
+sibling of ``resolve_display_names``, for surfaces that put a face next to
+a name (the Paw Bar concierge thread attributes each takeover reply to the
+teammate who typed it). A separate function rather than a widened return
+type: a dozen callers already read ``resolve_display_names`` as a plain
+``dict[str, str]``.
 
 Updated: 2026-05-21 — added the ``home_pocket_id`` get + atomic-claim
 pair. The pockets service owns home-pocket provisioning but stores the
@@ -25,7 +33,7 @@ from beanie import PydanticObjectId
 
 from pocketpaw_ee.cloud._core.context import RequestContext
 from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound, ValidationError
-from pocketpaw_ee.cloud.auth.domain import AuthUser, WorkspaceMembershipRef
+from pocketpaw_ee.cloud.auth.domain import AuthUser, UserIdentity, WorkspaceMembershipRef
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
 
 # ---------------------------------------------------------------------------
@@ -218,7 +226,45 @@ async def resolve_display_names(user_ids: set[str]) -> dict[str, str]:
     }
 
 
+async def resolve_identities(user_ids: set[str]) -> dict[str, UserIdentity]:
+    """Batch-resolve user ids → the name AND avatar a message header needs.
+
+    :func:`resolve_display_names`' sibling, for the surfaces that put a face next
+    to the name (the Paw Bar concierge thread attributes each takeover reply to
+    the teammate who typed it). Kept separate rather than widening that function's
+    return type, because a dozen callers already read it as a plain str map.
+
+    Same tolerances: a non-ObjectId id is skipped, an id with no matching user is
+    simply absent from the map, and the caller decides what an absence renders as.
+    Unlike ``resolve_display_names`` the name here falls back to the EMPTY string
+    rather than the raw id — an unresolvable author on a message header should
+    read as anonymous, not as a 24-character hex string in the sender slot.
+
+    ``avatar`` is stored as the app serves it (an ``/uploads/...`` path for an
+    uploaded picture, an absolute URL for an OAuth one). Clients resolve it the
+    same way they resolve their own profile picture; nothing here rewrites it.
+    """
+    object_ids: list[PydanticObjectId] = []
+    for uid in user_ids:
+        try:
+            object_ids.append(PydanticObjectId(uid))
+        except Exception:
+            continue
+    if not object_ids:
+        return {}
+    docs = await _UserDoc.find({"_id": {"$in": object_ids}}).to_list()
+    return {
+        str(u.id): UserIdentity(
+            id=str(u.id),
+            name=(u.full_name or "").strip() or (u.email or "").strip(),
+            avatar=(u.avatar or "").strip(),
+        )
+        for u in docs
+    }
+
+
 __all__ = [
+    "UserIdentity",
     "claim_home_pocket_id",
     "get_home_pocket_id",
     "get_profile",

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -2790,11 +2790,16 @@ async def get_agent_conversations(
         for key, value in page.counts.items():
             counts[key] = counts.get(key, 0) + value
 
-    # Newest first across the whole union, then cut to the page size. Sorting on
-    # the ISO timestamp is a string sort on purpose — the values are all produced
-    # by ``datetime.isoformat`` and an empty one sorts last, where a conversation
-    # with no timestamp belongs.
-    items.sort(key=lambda i: i.last_message_at or "", reverse=True)
+    # Newest first across the whole union, then cut to the page size. Sorted on the
+    # PARSED instant, not the string: a whole-second stamp and a fractional one at
+    # the same second compare in ASCII order of "+" against "." and land backwards,
+    # and the merge that now feeds these rows (see ``_latest_out_of_band``) emits
+    # both spellings. An undated row sorts last, where a conversation nobody can
+    # time belongs.
+    items.sort(
+        key=lambda i: (bool(i.last_message_at), _as_utc(i.last_message_at) or _EPOCH),
+        reverse=True,
+    )
     return AgentConversationsResponse(
         items=items[:limit],
         counts=counts,

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,34 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-08-24 (inbox freshness + who typed it) — the owner's conversation
+#   list stopped freezing the moment a human took over, and the thread learned to
+#   name them.
+#   (1) FRESHNESS. ``_list_conversations`` was built purely from ``ChatRunDoc``, and
+#   the two kinds of line that have NO run — an owner's takeover reply and the
+#   visitor's answer to it, which is the whole point of muting — live in
+#   ``paw_bar_owner_messages``. So a row kept the bot's last sentence at the bot's
+#   timestamp, and ordered by run recency it BURIED exactly the conversations a
+#   person was working. New ``_latest_out_of_band`` joins the newest such line per
+#   conversation (one bounded read for the page, like the state and decision joins),
+#   the row takes whichever of the two is later, and the page re-sorts on that
+#   merged clock. SYSTEM lines are excluded from the merge — see the store.
+#   (2) ONE CLOCK. New ``_as_utc`` / ``_newer``: run stamps come back from Mongo
+#   NAIVE (the client is not ``tz_aware``) while owner lines are aware-UTC ISO
+#   strings, so comparing them raw is wrong by the host's offset — and that
+#   comparison decides which line a row shows. ``last_message_at`` now goes out
+#   aware-UTC, which also fixes relative times reading wrong in any browser
+#   outside UTC.
+#   (3) A TOTAL ORDER. The run scan is re-sorted in Python with the ObjectId as the
+#   tie-break: Windows' clock advances in ~15.6ms steps, so a question and its
+#   follow-up routinely share a ``createdAt`` and the dedupe picked between them
+#   arbitrarily — which read as a flaky test rather than as a row showing the older
+#   sentence.
+#   (4) WHO TYPED IT. ``TranscriptMessage`` grows ``author_id`` / ``author_name`` /
+#   ``author_avatar``, resolved from the stored author id through the new
+#   ``auth.service.resolve_identities`` (batched per transcript, best-effort) and
+#   carried on the reply echo through the SAME resolver so the composer's optimistic
+#   append and the refetched line agree. OWNER lines only. The VISITOR's public poll
+#   is untouched and stays role + content + time — a stranger learns that a human
+#   replied, never which one.
 # Updated: 2026-08-21 (fix/paw-bar-preview-frame-ancestors) — the bar renders in the
 #   builder's site preview. GET /paw-bar/frame gated the embedder on the Site's
 #   ``allowed_origins`` alone, but the builder previews a site by framing its real
@@ -1900,6 +1930,15 @@ _CONVERSATION_PREVIEW_CHARS = 140
 # room to dedupe several runs per customer down to ``limit`` conversations.
 _CONVERSATION_SCAN_CAP = 200
 
+# Upper bound on the out-of-band lines a single conversations page reads to find
+# each row's newest one. Same shape as the run cap above: one bounded query for
+# the whole page rather than one per row.
+_OUT_OF_BAND_SCAN_CAP = 400
+
+# The sort floor for a row we cannot time. Never rendered — it only keeps the
+# comparator total so an undated row lands at the END of a newest-first list.
+_EPOCH = datetime.min.replace(tzinfo=UTC)
+
 # Max turns returned in one conversation transcript (the most recent N, presented
 # oldest-first). Bounds the drill-in read; a long-running visitor conversation
 # never ships the whole history in one response.
@@ -2210,11 +2249,28 @@ class TranscriptMessage(BaseModel):
     There is deliberately NO message id: run-derived messages have none (they are
     projections of a run doc, two per run), so an id here would exist for half the
     thread. Anything that needs to address a message keys off the RUN.
+
+    ``author_*`` names the HUMAN behind an ``owner`` line (2026-08-24). A site is
+    answered by a team, and "someone replied an hour ago" is not something a
+    second operator can act on — they cannot tell whether a colleague is still in
+    the conversation or whether it was them. Resolved from the stored author id
+    (``OwnerMessage.author``) at read time rather than denormalized onto the row,
+    so a renamed teammate is renamed everywhere and a deleted one degrades to
+    blanks instead of a stale name. Empty on every other role, and empty on an
+    owner line whose author no longer resolves — an anonymous line, never a raw id
+    in the sender slot.
+
+    OWNER-SIDE ONLY. The visitor's public poll projects :class:`VisitorMessage`,
+    which has no author fields at all: the customer learns that a human replied,
+    never which one. Do not add them there.
     """
 
     role: str
     content: str
     created_at: str
+    author_id: str = ""
+    author_name: str = ""
+    author_avatar: str = ""
 
 
 class ConversationReplyRequest(BaseModel):
@@ -2650,7 +2706,10 @@ async def post_site_conversation_reply(
     _pending, emails = await _decision_side_data(widget, [customer_ref])
     return ConversationReplyResponse(
         ok=True,
-        message=_owner_transcript_message(message),
+        # Attributed like the refetched line, from the same resolver: the composer
+        # appends this echo instead of refetching, so an unattributed echo would
+        # show the operator's own sentence as anonymous until the next poll.
+        message=_owner_transcript_message(message, await _resolve_message_authors([message])),
         conversation=_conversation_row(conversation, emails.get(customer_ref, "")),
     )
 
@@ -3136,18 +3195,60 @@ _TRANSCRIPT_ROLE_BY_STORED = {
 }
 
 
-def _owner_transcript_message(message: Any) -> TranscriptMessage:
+def _owner_transcript_message(
+    message: Any, authors: dict[str, Any] | None = None
+) -> TranscriptMessage:
     """Project one ``paw_bar_owner_messages`` row into the transcript's shape.
 
     Shared by the reply echo and the transcript merge so the composer's optimistic
-    append and the refetched thread can't render the same sentence two ways.
+    append and the refetched thread can't render the same sentence two ways — which
+    is also why ``authors`` is threaded through both: an echo that arrived without
+    a name would show the reply as anonymous until the next poll replaced it.
+
+    ``authors`` maps a stored author id to its :class:`UserIdentity`. Absent, or
+    missing this id, the line renders anonymously — a deleted teammate and a line
+    written before authors were stored look the same, and both are honest.
     """
     stored = getattr(message.role, "value", str(message.role))
+    role = _TRANSCRIPT_ROLE_BY_STORED.get(stored, "system")
+    author_id = getattr(message, "author", "") or ""
+    identity = (authors or {}).get(author_id) if role == "owner" else None
     return TranscriptMessage(
-        role=_TRANSCRIPT_ROLE_BY_STORED.get(stored, "system"),
+        role=role,
         content=message.content,
         created_at=message.created_at,
+        # Only an OWNER line is attributed. A visitor's muted line carries no
+        # author, and a system line was authored by nobody — stamping either with
+        # whoever happened to be in the map would invent a speaker.
+        author_id=author_id if role == "owner" else "",
+        author_name=getattr(identity, "name", "") or "",
+        author_avatar=getattr(identity, "avatar", "") or "",
     )
+
+
+async def _resolve_message_authors(messages: list[Any]) -> dict[str, Any]:
+    """Resolve the distinct OWNER authors of a set of stored lines, in one query.
+
+    One batched user read per transcript, never one per line — a long thread is
+    mostly one or two operators. Best-effort: if the lookup fails the thread still
+    renders, just without names, because a transcript is the record of what was
+    said and a missing avatar must not cost the owner the conversation.
+    """
+    ids = {
+        getattr(m, "author", "") or ""
+        for m in messages
+        if getattr(getattr(m, "role", None), "value", "") == OwnerMessageRole.OWNER.value
+    }
+    ids.discard("")
+    if not ids:
+        return {}
+    try:
+        from pocketpaw_ee.cloud.auth.service import resolve_identities
+
+        return await resolve_identities(ids)
+    except Exception:  # noqa: BLE001 — attribution is additive, never fatal
+        logger.warning("owner-message author lookup failed", exc_info=True)
+        return {}
 
 
 def _display_name(contact_email: str, customer_ref: str) -> str:
@@ -3231,6 +3332,78 @@ async def _conversation_side_data(
         logger.warning("conversation state read failed for widget %s", widget.id, exc_info=True)
     pending, emails = await _decision_side_data(widget, refs)
     return states, pending, emails
+
+
+def _as_utc(value: Any) -> datetime | None:
+    """Parse a timestamp from either store into an AWARE UTC datetime, or None.
+
+    The two halves of a conversation are stamped by different clocks and arrive in
+    different shapes. ``ChatRunDoc.createdAt`` is written aware-UTC but comes back
+    from Mongo NAIVE (the client is not ``tz_aware``), while an owner message is an
+    aware-UTC ISO string. Comparing those raw — as strings, or as datetimes — is
+    wrong by the host's offset on every machine that is not set to UTC, and the
+    comparison decides which line a conversation row shows.
+
+    A naive value is therefore read as UTC, which is what both writers meant.
+    Anything unparseable is None, and the caller keeps its existing order.
+    """
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    text = (value or "").strip() if isinstance(value, str) else ""
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _newer(candidate: Any, incumbent: Any) -> bool:
+    """Is ``candidate`` strictly later than ``incumbent``? Unparseable → False."""
+    a, b = _as_utc(candidate), _as_utc(incumbent)
+    if a is None:
+        return False
+    return b is None or a > b
+
+
+async def _latest_out_of_band(
+    widget: PawBarWidget | None, workspace_id: str, refs: list[str]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """The newest line WITHOUT a run doc, per conversation and per visitor.
+
+    Returns ``(newest by conversation_id, newest by customer_ref among lines that
+    carry no conversation_id)``. The second map is the unmigrated tail: a line
+    written before conversations had identity belongs to the visitor's active
+    conversation, which is the same fallback ``_list_conversations`` applies to a
+    run whose ``session_key`` predates the id.
+
+    ONE bounded read for the whole page (see the store's
+    ``list_recent_owner_messages``), newest-first, so the first line seen for a key
+    is that key's newest. Best-effort: a store hiccup costs the freshness merge,
+    never the list — the row falls back to what the runs say, which is what it
+    showed before this existed.
+    """
+    if widget is None or not refs:
+        return {}, {}
+    try:
+        lines = await _store().list_recent_owner_messages(
+            widget.id,
+            customer_refs=refs,
+            workspace_id=workspace_id,
+            limit=_OUT_OF_BAND_SCAN_CAP,
+        )
+    except Exception:  # noqa: BLE001 — freshness is additive, never fatal
+        logger.warning("owner-message read failed for widget %s", widget.id, exc_info=True)
+        return {}, {}
+    by_conversation: dict[str, Any] = {}
+    by_ref: dict[str, Any] = {}
+    for line in lines:
+        if line.conversation_id:
+            by_conversation.setdefault(line.conversation_id, line)
+        else:
+            by_ref.setdefault(line.customer_ref, line)
+    return by_conversation, by_ref
 
 
 async def _decision_side_data(
@@ -3327,6 +3500,17 @@ async def _list_conversations(
         logger.warning("conversations read failed for pocket %s", pocket_id, exc_info=True)
         return ConversationsResponse(items=[], cursor=None, unsupported=False)
 
+    # BREAK THE TIE. The sort above orders by ``createdAt`` alone, and two runs in
+    # the same conversation routinely share one: Windows' clock advances in ~15.6ms
+    # steps, so a question and its follow-up land in the same tick. The dedupe below
+    # keeps the FIRST run it sees per conversation, so an arbitrary tie-break there
+    # is the row showing the older sentence — nondeterministically, which is how it
+    # read as a flaky test rather than as a bug. The ObjectId's tail is a
+    # per-process counter, so it orders ties by insertion.
+    runs.sort(
+        key=lambda r: (_as_utc(r.createdAt) or _EPOCH, str(getattr(r, "id", ""))), reverse=True
+    )
+
     # Dedupe the scanned window first (most-recent run per CONVERSATION wins),
     # THEN join and filter, THEN cut to `limit` — cutting first would hide a
     # matching conversation behind a page of non-matching ones.
@@ -3389,8 +3573,52 @@ async def _list_conversations(
             )
         )
 
-    items: list[ConversationItem] = []
+    # THE RUNS ARE NOT THE WHOLE CONVERSATION. An owner's takeover reply and a
+    # visitor's answer to it both dispatch no run — that is the point of muting —
+    # so a list built only from run docs freezes the moment a human steps in. It
+    # kept showing the bot's last sentence at the bot's timestamp, and ordered by
+    # run recency it buried exactly the conversations someone was working. Merge
+    # the newest out-of-band line over each row, then re-sort on the merged clock.
+    by_conversation, legacy_by_ref = await _latest_out_of_band(widget, workspace_id, refs)
+    merged: list[tuple[datetime | None, str, str, str, str]] = []
     for ref, conversation_id, last_message_at, preview in candidates:
+        line = by_conversation.get(conversation_id) if conversation_id else None
+        # An unmigrated line carries no conversation, so it belongs to the
+        # visitor's ACTIVE one — the same fallback the run stream above uses, and
+        # for the same reason: both spellings name the one thread in progress.
+        legacy_row = active_by_ref.get(ref)
+        if legacy_row is None or not conversation_id or legacy_row.id == conversation_id:
+            fallback = legacy_by_ref.get(ref)
+            incumbent = getattr(line, "created_at", "")
+            if fallback is not None and _newer(fallback.created_at, incumbent):
+                line = fallback
+        run_at = _as_utc(last_message_at)
+        if line is not None:
+            line_at = _as_utc(line.created_at)
+            if line_at is not None and (run_at is None or line_at > run_at):
+                last_message_at = line.created_at
+                preview = (line.content or "")[:_CONVERSATION_PREVIEW_CHARS]
+                run_at = line_at
+        # Normalize the stamp on the way out. A run's ``createdAt`` comes back
+        # from Mongo NAIVE (the client is not tz_aware), so it went on the wire
+        # with no offset and every browser outside UTC read it as local time —
+        # relative times on this list were wrong by the reader's own offset.
+        merged.append(
+            (
+                run_at,
+                ref,
+                conversation_id,
+                run_at.isoformat() if run_at is not None else last_message_at,
+                preview,
+            )
+        )
+
+    # Newest first on the MERGED clock. Undated rows sort last rather than to the
+    # top: a row we cannot time is not a row that just happened.
+    merged.sort(key=lambda m: (m[0] is not None, m[0] or _EPOCH), reverse=True)
+
+    items: list[ConversationItem] = []
+    for _at, ref, conversation_id, last_message_at, preview in merged:
         row = states.get(conversation_id)
         row_state = row.state.value if row is not None else "open"
         if state and row_state != state:
@@ -3686,7 +3914,8 @@ async def _load_transcript(
             logger.warning("owner message read failed for widget %s", widget.id, exc_info=True)
     if not runs and not out_of_band:
         return None
-    messages.extend(_owner_transcript_message(m) for m in out_of_band if m.content)
+    authors = await _resolve_message_authors(out_of_band)
+    messages.extend(_owner_transcript_message(m, authors) for m in out_of_band if m.content)
 
     # Stable sort on the parsed instant: two lines stamped identically keep the
     # order they were added, so a run's question still precedes its own answer.

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -1,4 +1,10 @@
 # ee/paw_bar/store.py — Async SQLite store for Paw Bar widgets and events.
+# Updated: 2026-08-24 (inbox freshness) — new list_recent_owner_messages: the
+#   newest out-of-band lines for a PAGE of visitors in ONE bounded read, so the
+#   owner's conversation list can say what was said LAST instead of what the last
+#   RUN said. Owner + visitor roles by default; SYSTEM is excluded, because a
+#   resume notice becoming an inbox preview replaces a person's words with
+#   boilerplate and re-sorts the queue on an automatic event.
 # Updated: 2026-07-30 (owner inbox, slice 2 — type-to-takeover) — the lines that
 #   have no run doc get a home, and a muted bot gets a deadline:
 #   * new paw_bar_owner_messages table (sibling of paw_bar_conversations, same
@@ -1849,6 +1855,63 @@ class PawBarStore:
             ) as cur:
                 rows = [self._row_to_owner_message(row) async for row in cur]
         return list(reversed(rows))
+
+    async def list_recent_owner_messages(
+        self,
+        widget_id: str,
+        *,
+        customer_refs: list[str],
+        workspace_id: str | None = None,
+        roles: list[str] | None = None,
+        limit: int = 200,
+    ) -> list[OwnerMessage]:
+        """The widget's most recent out-of-band lines for a PAGE of visitors.
+
+        NEWEST-first, and deliberately not per-thread: the owner's inbox needs the
+        latest line of every conversation on the page in ONE bounded read, the same
+        way the state rows and the decision rows are joined. Reading
+        :meth:`list_owner_messages` per row would put one query per conversation on
+        a list endpoint that already promises two.
+
+        The caller buckets: a line's thread is ``conversation_id`` where it has one
+        and the visitor's active conversation where it doesn't (an unmigrated line),
+        which is the same fallback the run stream uses — so the bucketing rule lives
+        with the reader that owns it rather than being guessed here.
+
+        ``roles`` defaults to owner + visitor. SYSTEM is excluded by default on
+        purpose: a resume notice is the product narrating itself, and letting it
+        become an inbox preview replaces what a person actually said with
+        boilerplate — and re-sorts the whole queue on an automatic event.
+        """
+        if not customer_refs:
+            return []
+        wanted = roles
+        if wanted is None:
+            wanted = [OwnerMessageRole.OWNER.value, OwnerMessageRole.VISITOR.value]
+        if not wanted:
+            return []
+        conditions = "widget_id = ?"
+        params: list[Any] = [widget_id]
+        placeholders = ", ".join("?" for _ in customer_refs)
+        conditions += f" AND customer_ref IN ({placeholders})"
+        params.extend(customer_refs)
+        role_placeholders = ", ".join("?" for _ in wanted)
+        conditions += f" AND role IN ({role_placeholders})"
+        params.extend(wanted)
+        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
+        if ws_cond:
+            conditions += f" AND {ws_cond}"
+            params.extend(ws_params)
+        params.append(limit)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM paw_bar_owner_messages"
+                f" WHERE {conditions} ORDER BY created_at DESC, id DESC LIMIT ?",
+                params,
+            ) as cur:
+                return [self._row_to_owner_message(row) async for row in cur]
 
     # ---------------- Carts (C1 — visitor-scoped commerce state) ----------------
 

--- a/tests/cloud/test_paw_bar_inbox_freshness.py
+++ b/tests/cloud/test_paw_bar_inbox_freshness.py
@@ -1,0 +1,535 @@
+# tests/cloud/test_paw_bar_inbox_freshness.py — the owner inbox tells the truth
+# about what was said LAST, and says WHO said it.
+#
+# Created 2026-08-24. Two defects, one root cause: the conversation list is built
+# purely from ``ChatRunDoc`` (see ``_list_conversations``), and the lines that have
+# no run — an owner's takeover reply, and a visitor's answer that arrived while the
+# bot was muted — live in ``paw_bar_owner_messages`` instead. So the moment a human
+# stepped in, the row froze: it kept showing the bot's last sentence, stamped at
+# the bot's last timestamp, and sank down a list ordered by run recency while the
+# actual conversation was the most active one on the site.
+#
+# Layers:
+#   * Freshness — an owner reply and a muted visitor line each become the row's
+#     preview + last_message_at; a stale run never wins over a newer line.
+#   * Ordering — rows sort by the latest LINE, not the latest run.
+#   * Identity — an owner transcript line carries who typed it (name + avatar),
+#     resolved from the stored author id, on the transcript AND on the reply echo.
+#   * Privacy — the VISITOR's public poll still carries no operator identity.
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from beanie import PydanticObjectId
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.paw_bar.models import (
+    OwnerMessageRole,
+    PawBarBlock,
+    PawBarSpec,
+    PawBarWidget,
+)
+from pocketpaw.paw_bar.store import PawBarStore
+
+_KEY = "site_key_" + "a" * 24
+_REF = "cust-0001"
+_REF_2 = "cust-0002"
+
+
+# --------------------------------------------------------------------------- #
+# Builders
+# --------------------------------------------------------------------------- #
+
+
+async def _site(**ov: Any):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        script_name="",
+        signed_key=_KEY,
+        allowed_origins=["brewco.com"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+def _widget(**ov: Any) -> PawBarWidget:
+    d = dict(
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        spec=PawBarSpec(
+            widget_id="pp_seed",
+            pocket_id="pocket-1",
+            blocks=[PawBarBlock(type="text", content="Hi")],
+        ),
+        allowed_domains=["brewco.com"],
+        agent_id="agent-xyz",
+        workspace_id="ws-1",
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+async def _mk_run(ref: str = _REF, **ov: Any):
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    d = dict(
+        run_id=uuid.uuid4().hex,
+        workspace="ws-1",
+        context_type="concierge",
+        scope_id="pocket-1",
+        session_key=f"cloud:concierge:pocket-1:{ref}:agent-xyz",
+        user_id=ref,
+        agent_id="agent-xyz",
+        client_message_id=uuid.uuid4().hex,
+        user_message_id="",
+        status="completed",
+        partial_text="We open at 8.",
+    )
+    d.update(ov)
+    doc = ChatRunDoc(**d)
+    await doc.insert()
+    return doc
+
+
+_USER_ID = PydanticObjectId()
+
+
+async def _mk_user(user_id: PydanticObjectId = _USER_ID, **ov: Any):
+    """A real ``User`` document, so the author lookup has something to resolve."""
+    from pocketpaw_ee.cloud.models.user import User
+
+    d = dict(
+        id=user_id,
+        email="maya@brewco.com",
+        hashed_password="x",
+        full_name="Maya Oyelaran",
+        avatar="/uploads/avatars/maya.png",
+    )
+    d.update(ov)
+    u = User(**d)
+    await u.insert()
+    return u
+
+
+def _fake_user(role: str = "admin", workspace_id: str = "ws-1", user_id: Any = _USER_ID):
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role=role)],
+    )
+
+
+def _build_app(store, monkeypatch, *, role: str = "admin", workspace_id: str = "ws-1"):
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[current_active_user] = lambda: _fake_user(role, workspace_id)
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda: store)
+    return app
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    return PawBarStore(tmp_path / "freshness.db")
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db, store, monkeypatch):
+    app = _build_app(store, monkeypatch, role="admin")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c, store
+
+
+def _row_for(body: dict, ref: str = _REF) -> dict:
+    for item in body["items"]:
+        if item["customer_ref"] == ref:
+            return item
+    raise AssertionError(f"no row for {ref} in {body['items']}")
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — freshness: the row shows what was actually said last
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_owner_reply_becomes_the_row_preview(client):
+    """The owner takes over; the list row must follow the conversation.
+
+    Before: the row kept the bot's "We open at 8." at the bot's timestamp, so an
+    inbox open next to the thread disagreed with it about what had been said.
+    """
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    conversation = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+
+    reply = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply",
+        json={"text": "Maya here, we open at 7 on Saturdays.", "conversation_id": conversation.id},
+    )
+    assert reply.status_code == 200, reply.text
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations")
+    assert res.status_code == 200
+    row = _row_for(res.json())
+    assert row["preview"] == "Maya here, we open at 7 on Saturdays."
+    assert row["last_message_at"] >= reply.json()["message"]["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_muted_visitor_line_becomes_the_row_preview(client):
+    """A visitor answering a human dispatches no run — the row must still move."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    conversation = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.add_owner_message(
+        widget.id, _REF, "Maya here.", conversation_id=conversation.id, workspace_id="ws-1"
+    )
+    await store.add_owner_message(
+        widget.id,
+        _REF,
+        "Perfect, see you at 7.",
+        conversation_id=conversation.id,
+        role=OwnerMessageRole.VISITOR,
+        workspace_id="ws-1",
+    )
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations")
+    row = _row_for(res.json())
+    assert row["preview"] == "Perfect, see you at 7."
+
+
+@pytest.mark.asyncio
+async def test_a_newer_run_still_wins_over_an_older_owner_line(client):
+    """The merge takes the LATEST line, whichever store it came from."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    conversation = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.add_owner_message(
+        widget.id,
+        _REF,
+        "An hour ago I said this.",
+        conversation_id=conversation.id,
+        workspace_id="ws-1",
+    )
+    # The run is stamped AFTER the owner line, so the run's text is the newest.
+    await _mk_run(
+        partial_text="The bot answered after that.",
+        createdAt=datetime.now(UTC) + timedelta(minutes=5),
+    )
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations")
+    row = _row_for(res.json())
+    assert row["preview"] == "The bot answered after that."
+
+
+@pytest.mark.asyncio
+async def test_system_lines_never_become_the_row_preview(client):
+    """The bot handing itself back is the product narrating, not a party speaking.
+
+    Letting it preview the row replaces what a person actually said with
+    boilerplate — and re-sorts the whole queue on an automatic event.
+    """
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    conversation = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.add_owner_message(
+        widget.id,
+        _REF,
+        "See you Saturday.",
+        conversation_id=conversation.id,
+        workspace_id="ws-1",
+    )
+    await store.add_owner_message(
+        widget.id,
+        _REF,
+        "The assistant is answering again.",
+        conversation_id=conversation.id,
+        role=OwnerMessageRole.SYSTEM,
+        workspace_id="ws-1",
+    )
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations")
+    assert _row_for(res.json())["preview"] == "See you Saturday."
+
+
+@pytest.mark.asyncio
+async def test_each_row_previews_its_own_visitors_line(client):
+    """Two live conversations, two different last sentences. Neither borrows the
+    other's — the batched read is one query for a page, not one bucket."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run(_REF, createdAt=datetime.now(UTC) - timedelta(hours=1))
+    await _mk_run(_REF_2, createdAt=datetime.now(UTC) - timedelta(hours=1))
+    first = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    second = await store.upsert_conversation_on_visitor_turn(widget.id, _REF_2, "ws-1")
+    await store.add_owner_message(
+        widget.id, _REF, "Told to 0001.", conversation_id=first.id, workspace_id="ws-1"
+    )
+    await store.add_owner_message(
+        widget.id, _REF_2, "Told to 0002.", conversation_id=second.id, workspace_id="ws-1"
+    )
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()
+    assert _row_for(body, _REF)["preview"] == "Told to 0001."
+    assert _row_for(body, _REF_2)["preview"] == "Told to 0002."
+
+
+@pytest.mark.asyncio
+async def test_a_busy_widget_does_not_starve_the_page_of_its_own_lines(client, monkeypatch):
+    """The visitor filter is what keeps the bounded read ON the page.
+
+    Without it the scan cap is spent on whoever spoke most recently ANYWHERE on
+    the widget, and the rows actually being listed silently fall back to the run
+    preview — the exact staleness this whole merge exists to remove, returning
+    only on the busy sites where it matters most. The cap is patched down rather
+    than writing 400 rows: the interaction is the point, not the number.
+    """
+    from pocketpaw_ee.paw_bar import router as paw_bar_router
+
+    monkeypatch.setattr(paw_bar_router, "_OUT_OF_BAND_SCAN_CAP", 2)
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    # Only _REF has runs, so only _REF is on the page.
+    await _mk_run(_REF, createdAt=datetime.now(UTC) - timedelta(hours=1))
+    conversation = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.add_owner_message(
+        widget.id,
+        _REF,
+        "The line this row should show.",
+        conversation_id=conversation.id,
+        workspace_id="ws-1",
+    )
+    # Newer chatter from visitors who are NOT on this page — enough to fill the cap.
+    for i in range(3):
+        noisy = f"cust-noise-{i}"
+        other = await store.upsert_conversation_on_visitor_turn(widget.id, noisy, "ws-1")
+        await store.add_owner_message(
+            widget.id, noisy, f"noise {i}", conversation_id=other.id, workspace_id="ws-1"
+        )
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations")
+    assert _row_for(res.json())["preview"] == "The line this row should show."
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — ordering follows the latest line
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_rows_sort_by_the_latest_line_not_the_latest_run(client):
+    """A human-held conversation is the most active one — it must sort first.
+
+    Ordering by run recency buried exactly the conversations a human was working,
+    because taking over is what stops the runs.
+    """
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+
+    # cust-0001: an OLD run, then a fresh owner reply.
+    await _mk_run(_REF, createdAt=datetime.now(UTC) - timedelta(hours=2))
+    older = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.add_owner_message(
+        widget.id, _REF, "Still with you.", conversation_id=older.id, workspace_id="ws-1"
+    )
+
+    # cust-0002: a run from an hour ago and nothing since.
+    await _mk_run(_REF_2, createdAt=datetime.now(UTC) - timedelta(hours=1))
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF_2, "ws-1")
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations")
+    refs = [item["customer_ref"] for item in res.json()["items"]]
+    assert refs[0] == _REF, "the conversation a human is holding sank below a quiet one"
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — who typed it
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_transcript_owner_line_names_the_human_who_typed_it(client):
+    """A team inbox needs more than "someone replied" — the thread says who."""
+    c, store = client
+    await _mk_user()
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    conversation = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    posted = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply",
+        json={"text": "On it.", "conversation_id": conversation.id},
+    )
+    assert posted.status_code == 200, posted.text
+
+    res = await c.get(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}",
+        params={"conversation_id": conversation.id},
+    )
+    assert res.status_code == 200
+    owner_lines = [m for m in res.json()["messages"] if m["role"] == "owner"]
+    assert owner_lines, "the owner's reply is missing from the transcript"
+    assert owner_lines[0]["author_name"] == "Maya Oyelaran"
+    assert owner_lines[0]["author_avatar"] == "/uploads/avatars/maya.png"
+    assert owner_lines[0]["author_id"] == str(_USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_reply_echo_carries_the_author_identity(client):
+    """The composer's own echo renders identically to the refetched line."""
+    c, store = client
+    await _mk_user()
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    conversation = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply",
+        json={"text": "On it.", "conversation_id": conversation.id},
+    )
+    message = res.json()["message"]
+    assert message["author_name"] == "Maya Oyelaran"
+    assert message["author_avatar"] == "/uploads/avatars/maya.png"
+
+
+@pytest.mark.asyncio
+async def test_only_owner_lines_are_attributed(client):
+    """A visitor's muted line carries no author and a system line was authored by
+    nobody. Stamping either with whoever is in the map invents a speaker."""
+    c, store = client
+    await _mk_user()
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    conversation = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    # An OWNER line first, so the resolved-author map is actually populated —
+    # without one there is no identity in scope and the gate has nothing to leak.
+    posted = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply",
+        json={"text": "Maya here.", "conversation_id": conversation.id},
+    )
+    assert posted.status_code == 200, posted.text
+    # Written with an author on purpose: the role, not the column, is the gate.
+    await store.add_owner_message(
+        widget.id,
+        _REF,
+        "I asked this while a human was holding the thread.",
+        conversation_id=conversation.id,
+        role=OwnerMessageRole.VISITOR,
+        author=str(_USER_ID),
+        workspace_id="ws-1",
+    )
+    await store.add_owner_message(
+        widget.id,
+        _REF,
+        "The assistant is answering again.",
+        conversation_id=conversation.id,
+        role=OwnerMessageRole.SYSTEM,
+        author=str(_USER_ID),
+        workspace_id="ws-1",
+    )
+
+    res = await c.get(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}",
+        params={"conversation_id": conversation.id},
+    )
+    for message in res.json()["messages"]:
+        if message["role"] == "owner":
+            continue
+        assert message["author_id"] == ""
+        assert message["author_name"] == ""
+        assert message["author_avatar"] == ""
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_author_degrades_to_a_blank_name(client):
+    """A deleted teammate (or a legacy line with no author) renders anonymously."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    conversation = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.add_owner_message(
+        widget.id,
+        _REF,
+        "Written before authors were stored.",
+        conversation_id=conversation.id,
+        workspace_id="ws-1",
+    )
+
+    res = await c.get(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}",
+        params={"conversation_id": conversation.id},
+    )
+    owner_lines = [m for m in res.json()["messages"] if m["role"] == "owner"]
+    assert owner_lines[0]["author_name"] == ""
+    assert owner_lines[0]["author_avatar"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# Layer 4 — the visitor still learns nothing about the operator
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_visitor_poll_never_carries_the_operator_identity(client):
+    """The public read stays role + content + time. Widening it here would leak a
+    staff name and photo to every stranger on the internet."""
+    c, store = client
+    await _mk_user()
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    conversation = await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply",
+        json={"text": "Maya here.", "conversation_id": conversation.id},
+    )
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params={"signed_key": _KEY},
+        headers={"Origin": "https://brewco.com"},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["messages"], "the owner line should reach the visitor"
+    for message in res.json()["messages"]:
+        assert set(message) == {"role", "content", "at"}

--- a/tests/cloud/test_paw_bar_takeover.py
+++ b/tests/cloud/test_paw_bar_takeover.py
@@ -282,10 +282,17 @@ async def test_reply_persists_pauses_and_clears_unread(client):
     body = res.json()
     assert body["ok"] is True
     # The echo is a transcript message — the shape the thread already renders.
+    # The author id is carried; the name and avatar are blank because this rig's
+    # caller id ("u1") is not an ObjectId and so resolves to no user — the same
+    # degrade a deleted teammate gets. Attribution is proved against a real User
+    # doc in tests/cloud/test_paw_bar_inbox_freshness.py.
     assert body["message"] == {
         "role": "owner",
         "content": "Hi! I'm Maya, I can help.",
         "created_at": body["message"]["created_at"],
+        "author_id": "u1",
+        "author_name": "",
+        "author_avatar": "",
     }
     assert body["message"]["created_at"]
     row = body["conversation"]
@@ -1098,8 +1105,20 @@ async def test_transcript_messages_carry_no_ids(client):
 
     res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_REF}")
 
+    # The author block (2026-08-24) is the only thing that has been added since,
+    # and it is deliberately NOT an id for the message — it names the human who
+    # typed an owner line. Pinned as a whole set so the next field to appear here
+    # has to be argued for in a diff rather than arriving unnoticed.
     for message in res.json()["messages"]:
-        assert set(message) == {"role", "content", "created_at"}
+        assert set(message) == {
+            "role",
+            "content",
+            "created_at",
+            "author_id",
+            "author_name",
+            "author_avatar",
+        }
+        assert "id" not in message
 
 
 @pytest.mark.asyncio

--- a/tests/mutations/paw_bar_inbox_freshness.json
+++ b/tests/mutations/paw_bar_inbox_freshness.json
@@ -1,0 +1,96 @@
+[
+  {
+    "label": "the freshness merge is removed — the list row freezes at the last RUN again (the original bug)",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "            if line_at is not None and (run_at is None or line_at > run_at):\n                last_message_at = line.created_at\n                preview = (line.content or \"\")[:_CONVERSATION_PREVIEW_CHARS]\n                run_at = line_at",
+    "replace": "            pass",
+    "tests": [
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_owner_reply_becomes_the_row_preview",
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_muted_visitor_line_becomes_the_row_preview",
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_rows_sort_by_the_latest_line_not_the_latest_run"
+    ]
+  },
+  {
+    "label": "the out-of-band read returns nothing — the merge has no lines to merge",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "    if widget is None or not refs:\n        return {}, {}\n    try:\n        lines = await _store().list_recent_owner_messages(",
+    "replace": "    if True:\n        return {}, {}\n    try:\n        lines = await _store().list_recent_owner_messages(",
+    "tests": [
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_owner_reply_becomes_the_row_preview",
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_muted_visitor_line_becomes_the_row_preview"
+    ]
+  },
+  {
+    "label": "the merged re-sort is dropped — a human-held conversation sinks below a quiet one",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "    merged.sort(key=lambda m: (m[0] is not None, m[0] or _EPOCH), reverse=True)",
+    "replace": "    pass",
+    "tests": [
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_rows_sort_by_the_latest_line_not_the_latest_run"
+    ]
+  },
+  {
+    "label": "the newest-first sort inverts — the oldest conversation leads the inbox",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "    merged.sort(key=lambda m: (m[0] is not None, m[0] or _EPOCH), reverse=True)",
+    "replace": "    merged.sort(key=lambda m: (m[0] is not None, m[0] or _EPOCH))",
+    "tests": [
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_rows_sort_by_the_latest_line_not_the_latest_run"
+    ]
+  },
+  {
+    "label": "the store's role filter widens to SYSTEM — a resume notice becomes the inbox preview",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "            wanted = [OwnerMessageRole.OWNER.value, OwnerMessageRole.VISITOR.value]",
+    "replace": "            wanted = [r.value for r in OwnerMessageRole]",
+    "tests": [
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_system_lines_never_become_the_row_preview"
+    ]
+  },
+  {
+    "label": "the batched read ignores the visitor filter — another visitor's line can preview this row",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "        placeholders = \", \".join(\"?\" for _ in customer_refs)\n        conditions += f\" AND customer_ref IN ({placeholders})\"\n        params.extend(customer_refs)\n        role_placeholders",
+    "replace": "        role_placeholders",
+    "tests": [
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_a_busy_widget_does_not_starve_the_page_of_its_own_lines"
+    ]
+  },
+  {
+    "label": "an owner line stops carrying who typed it — the thread says \"someone replied\" again",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        author_name=getattr(identity, \"name\", \"\") or \"\",\n        author_avatar=getattr(identity, \"avatar\", \"\") or \"\",",
+    "replace": "        author_name=\"\",\n        author_avatar=\"\",",
+    "tests": [
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_transcript_owner_line_names_the_human_who_typed_it",
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_reply_echo_carries_the_author_identity"
+    ]
+  },
+  {
+    "label": "the reply echo goes out unattributed — the operator's own sentence reads as anonymous until the next poll",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        message=_owner_transcript_message(message, await _resolve_message_authors([message])),",
+    "replace": "        message=_owner_transcript_message(message),",
+    "tests": [
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_reply_echo_carries_the_author_identity"
+    ]
+  },
+  {
+    "label": "attribution stops being owner-only — a visitor's muted line is stamped with an operator",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "    identity = (authors or {}).get(author_id) if role == \"owner\" else None",
+    "replace": "    identity = (authors or {}).get(author_id)",
+    "tests": [
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_only_owner_lines_are_attributed"
+    ]
+  },
+  {
+    "label": "the public visitor poll starts carrying the operator's identity — a staff name and photo to every stranger",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "class VisitorMessage(BaseModel):\n    \"\"\"One owner/system line as the VISITOR's widget sees it.",
+    "replace": "class VisitorMessage(BaseModel):\n    author_name: str = \"\"\n\n    \"\"\"One owner/system line as the VISITOR's widget sees it.",
+    "tests": [
+      "tests/cloud/test_paw_bar_inbox_freshness.py::test_visitor_poll_never_carries_the_operator_identity"
+    ]
+  }
+]


### PR DESCRIPTION
The owner's conversation list was built from `ChatRunDoc` alone. The two kinds of line that have no run live in `paw_bar_owner_messages` instead: an owner's takeover reply, and the visitor's answer to it, which is exactly what muting the bot produces.

So the row froze the moment a human stepped in. It kept showing the bot's last sentence, stamped at the bot's last timestamp. And because the list was ordered by run recency, taking over a conversation pushed it down the queue: the more a person worked a thread, the further it sank below the ones nobody was answering.

## What changed

The list merges the newest out-of-band line over each row, then re-sorts on that merged clock. One extra bounded read for the whole page, the same shape as the state and decision joins already there. System lines stay out of it. "The assistant is answering again" replacing what a customer said is not a preview, and it would re-order the queue on an automatic event.

Two things fell out of comparing the two clocks:

Run stamps come back from Mongo naive (the client isn't `tz_aware`) while owner lines are aware UTC, so the comparison had to normalize. `last_message_at` now goes out with an offset, which also fixes relative times reading wrong by the reader's own offset in any browser outside UTC.

The run scan needed a tie-break. Windows' clock moves in ~15.6ms steps, so a question and its follow-up share a `createdAt` and the dedupe picked between them arbitrarily. That was already in the suite as an intermittent failure: `test_a_conversation_spanning_the_migration_is_ONE_row` fails about three times in five on `dev`.

Owner lines also carry who typed them: id, name and avatar, resolved from the stored author through a new `auth.service.resolve_identities`, and carried on the reply echo through the same resolver so the composer's optimistic append matches the refetch. A site answered by a team could only say "someone replied an hour ago", which tells the second person nothing about whether to step in.

The visitor's public poll is untouched. They learn a human replied, never which one, and a test pins the key set so widening it has to be deliberate.

## Testing

`tests/cloud/test_paw_bar_inbox_freshness.py`, 12 tests covering freshness, ordering, attribution and the privacy boundary.

Ten mutations in `tests/mutations/paw_bar_inbox_freshness.json`, all caught. Two escaped on the first run and the tests were wrong, not the mutations: one asserted per-visitor bucketing in a way that passed with no filter at all, the other had no owner line in scope so the owner-only gate had nothing to leak.

`uv run pytest tests/cloud/ -k "paw_bar or concierge"` → 657 passed, 15 failed. Those 15 fail identically on a clean checkout of `dev` (preamble and entitlement suites, unrelated to this). Baseline captured by stashing and re-running before any of this landed.

`mutate.py --validate` green across all 59 plans, so no anchor elsewhere rotted.
