### PR TITLE
Share the preview artifact cache across replicas

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1417,6 +1417,23 @@ miss's build is keyed on `pocket_id` in a stable directory, so `node_modules` /
 `bun install` stay cached; it skips the SSR smoke fail-gate (`smoke=False`) but still
 emits the static output that is read.
 
+**Shared store (opt-in) — `PAW_SITES_ARTIFACT_STORE=s3`.** The on-disk store above is
+per-container, so on a multi-replica deploy a view routed to replica B misses what
+replica A built, and a redeploy empties the cache entirely. Setting
+`PAW_SITES_ARTIFACT_STORE=s3` keeps the same `(pocket_id, content_hash)` key but puts
+the artifact in blob storage through the configured `StorageAdapter`, so it is shared
+across replicas and survives a redeploy. **Unset (the default) is the on-disk store** —
+OSS installs and local dev are unchanged. The adapter itself is chosen by
+`POCKETPAW_UPLOAD_ADAPTER`, which must also be `s3` for this to be remote storage; a box
+that sets only the first knob gets a local-disk adapter writing the same
+`~/.pocketpaw/site-artifacts/` layout. Both sides stay best-effort: a miss, a corrupt
+object, a timeout, or a failed write degrades to a rebuild and never fails a preview.
+The store also **refuses to persist an artifact whose rendered body or CSS carries a
+per-site capture key** — that secret is only acceptable because it lives in a container
+that is then destroyed, so such a pocket rebuilds on every view instead of caching. No
+eviction runs here (the on-disk store's `PAW_SITES_ARTIFACT_KEEP` does not apply); put a
+bucket lifecycle rule on the `site-artifacts/` prefix.
+
 **Auth is `fabric.write`, not a read scope,** because a cold miss still **arms a
 build**: it builds the pocket with a builder origin set so the generator stamps
 `data-uid` on the editable leaves and embeds the edit manifest — the endpoint can

--- a/docs/internal/2026-05-resumable-runs-deploy.md
+++ b/docs/internal/2026-05-resumable-runs-deploy.md
@@ -131,6 +131,8 @@ Env vars (all also documented in `backend/CLAUDE.md` → Key Conventions):
 | `POCKETPAW_CLOUD_STREAM_TRANSPORT` | `redis` | Future hook for non-Redis backends |
 | `PAW_SITES_BUILD_TIMEOUT_SEC[_<ENGINE>]` | `600` (floor) | Per-build sandbox budget for the site-build function. Read at worker **import**, so a change takes effect on the worker restart a deploy performs — see below |
 | `PAW_SITES_SVELTE_ASYNC_BUILD` | unset (off) | Routes STATIC svelte publishes to the Daytona build lane instead of building them inline. Read per call, so it takes effect without a restart — but set it on **both** the web service and the worker: the web side decides whether to enqueue, the worker side does the build. See the caveat below before turning it on |
+| `PAW_SITES_ARTIFACT_STORE` | `filesystem` | Set to `s3` to keep built preview artifacts in blob storage instead of the container's disk, so a view on one replica serves what another built and a redeploy does not empty the cache. Same `(pocket_id, content_hash)` key either way. Read per call. Only meaningful with `POCKETPAW_UPLOAD_ADAPTER=s3` — see below |
+| `PAW_SITES_ARTIFACT_S3_TIMEOUT_SEC` | `10` | Per-call deadline on one artifact blob round-trip. The store's seam is synchronous and runs on the request's event loop, so a wedged bucket must not block indefinitely; on a timeout the call degrades to a cache miss |
 
 ### Turning the svelte lane on (`PAW_SITES_SVELTE_ASYNC_BUILD`)
 
@@ -159,6 +161,36 @@ converts working svelte publishes into failures.
 That gap is why the flag is off by default rather than a straight flip. Its fix is a
 `paw-sites-gen` subcommand that judges an already-built tree, called by the worker on the
 unpacked artifact.
+
+### Sharing the preview artifact cache (`PAW_SITES_ARTIFACT_STORE`)
+
+Off by default, which keeps built preview artifacts on the container's own disk
+(`~/.pocketpaw/site-artifacts/<pocket_id>/<hash>.json`). That is correct for one box and
+wrong for several: a view routed to replica B misses what replica A built, a redeploy
+empties the cache, and a miss costs a full `bun install` + build.
+
+`PAW_SITES_ARTIFACT_STORE=s3` keeps the same `(pocket_id, content_hash)` key and puts the
+artifact in blob storage instead. **Set `POCKETPAW_UPLOAD_ADAPTER=s3` with it** — that is
+the knob that decides which backend `pocketpaw.uploads.build_adapter` returns, and with it
+left on `local` you get a local-disk adapter writing the same layout as before: no crash,
+no sharing. `cloud/uploads/bootstrap.verify_cloud_storage_backend` already warns about
+that at boot (and refuses to boot under `POCKETPAW_REQUIRE_S3_IN_CLOUD`).
+
+Nothing here is load-bearing for correctness. A miss, a corrupt object, a timeout, an
+unreachable bucket or a failed write all degrade to "rebuild this artifact" — the same
+best-effort contract the on-disk store has. A box where no adapter can be built falls back
+to the on-disk store rather than failing previews.
+
+Two behaviours differ from the on-disk store, both deliberate:
+
+- **A pocket whose rendered body or CSS carries a per-site capture key is never stored.**
+  That secret's exposure was only ever acceptable because it lives in a container that is
+  then destroyed (see the headers on `sites/build_job.py` and `sites/daytona_runner.py`);
+  a bucket is not destroyed. Such a pocket rebuilds on every view, and the refusal is
+  logged per pocket so it is visible rather than mysterious.
+- **No eviction.** `PAW_SITES_ARTIFACT_KEEP` prunes the on-disk store because a container
+  disk is small and shared. Put a lifecycle rule on the bucket's `site-artifacts/` prefix
+  instead of paying a LIST + DELETE on every write.
 
 ### The worker runs three functions, each with its own timeout
 

--- a/ee/pocketpaw_ee/sites/artifact_store_s3.py
+++ b/ee/pocketpaw_ee/sites/artifact_store_s3.py
@@ -1,0 +1,344 @@
+# ee/pocketpaw_ee/sites/artifact_store_s3.py — SP-4, the SHARED native-artifact store.
+#
+# Created 2026-08-24 (feat/sites-s3-artifact-store). New module. Nothing here existed
+# before; the only edit outside it is ``service._default_artifact_store``, which now
+# consults ``shared_artifact_store()`` before falling back to the filesystem store.
+#
+# WHY THIS EXISTS. ``service._FilesystemArtifactStore`` caches a built preview's
+# ``{body_html, css}`` on the CONTAINER'S OWN DISK, keyed on ``(pocket_id,
+# content_hash)``. That makes the cache per-replica and per-deploy: a view routed to
+# replica B misses what replica A built, and a redeploy empties it entirely. A cold miss
+# is a full ``bun install`` + SvelteKit build — 1-2 minutes on the prod box — so a miss is
+# not "slightly slower", it is the difference between an instant preview and one the user
+# gives up on. This store puts the same two-part key in blob storage instead, so the
+# artifact is shared across replicas and outlives the container.
+#
+# ┌───────────────────────────────────────────────────────────────────────────────────┐
+# │ THE PER-SITE CAPTURE KEY MUST NEVER REACH BLOB STORAGE.                            │
+# └───────────────────────────────────────────────────────────────────────────────────┘
+#
+# ``build_job``'s header records the decision this inherits: a svelte scaffold
+# substitutes the real per-site ``captureSignedKey`` into ``src/routes/api/submit/
+# +server.ts``, and the ENTIRE argument that its exposure is acceptable rests on it
+# living only in a container that is then destroyed. ``daytona_runner``'s header is the
+# same obligation reached from the other side — that lane never snapshots a sandbox,
+# because a snapshot moves an ephemeral secret into durable storage.
+#
+# S3 is durable in exactly the way both of those were avoiding, and unlike a sandbox it
+# is not destroyed on any schedule we control. So the write path REFUSES a payload
+# carrying a capture-key-shaped value (see ``carries_capture_key``) rather than storing
+# it. It is not hypothetical that one can appear: ``generator_client
+# ._resolve_capture_tokens`` substitutes ``__CAPTURE_SIGNED_KEY__`` into EVERY text entry
+# of a source map, and ``_rewire_legacy_submit_forms`` emits
+# ``<input type="hidden" name="paw_key" value="__CAPTURE_SIGNED_KEY__">`` into any form
+# still aimed at the removed ``/api/submit`` route. Both land in the rendered page body,
+# which is precisely what ``_read_native_artifact`` extracts into ``body_html``.
+#
+# TODAY THAT VALUE IS A THROWAWAY, AND THAT IS NOT THE POINT. ``service
+# ._build_native_artifact`` builds with ``capture_signed_key=f"site_key_{token_urlsafe
+# (24)}"`` — freshly minted per build, never the site's real key ("cosmetic here", says
+# the call site). So what the guard refuses today is a decoy. It is still the right
+# refusal: the publish path threads the REAL key through the same builder, the two paths
+# are one parameter apart, and a guard that only fires once the secret is already durable
+# has fired too late. The gap between "the decision was made" and "the code does it" is
+# one grep, and daytona_runner's header exists because nobody ran it.
+#
+# THE COST IS REAL AND IS ACCEPTED. A site whose rendered body carries a key-shaped
+# value never caches here — every view of it rebuilds. That degradation is the store's
+# own contract (a refusal reads as a MISS, and a MISS rebuilds), it is logged per pocket
+# so an operator can see the cache is off and why, and the alternatives are worse:
+# blanking the value would serve a form that posts an empty ``paw_key`` and silently
+# drops every lead, and re-tokenising would need the caller to hand the key back on read
+# — a change to the ``_store`` seam that this task deliberately does not make.
+#
+# WHAT THIS IS NOT. It does NOT go through ``EEUploadService``: that takes a FastAPI
+# ``UploadFile``, mints a Mongo ``FileRecord``, and runs chat-membership /
+# workspace-admin permission checks. An artifact store wants "put these bytes at this
+# key" and none of that. It talks to the low-level ``StorageAdapter`` the upload service
+# itself holds, built by ``pocketpaw.uploads.build_adapter`` — the same swap point
+# ``cloud/media/storage.py`` uses.
+#
+# TWO ENV KNOBS, AND THEY ARE NOT THE SAME ONE:
+#   * ``PAW_SITES_ARTIFACT_STORE`` (default ``filesystem``) — whether site artifacts go
+#     to blob storage at all. Default keeps OSS installs and local dev byte-for-byte on
+#     the prior filesystem store.
+#   * ``POCKETPAW_UPLOAD_ADAPTER`` (default ``local``) — WHICH backend
+#     ``build_adapter`` returns. Setting only the first one on a box whose upload
+#     adapter is still ``local`` gets a local-disk adapter: no crash, no sharing, and the
+#     objects land under ``~/.pocketpaw/site-artifacts/`` — the same place the filesystem
+#     store writes. ``cloud/uploads/bootstrap.verify_cloud_storage_backend`` already
+#     warns (or refuses to boot, under ``POCKETPAW_REQUIRE_S3_IN_CLOUD``) about exactly
+#     that misconfiguration, so this module does not duplicate the guard.
+#
+# NO EVICTION HERE, DELIBERATELY. The filesystem store prunes to
+# ``PAW_SITES_ARTIFACT_KEEP`` because a container's disk is small and shared. A bucket is
+# neither, and doing it in code would cost a LIST + DELETE round-trip on every write to
+# solve a problem object storage already has a native answer for. Put a lifecycle rule on
+# the ``site-artifacts/`` prefix instead.
+"""SP-4 — a blob-storage-backed native-artifact store for Paw Sites previews."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from collections.abc import AsyncIterator, Coroutine
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Key prefix inside the bucket. The two components after it are ``pocket_id`` and
+#: ``content_hash`` — the SAME key the filesystem store uses, in the same order, so the
+#: two stores address one artifact identically and a deployment can switch between them
+#: without invalidating anything.
+ARTIFACT_KEY_PREFIX = "site-artifacts"
+
+#: Local root handed to ``build_adapter`` for the LOCAL-adapter case. Mirrors
+#: ``cloud/media/storage.MEDIA_ROOT``; combined with the prefix above it resolves to
+#: ``~/.pocketpaw/site-artifacts/<pocket_id>/<hash>.json`` — the filesystem store's own
+#: layout, so a half-configured box degrades onto the path it was already using.
+LOCAL_ADAPTER_ROOT = Path.home() / ".pocketpaw"
+
+_MODE_FILESYSTEM = "filesystem"
+_MODE_S3 = "s3"
+
+#: A per-site capture key is ``site_key_`` + ``secrets.token_urlsafe(24)`` (~32 chars of
+#: the URL-safe alphabet) — minted that way in ``service`` (five call sites) and in
+#: ``cloud/models/site.Site``. The 16-char floor is borrowed from
+#: ``cloud/auth/site_keys._MIN_SITE_KEY_LEN`` and for the same reason: it is comfortably
+#: above short junk and below a real key, so it survives a future token-length tweak.
+_CAPTURE_KEY_RE = re.compile(r"site_key_[A-Za-z0-9_-]{16,}")
+
+#: Seconds a single blob round-trip may block the caller. The ``_store`` seam is SYNC and
+#: is called from inside the request's event loop, so an unbounded wait does not slow one
+#: preview down — it wedges the loop. Ten seconds is far above a healthy PUT/GET of a
+#: page-sized JSON and far below "the user has already left".
+_TIMEOUT_DEFAULT_SEC = 10.0
+
+
+def artifact_store_mode() -> str:
+    """Which native-artifact store this process should use.
+
+    ``filesystem`` (the default, and anything unrecognised) keeps the prior on-disk
+    store. ``s3`` routes artifacts through the configured ``StorageAdapter``.
+    """
+    return (os.environ.get("PAW_SITES_ARTIFACT_STORE") or _MODE_FILESYSTEM).strip().lower()
+
+
+def _timeout_sec() -> float:
+    """Per-call blob round-trip budget, overridable with
+    ``PAW_SITES_ARTIFACT_S3_TIMEOUT_SEC``. A non-numeric or non-positive value falls
+    back to the default rather than disabling the bound."""
+    raw = os.environ.get("PAW_SITES_ARTIFACT_S3_TIMEOUT_SEC")
+    try:
+        value = float(raw) if raw else _TIMEOUT_DEFAULT_SEC
+    except (TypeError, ValueError):
+        return _TIMEOUT_DEFAULT_SEC
+    return value if value > 0 else _TIMEOUT_DEFAULT_SEC
+
+
+def carries_capture_key(*values: str) -> bool:
+    """Whether any value carries a per-site capture-key-shaped token.
+
+    The one gate between a rendered artifact and durable storage — see the module
+    header for why the answer to "is this really a secret, or the build-time decoy?"
+    is deliberately not asked. A key-shaped value is treated as a key.
+    """
+    return any(_CAPTURE_KEY_RE.search(value) for value in values if isinstance(value, str))
+
+
+def artifact_key(pocket_id: str, content_hash: str) -> str:
+    """The blob key for one artifact. Same ``(pocket_id, content_hash)`` pair the
+    filesystem store puts in its path, under a fixed prefix."""
+    return f"{ARTIFACT_KEY_PREFIX}/{pocket_id}/{content_hash}.json"
+
+
+def _run_coro(coro: Coroutine[Any, Any, Any], timeout: float) -> Any:
+    """Drive a coroutine to completion from SYNCHRONOUS code, bounded by ``timeout``.
+
+    Mirrors ``pocketpaw.__main__._run_async`` / ``discovery.kb_compile._run_coro``, plus
+    a deadline. The ``_store`` seam is sync (``store.read(...)`` / ``store.write(...)``
+    with no ``await``) while ``StorageAdapter`` is async, and both call sites sit inside
+    a running loop — so ``asyncio.run`` here would raise "cannot be called from a running
+    event loop". The coroutine therefore runs on a worker thread with its own loop.
+
+    The executor is NOT used as a context manager on purpose: ``__exit__`` waits for the
+    worker, which would make the timeout meaningless. On a timeout the thread is left to
+    finish on its own (boto3 carries its own socket timeouts) and the caller degrades to
+    a MISS.
+    """
+    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="paw-artifact-blob")
+    try:
+        return executor.submit(asyncio.run, coro).result(timeout=timeout)
+    finally:
+        executor.shutdown(wait=False)
+
+
+async def _read_all(stream: AsyncIterator[bytes]) -> bytes:
+    """Drain an adapter byte stream. Artifacts are page-sized, so buffering is fine."""
+    chunks: list[bytes] = []
+    async for chunk in stream:
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _bytes_stream(data: bytes) -> AsyncIterator[bytes]:
+    """Adapt an in-memory payload into the async byte stream ``StorageAdapter.put``
+    consumes. Mirrors ``cloud/media/storage.bytes_stream``."""
+    yield data
+
+
+class S3ArtifactStore:
+    """Read-through native-artifact store backed by a ``StorageAdapter``.
+
+    Satisfies the same duck-typed ``_store`` seam as ``service._FilesystemArtifactStore``
+    — ``read(pocket_id, content_hash)`` and ``write(pocket_id, content_hash, body_html,
+    css)``, both SYNC — so ``get_native_artifact`` and the pre-warm are unchanged.
+
+    Best-effort on BOTH sides, matching the filesystem store exactly. A miss, a corrupt
+    or truncated object, a timeout, an unreachable bucket, denied credentials: every one
+    of them returns ``None`` so the caller rebuilds. A failed write is swallowed and
+    logged. Nothing raised in here may break a preview, so the ``except Exception``
+    breadth is the contract rather than laziness — the alternative is enumerating every
+    botocore error a bucket can produce and turning the one it missed into a 500.
+
+    Tenant isolation is the filesystem store's, unchanged: the key is built from a
+    ``pocket_id`` resolved by a tenant-scoped pockets read, so one tenant's prefix is not
+    addressable from another tenant's request.
+    """
+
+    def __init__(self, adapter: Any, *, timeout: float | None = None) -> None:
+        self._adapter = adapter
+        self._timeout = timeout if timeout and timeout > 0 else _timeout_sec()
+
+    def read(self, pocket_id: str, content_hash: str) -> tuple[str, str] | None:
+        key = artifact_key(pocket_id, content_hash)
+        try:
+            raw = _run_coro(_read_all(self._adapter.open(key)), self._timeout)
+        except Exception:
+            # A miss is the common case here (``NotFound`` on a cold key), so this is
+            # debug, not warning — a warning per cache miss would bury the write
+            # failures that actually want an operator.
+            logger.debug("sites.artifact_store_s3: read miss for %s", key, exc_info=True)
+            return None
+        try:
+            data = json.loads(raw)
+            body_html = data["body_html"]
+            css = data["css"]
+        except (ValueError, KeyError, TypeError):
+            logger.debug("sites.artifact_store_s3: corrupt artifact at %s", key)
+            return None
+        if not isinstance(body_html, str) or not isinstance(css, str):
+            return None
+        return body_html, css
+
+    def write(self, pocket_id: str, content_hash: str, body_html: str, css: str) -> None:
+        if carries_capture_key(body_html, css):
+            # Refused, not scrubbed. See the module header: the whole reason this key's
+            # exposure was ever acceptable is that it does not outlive its container.
+            logger.warning(
+                "sites.artifact_store_s3: refusing to store an artifact for pocket %s — "
+                "the rendered payload carries a per-site capture key, which must never "
+                "reach durable blob storage. This pocket's preview will rebuild on every "
+                "view until the key stops being substituted into its rendered body.",
+                pocket_id,
+            )
+            return
+
+        key = artifact_key(pocket_id, content_hash)
+        payload = json.dumps(
+            {
+                "body_html": body_html,
+                "css": css,
+                "stored_at": datetime.now(UTC).isoformat(),
+            }
+        ).encode("utf-8")
+        try:
+            _run_coro(
+                self._adapter.put(key, _bytes_stream(payload), "application/json"),
+                self._timeout,
+            )
+        except Exception:
+            # Best-effort cache — a write failure must not break the render path.
+            logger.warning(
+                "sites.artifact_store_s3: write failed for pocket %s", pocket_id, exc_info=True
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Process-wide resolution
+# --------------------------------------------------------------------------- #
+#
+# The adapter is cached because building one constructs a boto3 client; the store
+# wrapper around it is trivial and is rebuilt per call so an env change to the timeout
+# takes effect without a restart. A failed build is cached as a failure too — a box with
+# no S3 credentials must not attempt (and log) a fresh construction on every preview.
+
+_adapter: Any | None = None
+_adapter_failed = False
+
+
+def _shared_adapter() -> Any | None:
+    """The process's blob adapter, or ``None`` if one cannot be built."""
+    global _adapter, _adapter_failed
+
+    if _adapter is not None:
+        return _adapter
+    if _adapter_failed:
+        return None
+    try:
+        from pocketpaw.uploads.factory import build_adapter
+
+        _adapter = build_adapter(LOCAL_ADAPTER_ROOT)
+    except Exception:
+        _adapter_failed = True
+        logger.warning(
+            "sites.artifact_store_s3: PAW_SITES_ARTIFACT_STORE=s3 but no storage adapter "
+            "could be built (check POCKETPAW_UPLOAD_ADAPTER and the S3_* settings). "
+            "Falling back to the local filesystem artifact store.",
+            exc_info=True,
+        )
+        return None
+    return _adapter
+
+
+def shared_artifact_store() -> S3ArtifactStore | None:
+    """The shared artifact store for this process, or ``None`` to keep the filesystem one.
+
+    ``None`` is the default and the fallback: unset / unrecognised
+    ``PAW_SITES_ARTIFACT_STORE``, or ``s3`` on a box where no adapter can be built. The
+    caller (``service._default_artifact_store``) treats ``None`` as "use the prior
+    store", so a misconfiguration degrades to today's behaviour instead of failing a
+    preview.
+    """
+    if artifact_store_mode() != _MODE_S3:
+        return None
+    adapter = _shared_adapter()
+    if adapter is None:
+        return None
+    return S3ArtifactStore(adapter)
+
+
+def reset_shared_adapter() -> None:
+    """Drop the cached adapter. For tests that flip the env between cases."""
+    global _adapter, _adapter_failed
+
+    _adapter = None
+    _adapter_failed = False
+
+
+__all__ = [
+    "ARTIFACT_KEY_PREFIX",
+    "LOCAL_ADAPTER_ROOT",
+    "S3ArtifactStore",
+    "artifact_key",
+    "artifact_store_mode",
+    "carries_capture_key",
+    "reset_shared_adapter",
+    "shared_artifact_store",
+]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,15 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-08-24 (feat/sites-s3-artifact-store, SP-4): ``_default_artifact_store``
+# now consults ``artifact_store_s3.shared_artifact_store()`` before falling back to
+# ``_FilesystemArtifactStore``, so a deployment can set ``PAW_SITES_ARTIFACT_STORE=s3``
+# and have a preview artifact built on one replica served by another (and survive a
+# redeploy) on the SAME ``(pocket_id, content_hash)`` key. Unset is the default and
+# resolves the filesystem store, so OSS installs and local dev are unchanged. That one
+# function is the whole footprint here — the store, its best-effort semantics, and the
+# guard keeping a per-site capture key out of durable storage all live in the new module.
+#
 # Updated 2026-08-21 (feat/sites-billing-flag, PW-2): every billing seam in this
 # module now asks ``cloud.billing.enforcement.sites_enforced()`` instead of reading
 # ``billing_enforced`` itself. That function is the OR of the global flag and the
@@ -1185,11 +1194,20 @@ class _FilesystemArtifactStore:
 _DEFAULT_ARTIFACT_STORE = _FilesystemArtifactStore()
 
 
-def _default_artifact_store() -> _FilesystemArtifactStore:
-    """The process-wide default native-artifact store (a filesystem store). Factored so
+def _default_artifact_store() -> Any:
+    """The process-wide default native-artifact store. Factored so
     ``get_native_artifact`` / the pre-warm resolve the same instance and tests can pass
-    an in-memory ``_store`` instead."""
-    return _DEFAULT_ARTIFACT_STORE
+    an in-memory ``_store`` instead.
+
+    SP-4: a deployment may set ``PAW_SITES_ARTIFACT_STORE=s3`` to route artifacts through
+    blob storage instead, so an artifact built on one replica serves from another and
+    survives a redeploy (``artifact_store_s3``, same ``(pocket_id, content_hash)`` key).
+    UNSET IS THE DEFAULT and returns the filesystem store below — OSS installs and local
+    dev are byte-for-byte unchanged, and so is a box where the shared store cannot be
+    built (``shared_artifact_store`` returns ``None`` rather than raising)."""
+    from pocketpaw_ee.sites.artifact_store_s3 import shared_artifact_store
+
+    return shared_artifact_store() or _DEFAULT_ARTIFACT_STORE
 
 
 async def _build_native_artifact(

--- a/tests/ee/sites/conftest.py
+++ b/tests/ee/sites/conftest.py
@@ -1,5 +1,10 @@
 # tests/ee/sites/conftest.py
 # Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+# Updated 2026-08-24 (feat/sites-s3-artifact-store, SP-4): ``_artifact_store_tmp`` also
+#   clears PAW_SITES_ARTIFACT_STORE. PAW_SITES_ARTIFACT_DIR only points the store
+#   somewhere; the new knob SELECTS it, so an operator with it set to ``s3`` would send
+#   every cache write in this tree at their own bucket. Same class of leak as
+#   OPERATOR_ENV_VARS, kept in this fixture because it belongs to the artifact store.
 # Updated 2026-08-11 (fix/tests-ignore-operator-env): added the autouse
 #   ``_operator_env_cleared`` fixture. Nothing in this tree isolated the test process
 #   from the developer's own environment: ``config.py`` declares ``env_file=".env"`` and
@@ -188,8 +193,15 @@ def _artifact_store_tmp(tmp_path, monkeypatch):
     temp dir (feat/sites-native-artifact-no-build), mirroring how the build dir is kept
     out of the real ~/.pocketpaw. get_native_artifact's default filesystem store writes
     the rendered {body_html, css} here on a cache MISS, so without this a test that
-    exercises the miss path would pollute the developer's real home."""
+    exercises the miss path would pollute the developer's real home.
+
+    SP-4: also clears PAW_SITES_ARTIFACT_STORE, which SELECTS the store rather than
+    pointing it somewhere. An operator with it set to ``s3`` would otherwise send every
+    cache write in this tree at their own bucket — the same class of leak
+    OPERATOR_ENV_VARS exists for, kept here because it belongs to the artifact store
+    rather than to Cloudflare / Daytona."""
     monkeypatch.setenv("PAW_SITES_ARTIFACT_DIR", str(tmp_path / "site-artifacts"))
+    monkeypatch.delenv("PAW_SITES_ARTIFACT_STORE", raising=False)
     yield
 
 

--- a/tests/ee/sites/test_artifact_store_s3.py
+++ b/tests/ee/sites/test_artifact_store_s3.py
@@ -1,0 +1,357 @@
+# tests/ee/sites/test_artifact_store_s3.py — SP-4, the SHARED native-artifact store.
+# Created 2026-08-24 (feat/sites-s3-artifact-store). New file.
+#
+# Under test: ``pocketpaw_ee.sites.artifact_store_s3`` — the blob-storage-backed
+# ``_store`` seam that lets an artifact built on one replica be served by another and
+# survive a redeploy. The filesystem store it stands beside is per-container, so a view
+# routed elsewhere pays a full ``bun install`` + build.
+#
+# The adapter is FAKED (a dict, not boto3): these prove the store's own contract, which
+# is entirely about what it does when the backend behaves and when it does not. The real
+# ``S3StorageAdapter`` is covered by the uploads tests.
+#
+# THE ASYNC-FROM-SYNC LEG IS NOT INCIDENTAL. ``get_native_artifact`` and the pre-warm
+# call ``store.read(...)`` / ``store.write(...)`` with no ``await``, from inside a
+# running event loop, while ``StorageAdapter`` is async throughout. A bridge that only
+# works when no loop is running would pass a naive unit test and then raise
+# "asyncio.run() cannot be called from a running event loop" on the first real preview —
+# so ``TestFromInsideARunningLoop`` exercises both halves in an async test, which is the
+# production call shape.
+#
+# What these prove:
+#   * round-trip — a write then a read returns the same (body_html, css);
+#   * the key is ``(pocket_id, content_hash)``, the filesystem store's pair, unchanged;
+#   * all three fallback arms degrade to a rebuild and never raise: a cold MISS, a
+#     CORRUPT object, and a FAILED WRITE (plus a hung backend on either side);
+#   * THE CAPTURE KEY NEVER REACHES BLOB STORAGE — a rendered payload carrying a
+#     ``site_key_...`` value is refused outright rather than stored, from either field;
+#   * an ordinary artifact is not caught by that guard (it is a real cache, not a
+#     permanently-closed one);
+#   * selection is env-driven and DEFAULTS to the filesystem store, so OSS installs and
+#     local dev are unchanged, and a box that cannot build an adapter falls back rather
+#     than failing a preview.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+
+import pytest
+from pocketpaw_ee.sites import artifact_store_s3 as mod
+from pocketpaw_ee.sites import service as sites_service
+
+BODY = "<section data-uid='Hero:0'><h1>Hello</h1></section>"
+CSS = ".hero{color:red}"
+
+
+class _FakeAdapter:
+    """The two ``StorageAdapter`` methods the artifact store actually uses, in memory.
+
+    ``open`` is an async GENERATOR, like the real S3 adapter's — so a missing key raises
+    on the first ``__anext__``, not at the call. Getting that wrong in the fake would
+    hide a bridge that never iterates the stream.
+    """
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.puts: list[tuple[str, str]] = []
+        self.put_error: Exception | None = None
+        self.open_error: Exception | None = None
+        self.delay_sec: float = 0.0
+
+    async def put(self, key: str, stream, mime: str):  # noqa: ANN001 — duck-typed seam
+        if self.delay_sec:
+            await asyncio.sleep(self.delay_sec)
+        if self.put_error is not None:
+            raise self.put_error
+        buf = b""
+        async for chunk in stream:
+            buf += chunk
+        self.objects[key] = buf
+        self.puts.append((key, mime))
+
+    async def open(self, key: str):
+        if self.delay_sec:
+            await asyncio.sleep(self.delay_sec)
+        if self.open_error is not None:
+            raise self.open_error
+        if key not in self.objects:
+            from pocketpaw.uploads.errors import NotFound
+
+            raise NotFound(f"missing: {key}")
+        yield self.objects[key]
+
+
+@pytest.fixture(autouse=True)
+def _clean_selection(monkeypatch):
+    """Neither env knob may be inherited from the developer's shell, and the process
+    adapter cache must not leak between cases that flip them."""
+    monkeypatch.delenv("PAW_SITES_ARTIFACT_STORE", raising=False)
+    monkeypatch.delenv("POCKETPAW_UPLOAD_ADAPTER", raising=False)
+    monkeypatch.delenv("PAW_SITES_ARTIFACT_S3_TIMEOUT_SEC", raising=False)
+    mod.reset_shared_adapter()
+    yield
+    mod.reset_shared_adapter()
+
+
+@pytest.fixture
+def store_and_adapter():
+    adapter = _FakeAdapter()
+    return mod.S3ArtifactStore(adapter), adapter
+
+
+class TestTheRoundTrip:
+    def test_a_write_then_a_read_returns_the_same_artifact(self, store_and_adapter):
+        store, adapter = store_and_adapter
+
+        store.write("pocketA", "hash1", BODY, CSS)
+        assert store.read("pocketA", "hash1") == (BODY, CSS)
+        assert adapter.puts == [("site-artifacts/pocketA/hash1.json", "application/json")]
+
+    def test_the_key_is_the_pocket_id_and_content_hash_pair(self, store_and_adapter):
+        """The filesystem store writes ``<pocket_id>/<hash>.json``. Changing the pair, or
+        its order, would make the two stores address different artifacts and silently
+        invalidate every cached render on a backend switch."""
+        store, adapter = store_and_adapter
+
+        store.write("pocketA", "hash1", BODY, CSS)
+
+        assert "site-artifacts/pocketA/hash1.json" in adapter.objects
+        assert mod.artifact_key("pocketA", "hash1") == "site-artifacts/pocketA/hash1.json"
+
+    def test_the_stored_payload_is_the_filesystem_stores_shape(self, store_and_adapter):
+        """``{body_html, css, stored_at}`` — the same JSON ``_FilesystemArtifactStore``
+        writes, so the two are interchangeable for anything that reads an artifact."""
+        store, adapter = store_and_adapter
+
+        store.write("pocketA", "hash1", BODY, CSS)
+
+        data = json.loads(adapter.objects["site-artifacts/pocketA/hash1.json"])
+        assert data["body_html"] == BODY
+        assert data["css"] == CSS
+        assert data["stored_at"]
+
+    def test_two_pockets_do_not_collide_on_a_shared_hash(self, store_and_adapter):
+        """Identical source in two pockets hashes identically; the pocket id is what
+        keeps one tenant's artifact out of another's read."""
+        store, _ = store_and_adapter
+
+        store.write("pocketA", "same", "<b>A</b>", ".a{}")
+        store.write("pocketB", "same", "<b>B</b>", ".b{}")
+
+        assert store.read("pocketA", "same") == ("<b>A</b>", ".a{}")
+        assert store.read("pocketB", "same") == ("<b>B</b>", ".b{}")
+
+
+class TestEveryFailureDegradesToARebuild:
+    """Best-effort on both sides, matching the filesystem store: a read returns None so
+    the caller rebuilds, and a write is swallowed so the render still returns."""
+
+    def test_a_cold_key_is_a_miss_not_an_error(self, store_and_adapter):
+        store, _ = store_and_adapter
+        assert store.read("pocketA", "never-written") is None
+
+    def test_a_corrupt_object_is_a_miss(self, store_and_adapter):
+        store, adapter = store_and_adapter
+        adapter.objects["site-artifacts/pocketA/hash1.json"] = b"{ not json"
+
+        assert store.read("pocketA", "hash1") is None
+
+    def test_an_object_missing_a_field_is_a_miss(self, store_and_adapter):
+        store, adapter = store_and_adapter
+        adapter.objects["site-artifacts/pocketA/hash1.json"] = json.dumps(
+            {"body_html": BODY}
+        ).encode()
+
+        assert store.read("pocketA", "hash1") is None
+
+    def test_a_non_string_field_is_a_miss(self, store_and_adapter):
+        """A JSON object of the right shape but the wrong types would otherwise be handed
+        to a caller that unpacks it into two strings."""
+        store, adapter = store_and_adapter
+        adapter.objects["site-artifacts/pocketA/hash1.json"] = json.dumps(
+            {"body_html": BODY, "css": {"not": "a string"}}
+        ).encode()
+
+        assert store.read("pocketA", "hash1") is None
+
+    def test_an_unreachable_backend_reads_as_a_miss(self, store_and_adapter):
+        store, adapter = store_and_adapter
+        adapter.open_error = RuntimeError("bucket unreachable")
+
+        assert store.read("pocketA", "hash1") is None
+
+    def test_a_failed_write_is_swallowed(self, store_and_adapter):
+        """The render has already succeeded by the time write() is called. Raising here
+        would turn a healthy preview into a 500 because a cache was full."""
+        store, adapter = store_and_adapter
+        adapter.put_error = RuntimeError("access denied")
+
+        store.write("pocketA", "hash1", BODY, CSS)  # must not raise
+
+        assert adapter.objects == {}
+
+    def test_a_hung_backend_does_not_block_forever(self, store_and_adapter):
+        """The seam is sync and runs on the request's event loop, so an unbounded wait
+        wedges the loop rather than slowing one preview. Both sides carry the deadline."""
+        store, adapter = store_and_adapter
+        adapter.delay_sec = 5.0
+        store._timeout = 0.05
+
+        assert store.read("pocketA", "hash1") is None
+        store.write("pocketA", "hash1", BODY, CSS)  # must not raise
+        assert adapter.objects == {}
+
+
+class TestTheCaptureKeyNeverReachesBlobStorage:
+    """The per-site capture key's exposure was only ever acceptable because it lives in a
+    container that is then destroyed (see ``build_job`` / ``daytona_runner`` headers).
+    Blob storage is durable, so the write path refuses a payload carrying one."""
+
+    def _real_shaped_key(self) -> str:
+        # The exact mint used by service._build_native_artifact and Site.rotate.
+        return f"site_key_{secrets.token_urlsafe(24)}"
+
+    def test_a_body_carrying_a_capture_key_is_never_stored(self, store_and_adapter):
+        store, adapter = store_and_adapter
+        key = self._real_shaped_key()
+        body = (
+            '<form action="/capture/form">'
+            f'<input type="hidden" name="paw_key" value="{key}">'
+            "</form>"
+        )
+
+        store.write("pocketA", "hash1", body, CSS)
+
+        assert adapter.puts == [], "the artifact was uploaded instead of being refused"
+        # The invariant, asserted over the bytes rather than over "nothing was written":
+        # it still holds a future implementation that stores a scrubbed copy to the same
+        # standard, which "objects == {}" would not.
+        assert not any(key.encode() in blob for blob in adapter.objects.values()), (
+            "a per-site capture key reached durable blob storage"
+        )
+
+    def test_a_stylesheet_carrying_a_capture_key_is_never_stored(self, store_and_adapter):
+        """Both fields are scanned. Guarding only the field the key is expected in is how
+        the next substitution site gets missed."""
+        store, adapter = store_and_adapter
+        css = f'.x{{content:"{self._real_shaped_key()}"}}'
+
+        store.write("pocketA", "hash1", BODY, css)
+
+        assert adapter.objects == {}
+
+    def test_a_refusal_reads_back_as_a_miss_so_the_caller_rebuilds(self, store_and_adapter):
+        """Refusing is not an error path — it collapses into the store's existing
+        best-effort contract, which the caller already handles by rebuilding."""
+        store, _ = store_and_adapter
+
+        store.write("pocketA", "hash1", f"<p>{self._real_shaped_key()}</p>", CSS)
+
+        assert store.read("pocketA", "hash1") is None
+
+    def test_an_ordinary_artifact_is_not_caught_by_the_guard(self, store_and_adapter):
+        """A guard that refuses everything is indistinguishable from a broken cache. The
+        near-miss strings here are the ones a real page can plausibly contain."""
+        store, adapter = store_and_adapter
+        body = (
+            "<p>Set your site_key_ in the dashboard</p>"
+            "<code>site_key_short</code>"
+            "<a href='/docs/site-keys'>site keys</a>"
+        )
+
+        store.write("pocketA", "hash1", body, CSS)
+
+        assert store.read("pocketA", "hash1") == (body, CSS)
+
+    def test_the_detector_recognises_a_real_key_anywhere_in_the_payload(self):
+        key = self._real_shaped_key()
+        assert mod.carries_capture_key(f"prefix {key} suffix")
+        assert mod.carries_capture_key("clean", f"<i>{key}</i>")
+        assert not mod.carries_capture_key(BODY, CSS)
+        assert not mod.carries_capture_key("site_key_", "site_key_tooshort")
+
+
+class TestFromInsideARunningLoop:
+    """The production call shape: a SYNC store call made from inside a running event
+    loop. ``asyncio.run`` raises there, so a bridge that skips the worker thread passes
+    every test above and fails on the first real preview."""
+
+    async def test_read_and_write_work_with_a_loop_already_running(self, store_and_adapter):
+        store, _ = store_and_adapter
+        assert asyncio.get_running_loop() is not None
+
+        store.write("pocketA", "hash1", BODY, CSS)
+
+        assert store.read("pocketA", "hash1") == (BODY, CSS)
+
+    async def test_the_calling_loop_still_works_afterwards(self, store_and_adapter):
+        """A bridge that closed or stole the caller's loop would only show up here."""
+        store, _ = store_and_adapter
+
+        store.write("pocketA", "hash1", BODY, CSS)
+        await asyncio.sleep(0)
+
+        assert store.read("pocketA", "hash1") == (BODY, CSS)
+
+
+class TestSelectingTheStore:
+    def test_the_default_is_the_filesystem_store(self):
+        """Unset env keeps OSS installs and local dev byte-for-byte on the prior store."""
+        assert mod.shared_artifact_store() is None
+        assert isinstance(
+            sites_service._default_artifact_store(), sites_service._FilesystemArtifactStore
+        )
+
+    def test_an_unrecognised_mode_is_the_filesystem_store(self, monkeypatch):
+        monkeypatch.setenv("PAW_SITES_ARTIFACT_STORE", "gcs")
+        assert mod.shared_artifact_store() is None
+        assert isinstance(
+            sites_service._default_artifact_store(), sites_service._FilesystemArtifactStore
+        )
+
+    def test_s3_mode_selects_the_shared_store(self, monkeypatch):
+        adapter = _FakeAdapter()
+        monkeypatch.setenv("PAW_SITES_ARTIFACT_STORE", "s3")
+        monkeypatch.setattr(mod, "_shared_adapter", lambda: adapter)
+
+        selected = sites_service._default_artifact_store()
+
+        assert isinstance(selected, mod.S3ArtifactStore)
+        selected.write("pocketA", "hash1", BODY, CSS)
+        assert "site-artifacts/pocketA/hash1.json" in adapter.objects
+
+    def test_mode_matching_ignores_case_and_padding(self, monkeypatch):
+        monkeypatch.setenv("PAW_SITES_ARTIFACT_STORE", "  S3 ")
+        monkeypatch.setattr(mod, "_shared_adapter", lambda: _FakeAdapter())
+
+        assert isinstance(mod.shared_artifact_store(), mod.S3ArtifactStore)
+
+    def test_an_unbuildable_adapter_falls_back_instead_of_failing_a_preview(self, monkeypatch):
+        """``build_adapter`` raises when POCKETPAW_UPLOAD_ADAPTER=s3 and no bucket is
+        configured. A preview must degrade to the local store, not 500."""
+        monkeypatch.setenv("PAW_SITES_ARTIFACT_STORE", "s3")
+        monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
+        monkeypatch.delenv("S3_PRIVATE_BUCKET", raising=False)
+        monkeypatch.delenv("S3_BUCKET", raising=False)
+
+        assert mod.shared_artifact_store() is None
+        assert isinstance(
+            sites_service._default_artifact_store(), sites_service._FilesystemArtifactStore
+        )
+
+    def test_a_failed_adapter_build_is_not_retried_on_every_preview(self, monkeypatch):
+        calls: list[int] = []
+
+        def _boom(_root):
+            calls.append(1)
+            raise RuntimeError("no bucket")
+
+        monkeypatch.setenv("PAW_SITES_ARTIFACT_STORE", "s3")
+        monkeypatch.setattr("pocketpaw.uploads.factory.build_adapter", _boom)
+
+        assert mod.shared_artifact_store() is None
+        assert mod.shared_artifact_store() is None
+
+        assert len(calls) == 1, "a box with no S3 config must not rebuild (and log) per view"

--- a/tests/mutations/sites_s3_artifact_store.json
+++ b/tests/mutations/sites_s3_artifact_store.json
@@ -1,0 +1,139 @@
+[
+  {
+    "label": "the write path stops checking for a capture key, so a rendered body carrying a real per-site secret is uploaded into durable blob storage — the exact exposure the ephemeral-container decision in build_job / daytona_runner rests on NOT happening",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "        if carries_capture_key(body_html, css):",
+    "replace": "        if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestTheCaptureKeyNeverReachesBlobStorage"
+    ]
+  },
+  {
+    "label": "the guard scans only body_html, so a key substituted into the stylesheet half of the artifact is stored — a payload is two fields and checking one of them is how the next substitution site gets missed",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "        if carries_capture_key(body_html, css):",
+    "replace": "        if carries_capture_key(body_html):",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestTheCaptureKeyNeverReachesBlobStorage::test_a_stylesheet_carrying_a_capture_key_is_never_stored"
+    ]
+  },
+  {
+    "label": "the key detector requires the token at the START of a value, so the real case — a key substituted INTO a rendered hidden input, mid-document — never matches and the guard is decorative",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "    return any(_CAPTURE_KEY_RE.search(value) for value in values if isinstance(value, str))",
+    "replace": "    return any(_CAPTURE_KEY_RE.match(value) for value in values if isinstance(value, str))",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestTheCaptureKeyNeverReachesBlobStorage"
+    ]
+  },
+  {
+    "label": "the refusal logs and then writes anyway — the operator sees a warning saying the artifact was refused while the secret sits in the bucket, which is worse than no guard because it reads as covered",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "                pocket_id,\n            )\n            return\n\n        key = artifact_key(pocket_id, content_hash)",
+    "replace": "                pocket_id,\n            )\n\n        key = artifact_key(pocket_id, content_hash)",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestTheCaptureKeyNeverReachesBlobStorage::test_a_body_carrying_a_capture_key_is_never_stored"
+    ]
+  },
+  {
+    "label": "a read failure propagates instead of degrading to a MISS, so an unreachable bucket / denied credentials turns every preview into a 500 rather than a rebuild — a cache outage becomes a site outage",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "            raw = _run_coro(_read_all(self._adapter.open(key)), self._timeout)\n        except Exception:",
+    "replace": "            raw = _run_coro(_read_all(self._adapter.open(key)), self._timeout)\n        except ZeroDivisionError:",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestEveryFailureDegradesToARebuild::test_a_cold_key_is_a_miss_not_an_error",
+      "tests/ee/sites/test_artifact_store_s3.py::TestEveryFailureDegradesToARebuild::test_an_unreachable_backend_reads_as_a_miss"
+    ]
+  },
+  {
+    "label": "a corrupt or truncated object is handed to the caller instead of read as a MISS, so a half-written artifact is unpacked as two strings and the preview fails on data the store itself stored",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "        except (ValueError, KeyError, TypeError):\n            logger.debug(\"sites.artifact_store_s3: corrupt artifact at %s\", key)\n            return None",
+    "replace": "        except (KeyError, TypeError):\n            logger.debug(\"sites.artifact_store_s3: corrupt artifact at %s\", key)\n            return None",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestEveryFailureDegradesToARebuild::test_a_corrupt_object_is_a_miss"
+    ]
+  },
+  {
+    "label": "a failed write is re-raised, so a full / denied / unreachable bucket breaks the preview that had already rendered successfully — the cache write is the last thing get_native_artifact does before returning",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "            logger.warning(\n                \"sites.artifact_store_s3: write failed for pocket %s\", pocket_id, exc_info=True\n            )",
+    "replace": "            raise",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestEveryFailureDegradesToARebuild::test_a_failed_write_is_swallowed"
+    ]
+  },
+  {
+    "label": "the blob round-trip loses its deadline, so a wedged bucket blocks the SYNC store call — which runs on the request's event loop — until the socket gives up, stalling every other request on that replica and not just this preview",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "        return executor.submit(asyncio.run, coro).result(timeout=timeout)",
+    "replace": "        return executor.submit(asyncio.run, coro).result()",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestEveryFailureDegradesToARebuild::test_a_hung_backend_does_not_block_forever"
+    ]
+  },
+  {
+    "label": "the sync->async bridge calls asyncio.run directly on the caller's thread, so the store works in a unit test and raises 'cannot be called from a running event loop' on the first real preview — every call site is inside a running loop",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=\"paw-artifact-blob\")",
+    "replace": "    if True:\n        return asyncio.run(coro)\n    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=\"paw-artifact-blob\")",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestFromInsideARunningLoop"
+    ]
+  },
+  {
+    "label": "the blob key drops the content hash, so every render of a pocket overwrites the same object and a stale artifact is served for source it was never built from — the cache stops being keyed on what it caches",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "    return f\"{ARTIFACT_KEY_PREFIX}/{pocket_id}/{content_hash}.json\"",
+    "replace": "    return f\"{ARTIFACT_KEY_PREFIX}/{pocket_id}.json\"",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestTheRoundTrip::test_the_key_is_the_pocket_id_and_content_hash_pair"
+    ]
+  },
+  {
+    "label": "the blob key drops the pocket id, so two pockets whose source hashes identically share one object — a cross-tenant read of a rendered page, through a store whose only isolation IS the key",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "    return f\"{ARTIFACT_KEY_PREFIX}/{pocket_id}/{content_hash}.json\"",
+    "replace": "    return f\"{ARTIFACT_KEY_PREFIX}/{content_hash}.json\"",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestTheRoundTrip::test_two_pockets_do_not_collide_on_a_shared_hash",
+      "tests/ee/sites/test_artifact_store_s3.py::TestTheRoundTrip::test_the_key_is_the_pocket_id_and_content_hash_pair"
+    ]
+  },
+  {
+    "label": "the store defaults to blob storage instead of the filesystem, so every OSS install and every local dev box starts writing site artifacts at whatever adapter is configured — the opposite of the opt-in this was specified as",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "    return (os.environ.get(\"PAW_SITES_ARTIFACT_STORE\") or _MODE_FILESYSTEM).strip().lower()",
+    "replace": "    return (os.environ.get(\"PAW_SITES_ARTIFACT_STORE\") or _MODE_S3).strip().lower()",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestSelectingTheStore::test_the_default_is_the_filesystem_store"
+    ]
+  },
+  {
+    "label": "an unbuildable adapter (POCKETPAW_UPLOAD_ADAPTER=s3 with no bucket configured) propagates out of the selector, so a misconfigured deploy fails every preview with a 500 instead of degrading to the local store",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "        _adapter = build_adapter(LOCAL_ADAPTER_ROOT)\n    except Exception:",
+    "replace": "        _adapter = build_adapter(LOCAL_ADAPTER_ROOT)\n    except ZeroDivisionError:",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestSelectingTheStore::test_an_unbuildable_adapter_falls_back_instead_of_failing_a_preview"
+    ]
+  },
+  {
+    "label": "a failed adapter build is retried on every call, so a box with no S3 credentials re-runs the construction and logs the same warning once per preview — the log that would have told an operator what is wrong becomes the noise that hides it",
+    "file": "ee/pocketpaw_ee/sites/artifact_store_s3.py",
+    "find": "    if _adapter_failed:\n        return None",
+    "replace": "    if False:\n        return None",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestSelectingTheStore::test_a_failed_adapter_build_is_not_retried_on_every_preview"
+    ]
+  },
+  {
+    "label": "the service stops consulting the shared store, so PAW_SITES_ARTIFACT_STORE=s3 is silently ignored and a deploy that believes its artifacts are shared across replicas is still on per-container disk",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return shared_artifact_store() or _DEFAULT_ARTIFACT_STORE",
+    "replace": "    return _DEFAULT_ARTIFACT_STORE",
+    "tests": [
+      "tests/ee/sites/test_artifact_store_s3.py::TestSelectingTheStore::test_s3_mode_selects_the_shared_store"
+    ]
+  }
+]


### PR DESCRIPTION
Preview artifacts are cached as `{body_html, css}` keyed on `(pocket_id, content_hash)`. Today they land on the container's own disk, so a redeploy empties the cache and a second replica cannot read what the first one built. A miss costs a full `bun install` plus a build, which is the difference between a preview that feels instant and one that feels broken.

This adds an opt-in blob-storage store behind the existing `_store` seam. `PAW_SITES_ARTIFACT_STORE=s3` selects it. Unset stays on the filesystem store, so OSS installs and local dev are unchanged.

It talks to the low-level `StorageAdapter` rather than `EEUploadService`. That service wants a FastAPI `UploadFile`, mints a Mongo `FileRecord`, and runs chat-membership checks; an artifact store wants none of it.

Best-effort in both directions, matching the store it replaces. A miss, a corrupt object, or an unreachable bucket reads as a cache miss and the caller rebuilds. A failed write is logged and swallowed. A cache outage must not become a site outage, and the write is the last thing `get_native_artifact` does after a render has already succeeded.

## The capture key does not go in the bucket

A svelte scaffold substitutes a real per-site `captureSignedKey` into the rendered output, and `_resolve_capture_tokens` puts it in every text entry plus any form's hidden input — so it can land in either half of the payload. The whole reason that exposure was accepted is that the key lives only in a container that is then destroyed, which is also why the Daytona lane never snapshots a sandbox. Blob storage is durable in exactly the way that decision was avoiding.

So an artifact carrying one is **refused, not scrubbed**. A scrubbed artifact would be a mangled artifact cached as if it were real. Both fields are scanned.

## Tests

24 new tests. Store plus its direct consumers, run in a clean worktree:

```
47 passed in 7.62s
```

Mutation plan `tests/mutations/sites_s3_artifact_store.json`, 15 entries:

```
all 15 mutations caught
```

Those cover the security guard three ways, plus cross-tenant key collision, a corrupt object served as valid, a wedged bucket stalling the request loop, `asyncio.run` on a live loop, and the store silently defaulting to blob storage instead of disk.

## Also here

`tests/ee/sites/conftest.py` clears `PAW_SITES_ARTIFACT_STORE` in the autouse fixture. The existing knob only points the store somewhere; this one selects it, so a developer with it set to `s3` would have the whole test tree writing at their own bucket.

## Known follow-up

`_default_artifact_store()` now returns `Any` where it used to return the concrete class. A `Protocol` would match the repo's convention better. Left alone deliberately: one of the mutation anchors targets that function, and editing anchored code is how a mutation quietly stops matching.