### PR TITLE
Build the draft preview in a sandbox instead of in the API container

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -97,6 +97,14 @@ rebuild — dynamic-source split + input-keyspace confinement) and GET
 /sites/by-pocket/{id}/native-artifact (serve the armed build's body_html + css
 for shadow render — per-GET arm-build cost, path-traversal-guarded CSS reader).
 
+Updated: 2026-08-24 (SP-2) — GET /sites/by-pocket/{id}/native-artifact has two
+response shapes now. A cold miss no longer builds in the API container (there is
+no bun there, so it 5xx'd as sites.generator_failed on every cold preview); it
+queues the armed build in an ephemeral Daytona sandbox and returns
+build_status / build_reason / build_job_id with body_html and css empty. A cache
+hit is unchanged and still costs nothing. An enqueue that fails is a 503
+(sites.preview_build_unavailable), never a job id for a job nobody will run.
+
 Updated: 2026-07-27 (feat/growth-g1) — documented the Growth — Prospects
 section: workspace-scoped prospect store under /growth/prospects (create /
 get / list with tier|status|source filters / update), domain-deduped per
@@ -1390,13 +1398,19 @@ map). Both armable engines emit a prerendered `index.html`; only the build outpu
 directory differs (`.svelte-kit/cloudflare` or `build` vs `dist`), and the server
 resolves that per engine.
 
-Response `200`:
+**Two response shapes, and `build_status` says which.** A warm read returns the
+render; a cold one returns a build to poll.
+
+Response `200` — the **render** (cache hit):
 
 ```json
 {
   "pocket_id": "p_abc123",
   "body_html": "<div data-uid=\"Hero:root:0\">…<script id=\"paw-edit-manifest\">…</script></div>",
-  "css": "/* concatenated stylesheets */"
+  "css": "/* concatenated stylesheets */",
+  "build_status": "none",
+  "build_reason": null,
+  "build_job_id": null
 }
 ```
 
@@ -1405,17 +1419,44 @@ Response `200`:
   frontend injects it into a shadow root.
 - `css` is the built stylesheet(s) — inline `<style>` blocks plus every linked
   stylesheet — concatenated into one string, injected as a single `<style>`.
+- `build_status` is `"none"` — a served render is not a build in any state.
 
-**Read-through cache — a plain view no longer rebuilds.** The endpoint hashes the
+Response `200` — **build pending** (cache miss, SP-2):
+
+```json
+{
+  "pocket_id": "p_abc123",
+  "body_html": "",
+  "css": "",
+  "build_status": "queued",
+  "build_reason": null,
+  "build_job_id": "site-preview-p_abc123-9f2c…"
+}
+```
+
+- `body_html` and `css` are empty strings, not null — the field types never change
+  between the two shapes.
+- `build_status` is `queued` (this call started the build), `building` (one was
+  already in flight for this exact render), or `failed` (a build of this exact
+  render already finished without producing an artifact). The vocabulary is the
+  publish lane's, unchanged, and **an unrecognised value means in-progress**.
+- `build_reason` carries a rung name on a failure (`build_failed:…`,
+  `scaffold_failed:…`, `sandbox_unavailable:…`, `preview_unreadable:…`) — never the
+  build's stderr, which stays in the worker log.
+- `build_job_id` is the handle to poll with. **Re-fetch this endpoint** until
+  `build_status` reads `"none"`, which is the render shape above.
+
+**One render is one sandbox.** The job id is derived from the same content hash the
+cache is keyed on, so polling during a build addresses the job already running
+rather than queueing another. A source change produces a different hash and
+therefore a different job.
+
+**Read-through cache — a plain view never builds.** The endpoint hashes the
 pocket's render inputs (source map + theme + builder origin + engine + generator
 version) and serves a prior render from the on-disk artifact store
 (`~/.pocketpaw/site-artifacts/<pocket_id>/<hash>.json`) on a **cache hit** — zero
-subprocess builds. It builds once only on a **cold miss** (then stores the result),
-and publishing a site plus every source-changing edit **pre-warm** the store in the
-background, so a live/clean site is a hit and a view never triggers a build. A cold
-miss's build is keyed on `pocket_id` in a stable directory, so `node_modules` /
-`bun install` stay cached; it skips the SSR smoke fail-gate (`smoke=False`) but still
-emits the static output that is read.
+builds, zero sandboxes. Publishing a site and every source-changing edit **pre-warm**
+the store in the background, so a live/clean site is a hit.
 
 **Shared store (opt-in) — `PAW_SITES_ARTIFACT_STORE=s3`.** The on-disk store above is
 per-container, so on a multi-replica deploy a view routed to replica B misses what
@@ -1434,10 +1475,24 @@ that is then destroyed, so such a pocket rebuilds on every view instead of cachi
 eviction runs here (the on-disk store's `PAW_SITES_ARTIFACT_KEEP` does not apply); put a
 bucket lifecycle rule on the `site-artifacts/` prefix.
 
-**Auth is `fabric.write`, not a read scope,** because a cold miss still **arms a
-build**: it builds the pocket with a builder origin set so the generator stamps
-`data-uid` on the editable leaves and embeds the edit manifest — the endpoint can
-still trigger on-disk work, so it is not a pure read. The builder origin is resolved
+**A cold miss builds in an ephemeral Daytona sandbox, not in this process (SP-2).**
+It used to shell out to `bun` here, which works on a laptop and cannot work in the
+deployed API container — there is no toolchain, so every cold preview raised and
+reached users as `sites.generator_failed`. The build is now handed to the same
+ephemeral lane the async publish path has used since SL-3: the API scaffolds nothing
+and returns immediately, a worker scaffolds, installs and builds in a throwaway
+sandbox, and writes the resulting `{body_html, css}` into the artifact store under
+the content hash this call looked up. The per-site capture key is scrubbed out of the
+job payload before it reaches Redis or the sandbox.
+
+Because a miss now costs a sandbox rather than a local subprocess, the cache check is
+what keeps an editing session affordable — measured in-sandbox build times are 8.70s
+(react) and 14.67s (svelte), before sandbox create, upload and teardown.
+
+**Auth is `fabric.write`, not a read scope,** because a cold miss still **queues an
+armed build**: the build carries a builder origin so the generator stamps `data-uid`
+on the editable leaves and embeds the edit manifest — the endpoint spends a sandbox,
+so it is not a pure read. The builder origin is resolved
 from the request's `Origin` header, falling back to the configured
 `PAW_SITES_BUILDER_ORIGIN` when absent (the same precedence as `/editable` and
 `/dev-preview`), so the call works with no header.
@@ -1469,7 +1524,7 @@ Errors:
 | 422 | `pocket.no_native_edit_lane` | The pocket's engine has no armable build to render (html, ripple). Renamed from `pocket.not_svelte_site` in RX-2, when react joined the lane. |
 | 404 | `pocket.not_found` | Unknown pocket id. |
 | 403 | `pocket.access_denied` | The caller lacks access to the pocket. |
-| 500 | `sites.generator_failed` | The arm build failed (missing toolchain, non-zero build, or smoke-gate failure). |
+| 503 | `sites.preview_build_unavailable` | The armed build could not be QUEUED (the job queue is unreachable). Retryable. A failed enqueue is deliberately an error rather than a pending response — a job id for a job nobody will run makes a client poll forever. A build that queues and then FAILS is not an error here: it comes back `200` with `build_status: "failed"` and a rung in `build_reason`. |
 
 ## Ship — Managed Deploys
 

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -95,7 +95,11 @@ from pocketpaw_ee.sites.build_job import (
     ARQ_FUNCTION_NAME as SITE_BUILD_FUNCTION_NAME,
 )
 from pocketpaw_ee.sites.build_job import (
+    PREVIEW_ARQ_FUNCTION_NAME as SITE_PREVIEW_BUILD_FUNCTION_NAME,
+)
+from pocketpaw_ee.sites.build_job import (
     run_site_build,
+    run_site_preview_build,
     site_build_job_timeout_seconds,
 )
 
@@ -307,6 +311,17 @@ _site_build_fn = func(
     max_tries=1,
 )
 
+# SP-2: the DRAFT-PREVIEW build. Same sandbox, same budget (it is the same build — only
+# what happens to the artifact differs), and the same ``max_tries=1``: a preview is billed
+# per attempt too, and a client re-triggers by asking for the render again rather than by
+# arq silently re-running a job whose result already says why it failed.
+_site_preview_build_fn = func(
+    run_site_preview_build,
+    name=SITE_PREVIEW_BUILD_FUNCTION_NAME,
+    timeout=site_build_job_timeout_seconds(),
+    max_tries=1,
+)
+
 
 class WorkerSettings:
     """arq worker configuration. Loaded by ``arq <dotted-path>``."""
@@ -321,6 +336,7 @@ class WorkerSettings:
         _ship_provision_fn,
         _ship_deploy_fn,
         _site_build_fn,
+        _site_preview_build_fn,
     ]
     on_startup = _startup
     on_shutdown = _shutdown

--- a/ee/pocketpaw_ee/sites/build_job.py
+++ b/ee/pocketpaw_ee/sites/build_job.py
@@ -24,6 +24,38 @@
 # nothing. That is not dead code — a build queued to verify an artifact is a real use of
 # this lane, and it is what the fault-ladder tests drive.
 #
+# Edited 2026-08-24 (SP-2): THE LANE GREW A SECOND JOB — :func:`run_site_preview_build`,
+# for the DRAFT PREVIEW the native editor shadow-renders. Preview used to build inline in
+# the API container (``service._build_native_artifact`` → ``generator.build`` → ``bun``),
+# which in the deployed container fails and surfaces as ``sites.generator_failed``. It now
+# rides the same sandbox this module already drives.
+#
+# IT IS A SEPARATE JOB RATHER THAN A FLAG ON ``run_site_build``, and the reason is the
+# thing a preview does NOT have: a Site row. ``run_site_build`` opens by loading one
+# (``load_build_site``) and every step after that writes to it — ``mark_build_running``,
+# ``_record``, and the ``claim_build_queued`` its enqueue depends on. A DRAFT that was
+# never published has no Site row at all, which is precisely why ``get_native_artifact``
+# works on one. Threading "sometimes there is no row" through the publish job would put a
+# None-check on every write in the lane's most load-bearing function, to serve a caller
+# that also wants a different OUTPUT (``{body_html, css}`` in the artifact store, not a
+# deploy) and a different SINGLE-FLIGHT KEY (the content hash, not the site).
+#
+# THE SINGLE-FLIGHT KEY IS THE CONTENT HASH, AND IT IS THE arq JOB ID. The publish lane
+# guards with a conditional write to the Site row because that is the state it owns; with
+# no row, this lane spends the id instead: ``_preview_job_id`` is deterministic over
+# ``(pocket_id, content_hash)``, so arq itself refuses a second enqueue of a render that
+# is already in flight. That is not a lucky reuse of a refusal — it is the same guard,
+# keyed on the thing that actually distinguishes one preview build from another. Without
+# it a client polling a 15s build every 2s would open a sandbox per poll.
+#
+# ``_mint_job_id``'s warning about deterministic ids still stands and is answered rather
+# than ignored: a completed job's RESULT holds the id for ``keep_result`` (an hour), so a
+# refused enqueue is inspected (:func:`_preview_job_outcome`) instead of assumed to be in
+# flight. A build that already FINISHED and left the store empty is reported as failed,
+# with its reason — not as a build that is still coming. Re-enqueueing there instead
+# would put a polling client in a rebuild loop, one sandbox per build duration, on inputs
+# that just failed.
+#
 # WHICH ENGINES ARRIVE HERE IS DECIDED IN ``service.build_runs_async``, not here, and it is
 # react-only today. The reason is the artifact, not the queue: an adapter-cloudflare build
 # (ripple, dynamic svelte) emits pages rendered by a ``_worker.js`` whose imports sit
@@ -149,6 +181,7 @@ from typing import Any
 
 from arq import create_pool
 from arq.connections import ArqRedis, RedisSettings
+from arq.jobs import Job, JobStatus
 
 from pocketpaw_ee.sites import service as sites_service
 from pocketpaw_ee.sites.build_state import BuildStatus, settle
@@ -167,6 +200,11 @@ logger = logging.getLogger(__name__)
 #: pins its own: an enqueue name and a registration name that drift produce a job that
 #: sits in Redis forever with no worker willing to claim it, and no error anywhere.
 ARQ_FUNCTION_NAME = "run_site_build"
+
+#: The preview lane's own registered name (SP-2). Separate from the publish job's for the
+#: same reason the function is: a worker that registered one name for both would run a
+#: preview payload through the publish job's signature.
+PREVIEW_ARQ_FUNCTION_NAME = "run_site_preview_build"
 
 #: Engines this lane can build. Every one needs a per-site Node build AND emits its
 #: output into a SUBDIRECTORY — ``artifact_tar_command`` refuses an engine whose output
@@ -233,6 +271,11 @@ RUNG_ENQUEUE_FAILED = "enqueue_failed"
 #: wrong, so blaming it would send them to debug a site that compiles. Retryable — a
 #: failed wrangler run or an unreachable Cloudflare is worth another publish.
 RUNG_DEPLOY_FAILED = "deploy_failed"
+#: SP-2. The preview build was clean and the artifact could not be turned into
+#: ``{body_html, css}`` — a tar that unpacked to no ``index.html``, or a store write that
+#: raised. Its own rung for the same reason :data:`RUNG_DEPLOY_FAILED` is: the user's
+#: build compiled, so naming this a build failure would send them to debug working code.
+RUNG_PREVIEW_UNREADABLE = "preview_unreadable"
 
 
 @dataclass(frozen=True)
@@ -884,24 +927,322 @@ async def enqueue_site_build(
     return job_id
 
 
+# ---------------------------------------------------------------------------
+# The PREVIEW lane (SP-2) — same sandbox, no Site row, and the artifact becomes
+# ``{body_html, css}`` in the native-artifact store instead of a deploy.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PreviewBuildEnqueue:
+    """What :func:`enqueue_preview_build` tells its caller to put on the wire.
+
+    ``status`` reuses the publish lane's vocabulary verbatim (``queued`` / ``building`` /
+    ``failed``) because the frontend already codes to it, and SL-3's contract that an
+    UNRECOGNISED status means in-progress only holds while nobody mints a second
+    vocabulary for the same idea.
+
+    ``reason`` is populated on ``failed`` only, and carries a RUNG — never stderr. The
+    same rule ``Site.build_reason`` follows, for the same reason: this value crosses to a
+    client, and a build's error text is the user's own content.
+    """
+
+    job_id: str
+    status: str
+    reason: str | None = None
+
+
+def _preview_job_id(pocket_id: str, content_hash: str) -> str:
+    """The arq id for one pocket's one render — and, being unique per render, the lane's
+    single-flight guard.
+
+    DELIBERATELY DETERMINISTIC, which is the opposite of :func:`_mint_job_id` and for a
+    reason that inverts its argument. There the id names a SITE, so a stable one refuses
+    every rebuild of that site for as long as a result lives. Here it names the exact
+    ``(pocket, render inputs)`` pair the store is keyed on, so "a job with this id already
+    exists" is exactly the question the caller is asking: is this render already being
+    built? A uuid tail would answer "no" every time and open a sandbox per poll.
+
+    The content hash is a sha256 hex digest, so the id is bounded and contains nothing
+    that needs escaping.
+    """
+    return f"site-preview-{pocket_id}-{content_hash}"
+
+
+async def _preview_job_outcome(pool: Any, job_id: str) -> tuple[str, str | None]:
+    """Read a REFUSED enqueue: is that id an in-flight build, or one that already ended?
+
+    Looked up on the module by :func:`enqueue_preview_build` (the ``_default_prewarm_scheduler``
+    convention) so a test can substitute it without faking arq's Redis surface.
+
+    Three answers, and the middle one is why this function exists at all:
+
+      * still queued / running → ``building``. The polling case, and the common one.
+      * COMPLETE → the store missed, so whatever that job did it did not leave a usable
+        artifact: report ``failed`` with its rung. Reporting ``building`` here would spin
+        a client forever on a build that is over; re-enqueueing would rebuild identical
+        inputs on a loop.
+      * gone (a result that expired between the enqueue and this read) → ``building``.
+        A pure race, and the next poll enqueues cleanly because the id is free again.
+    """
+    job = Job(job_id, pool)
+    status = await job.status()
+    if status is not JobStatus.complete:
+        return "building", None
+    info = await job.result_info()
+    if info is None:
+        return "building", None
+    if not info.success:
+        # The job raised. ``run_site_preview_build`` only re-raises for a sandbox it
+        # never reached, and the exception text can name paths, so the rung is all that
+        # travels.
+        return "failed", f"{RUNG_SANDBOX_UNAVAILABLE}:job_raised"
+    result = info.result
+    if isinstance(result, dict):
+        return str(result.get("status") or "failed"), result.get("reason")
+    return "failed", "preview_result_unreadable"
+
+
+def _store_preview_artifact(
+    artifact: bytes,
+    *,
+    engine: str,
+    pocket_id: str,
+    content_hash: str,
+    output_rel: str,
+    store: Any,
+) -> None:
+    """Turn the built tar into ``{body_html, css}`` and cache it under the content hash.
+
+    The preview lane's answer to :func:`_deploy_built_artifact`, and it borrows that
+    function's two hard-won decisions rather than re-deciding them: the tar is unpacked
+    through ``artifact_preview.unpack_artifact`` (the extractor whose path-escape and
+    zip-bomb guards each have a mutation proving they fire), and it is unpacked UNDER
+    ``output_rel`` — the same rel the tar was PACKED from — because the reader probes for
+    the engine's static output dir and a flat extraction leaves it nothing to find.
+
+    THE SERVER-ENTRY REFUSAL THE DEPLOY MAKES IS DELIBERATELY ABSENT. There it matters
+    because dropping ``_worker.js`` deploys a shell that cannot start. Here nothing is
+    deployed and the reader only ever opens ``index.html``, which is the same file the
+    inline arm build read off disk — so a worker-rendered site previews exactly as
+    poorly as it did before this lane existed, and no worse.
+
+    Synchronous, and deliberately: every step is blocking work (untar, read, write) and
+    the store seam (``service._default_artifact_store``) is sync — the same one
+    ``get_native_artifact`` reads through, so an S3 or other backend swapped in there is
+    picked up here for free. An ``async def`` with no awaits would only add indirection.
+
+    Raises on an unreadable tree or a failed read; the caller settles that as
+    :data:`RUNG_PREVIEW_UNREADABLE`.
+    """
+    from pocketpaw_ee.sites import artifact_preview
+
+    project_dir = tempfile.mkdtemp(prefix="paw-preview-")
+    try:
+        unpacked = artifact_preview.unpack_artifact(artifact, Path(project_dir, output_rel))
+        body_html, css = sites_service._read_native_artifact(project_dir, engine)
+        logger.info(
+            "sites.preview: materialised %d entries (%d bytes) under %s for pocket %s",
+            unpacked.entries,
+            unpacked.bytes_written,
+            output_rel,
+            pocket_id,
+        )
+    finally:
+        shutil.rmtree(project_dir, ignore_errors=True)
+    store.write(pocket_id, content_hash, body_html, css)
+
+
+async def run_site_preview_build(
+    ctx: dict[str, Any],
+    pocket_id: str,
+    content_hash: str,
+    generator_input: dict[str, Any],
+    engine: str,
+    timeout_seconds: int,
+    *,
+    _runner: Any = None,
+    _client: Any = None,
+    _store: Any = None,
+) -> dict[str, str]:
+    """arq job: build a pocket's ARMED draft in a sandbox and cache the native artifact.
+
+    The same five steps :func:`run_site_build` runs — scaffold, refuse an empty tree,
+    build, classify, act on the verdict — with the last step writing ``{body_html, css}``
+    to the native-artifact store instead of deploying. ``ctx`` is unused; everything the
+    build needs rides the payload.
+
+    ``content_hash`` is carried rather than recomputed. It is the store's key AND this
+    job's id, and it was computed in the web process from the pocket read that decided to
+    enqueue. Recomputing it here from the payload would let a source that changed between
+    the enqueue and the run write this build's output under the NEW hash — caching a
+    render of the old source as if it were the new one.
+
+    RETURNS THE SETTLEMENT RATHER THAN WRITING IT. With no Site row there is nowhere to
+    record, so the outcome lives in the arq result — which is what a refused enqueue
+    reads (:func:`_preview_job_outcome`) to tell a poller "this render already failed"
+    instead of spinning it. The returned ``reason`` is a rung and never stderr, because
+    it crosses to a client.
+
+    NEVER RAISES FOR A BUILD OUTCOME, matching the publish job: a failed build, a timeout
+    and a lost sandbox are results. It DOES re-raise when the sandbox could not be reached
+    at all, after the settlement is already lost to the raise — the worker log is where
+    that condition belongs, and ``_preview_job_outcome`` maps the failed job back to the
+    ``sandbox_unavailable`` rung.
+    """
+    if not is_buildable_engine(engine):
+        # A routing bug — ``service.get_native_artifact`` gates on ``has_native_edit_lane``
+        # and every engine that passes it also builds here. Checked anyway rather than
+        # spending a sandbox to discover the day that stops being true.
+        logger.error(
+            "sites.preview: engine %r cannot build in this lane (pocket %s)", engine, pocket_id
+        )
+        return {
+            "status": "failed",
+            "reason": f"{RUNG_ENGINE_NOT_BUILDABLE}:{normalize_engine(engine)}",
+        }
+
+    from pocketpaw_ee.sites.generator_client import expected_static_output_rel
+
+    artifact_rel = expected_static_output_rel(engine, generator_input)
+    store = _store if _store is not None else sites_service._default_artifact_store()
+
+    work_dir = tempfile.mkdtemp(prefix=f"paw-preview-{pocket_id}-")
+    try:
+        try:
+            project_dir = await _scaffold(generator_input, work_dir, runner=_runner)
+        except Exception:
+            logger.exception("sites.preview: scaffold failed for pocket %s", pocket_id)
+            return {"status": "failed", "reason": f"{RUNG_SCAFFOLD_FAILED}:generator_raised"}
+
+        files = read_generated_tree(project_dir)
+        if not files:
+            logger.error("sites.preview: scaffold of pocket %s produced no files", pocket_id)
+            return {"status": "failed", "reason": f"{RUNG_SCAFFOLD_EMPTY}:no_files_generated"}
+
+        try:
+            result = await run_build(
+                files,
+                engine=normalize_engine(engine),
+                timeout_seconds=timeout_seconds,
+                client=_client,
+                artifact_rel=artifact_rel,
+            )
+        except Exception:
+            logger.exception("sites.preview: no sandbox for pocket %s", pocket_id)
+            raise
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+    settlement = resolve_build_settlement(result)
+    _log_outcome(f"preview:{pocket_id}", result, settlement)
+    if settlement.status != "built":
+        # ``settle`` can answer None to keep a publish attempt in flight between retries.
+        # This lane has no attempt loop and no row to leave in flight, so the caller gets
+        # a terminal answer — a poller with nothing coming must not be told to keep
+        # waiting.
+        return {"status": settlement.status or "failed", "reason": settlement.reason}
+
+    try:
+        _store_preview_artifact(
+            result.artifact or b"",
+            engine=engine,
+            pocket_id=pocket_id,
+            content_hash=content_hash,
+            output_rel=artifact_rel,
+            store=store,
+        )
+    except Exception:
+        logger.exception(
+            "sites.preview: pocket %s built cleanly and the artifact could not be read",
+            pocket_id,
+        )
+        return {"status": "failed", "reason": f"{RUNG_PREVIEW_UNREADABLE}:read_or_store_raised"}
+
+    return {"status": "built", "reason": settlement.reason}
+
+
+async def enqueue_preview_build(
+    *,
+    pocket_id: str,
+    content_hash: str,
+    engine: str,
+    generator_input: dict[str, Any],
+    timeout_seconds: int | None = None,
+    _pool_override: Any = None,
+) -> PreviewBuildEnqueue:
+    """Queue a preview build for one render, or report the one already running.
+
+    No claim write, because there is no row to claim: the deterministic job id IS the
+    single-flight guard (see :func:`_preview_job_id`). arq refuses a duplicate id by
+    returning ``None``, and that refusal is inspected rather than assumed — a render that
+    already finished and left the store empty comes back ``failed``, not ``building``.
+
+    THE FAILURE MODE THIS EXISTS TO PREVENT IS A SILENT ONE. A dead Redis, or an arq that
+    cannot take the job, must NOT return a job id and a ``queued`` status — a client that
+    got one would poll a build nobody will run, forever, with the endpoint reporting
+    progress the whole time. So an enqueue failure RAISES, and the service turns it into
+    an error the user sees.
+    """
+    if not is_buildable_engine(engine):
+        raise RuntimeError(
+            f"engine {normalize_engine(engine)!r} cannot build in the preview lane "
+            f"(pocket {pocket_id})"
+        )
+
+    timeout = (
+        timeout_seconds if timeout_seconds is not None else resolve_build_timeout_seconds(engine)
+    )
+    job_id = _preview_job_id(pocket_id, content_hash)
+    pool = _pool_override or await _get_pool()
+    job = await pool.enqueue_job(
+        PREVIEW_ARQ_FUNCTION_NAME,
+        pocket_id,
+        content_hash,
+        scrub_build_input(generator_input),
+        normalize_engine(engine),
+        timeout,
+        _job_id=job_id,
+    )
+    if job is None:
+        status, reason = await _preview_job_outcome(pool, job_id)
+        logger.info(
+            "sites.preview: pocket %s render %s already has a job (%s) — not enqueueing",
+            pocket_id,
+            content_hash[:12],
+            status,
+        )
+        return PreviewBuildEnqueue(job_id=job_id, status=status, reason=reason)
+
+    logger.info(
+        "sites.preview: queued build %s for pocket %s (%ds budget)", job_id, pocket_id, timeout
+    )
+    return PreviewBuildEnqueue(job_id=job_id, status="queued")
+
+
 __all__ = [
     "ARQ_FUNCTION_NAME",
     "BUILDABLE_ENGINES",
     "OUT_OF_SANDBOX_MARGIN_SECONDS",
+    "PREVIEW_ARQ_FUNCTION_NAME",
     "RUNG_ARTIFACT_MISSING",
     "RUNG_ENGINE_NOT_BUILDABLE",
     "RUNG_DEPLOY_FAILED",
     "RUNG_ENQUEUE_FAILED",
+    "RUNG_PREVIEW_UNREADABLE",
     "RUNG_SANDBOX_UNAVAILABLE",
     "RUNG_SCAFFOLD_EMPTY",
     "RUNG_SCAFFOLD_FAILED",
     "SKIPPED_TREE_DIRS",
     "BuildSettlement",
+    "PreviewBuildEnqueue",
+    "enqueue_preview_build",
     "enqueue_site_build",
     "is_buildable_engine",
     "read_generated_tree",
     "resolve_build_settlement",
     "run_site_build",
+    "run_site_preview_build",
     "scrub_build_input",
     "site_build_job_timeout_seconds",
 ]

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -2,6 +2,15 @@
 # plane. Distinct request and response shapes per the cloud 4-file rules.
 # Created: 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.5).
 #
+# Updated 2026-08-24 (SP-2 — draft preview joins the ephemeral build lane):
+# ``NativeArtifactResponse`` gained ``build_status`` / ``build_reason`` /
+# ``build_job_id`` and defaulted ``body_html`` / ``css`` to empty strings. A cold
+# native-artifact read no longer builds in the request — it queues a sandbox build and
+# returns a handle — so the model now carries both shapes. The status vocabulary is the
+# publish lane's, reused verbatim rather than re-minted: a client already treats an
+# unrecognised ``build_status`` as in-progress, and a second set of names for the same
+# idea is how a failure comes to read as progress.
+#
 # Updated 2026-08-12 (sites Settings consolidation — the client record gets a
 # backend): added ``SiteClientResponse`` / ``SiteClientUpdate`` / ``SiteInvoiceOut``
 # / ``SiteInvoiceCreate``, backing GET+PATCH /sites/{site_id}/client and
@@ -770,8 +779,24 @@ class NativeArtifactResponse(BaseModel):
     HTML — the data-uid-stamped editable leaves plus the embedded
     ``<script id="paw-edit-manifest">`` — which the FE injects into a shadow root.
     ``css`` is the built stylesheet(s) concatenated into one string the FE injects as
-    a single ``<style>``."""
+    a single ``<style>``.
+
+    SP-2 — THE RESPONSE HAS TWO SHAPES AND ``build_status`` IS WHICH ONE THIS IS.
+    A cold miss no longer builds in the request; it queues the build in the ephemeral
+    Daytona lane and answers immediately with ``body_html`` / ``css`` EMPTY and a job to
+    poll. A client renders the artifact when ``build_status`` is ``"none"`` (the served
+    render — not a build in any state) and shows progress otherwise, re-fetching until it
+    flips. Empty strings rather than nulls so the field's type never changes under a
+    client that reads it before checking the status.
+
+    The status vocabulary is the publish lane's, unchanged: ``queued`` / ``building`` /
+    ``failed``, with an UNRECOGNISED value meaning in-progress (SL-3's wire contract).
+    ``build_reason`` carries a rung name on a failure — never a build's stderr, which is
+    the user's own content and stays in the worker log."""
 
     pocket_id: str
-    body_html: str
-    css: str
+    body_html: str = ""
+    css: str = ""
+    build_status: str = "none"
+    build_reason: str | None = None
+    build_job_id: str | None = None

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -3,6 +3,16 @@
 # and gated by the same plan feature (fabric) + action (fabric.write/read) as
 # the Leads surface (Task 3.4). Mirrors the leads router's context/deps wiring.
 #
+# Updated 2026-08-24 (SP-2 — draft preview joins the ephemeral build lane): GET
+# ``/sites/by-pocket/{pocket_id}/native-artifact`` now has TWO response shapes and
+# ``build_status`` says which. A cache hit is unchanged (the render, ``build_status``
+# ``"none"``); a cold miss queues the armed build in a Daytona sandbox and answers
+# immediately with empty ``body_html`` / ``css`` plus ``build_status`` / ``build_job_id``
+# to poll. The endpoint stops 5xxing as ``sites.generator_failed``, which is what it did
+# on every cold preview in the deployed container — there is no ``bun`` there to build
+# with. An enqueue that fails is a 503, deliberately: a job id for a job nobody will run
+# makes a client poll forever.
+#
 # Updated 2026-08-12 (the custom-domain routing lane): added DELETE
 # ``/sites/{site_id}/domains/{hostname}``. Domains could be connected and never
 # disconnected, so a removed or re-pointed domain left its Cloudflare custom hostname
@@ -384,9 +394,19 @@ async def native_artifact_by_pocket(
 
     READ-THROUGH cache (feat/sites-native-artifact-no-build): the service serves a
     prior render from disk when the pocket's render inputs are unchanged (ZERO builds
-    — a plain VIEW never triggers a build), and builds once only on a cold miss.
-    Carries fabric.write because a cold miss still triggers the armed build (mutates
-    on-disk state) — it is not a pure read. The builder origin — which the armed build
+    — a plain VIEW never triggers a build).
+
+    A COLD MISS ANSWERS WITH A BUILD TO POLL, NOT WITH A RENDER (SP-2). The armed build
+    now runs in an ephemeral Daytona sandbox rather than in this container — there is no
+    ``bun`` here, which is why a cold preview used to 5xx as ``sites.generator_failed``.
+    The response then carries empty ``body_html`` / ``css`` plus ``build_status``
+    (``queued`` / ``building`` / ``failed``) and ``build_job_id``; the client re-fetches
+    until ``build_status`` reads ``"none"``, which is the served-render shape. An enqueue
+    that fails is a 503, never a job id — a client handed one for a job nobody will run
+    would poll forever.
+
+    Carries fabric.write because a cold miss still queues the armed build (spends a
+    sandbox) — it is not a pure read. The builder origin — which the armed build
     needs to stamp data-uid + the manifest — is resolved from the request's ``Origin``
     header, with the service applying the ``PAW_SITES_BUILDER_ORIGIN`` env fallback when
     it is absent (the same precedence as ``/editable`` / ``/dev-preview``), so the call

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,32 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-08-24 (SP-2 — draft preview joins the ephemeral build lane): a cold
+# ``get_native_artifact`` no longer builds in this process. ``_build_native_artifact``
+# used to call ``generator.build``, which shells out to ``bun``; the deployed API
+# container has no toolchain, so every cold preview raised and surfaced to users as
+# ``sites.generator_failed`` on the native-editor path. It now assembles the same armed
+# generator input and QUEUES it through ``build_job.enqueue_preview_build``, returning a
+# build-pending shape (``body_html`` / ``css`` empty plus ``build_status`` /
+# ``build_reason`` / ``build_job_id``) for the client to poll. The worker writes
+# ``{body_html, css}`` into the artifact store under the SAME content hash, so the next
+# call is an ordinary cache hit. Three things about this are load-bearing:
+#
+#   * THE CACHE CHECK STAYS IN FRONT, and it now guards money rather than seconds. A
+#     miss costs a Daytona sandbox (react 8.70s, svelte 14.67s in-sandbox, before
+#     create / upload / teardown), so a bypassed check would bill one per keystroke.
+#   * THE PRE-WARM MOVED TOO. ``_prewarm_native_artifact`` shares the lane rather than
+#     keeping an inline build, because an inline build in the container fails and
+#     ``_safe_prewarm`` swallows it — the store would never warm and every view would
+#     wait on its own build. Sharing it also collapses an edit's pre-warm and the view
+#     that follows onto ONE sandbox: the lane's job id is the content hash.
+#   * A FAILED ENQUEUE IS AN ERROR, NOT A PENDING BUILD (``sites.preview_build_unavailable``,
+#     503). Handing back a job id nobody will run makes a client poll forever while the
+#     endpoint reports progress.
+#
+# The ``_generator`` / ``_read_built`` seams on this path are gone with the inline build;
+# ``_pool`` replaces them as the thing a test substitutes. The publish path is untouched.
+#
 # Updated 2026-08-24 (feat/sites-s3-artifact-store, SP-4): ``_default_artifact_store``
 # now consults ``artifact_store_s3.shared_artifact_store()`` before falling back to
 # ``_FilesystemArtifactStore``, so a deployment can set ``PAW_SITES_ARTIFACT_STORE=s3``
@@ -1212,52 +1238,77 @@ def _default_artifact_store() -> Any:
 
 async def _build_native_artifact(
     *,
-    generator: GeneratorClient,
     theme: dict[str, Any],
     source: dict[str, Any],
     site_name: str,
     builder_origin: str,
     pocket_id: str,
-    read: Callable[[str], tuple[str, str]],
+    content_hash: str,
     engine: str = "svelte",
-) -> tuple[str, str]:
-    """Run the ARMED build for a native artifact and extract ``(body_html, css)``.
+    _pool: Any | None = None,
+) -> Any:
+    """QUEUE the ARMED build for a native artifact in the ephemeral Daytona lane.
 
-    ``engine`` selects which track is built — ``"svelte"`` or, since RX-2,
-    ``"react"``. Both arm the same way (the generator stamps ``data-uid`` and
-    embeds the manifest when ``builder_origin`` is set) and both emit a prerendered
-    ``index.html``; only the output directory differs, and the ``read`` seam owns
-    that. Anything without a native edit lane never reaches here — the callers
-    gate on ``has_native_edit_lane`` first.
+    Returns a ``build_job.PreviewBuildEnqueue`` — a job id plus ``queued`` /
+    ``building`` / ``failed``. It does NOT return ``(body_html, css)``, and that is the
+    whole of SP-2: this used to run ``generator.build`` inline, which shells out to
+    ``bun``. On a laptop that works; in the deployed API container there is no toolchain,
+    so every cold preview died as ``sites.generator_failed``. The publish path solved this
+    at SL-3 by handing the build to a sandbox, and preview simply never adopted it.
 
-    The single build path shared by get_native_artifact's cache MISS and the
-    background pre-warm. It builds with ``builder_origin`` set (so the paw-sites
-    generator stamps ``data-uid`` on the editable leaves + embeds the
-    ``paw-edit-manifest``) through ``_build_or_cloud_error`` (a toolchain / non-zero /
-    SmokeGate failure becomes a clean CloudError, not an opaque 500), then reads the
-    built ``<body>`` inner HTML + concatenated CSS off disk. ``smoke=False`` is the
-    arm/preview gate — skip the SSR fail-check but still emit the static output. A
-    svelte pocket has no rippleSpec, so ``ripple_spec={}`` (mirrors the prior inline
-    call); PERF-3's stable per-pocket build dir keeps node_modules / bun install
-    cached across builds so the arm build reuses the publish build's install."""
-    build = await _build_or_cloud_error(
-        generator,
-        ripple_spec={},
+    THE CALLER MUST HAVE CHECKED THE STORE FIRST. A cache HIT has to be served without
+    reaching here — the store is what makes a VIEW a disk read, and measured in-sandbox
+    build times are 8.70s (react) / 14.67s (svelte) before create, upload and teardown.
+    An editor that queued one of those per keystroke would be unusable and expensive, in
+    that order.
+
+    ``content_hash`` is passed rather than recomputed because it is BOTH the store key
+    the finished build writes under and the job id that makes this lane single-flight
+    (``build_job._preview_job_id``). One value, decided once by the caller that read the
+    pocket, so the render that gets built and the slot it lands in cannot disagree.
+
+    ``engine`` selects the track — ``"svelte"`` or, since RX-2, ``"react"``. Both arm the
+    same way (the generator stamps ``data-uid`` and embeds the manifest when
+    ``builder_origin`` is set) and both emit a prerendered ``index.html``. Anything
+    without a native edit lane never reaches here; the callers gate on
+    ``has_native_edit_lane`` first.
+
+    No ``smoke=False`` argument survives the move, and nothing is lost with it: the
+    arm/preview gate skipped ``paw-sites``'s workerd SSR fail-check, and that check runs
+    inside ``generator.build`` — which this path no longer calls. The lane scaffolds and
+    then builds with ``bun`` in the sandbox, so there was never a smoke render to skip.
+
+    Raises whatever the enqueue raises (a dead Redis, an arq that will not take the job).
+    The callers turn that into a clean error rather than a job id nobody will run."""
+    # Lazy import: keeps the sites service free of an eager arq/Redis dependency at
+    # module load, and breaks the cycle (``build_job`` imports this module).
+    from pocketpaw_ee.sites import build_job
+    from pocketpaw_ee.sites.generator_client import build_generator_input
+
+    generator_input = build_generator_input(
+        engine=engine,
         theme=theme,
-        # Transient, per-pocket-stable id — cosmetic here (only rides the built page's
-        # capture config, which the native editor ignores). The build DIR is keyed on
-        # pocket_id (PERF-3), not this, so it does not affect where the output lands.
+        # Transient, per-pocket-stable id — cosmetic here (it only rides the built page's
+        # capture config, which the native editor ignores).
         site_id=_preview_id(pocket_id),
         title=site_name,
         capture_api_base=_capture_base(),
+        # Minted per build and immediately scrubbed by ``build_job.scrub_build_input``
+        # before the payload reaches Redis or a sandbox. A preview captures no leads, so
+        # nothing downstream reads it.
         capture_signed_key=f"site_key_{secrets.token_urlsafe(24)}",
-        engine=engine,
+        # A svelte pocket has no rippleSpec, so this mirrors the prior inline call.
+        ripple_spec={},
         source=source,
         builder_origin=builder_origin,
-        pocket_id=pocket_id,
-        smoke=False,
     )
-    return read(build.project_dir)
+    return await build_job.enqueue_preview_build(
+        pocket_id=pocket_id,
+        content_hash=content_hash,
+        engine=engine,
+        generator_input=generator_input,
+        _pool_override=_pool,
+    )
 
 
 async def _prewarm_native_artifact(
@@ -1266,23 +1317,32 @@ async def _prewarm_native_artifact(
     user_id: str,
     pocket_id: str,
     builder_origin: str | None = None,
-    _generator: GeneratorClient | None = None,
-    _read_built: Callable[[str], tuple[str, str]] | None = None,
     _store: Any | None = None,
+    _pool: Any | None = None,
 ) -> None:
-    """Produce + cache the ARMED native artifact for a pocket in the BACKGROUND so the
-    next preview/arm is a read-through cache HIT instead of an on-interaction build.
+    """QUEUE the ARMED native-artifact build for a pocket in the BACKGROUND so the next
+    preview/arm is a read-through cache HIT instead of a wait.
 
     Fired after a source mutation (leaf edit / component edit) and after a LIVE svelte
     publish. It re-reads the pocket (source is the source of truth and may have just
     changed), computes the SAME content hash ``get_native_artifact`` uses, and — only
-    if the store does not already hold that render — builds once and stores it. So a
-    mutation that lands identical source, or a re-publish of unchanged source, rebuilds
-    nothing.
+    if the store does not already hold that render — hands the build to the ephemeral
+    lane. A mutation that lands identical source, or a re-publish of unchanged source,
+    queues nothing.
+
+    SP-2 MOVED THE BUILD OUT OF THIS PROCESS, and the pre-warm had to follow
+    ``get_native_artifact`` rather than keep its own inline build. Two reasons, and the
+    second is the one that matters: an inline ``bun`` build cannot run in the deployed
+    API container at all, so a pre-warm left behind would have been a background failure
+    fired on every edit and swallowed by ``_safe_prewarm``, warming nothing — the store
+    would then miss forever and every view would wait for its own build. Sharing the lane
+    also makes the two paths COLLAPSE onto one sandbox: the job id is the content hash
+    (``build_job._preview_job_id``), so an edit's pre-warm and the view that follows it
+    are the same job rather than two builds of one render.
 
     Best-effort by contract: callers schedule it through ``_safe_prewarm`` (which
     swallows + logs) so the edit / publish they own returns regardless of a pre-warm
-    failure (missing toolchain, a non-svelte pocket, a read error)."""
+    failure (an unreachable queue, a non-svelte pocket, a read error)."""
     from pocketpaw_ee.cloud.pockets import service as pockets_service
     from pocketpaw_ee.sites import generator_client
     from pocketpaw_ee.sites.engines import has_native_edit_lane, normalize_engine
@@ -1311,21 +1371,16 @@ async def _prewarm_native_artifact(
     )
     if store.read(pocket_id, content_hash) is not None:
         return  # already warm — no rebuild
-    generator = _generator or GeneratorClient()
-    # The ``_read_built`` seam stays SINGLE-ARG so injected test doubles keep
-    # working; the engine is bound into the default reader instead.
-    read = _read_built or (lambda d: _read_native_artifact(d, engine))
-    body_html, css = await _build_native_artifact(
-        generator=generator,
+    await _build_native_artifact(
         theme=theme,
         source=source,
         site_name=site_name,
         builder_origin=origin,
         pocket_id=pocket_id,
-        read=read,
+        content_hash=content_hash,
         engine=engine,
+        _pool=_pool,
     )
-    store.write(pocket_id, content_hash, body_html, css)
 
 
 async def _safe_prewarm(**kwargs: Any) -> None:
@@ -1367,24 +1422,25 @@ def _schedule_native_prewarm(
     user_id: str,
     pocket_id: str,
     builder_origin: str | None = None,
-    _generator: GeneratorClient | None = None,
-    _read_built: Callable[[str], tuple[str, str]] | None = None,
     _store: Any | None = None,
+    _pool: Any | None = None,
 ) -> None:
     """Fire a background native-artifact pre-warm for a pocket. A thin, non-async
     wrapper the mutation / publish call sites invoke; it never blocks or raises. The
-    injected ``_generator`` seam is forwarded so a faked-generator publish/edit
-    pre-warms with the SAME fake (unit tests never shell out). The scheduler is looked
-    up on the module (``_default_prewarm_scheduler``) so tests can patch it."""
+    scheduler is looked up on the module (``_default_prewarm_scheduler``) so tests can
+    patch it.
+
+    SP-2 replaced the forwarded ``_generator`` / ``_read_built`` seams with ``_pool``.
+    The pre-warm no longer builds in-process, so a fake generator has nothing to fake;
+    the queue is the seam a test now substitutes."""
     _default_prewarm_scheduler(
         _safe_prewarm(
             workspace_id=workspace_id,
             user_id=user_id,
             pocket_id=pocket_id,
             builder_origin=builder_origin,
-            _generator=_generator,
-            _read_built=_read_built,
             _store=_store,
+            _pool=_pool,
         )
     )
 
@@ -5128,15 +5184,14 @@ async def publish_pocket(
     #
     # Only svelte sites have a native build; a dynamic site deferred to the provision
     # job returns deployed=False, so guard on doc.deployed too. Best-effort, off the
-    # publish's path. Forwards the injected generator so a faked publish warms with the
-    # same fake (unit tests never shell out).
+    # publish's path. Since SP-2 the pre-warm QUEUES the build rather than running it
+    # here, so there is no generator to forward.
     if engine == "svelte" and getattr(doc, "deployed", False):
         _schedule_native_prewarm(
             workspace_id=workspace_id,
             user_id=user_id,
             pocket_id=pocket_id,
             builder_origin=prewarm_origin or builder_origin,
-            _generator=_generator,
         )
 
     # Stamp the per-site annual plan, open the per-site Dodo sub (degrading
@@ -6048,10 +6103,9 @@ async def get_native_artifact(
     user_id: str,
     pocket_id: str,
     builder_origin: str | None = None,
-    _generator: GeneratorClient | None = None,
-    _read_built: Callable[[str], tuple[str, str]] | None = None,
     _store: Any | None = None,
-) -> dict[str, str]:
+    _pool: Any | None = None,
+) -> dict[str, Any]:
     """Serve a svelte Paw Site's ARMED render as ``{pocket_id, body_html, css}`` so the
     native editor can shadow-render it (NE-5b) instead of framing an iframe.
 
@@ -6067,23 +6121,38 @@ async def get_native_artifact(
          like ``make_site_editable``) and hash them with the generator version into a
          content hash;
       3. CACHE HIT — the store already holds that render → return it from disk with
-         ZERO subprocess builds (the whole point). Publish and the post-edit pre-warm
-         populate the store ahead of the view, so a live/clean site is a hit;
-      4. CACHE MISS — build ONCE (armed: ``builder_origin`` set so the generator stamps
-         ``data-uid`` + embeds ``paw-edit-manifest``; ``smoke=False`` arm gate) through
-         ``_build_or_cloud_error`` (a toolchain / non-zero / SmokeGate failure becomes a
-         clean CloudError, not an opaque 500), read the built ``<body>`` inner HTML +
-         concatenated CSS, STORE it, and return. PERF-3's stable per-pocket build dir
-         keeps node_modules / bun install cached across builds.
+         ZERO builds and ZERO sandboxes (the whole point). Publish and the post-edit
+         pre-warm populate the store ahead of the view, so a live/clean site is a hit;
+      4. CACHE MISS — QUEUE the armed build in the ephemeral Daytona lane (SP-2) and
+         return the BUILD-PENDING shape: ``body_html`` / ``css`` empty, plus
+         ``build_status`` / ``build_job_id`` / ``build_reason`` for the client to poll.
+         When the job lands it writes ``{body_html, css}`` under this same content hash,
+         so the next call is step 3.
 
-    Local-mode degrade: a store miss on a box where no build has ever run just takes
-    the MISS branch (build once); a build failure still maps to a clean CloudError, so
-    the endpoint degrades cleanly rather than 500ing opaquely — unchanged from before.
+    ── WHY THE MISS NO LONGER BUILDS HERE (SP-2) ───────────────────────────────────────
 
-    ``_generator`` (defaults to a real ``GeneratorClient``), ``_read_built`` (defaults
-    to ``_read_native_artifact`` — the disk read + HTML/CSS extraction), and ``_store``
-    (defaults to the filesystem artifact store) are injectable seams so the path is
-    unit-testable without Bun / a real build / disk."""
+    It used to call ``generator.build``, which shells out to ``bun``. There is no
+    toolchain in the deployed API container, so every cold preview raised and surfaced as
+    ``sites.generator_failed`` — the endpoint's headline failure. The publish path had
+    already solved exactly this at SL-3 by handing the build to an ephemeral sandbox; the
+    preview path simply never adopted it.
+
+    THE CACHE CHECK IN STEP 3 IS LOAD-BEARING IN A WAY IT WAS NOT BEFORE. A miss used to
+    cost a local subprocess; it now costs a Daytona sandbox (measured in-sandbox build
+    times: react 8.70s, svelte 14.67s, before create / upload / teardown). Bypassing it
+    would bill a sandbox per keystroke in the editor. The lane's job id is the content
+    hash, so a client polling this endpoint during a build re-reads the SAME job instead
+    of queueing another — but that is the second guard, not a reason to weaken the first.
+
+    ``build_status`` uses the publish lane's vocabulary verbatim — ``queued`` /
+    ``building`` / ``failed``, the same values ``_to_response`` and ``pocket_status``
+    already put on the wire — because a client is told to treat an UNRECOGNISED status as
+    in-progress, and a second vocabulary for the same idea would make a failure read as
+    progress somewhere.
+
+    ``_store`` (defaults to the filesystem artifact store) and ``_pool`` (defaults to the
+    process arq pool) are injectable seams so the path is unit-testable without disk or
+    Redis."""
     from pocketpaw_ee.cloud.pockets import service as pockets_service
     from pocketpaw_ee.sites import generator_client
 
@@ -6123,32 +6192,59 @@ async def get_native_artifact(
         gen_version=generator_client.generator_version(),
         engine=engine,
     )
-    # READ-THROUGH: a hit serves the prior render straight off disk — no generator, no
-    # subprocess, no build. This is what makes a VIEW instant on the prod box.
+    # READ-THROUGH: a hit serves the prior render straight off disk — no queue, no
+    # sandbox, no build. This is what makes a VIEW instant, and since SP-2 it is also
+    # what keeps an editing session from billing a sandbox per keystroke.
     cached = store.read(pocket_id, content_hash)
     if cached is not None:
         body_html, css = cached
-        return {"pocket_id": pocket_id, "body_html": body_html, "css": css}
+        return {
+            "pocket_id": pocket_id,
+            "body_html": body_html,
+            "css": css,
+            # A served render is not a build in any state. "none" is the same value
+            # ``pocket_status`` gives a pocket that has never built, and it is what stops
+            # a client badging a finished preview as mid-build.
+            "build_status": "none",
+            "build_reason": None,
+            "build_job_id": None,
+        }
 
-    # MISS: build once (armed), cache, return. ``_build_native_artifact`` routes through
-    # _build_or_cloud_error so a missing-toolchain / non-zero build / SmokeGateFailed
-    # becomes a clean CloudError (sites.generator_failed → 5xx), not an opaque 500.
-    generator = _generator or GeneratorClient()
-    # Single-arg seam preserved for injected test doubles; the engine is bound into
-    # the default reader, which resolves the per-engine output dir off disk.
-    read = _read_built or (lambda d: _read_native_artifact(d, engine))
-    body_html, css = await _build_native_artifact(
-        generator=generator,
-        theme=theme,
-        source=source,
-        site_name=site_name,
-        builder_origin=origin,
-        pocket_id=pocket_id,
-        read=read,
-        engine=engine,
-    )
-    store.write(pocket_id, content_hash, body_html, css)
-    return {"pocket_id": pocket_id, "body_html": body_html, "css": css}
+    # MISS: queue the armed build and hand back a handle. The job writes {body_html, css}
+    # under this exact content hash when it lands, so the next call takes the branch above.
+    try:
+        enqueued = await _build_native_artifact(
+            theme=theme,
+            source=source,
+            site_name=site_name,
+            builder_origin=origin,
+            pocket_id=pocket_id,
+            content_hash=content_hash,
+            engine=engine,
+            _pool=_pool,
+        )
+    except Exception as exc:
+        # A FAILED ENQUEUE MUST NOT READ AS A PENDING BUILD. Returning the pending shape
+        # here would hand the client a job id nobody will ever run: it would poll a build
+        # that does not exist, and the endpoint would report progress forever. An error
+        # is recoverable — the user retries and gets a real queue slot.
+        logger.exception("sites.preview: could not queue the preview build for %s", pocket_id)
+        raise CloudError(
+            503,
+            "sites.preview_build_unavailable",
+            "The preview build could not be queued. Try again in a moment.",
+        ) from exc
+
+    return {
+        "pocket_id": pocket_id,
+        # Empty rather than absent: the field is the same shape on both branches, so a
+        # client reads one response type and decides on ``build_status``.
+        "body_html": "",
+        "css": "",
+        "build_status": enqueued.status,
+        "build_reason": enqueued.reason,
+        "build_job_id": enqueued.job_id,
+    }
 
 
 async def edit_svelte_component(
@@ -6299,7 +6395,6 @@ async def edit_svelte_component(
         user_id=user_id,
         pocket_id=pocket_id,
         builder_origin=builder_origin or None,
-        _generator=_generator,
     )
     return doc
 

--- a/tests/ee/sites/test_native_artifact.py
+++ b/tests/ee/sites/test_native_artifact.py
@@ -1,5 +1,19 @@
 # tests/ee/sites/test_native_artifact.py — the native-artifact render path (NE-5b).
 # Created 2026-07-01 (feat/native-editing-ne4b).
+# Updated 2026-08-24 (SP-2 — the cold miss QUEUES instead of building here): every test
+# in this file that drove a cache MISS used to assert on an inline ``generator.build``.
+# That build has moved to an ephemeral Daytona sandbox, because there is no ``bun`` in
+# the deployed API container and every cold preview died as ``sites.generator_failed``.
+# So the ``_generator`` / ``_read_built`` seams are gone from ``get_native_artifact`` and
+# the pre-warm, and ``_pool`` replaces them. What each test now pins:
+#   * the HIT path is unchanged and is the one that must stay free — it is asserted
+#     against a pool that must not be called, not only against a build that must not run;
+#   * the MISS path returns the build-pending shape and queues exactly one job;
+#   * the origin precedence (request Origin > PAW_SITES_BUILDER_ORIGIN) is asserted
+#     through the CONTENT HASH, which is what it actually decides: warm at one origin and
+#     a view at the other misses.
+# The lane itself — the queued job, single-flight, the enqueue-failure arm, the worker's
+# artifact read — lives in test_preview_build_lane.py.
 # Updated 2026-07-17 (fix/sites-prewarm-origin): the pre-warm must build with the SAME
 # origin a browser VIEW resolves (its request Origin header) or the content hashes never
 # match. New tests prove: a publish given an explicit prewarm_origin warms THAT origin
@@ -82,8 +96,8 @@ _LINKED_CSS = ".hero{color:#0A84FF}"
 
 class _FakeGenerator:
     """Records the build kwargs and returns a BuildResult pointing at a pre-populated
-    ``project_dir`` (a real .svelte-kit/cloudflare/ tree the test wrote), so the REAL
-    ``_read_native_artifact`` extraction runs without Bun."""
+    ``project_dir``. Still used by the PUBLISH paths in this file (publish builds
+    inline); ``get_native_artifact`` no longer takes a generator at all."""
 
     def __init__(self, project_dir: str) -> None:
         self.project_dir = project_dir
@@ -96,12 +110,64 @@ class _FakeGenerator:
         return BuildResult(project_dir=self.project_dir, ripple_version=None)
 
 
-class _NoBuildGenerator:
-    """A generator whose build MUST NOT run — used by the reject paths (a non-svelte
-    or missing pocket must fail before any build is triggered)."""
+class _RecordingPool:
+    """An arq pool that records the enqueue instead of performing it (SP-2).
 
-    async def build(self, **kw):  # pragma: no cover - must not be reached
-        raise AssertionError("the build must not run on the reject path")
+    The replacement for ``_NoBuildGenerator`` on the reject paths: what must not happen
+    on a rejected read is no longer "a build must not run" but "a sandbox must not be
+    queued", and the two stopped being the same assertion when the build left this
+    process.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def enqueue_job(self, function: str, *args, _job_id: str | None = None, **kw):
+        self.calls.append({"function": function, "args": args, "job_id": _job_id})
+        return object()
+
+
+def _install_pool(monkeypatch) -> _RecordingPool:
+    """Make ``build_job``'s process pool a recording fake for this test.
+
+    The ``_pool`` seam only reaches ``get_native_artifact`` — a pre-warm is scheduled
+    BY ``publish_pocket`` / the edit paths, which have no pool to forward, so the
+    injection point for those is the module-level getter the enqueue falls back to.
+    """
+    from pocketpaw_ee.sites import build_job as bj
+
+    pool = _RecordingPool()
+
+    async def _fake_get_pool():
+        return pool
+
+    monkeypatch.setattr(bj, "_get_pool", _fake_get_pool)
+    return pool
+
+
+def _seed_store(store, pocket_id: str, content_hash: str, project_dir: Path, engine="svelte"):
+    """Put the REAL extraction of a built tree into the store under ``content_hash`` —
+    what the preview worker does when its build lands. Lets a test assert the endpoint
+    serves the genuine body/CSS without the extraction happening in-process."""
+    body_html, css = sites_service._read_native_artifact(str(project_dir), engine)
+    store.data[(pocket_id, content_hash)] = (body_html, css)
+    return body_html, css
+
+
+async def _hash_for(pocket_id: str, *, origin: str, engine: str = "svelte") -> str:
+    """The content hash the service will look up for this pocket at ``origin``."""
+    from pocketpaw_ee.sites import generator_client
+
+    wire = await pockets_service.get(pocket_id, "u1")
+    ripple_spec = wire.get("rippleSpec") or {}
+    theme = (ripple_spec.get("theme") if isinstance(ripple_spec, dict) else {}) or {}
+    return sites_service._artifact_content_hash(
+        source=wire["source"],
+        theme=theme,
+        builder_origin=origin,
+        gen_version=generator_client.generator_version(),
+        engine=engine,
+    )
 
 
 def _write_built_output(project_dir: Path) -> None:
@@ -135,19 +201,28 @@ async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
 
 @pytest.mark.asyncio
 async def test_native_artifact_returns_body_and_css(beanie_test_db, tmp_path):
-    """A svelte pocket → {pocket_id, body_html, css}: body_html is the built <body>
-    INNER (data-uid leaf + manifest, no <body>/<head> wrapper); css concatenates the
-    inline <style> + the linked stylesheet; and the build was ARMED with the source."""
+    """A warmed svelte pocket → {pocket_id, body_html, css}: body_html is the built
+    <body> INNER (data-uid leaf + manifest, no <body>/<head> wrapper) and css
+    concatenates the inline <style> + the linked stylesheet.
+
+    SP-2 moved the BUILD out of this call, so the render is seeded into the store the way
+    the preview worker seeds it. What is still asserted here is the ENDPOINT's contract —
+    that it hands back the stored extraction verbatim under the hash it looked up — and
+    the extraction itself runs for real inside ``_seed_store``, off the built tree."""
     pocket_id = await _make_svelte_pocket("ws1", "u1")
     _write_built_output(tmp_path)
-    gen = _FakeGenerator(str(tmp_path))
+    store = _MemoryArtifactStore()
+    origin = "https://dash.paw.example"
+    _seed_store(store, pocket_id, await _hash_for(pocket_id, origin=origin), tmp_path)
+    pool = _RecordingPool()
 
     result = await sites_service.get_native_artifact(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
-        builder_origin="https://dash.paw.example",
-        _generator=gen,
+        builder_origin=origin,
+        _store=store,
+        _pool=pool,
     )
 
     assert result["pocket_id"] == pocket_id
@@ -160,62 +235,49 @@ async def test_native_artifact_returns_body_and_css(beanie_test_db, tmp_path):
     # css concatenates the inline critical style AND the linked stylesheet.
     assert ".inline-critical{margin:0}" in result["css"]
     assert _LINKED_CSS in result["css"]
-    # The build was ARMED (the resolved builder_origin threaded through) and carried
-    # the pocket's svelte source on the svelte track, with the arm/preview smoke gate.
-    assert gen.built is not None
-    assert gen.built["builder_origin"] == "https://dash.paw.example"
-    assert gen.built["engine"] == "svelte"
-    assert gen.built["pocket_id"] == pocket_id
-    assert gen.built["smoke"] is False
-    assert gen.built["source"]["src/lib/components/Hero.svelte"] == _HERO_V1
+    # A served render is not a build in any state, and it cost nothing.
+    assert result["build_status"] == "none"
+    assert pool.calls == []
 
 
 @pytest.mark.asyncio
 async def test_native_artifact_default_origin_from_config(beanie_test_db, tmp_path, monkeypatch):
     """With no builder_origin passed, the service falls back to the configured
-    PAW_SITES_BUILDER_ORIGIN — the armed build still gets a non-empty origin so the
-    generator stamps data-uid + the manifest."""
+    PAW_SITES_BUILDER_ORIGIN.
+
+    Asserted through the CONTENT HASH, which is what the origin actually decides: an
+    artifact warmed at the configured origin HITs for a caller that passes none. Under a
+    fallback that resolved to anything else the lookup would miss and the call would
+    queue a build instead of serving one."""
     monkeypatch.setenv("PAW_SITES_BUILDER_ORIGIN", "https://configured.paw.example")
     pocket_id = await _make_svelte_pocket("ws1", "u1")
     _write_built_output(tmp_path)
-    gen = _FakeGenerator(str(tmp_path))
+    store = _MemoryArtifactStore()
+    _seed_store(
+        store,
+        pocket_id,
+        await _hash_for(pocket_id, origin="https://configured.paw.example"),
+        tmp_path,
+    )
+    pool = _RecordingPool()
 
     result = await sites_service.get_native_artifact(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
         builder_origin="",
-        _generator=gen,
+        _store=store,
+        _pool=pool,
     )
 
     assert result["pocket_id"] == pocket_id
-    assert gen.built["builder_origin"] == "https://configured.paw.example"
+    assert 'data-uid="Hero:headline:0"' in result["body_html"]
+    assert pool.calls == [], "the env fallback must resolve the same hash the warm used"
 
 
-@pytest.mark.asyncio
-async def test_native_artifact_read_seam_is_injectable(beanie_test_db):
-    """The _read_built seam is honored: the service returns whatever it yields, keyed
-    on the build's project_dir — so a caller can bypass disk entirely."""
-    pocket_id = await _make_svelte_pocket("ws1", "u1")
-    gen = _FakeGenerator("/tmp/paw-native-artifact-nonexistent")
-
-    def _fake_read(project_dir: str) -> tuple[str, str]:
-        assert project_dir == "/tmp/paw-native-artifact-nonexistent"
-        return "<h1 data-uid='x:0'>hi</h1>", ".x{color:red}"
-
-    result = await sites_service.get_native_artifact(
-        workspace_id="ws1",
-        user_id="u1",
-        pocket_id=pocket_id,
-        builder_origin="https://dash.paw.example",
-        _generator=gen,
-        _read_built=_fake_read,
-    )
-    assert result == {
-        "pocket_id": pocket_id,
-        "body_html": "<h1 data-uid='x:0'>hi</h1>",
-        "css": ".x{color:red}",
-    }
+# The ``_read_built`` seam is gone with SP-2: the built tree is read by the preview
+# worker rather than by this call, and that read is covered in
+# ``test_preview_build_lane.py::TestThePreviewJob``.
 
 
 @pytest.mark.asyncio
@@ -232,48 +294,48 @@ async def test_native_artifact_non_svelte_pocket_rejected(beanie_test_db):
     )
     assert err is None, err
 
+    pool = _RecordingPool()
     with pytest.raises(ValidationError):
         await sites_service.get_native_artifact(
             workspace_id="ws1",
             user_id="u1",
             pocket_id=pocket_id,
             builder_origin="https://dash.paw.example",
-            _generator=_NoBuildGenerator(),
+            _pool=pool,
         )
+    assert pool.calls == [], "a rejected pocket must not queue a sandbox"
 
 
 @pytest.mark.asyncio
 async def test_native_artifact_missing_pocket_raises_not_found(beanie_test_db):
     """A missing / cross-tenant pocket surfaces the pockets service's NotFound (404),
     before any build."""
+    pool = _RecordingPool()
     with pytest.raises(NotFound):
         await sites_service.get_native_artifact(
             workspace_id="ws1",
             user_id="u1",
             pocket_id="0123456789abcdef01234567",
             builder_origin="https://dash.paw.example",
-            _generator=_NoBuildGenerator(),
+            _pool=pool,
         )
+    assert pool.calls == []
 
 
-class _SmokeGateFailGenerator:
-    """A generator whose build raises SmokeGateFailed — the failure a misconfigured
-    toolchain / broken build produces. DEP-3 routes get_native_artifact's build
-    through _build_or_cloud_error, so this must surface as a clean CloudError, not an
-    opaque 500."""
+class _DeadPool:
+    """An arq pool that cannot take the job — a dead Redis, or arq refusing outright."""
 
-    async def build(self, **kw):
-        from pocketpaw_ee.sites.generator_client import SmokeGateFailed
-
-        raise SmokeGateFailed("workerd SSR render failed")
+    async def enqueue_job(self, *a, **kw):
+        raise RuntimeError("redis is gone")
 
 
 @pytest.mark.asyncio
-async def test_native_artifact_build_failure_maps_to_cloud_error(beanie_test_db):
-    """DEP-3: a generator build failure (SmokeGateFailed / missing toolchain / non-zero
-    build) is mapped to a clean CloudError (sites.generator_failed) instead of escaping
-    as an opaque unhandled 500 — get_native_artifact routes its build through
-    _build_or_cloud_error like the publish paths, NOT a bare generator.build()."""
+async def test_native_artifact_enqueue_failure_maps_to_cloud_error(beanie_test_db):
+    """DEP-3's property, on the seam that replaced the inline build (SP-2): a cold miss
+    that cannot reach the queue surfaces as a clean CloudError, not an opaque unhandled
+    500 — and NOT as a pending build, which would be worse than either. A job id for a
+    job nobody will run makes a client poll forever with the endpoint reporting
+    progress."""
     pocket_id = await _make_svelte_pocket("ws1", "u1")
 
     with pytest.raises(CloudError) as excinfo:
@@ -282,15 +344,13 @@ async def test_native_artifact_build_failure_maps_to_cloud_error(beanie_test_db)
             user_id="u1",
             pocket_id=pocket_id,
             builder_origin="https://dash.paw.example",
-            _generator=_SmokeGateFailGenerator(),
+            _store=_MemoryArtifactStore(),
+            _pool=_DeadPool(),
         )
 
-    # A structured envelope with the DEP-3 machine code + a 5xx status — not a bare
-    # RuntimeError / SmokeGateFailed escaping as an unhandled 500.
-    assert excinfo.value.code == "sites.generator_failed"
+    assert excinfo.value.code == "sites.preview_build_unavailable"
     assert excinfo.value.status_code >= 500
-    # SmokeGateFailed is a RuntimeError subclass, so confirm what surfaced is the
-    # mapped CloudError, not the raw RuntimeError.
+    # The mapped envelope, not the raw RuntimeError escaping as an unhandled 500.
     assert not isinstance(excinfo.value, RuntimeError)
 
 
@@ -339,37 +399,46 @@ def _fake_local_deploy(site_id: str, project_dir: str) -> str:  # noqa: ARG001
 
 
 @pytest.mark.asyncio
-async def test_native_artifact_repeat_call_is_cache_hit_zero_builds(beanie_test_db, tmp_path):
-    """The core DoD: a repeat GET with UNCHANGED source performs ZERO subprocess builds.
-    The first call is a MISS (build once, store); the second is a read-through HIT off
-    the default filesystem store (redirected to tmp by the conftest fixture)."""
+async def test_native_artifact_repeat_call_is_cache_hit_zero_sandboxes(beanie_test_db, tmp_path):
+    """The core DoD, in the units SP-2 made it cost: a repeat GET with UNCHANGED source
+    spends ZERO sandboxes. The first call is a MISS (queue once, pending); once the
+    worker's artifact lands under that hash the second call is a read-through HIT and
+    queues nothing.
+
+    The intermediate write is what the preview job does. Doing it here rather than
+    running the job keeps this test about the ENDPOINT's caching — the job's own half is
+    ``test_preview_build_lane.py``."""
     pocket_id = await _make_svelte_pocket("ws1", "u1")
     _write_built_output(tmp_path)
-    gen = _CountingGenerator(str(tmp_path))
-
-    r1 = await sites_service.get_native_artifact(
+    origin = "https://dash.paw.example"
+    store = _MemoryArtifactStore()
+    pool = _RecordingPool()
+    kw = dict(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
-        builder_origin="https://dash.paw.example",
-        _generator=gen,
-    )
-    r2 = await sites_service.get_native_artifact(
-        workspace_id="ws1",
-        user_id="u1",
-        pocket_id=pocket_id,
-        builder_origin="https://dash.paw.example",
-        _generator=gen,
+        builder_origin=origin,
+        _store=store,
+        _pool=pool,
     )
 
-    assert r1 == r2
-    assert gen.calls == 1, "the second identical view must be a cache HIT — zero rebuilds"
+    r1 = await sites_service.get_native_artifact(**kw)
+    assert r1["build_status"] == "queued"
+    assert len(pool.calls) == 1
+
+    # The worker lands: it writes the render under the hash the enqueue carried.
+    _seed_store(store, pocket_id, await _hash_for(pocket_id, origin=origin), tmp_path)
+
+    r2 = await sites_service.get_native_artifact(**kw)
+    assert 'data-uid="Hero:headline:0"' in r2["body_html"]
+    assert r2["build_status"] == "none"
+    assert len(pool.calls) == 1, "the second identical view must be a cache HIT — no sandbox"
 
 
 @pytest.mark.asyncio
 async def test_native_artifact_store_hit_skips_build(beanie_test_db):
     """A store that already holds the content-hashed render serves it WITHOUT any build
-    — proven by a generator whose build must never run."""
+    — proven by a pool that must never be enqueued to."""
     from pocketpaw_ee.sites import generator_client
 
     pocket_id = await _make_svelte_pocket("ws1", "u1")
@@ -383,43 +452,50 @@ async def test_native_artifact_store_hit_skips_build(beanie_test_db):
     )
     store.data[(pocket_id, content_hash)] = ("<h1>cached</h1>", ".x{color:red}")
 
+    pool = _RecordingPool()
     result = await sites_service.get_native_artifact(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
         builder_origin="https://dash.paw.example",
-        _generator=_NoBuildGenerator(),
         _store=store,
+        _pool=pool,
     )
 
     assert result == {
         "pocket_id": pocket_id,
         "body_html": "<h1>cached</h1>",
         "css": ".x{color:red}",
+        "build_status": "none",
+        "build_reason": None,
+        "build_job_id": None,
     }
     assert store.writes == 0, "a cache hit must not re-store"
+    assert pool.calls == [], "a cache hit must not queue a sandbox"
 
 
 @pytest.mark.asyncio
 async def test_native_artifact_source_change_is_cache_miss(beanie_test_db, tmp_path):
     """The content hash tracks the source: an unchanged view HITs, but a source mutation
-    changes the hash → MISS → rebuild."""
+    changes the hash → MISS → a new build queued."""
     pocket_id = await _make_svelte_pocket("ws1", "u1")
     _write_built_output(tmp_path)
-    gen = _CountingGenerator(str(tmp_path))
+    origin = "https://dash.paw.example"
     store = _MemoryArtifactStore()
+    pool = _RecordingPool()
     kw = dict(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
-        builder_origin="https://dash.paw.example",
-        _generator=gen,
+        builder_origin=origin,
         _store=store,
+        _pool=pool,
     )
 
-    await sites_service.get_native_artifact(**kw)  # MISS → build 1
+    await sites_service.get_native_artifact(**kw)  # MISS → queue 1
+    _seed_store(store, pocket_id, await _hash_for(pocket_id, origin=origin), tmp_path)
     await sites_service.get_native_artifact(**kw)  # HIT → still 1
-    assert gen.calls == 1
+    assert len(pool.calls) == 1
 
     await pockets_service.set_svelte_source_file(
         pocket_id,
@@ -427,23 +503,31 @@ async def test_native_artifact_source_change_is_cache_miss(beanie_test_db, tmp_p
         component_path="src/lib/components/Hero.svelte",
         new_source="<section class='hero'><h1>Changed</h1></section>",
     )
-    await sites_service.get_native_artifact(**kw)  # source changed → MISS → build 2
-    assert gen.calls == 2, "a source change must be a cache MISS and rebuild"
+    await sites_service.get_native_artifact(**kw)  # source changed → MISS → queue 2
+    assert len(pool.calls) == 2, "a source change must be a cache MISS and queue a build"
 
 
 @pytest.mark.asyncio
 async def test_publish_prewarms_then_native_artifact_hits(
     beanie_test_db, tmp_path, monkeypatch, _captured_prewarms
 ):
-    """DoD: a LIVE svelte publish stores an artifact (via the scheduled pre-warm) so the
-    NEXT native-artifact view is a cache HIT — no on-view build."""
+    """DoD, re-aimed by SP-2: a LIVE svelte publish schedules a pre-warm that QUEUES the
+    armed build for the SAME render the next view asks for.
+
+    The pre-warm no longer builds in-process, so what it has to get right is the JOB ID —
+    which is the content hash. A pre-warm that warmed a different render would leave the
+    view queueing a SECOND sandbox for the same page, so "same render" is asserted as
+    "same job". Once that job lands, the view is a plain cache hit."""
     # Force the LOCAL deploy branch so the live publish never shells out to a real
     # deployer (the workspace .env sets PAW_CF_DEPLOY_MODE=workers, which would route to
     # a real wrangler deploy); the fake local deploy makes doc.deployed=True.
     monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
+    monkeypatch.setenv("PAW_SITES_BUILDER_ORIGIN", "https://configured.paw.example")
     pocket_id = await _make_svelte_pocket("ws1", "u1")
     _write_built_output(tmp_path)
     gen = _CountingGenerator(str(tmp_path))
+    store = _MemoryArtifactStore()
+    pool = _install_pool(monkeypatch)
 
     await sites_service.publish_pocket(
         workspace_id="ws1",
@@ -456,19 +540,31 @@ async def test_publish_prewarms_then_native_artifact_hits(
 
     # A live svelte publish scheduled exactly one background pre-warm.
     assert len(_captured_prewarms) == 1, "a live svelte publish must schedule a pre-warm"
-    # Run it — the pre-warm builds the ARMED artifact and stores it (default fs store).
+    # Run it — the pre-warm queues the ARMED build.
     await _captured_prewarms[0]
+    assert len(pool.calls) == 1, "the pre-warm must queue the armed build"
+    prewarmed_job = pool.calls[0]["job_id"]
 
-    # The next view is a read-through HIT — proven by a generator that must not build.
-    result = await sites_service.get_native_artifact(
+    # A view with no explicit origin resolves the same PAW_SITES_BUILDER_ORIGIN fallback
+    # the pre-warm used, so it addresses the job already in flight.
+    view_kw = dict(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
-        # No explicit origin → the same PAW_SITES_BUILDER_ORIGIN fallback the publish
-        # pre-warm resolved, so the content hash matches and the store hits.
         builder_origin="",
-        _generator=_NoBuildGenerator(),
+        _store=store,
     )
+    pending = await sites_service.get_native_artifact(**view_kw)
+    assert pending["build_job_id"] == prewarmed_job
+
+    # Once that job lands, the view is a read-through HIT.
+    _seed_store(
+        store,
+        pocket_id,
+        await _hash_for(pocket_id, origin="https://configured.paw.example"),
+        tmp_path,
+    )
+    result = await sites_service.get_native_artifact(**view_kw)
     assert result["pocket_id"] == pocket_id
     assert 'data-uid="Hero:headline:0"' in result["body_html"]
     assert 'id="paw-edit-manifest"' in result["body_html"]
@@ -556,8 +652,10 @@ async def test_publish_prewarm_uses_prewarm_origin_over_env(
     """A live publish given an explicit ``prewarm_origin`` warms the artifact for THAT
     origin — the one a browser view resolves from its request Origin header — NOT the
     PAW_SITES_BUILDER_ORIGIN env fallback. Proven by setting the env to a DIFFERENT
-    origin: with the pre-warm-origin bug, the pre-warm would warm at the env origin and
-    the next view AT THE REQUEST ORIGIN would MISS — the _NoBuildGenerator would fire."""
+    origin: with the pre-warm-origin bug the pre-warm would queue the env origin's render
+    and a view at the request origin would queue a SECOND sandbox for the same page.
+    Since SP-2 the job id IS the content hash, so "same render" and "same job" are one
+    assertion."""
     monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
     # The env fallback is a DIFFERENT origin than the request origin: the OLD behaviour
     # warmed here, so a view at the request origin would have been a cold miss.
@@ -566,6 +664,8 @@ async def test_publish_prewarm_uses_prewarm_origin_over_env(
     pocket_id = await _make_svelte_pocket("ws1", "u1")
     _write_built_output(tmp_path)
     gen = _CountingGenerator(str(tmp_path))
+    store = _MemoryArtifactStore()
+    pool = _install_pool(monkeypatch)
 
     await sites_service.publish_pocket(
         workspace_id="ws1",
@@ -578,17 +678,24 @@ async def test_publish_prewarm_uses_prewarm_origin_over_env(
     )
 
     assert len(_captured_prewarms) == 1, "a live svelte publish must schedule a pre-warm"
-    await _captured_prewarms[0]  # build + store the armed artifact at view_origin
+    await _captured_prewarms[0]  # queue the armed build at view_origin
+    assert len(pool.calls) == 1
 
-    # The next view AT THE REQUEST ORIGIN is a read-through HIT (zero builds) — the
+    # A view AT THE REQUEST ORIGIN addresses the job the pre-warm already queued — the
     # pre-warm used prewarm_origin, not the (different) env fallback.
-    result = await sites_service.get_native_artifact(
+    view_kw = dict(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
         builder_origin=view_origin,
-        _generator=_NoBuildGenerator(),
+        _store=store,
     )
+    pending = await sites_service.get_native_artifact(**view_kw)
+    assert pending["build_job_id"] == pool.calls[0]["job_id"]
+
+    # And once that render lands it serves, which is what the origin actually decides.
+    _seed_store(store, pocket_id, await _hash_for(pocket_id, origin=view_origin), tmp_path)
+    result = await sites_service.get_native_artifact(**view_kw)
     assert result["pocket_id"] == pocket_id
     assert 'data-uid="Hero:headline:0"' in result["body_html"]
 
@@ -599,13 +706,15 @@ async def test_publish_no_prewarm_origin_keeps_env_fallback(
 ):
     """A publish with NO prewarm_origin (a chat-agent / MCP publish — no request origin)
     keeps the pre-warm's PAW_SITES_BUILDER_ORIGIN env fallback, so a view with no origin
-    (which resolves the same env fallback) still HITs. Guards the defaulted param: the
-    fix must not regress the no-request-origin path."""
+    resolves the SAME render and rides the pre-warm's job rather than queueing its own.
+    Guards the defaulted param: the fix must not regress the no-request-origin path."""
     monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
     monkeypatch.setenv("PAW_SITES_BUILDER_ORIGIN", "https://configured.paw.example")
     pocket_id = await _make_svelte_pocket("ws1", "u1")
     _write_built_output(tmp_path)
     gen = _CountingGenerator(str(tmp_path))
+    store = _MemoryArtifactStore()
+    pool = _install_pool(monkeypatch)
 
     await sites_service.publish_pocket(
         workspace_id="ws1",
@@ -617,15 +726,17 @@ async def test_publish_no_prewarm_origin_keeps_env_fallback(
     )
     assert len(_captured_prewarms) == 1
     await _captured_prewarms[0]
+    assert len(pool.calls) == 1
 
     result = await sites_service.get_native_artifact(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
         builder_origin="",  # resolves the same env fallback the pre-warm used
-        _generator=_NoBuildGenerator(),
+        _store=store,
     )
     assert result["pocket_id"] == pocket_id
+    assert result["build_job_id"] == pool.calls[0]["job_id"]
 
 
 @pytest.mark.asyncio

--- a/tests/ee/sites/test_native_artifact_react.py
+++ b/tests/ee/sites/test_native_artifact_react.py
@@ -72,26 +72,32 @@ _ARMED_DIST_HTML = """<!DOCTYPE html>
 _LINKED_CSS = ".hero{color:#0A84FF}"
 
 
-class _FakeGenerator:
-    """Records build kwargs and points at a pre-populated `dist/` tree so the REAL
-    extraction runs without Bun or Vite."""
+class _RecordingPool:
+    """An arq pool that records the enqueue instead of performing it (SP-2).
 
-    def __init__(self, project_dir: str) -> None:
-        self.project_dir = project_dir
-        self.built: dict | None = None
+    Replaces the generator fakes this file used to carry: the cold path no longer builds
+    in-process, so what a reject path must not do is QUEUE a sandbox.
+    """
 
-    async def build(self, **kw):
-        from pocketpaw_ee.sites.generator_client import BuildResult
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
 
-        self.built = kw
-        return BuildResult(project_dir=self.project_dir, ripple_version=None)
+    async def enqueue_job(self, function: str, *args, _job_id: str | None = None, **kw):
+        self.calls.append({"function": function, "args": args, "job_id": _job_id})
+        return object()
 
 
-class _NoBuildGenerator:
-    """A generator whose build MUST NOT run — the reject paths must fail first."""
+class _MemoryArtifactStore:
+    """In-memory ``_store`` seam - the read-through logic without disk."""
 
-    async def build(self, **kw):  # pragma: no cover - must not be reached
-        raise AssertionError("the build must not run on the reject path")
+    def __init__(self) -> None:
+        self.data: dict[tuple[str, str], tuple[str, str]] = {}
+
+    def read(self, pocket_id: str, content_hash: str) -> tuple[str, str] | None:
+        return self.data.get((pocket_id, content_hash))
+
+    def write(self, pocket_id: str, content_hash: str, body_html: str, css: str) -> None:
+        self.data[(pocket_id, content_hash)] = (body_html, css)
 
 
 def _write_react_dist(project_dir: Path) -> None:
@@ -122,17 +128,44 @@ async def _make_pocket(engine: str, source, workspace_id="ws1", user_id="u1") ->
 
 @pytest.mark.asyncio
 async def test_react_pocket_renders_from_dist(beanie_test_db, tmp_path):
-    """A react pocket is accepted, armed on the REACT track, and read from dist/."""
+    """A react pocket is accepted, armed on the REACT track, and read from dist/.
+
+    SP-2 split this across the two halves it now has: the ARMED ENQUEUE happens here (the
+    payload's engine + builderOrigin + source), and the dist/ read happens in the preview
+    worker — exercised here by seeding the store with the REAL extraction of a react
+    build tree, which resolves ``dist`` and not the SvelteKit path (absent here)."""
     pocket_id = await _make_pocket("react", dict(_REACT_SOURCE))
     _write_react_dist(tmp_path)
-    gen = _FakeGenerator(str(tmp_path))
+    origin = "https://dash.paw.example"
+    store = _MemoryArtifactStore()
+    pool = _RecordingPool()
+
+    # Cold: the armed build is QUEUED, on the react track, with the pocket's source.
+    pending = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin=origin,
+        _store=store,
+        _pool=pool,
+    )
+    assert pending["build_status"] == "queued"
+    _pk, content_hash, generator_input, engine, _timeout = pool.calls[0]["args"]
+    assert engine == "react"
+    assert generator_input["siteConfig"]["builderOrigin"] == origin
+    assert generator_input["source"]["src/App.tsx"] == _REACT_SOURCE["src/App.tsx"]
+
+    # The worker lands: it reads dist/ off the built tree and stores the extraction.
+    body_html, css = sites_service._read_native_artifact(str(tmp_path), "react")
+    store.data[(pocket_id, content_hash)] = (body_html, css)
 
     result = await sites_service.get_native_artifact(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
-        builder_origin="https://dash.paw.example",
-        _generator=gen,
+        builder_origin=origin,
+        _store=store,
+        _pool=pool,
     )
 
     assert result["pocket_id"] == pocket_id
@@ -144,12 +177,7 @@ async def test_react_pocket_renders_from_dist(beanie_test_db, tmp_path):
     # the read resolved dist/, not the SvelteKit path (which does not exist here).
     assert ".inline-critical{margin:0}" in result["css"]
     assert _LINKED_CSS in result["css"]
-    # The build was ARMED, and on the react track.
-    assert gen.built is not None
-    assert gen.built["engine"] == "react"
-    assert gen.built["builder_origin"] == "https://dash.paw.example"
-    assert gen.built["smoke"] is False
-    assert gen.built["source"]["src/App.tsx"] == _REACT_SOURCE["src/App.tsx"]
+    assert len(pool.calls) == 1, "the warm view must not queue a second sandbox"
 
 
 @pytest.mark.asyncio
@@ -158,13 +186,15 @@ async def test_html_pocket_still_rejected(beanie_test_db):
     its source. Widening the guard to `is_source_engine` would have swept it in."""
     pocket_id = await _make_pocket("html", {"index.html": "<h1>hi</h1>"})
 
+    pool = _RecordingPool()
     with pytest.raises(ValidationError):
         await sites_service.get_native_artifact(
             workspace_id="ws1",
             user_id="u1",
             pocket_id=pocket_id,
-            _generator=_NoBuildGenerator(),
+            _pool=pool,
         )
+    assert pool.calls == [], "a rejected engine must not queue a sandbox"
 
 
 @pytest.mark.asyncio
@@ -183,13 +213,15 @@ async def test_ripple_pocket_still_rejected(beanie_test_db):
     )
     assert err is None, err
 
+    pool = _RecordingPool()
     with pytest.raises(ValidationError):
         await sites_service.get_native_artifact(
             workspace_id="ws1",
             user_id="u1",
             pocket_id=pocket_id,
-            _generator=_NoBuildGenerator(),
+            _pool=pool,
         )
+    assert pool.calls == []
 
 
 def test_content_hash_separates_engines():

--- a/tests/ee/sites/test_preview_build_lane.py
+++ b/tests/ee/sites/test_preview_build_lane.py
@@ -1,0 +1,643 @@
+# tests/ee/sites/test_preview_build_lane.py — SP-2: the DRAFT PREVIEW builds in the
+# ephemeral Daytona lane instead of shelling out to bun in the API container.
+# Created 2026-08-24.
+#
+# WHAT BROKE, AND WHAT THIS PINS. ``get_native_artifact``'s cold miss used to call
+# ``generator.build`` → ``bun``. The deployed API container has no toolchain, so every
+# cold preview raised and reached the user as ``sites.generator_failed``. The PUBLISH
+# path had already solved this (SL-3: scaffold locally, build in a sandbox, verify the
+# bytes); preview never adopted it. It does now, and the properties worth pinning are:
+#
+#   * A CACHE HIT IS STILL SYNCHRONOUS AND STILL FREE. This is the one that costs money
+#     if it regresses: a miss now spends a Daytona sandbox (react 8.70s, svelte 14.67s
+#     in-sandbox, before create / upload / teardown), so a bypassed cache check bills one
+#     per keystroke in the editor. ``tests/mutations/site_preview_daytona.json`` mutates
+#     the check away and this file is what must fail.
+#   * A COLD MISS QUEUES AND SAYS SO — the build-pending shape, in the PUBLISH LANE'S
+#     vocabulary (``queued`` / ``building`` / ``failed``), not a second one.
+#   * A FAILED ENQUEUE IS AN ERROR, NOT A PENDING BUILD. Handing back a job id for a job
+#     nobody will run makes a client poll forever while the endpoint reports progress —
+#     strictly worse than a 503 the user can retry.
+#   * THE LANE IS SINGLE-FLIGHT ON THE CONTENT HASH. The job id IS the hash, so a client
+#     polling a 15s build every 2s reads the SAME job instead of opening a sandbox per
+#     poll. A render that already FINISHED and left the store empty reports ``failed``
+#     rather than spinning the poller or rebuilding identical inputs on a loop.
+#   * THE JOB WRITES THE ARTIFACT THE ENDPOINT READS. The worker unpacks the tar and
+#     stores ``{body_html, css}`` under the SAME content hash the enqueue used, which is
+#     the whole reason the next call is a hit.
+#
+# The publish lane (``run_site_build`` / ``enqueue_site_build``) is untouched and is
+# covered by test_build_job.py; nothing here should need to change if it does.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import build_job as bj
+from pocketpaw_ee.sites import service as sites_service
+
+from tests.ee.sites.faults import FaultyDaytonaClient, tar_bytes
+from tests.ee.sites.test_build_job import FakeRunner
+
+# asyncio_mode = "auto" is set project-wide, so async tests need no per-test mark and a
+# sync one (the worker-registration check below) stays sync.
+_ORIGIN = "https://dash.paw.example"
+
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/lib/components/Hero.svelte": "<section class='hero'><h1>Bright Smile</h1></section>",
+    "src/app.css": ":root{--brand:#0A84FF}",
+}
+
+# What a real armed build leaves in the static output dir, packed the way
+# ``artifact_tar_command`` packs it: rooted AT the output dir's contents, so the members
+# are ``./index.html`` and not ``./dist/index.html``.
+_ARMED_INDEX = (
+    b"<!DOCTYPE html><html><head>"
+    b'<link rel="stylesheet" href="./assets/page.css" />'
+    b"<style>.inline-critical{margin:0}</style>"
+    b"</head><body>"
+    b'<section data-paw-section="Hero"><h1 data-uid="Hero:headline:0">Bright Smile</h1></section>'
+    b'<script id="paw-edit-manifest" type="application/json">{"leaves":[]}</script>'
+    b"</body></html>"
+)
+_ARMED_CSS = b".hero{color:#0A84FF}"
+
+
+def armed_artifact() -> bytes:
+    """A clean build's tar carrying a prerendered ARMED page and its stylesheet."""
+    return tar_bytes({"./index.html": _ARMED_INDEX, "./assets/page.css": _ARMED_CSS})
+
+
+class FakePool:
+    """An arq pool that records the enqueue instead of performing it.
+
+    ``refuse=True`` is arq's duplicate-id answer (a ``None`` return), which is this
+    lane's single-flight signal rather than an error.
+    """
+
+    def __init__(self, *, error: BaseException | None = None, refuse: bool = False) -> None:
+        self.error = error
+        self.refuse = refuse
+        self.calls: list[dict[str, Any]] = []
+
+    async def enqueue_job(self, function: str, *args: Any, _job_id: str | None = None, **kw: Any):
+        self.calls.append({"function": function, "args": args, "job_id": _job_id, "kwargs": kw})
+        if self.error is not None:
+            raise self.error
+        return None if self.refuse else object()
+
+
+class MemoryArtifactStore:
+    """In-memory ``_store`` seam — the read-through logic without disk."""
+
+    def __init__(self) -> None:
+        self.data: dict[tuple[str, str], tuple[str, str]] = {}
+        self.writes = 0
+
+    def read(self, pocket_id: str, content_hash: str) -> tuple[str, str] | None:
+        return self.data.get((pocket_id, content_hash))
+
+    def write(self, pocket_id: str, content_hash: str, body_html: str, css: str) -> None:
+        self.data[(pocket_id, content_hash)] = (body_html, css)
+        self.writes += 1
+
+
+async def _make_pocket(engine: str = "svelte", source: dict[str, str] | None = None) -> str:
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine=engine,
+        source=dict(source if source is not None else _SVELTE_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+async def _content_hash(pocket_id: str, *, engine: str = "svelte", origin: str = _ORIGIN) -> str:
+    """The hash the service will compute for this pocket — the store key AND the job id.
+
+    Derived from the PERSISTED pocket rather than from ``_SVELTE_SOURCE`` so a test that
+    seeds the store seeds the key the service actually looks up.
+    """
+    from pocketpaw_ee.sites import generator_client
+
+    wire = await pockets_service.get(pocket_id, "u1")
+    return sites_service._artifact_content_hash(
+        source=wire["source"],
+        theme={},
+        builder_origin=origin,
+        gen_version=generator_client.generator_version(),
+        engine=engine,
+    )
+
+
+async def _get(pocket_id: str, **kw: Any) -> dict[str, Any]:
+    return await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin=kw.pop("builder_origin", _ORIGIN),
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Arm 1 — the WARM request. Synchronous, and it must not reach the queue.
+# ---------------------------------------------------------------------------
+
+
+class TestACacheHitCostsNothing:
+    async def test_a_hit_returns_the_render_and_never_enqueues(self, beanie_test_db) -> None:
+        """The acceptance criterion that guards the bill: a warm request returns
+        ``{body_html, css}`` with no enqueue and no sandbox.
+
+        The pool is the assertion. A store fake alone would prove the render came from
+        the cache but not that nothing was ALSO queued behind it — and a miss that
+        happened to serve stale bytes while queueing a rebuild is exactly the regression
+        that costs a sandbox per keystroke.
+        """
+        pocket_id = await _make_pocket()
+        store = MemoryArtifactStore()
+        store.data[(pocket_id, await _content_hash(pocket_id))] = (
+            "<h1>cached</h1>",
+            ".x{color:red}",
+        )
+        pool = FakePool()
+
+        result = await _get(pocket_id, _store=store, _pool=pool)
+
+        assert result["body_html"] == "<h1>cached</h1>"
+        assert result["css"] == ".x{color:red}"
+        assert pool.calls == [], "a cache hit must not queue a build"
+        assert store.writes == 0, "a cache hit must not re-store"
+
+    async def test_a_served_render_is_not_reported_as_a_build(self, beanie_test_db) -> None:
+        """``build_status`` is how a client tells the two response shapes apart, so the
+        hit branch has to say "not building" rather than leave the field at whatever the
+        last miss set. ``"none"`` is the same value ``pocket_status`` gives a pocket that
+        has never built."""
+        pocket_id = await _make_pocket()
+        store = MemoryArtifactStore()
+        store.data[(pocket_id, await _content_hash(pocket_id))] = ("<h1>c</h1>", "")
+
+        result = await _get(pocket_id, _store=store, _pool=FakePool())
+
+        assert result["build_status"] == "none"
+        assert result["build_job_id"] is None
+        assert result["build_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# Arm 2 — the COLD request. Queues, and says so.
+# ---------------------------------------------------------------------------
+
+
+class TestAColdMissQueuesTheBuild:
+    async def test_it_enqueues_and_returns_the_pending_shape(self, beanie_test_db) -> None:
+        pocket_id = await _make_pocket()
+        pool = FakePool()
+
+        result = await _get(pocket_id, _store=MemoryArtifactStore(), _pool=pool)
+
+        assert len(pool.calls) == 1, "a cold miss must queue exactly one build"
+        assert pool.calls[0]["function"] == bj.PREVIEW_ARQ_FUNCTION_NAME
+        assert result["build_status"] == "queued"
+        assert result["build_job_id"] == pool.calls[0]["job_id"]
+        # Empty rather than absent: the field's type must not change under a client that
+        # reads it before checking the status.
+        assert result["body_html"] == ""
+        assert result["css"] == ""
+
+    async def test_the_queued_payload_is_the_armed_build(self, beanie_test_db) -> None:
+        """The whole point of the preview build is the ARMING — ``builderOrigin`` is what
+        makes the generator stamp ``data-uid`` and embed the ``paw-edit-manifest``. A
+        payload that lost it would build a page the native editor cannot select in, and
+        the render would look correct."""
+        pocket_id = await _make_pocket()
+        pool = FakePool()
+
+        await _get(pocket_id, _store=MemoryArtifactStore(), _pool=pool)
+
+        _pocket, _hash, generator_input, engine, _timeout = pool.calls[0]["args"]
+        assert engine == "svelte"
+        assert generator_input["siteConfig"]["builderOrigin"] == _ORIGIN
+        assert (
+            generator_input["source"]["src/lib/components/Hero.svelte"]
+            == (_SVELTE_SOURCE["src/lib/components/Hero.svelte"])
+        )
+
+    async def test_the_job_carries_the_hash_the_store_is_keyed_on(self, beanie_test_db) -> None:
+        """The job id and the payload's ``content_hash`` are the SAME value the endpoint
+        just looked up, and the worker writes under it. Recomputing it anywhere else is
+        how a build's output lands under a key nothing reads."""
+        pocket_id = await _make_pocket()
+        pool = FakePool()
+
+        result = await _get(pocket_id, _store=MemoryArtifactStore(), _pool=pool)
+
+        expected = await _content_hash(pocket_id)
+        assert pool.calls[0]["args"][0] == pocket_id
+        assert pool.calls[0]["args"][1] == expected
+        assert result["build_job_id"] == bj._preview_job_id(pocket_id, expected)
+
+    async def test_the_capture_key_is_scrubbed_before_it_reaches_redis(
+        self, beanie_test_db
+    ) -> None:
+        """The per-site capture secret never enters a queue payload or a third-party
+        sandbox — the obligation ``build_job``'s header records, and the preview enqueue
+        is a new way into the same pipe."""
+        pocket_id = await _make_pocket()
+        pool = FakePool()
+
+        await _get(pocket_id, _store=MemoryArtifactStore(), _pool=pool)
+
+        generator_input = pool.calls[0]["args"][2]
+        assert generator_input["siteConfig"]["captureSignedKey"] == ""
+
+    async def test_the_default_origin_falls_back_to_the_configured_one(
+        self, beanie_test_db, monkeypatch
+    ) -> None:
+        """A caller with no request Origin still queues an ARMED build — the same
+        ``PAW_SITES_BUILDER_ORIGIN`` precedence ``/editable`` and ``/dev-preview`` use."""
+        monkeypatch.setenv("PAW_SITES_BUILDER_ORIGIN", "https://configured.paw.example")
+        pocket_id = await _make_pocket()
+        pool = FakePool()
+
+        await _get(pocket_id, builder_origin="", _store=MemoryArtifactStore(), _pool=pool)
+
+        generator_input = pool.calls[0]["args"][2]
+        assert generator_input["siteConfig"]["builderOrigin"] == "https://configured.paw.example"
+
+
+# ---------------------------------------------------------------------------
+# Arm 3 — the enqueue that FAILED. Never a pending build.
+# ---------------------------------------------------------------------------
+
+
+class TestAFailedEnqueueIsNotAPendingBuild:
+    async def test_a_dead_queue_is_an_error_not_a_job_id(self, beanie_test_db) -> None:
+        """The failure this arm exists to prevent is the SILENT one. Returning the
+        pending shape here hands the client a handle for a job nobody will run: it polls
+        forever, and the endpoint reports progress the whole time. A 503 is recoverable —
+        the user retries and gets a real slot."""
+        pocket_id = await _make_pocket()
+        pool = FakePool(error=RuntimeError("redis is gone"))
+
+        with pytest.raises(CloudError) as excinfo:
+            await _get(pocket_id, _store=MemoryArtifactStore(), _pool=pool)
+
+        assert excinfo.value.code == "sites.preview_build_unavailable"
+        assert excinfo.value.status_code >= 500
+        # The mapped envelope, not the raw RuntimeError escaping as an opaque 500.
+        assert not isinstance(excinfo.value, RuntimeError)
+
+    async def test_nothing_is_written_to_the_store_on_a_failed_enqueue(
+        self, beanie_test_db
+    ) -> None:
+        """A queue failure must not leave a cache entry behind — the next request has to
+        be a genuine miss that tries again, not a hit on an artifact that was never
+        built."""
+        pocket_id = await _make_pocket()
+        store = MemoryArtifactStore()
+
+        with pytest.raises(CloudError):
+            await _get(pocket_id, _store=store, _pool=FakePool(error=RuntimeError("boom")))
+
+        assert store.writes == 0
+        assert store.data == {}
+
+
+# ---------------------------------------------------------------------------
+# Single-flight — the job id IS the content hash.
+# ---------------------------------------------------------------------------
+
+
+class TestOneRenderIsOneSandbox:
+    async def test_the_same_render_gets_the_same_job_id(self, beanie_test_db) -> None:
+        """Two requests for an unchanged draft address the SAME job. This is what makes a
+        polling client cost one sandbox instead of one per poll — arq refuses the second
+        enqueue because the id is taken."""
+        pocket_id = await _make_pocket()
+        pool = FakePool()
+        store = MemoryArtifactStore()
+
+        first = await _get(pocket_id, _store=store, _pool=pool)
+        second = await _get(pocket_id, _store=store, _pool=pool)
+
+        assert first["build_job_id"] == second["build_job_id"]
+
+    async def test_a_source_change_gets_a_different_job(self, beanie_test_db) -> None:
+        """The other half of the same property: the guard must not be so sticky that an
+        EDITED draft rides the previous render's build."""
+        pocket_id = await _make_pocket()
+        pool = FakePool()
+        store = MemoryArtifactStore()
+
+        before = await _get(pocket_id, _store=store, _pool=pool)
+        await pockets_service.set_svelte_source_file(
+            pocket_id,
+            "u1",
+            component_path="src/lib/components/Hero.svelte",
+            new_source="<section class='hero'><h1>Changed</h1></section>",
+        )
+        after = await _get(pocket_id, _store=store, _pool=pool)
+
+        assert before["build_job_id"] != after["build_job_id"]
+
+    async def test_a_refused_enqueue_reports_the_build_already_running(
+        self, beanie_test_db, monkeypatch
+    ) -> None:
+        """arq answers a duplicate id with ``None``. That is the guard firing, not an
+        error, and it must read as an in-flight build carrying the SAME handle — a client
+        that got a fresh id here would abandon the build it is actually waiting on."""
+        pocket_id = await _make_pocket()
+        pool = FakePool(refuse=True)
+
+        async def _in_flight(_pool: Any, job_id: str) -> tuple[str, str | None]:
+            return "building", None
+
+        monkeypatch.setattr(bj, "_preview_job_outcome", _in_flight)
+        result = await _get(pocket_id, _store=MemoryArtifactStore(), _pool=pool)
+
+        assert result["build_status"] == "building"
+        assert result["build_job_id"] == bj._preview_job_id(
+            pocket_id, await _content_hash(pocket_id)
+        )
+
+    async def test_a_render_that_already_failed_reports_failed_not_pending(
+        self, beanie_test_db, monkeypatch
+    ) -> None:
+        """The reason a refused enqueue is INSPECTED rather than assumed to be in flight.
+        A completed job holds its id for ``keep_result`` (an hour by default), so
+        reporting ``building`` here would spin a client on a build that is over — for an
+        hour, on inputs that already failed."""
+        pocket_id = await _make_pocket()
+
+        async def _already_failed(_pool: Any, job_id: str) -> tuple[str, str | None]:
+            return "failed", "build_failed:exit_1"
+
+        monkeypatch.setattr(bj, "_preview_job_outcome", _already_failed)
+        result = await _get(pocket_id, _store=MemoryArtifactStore(), _pool=FakePool(refuse=True))
+
+        assert result["build_status"] == "failed"
+        assert result["build_reason"] == "build_failed:exit_1"
+        assert result["body_html"] == ""
+
+
+class TestReadingARefusedEnqueue:
+    """``_preview_job_outcome`` against a stand-in for arq's ``Job``."""
+
+    def _patch_job(self, monkeypatch, *, status: Any, info: Any) -> None:
+        from arq.jobs import JobStatus
+
+        class _FakeJob:
+            def __init__(self, job_id: str, pool: Any) -> None:
+                self.job_id = job_id
+
+            async def status(self) -> Any:
+                return status
+
+            async def result_info(self) -> Any:
+                return info
+
+        monkeypatch.setattr(bj, "Job", _FakeJob)
+        assert JobStatus.complete is not None  # the enum the production code compares on
+
+    async def test_a_running_job_reads_as_building(self, monkeypatch) -> None:
+        from arq.jobs import JobStatus
+
+        self._patch_job(monkeypatch, status=JobStatus.in_progress, info=None)
+        assert await bj._preview_job_outcome(object(), "j1") == ("building", None)
+
+    async def test_a_completed_job_reports_its_own_settlement(self, monkeypatch) -> None:
+        from arq.jobs import JobStatus
+
+        class _Info:
+            success = True
+            result = {"status": "failed", "reason": "scaffold_failed:generator_raised"}
+
+        self._patch_job(monkeypatch, status=JobStatus.complete, info=_Info())
+        assert await bj._preview_job_outcome(object(), "j1") == (
+            "failed",
+            "scaffold_failed:generator_raised",
+        )
+
+    async def test_a_job_that_raised_reads_as_a_lost_sandbox(self, monkeypatch) -> None:
+        """``run_site_preview_build`` re-raises for exactly one condition — a sandbox it
+        never reached. The exception text can name paths, so only the rung travels."""
+        from arq.jobs import JobStatus
+
+        class _Info:
+            success = False
+            result = RuntimeError("Daytona is not configured")
+
+        self._patch_job(monkeypatch, status=JobStatus.complete, info=_Info())
+        status, reason = await bj._preview_job_outcome(object(), "j1")
+        assert status == "failed"
+        assert reason == f"{bj.RUNG_SANDBOX_UNAVAILABLE}:job_raised"
+        assert "Daytona" not in (reason or "")
+
+    async def test_an_expired_result_reads_as_building_not_failed(self, monkeypatch) -> None:
+        """A result that lapsed between the enqueue and this read is a pure race. The
+        next poll enqueues cleanly because the id is free again, so the honest answer is
+        "still coming" rather than a failure that never happened."""
+        from arq.jobs import JobStatus
+
+        self._patch_job(monkeypatch, status=JobStatus.complete, info=None)
+        assert await bj._preview_job_outcome(object(), "j1") == ("building", None)
+
+
+# ---------------------------------------------------------------------------
+# The worker — what the queued job actually does.
+# ---------------------------------------------------------------------------
+
+
+def _preview_input(builder_origin: str = _ORIGIN) -> dict[str, Any]:
+    from pocketpaw_ee.sites.generator_client import build_generator_input
+
+    return build_generator_input(
+        engine="react",
+        theme={},
+        site_id="preview-1",
+        title="Bright Smile",
+        capture_api_base="http://localhost:8888/api/v1",
+        capture_signed_key="",
+        ripple_spec={},
+        source={"src/App.tsx": "export default () => null"},
+        builder_origin=builder_origin,
+    )
+
+
+def _sandbox(artifact: bytes | None = None, **over: Any) -> FaultyDaytonaClient:
+    """A Daytona fake whose sentinel PROMISES the artifact it will actually hand back.
+
+    ``ok_sentinel`` defaults its ``artifact_bytes`` to the size of ``clean_artifact()``,
+    and ``verify_artifact`` compares the promise against what arrives — so a fake handing
+    back a differently-sized tar under the default sentinel either fails as
+    ``artifact_truncated`` or passes only because it happened to be bigger. Both make the
+    test say something other than what it claims.
+    """
+    from tests.ee.sites.faults import ok_sentinel
+
+    payload = armed_artifact() if artifact is None else artifact
+    sentinel = over.pop("sentinel", None) or ok_sentinel(artifact_bytes=len(payload))
+    return FaultyDaytonaClient(artifact=payload, sentinel=sentinel, **over)
+
+
+async def _run_preview_job(
+    *,
+    pocket_id: str = "pk1",
+    content_hash: str = "c0ffee",
+    engine: str = "react",
+    client: Any = None,
+    runner: Any = None,
+    store: Any = None,
+) -> dict[str, str]:
+    return await bj.run_site_preview_build(
+        {},
+        pocket_id,
+        content_hash,
+        _preview_input(),
+        engine,
+        600,
+        _runner=runner or FakeRunner(),
+        _client=client if client is not None else _sandbox(),
+        _store=store,
+    )
+
+
+class TestThePreviewJob:
+    async def test_a_clean_build_lands_in_the_store_as_body_and_css(self) -> None:
+        """The join the whole slice rests on: the tar the sandbox produced becomes the
+        exact ``{body_html, css}`` the endpoint serves, under the SAME content hash the
+        enqueue used. Asserted on the ARMED markers, because a job that stored the
+        untouched ``index.html`` (or the wrong dir's) would also write two strings."""
+        store = MemoryArtifactStore()
+        settlement = await _run_preview_job(store=store)
+
+        assert settlement["status"] == "built"
+        body_html, css = store.data[("pk1", "c0ffee")]
+        # <body> INNER — the stamped leaf and the manifest, without the head chrome.
+        assert 'data-uid="Hero:headline:0"' in body_html
+        assert 'id="paw-edit-manifest"' in body_html
+        assert "<head" not in body_html
+        # CSS concatenates the inline critical block AND the linked stylesheet, which is
+        # only possible if the tar was unpacked UNDER the engine's output dir — the read
+        # resolves the href relative to it.
+        assert ".inline-critical{margin:0}" in css
+        assert _ARMED_CSS.decode() in css
+
+    async def test_a_failed_build_stores_nothing_and_names_the_rung(self) -> None:
+        """A build that did not produce an artifact must leave the cache untouched — a
+        stored empty render would be served forever as a successful preview."""
+        store = MemoryArtifactStore()
+        from tests.ee.sites.faults import ok_sentinel
+
+        settlement = await _run_preview_job(
+            client=_sandbox(sentinel=ok_sentinel(build_exit=1, stderr_tail="TS2304")),
+            store=store,
+        )
+
+        assert settlement["status"] == "failed"
+        assert settlement["reason"].startswith("build_failed")
+        assert store.data == {}
+
+    async def test_a_scaffold_that_raises_settles_without_a_sandbox(self) -> None:
+        """Nothing was billed, so the settlement is the whole outcome. The generator's
+        stderr can name paths and carry the user's content, so only the rung travels."""
+        client = _sandbox()
+        settlement = await _run_preview_job(
+            runner=FakeRunner(raises=RuntimeError("bun: not found")),
+            client=client,
+        )
+
+        assert settlement == {
+            "status": "failed",
+            "reason": f"{bj.RUNG_SCAFFOLD_FAILED}:generator_raised",
+        }
+        assert client.calls == [], "a scaffold failure must not create a sandbox"
+        assert "bun: not found" not in settlement["reason"]
+
+    async def test_an_empty_scaffold_is_caught_before_a_sandbox_exists(self) -> None:
+        client = _sandbox()
+        settlement = await _run_preview_job(runner=FakeRunner(tree={}), client=client)
+
+        assert settlement["reason"] == f"{bj.RUNG_SCAFFOLD_EMPTY}:no_files_generated"
+        assert client.calls == []
+
+    async def test_a_clean_build_whose_artifact_cannot_be_read_is_its_own_rung(self) -> None:
+        """The build compiled; the tar carried no page. Naming this a build failure would
+        send the user to debug working code, which is the same reason the deploy path
+        gives ``deploy_failed`` its own rung."""
+        store = MemoryArtifactStore()
+        settlement = await _run_preview_job(
+            client=_sandbox(tar_bytes({"./assets/app.js": b"console.log(1)"})),
+            store=store,
+        )
+
+        assert settlement["status"] == "failed"
+        assert settlement["reason"] == f"{bj.RUNG_PREVIEW_UNREADABLE}:read_or_store_raised"
+        assert store.data == {}
+
+    async def test_a_lost_sandbox_re_raises_for_the_worker_log(self) -> None:
+        """The one condition the job does NOT swallow. ``_preview_job_outcome`` maps the
+        failed arq job back to the ``sandbox_unavailable`` rung, so a poller still gets a
+        terminal answer — but an operator needs the real exception in the log."""
+        with pytest.raises(Exception):
+            await _run_preview_job(client=_sandbox(fail_at="create"))
+
+    async def test_an_unbuildable_engine_is_refused_before_a_sandbox(self) -> None:
+        """A routing bug, not a build failure. ``get_native_artifact`` gates on
+        ``has_native_edit_lane`` and every engine that passes also builds here — checked
+        anyway rather than spending a sandbox to discover the day that stops holding."""
+        client = _sandbox()
+        settlement = await _run_preview_job(engine="html", client=client)
+
+        assert settlement["reason"] == f"{bj.RUNG_ENGINE_NOT_BUILDABLE}:html"
+        assert client.calls == []
+
+    async def test_the_enqueue_refuses_an_unbuildable_engine_too(self) -> None:
+        """The same guard on the near side, so a routing bug never even reaches Redis."""
+        pool = FakePool()
+        with pytest.raises(RuntimeError):
+            await bj.enqueue_preview_build(
+                pocket_id="pk1",
+                content_hash="c0ffee",
+                engine="html",
+                generator_input=_preview_input(),
+                _pool_override=pool,
+            )
+        assert pool.calls == []
+
+
+class TestTheWorkerRunsThePreviewLane:
+    def test_the_preview_job_is_registered_under_the_name_the_enqueue_writes(
+        self, monkeypatch
+    ) -> None:
+        """An enqueue name and a registration name that drift produce a job that sits in
+        Redis forever with no worker willing to claim it, and no error anywhere."""
+        monkeypatch.setenv("POCKETPAW_REDIS_URL", "redis://localhost:6379")
+        from pocketpaw_ee.cloud.chat.runs import worker as worker_mod
+
+        registered = {f.name: f for f in worker_mod.WorkerSettings.functions if hasattr(f, "name")}
+
+        assert bj.PREVIEW_ARQ_FUNCTION_NAME in registered
+        preview = registered[bj.PREVIEW_ARQ_FUNCTION_NAME]
+        assert preview.coroutine is bj.run_site_preview_build
+        # Same budget as the publish build — it IS the same build; only what happens to
+        # the artifact differs.
+        assert preview.timeout_s == bj.site_build_job_timeout_seconds()
+        # A preview is billed per attempt too, so the retry decision is the caller's.
+        assert preview.max_tries == 1

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -1019,6 +1019,35 @@ async def test_native_artifact_route_returns_body_and_css(beanie_test_db, monkey
 
 
 @pytest.mark.asyncio
+async def test_native_artifact_route_carries_the_build_pending_shape(beanie_test_db, monkeypatch):
+    """SP-2: a cold miss answers with a build to POLL, and the route has to carry the
+    handle. ``NativeArtifactResponse`` defaults ``build_status`` to "none", so a response
+    model that had not been widened would 200 with the pending fields silently dropped —
+    the client would see an empty render and no reason, forever."""
+
+    async def _pending(**kw):
+        return {
+            "pocket_id": "pk1",
+            "body_html": "",
+            "css": "",
+            "build_status": "queued",
+            "build_reason": None,
+            "build_job_id": "site-preview-pk1-deadbeef",
+        }
+
+    monkeypatch.setattr(sites_service, "get_native_artifact", _pending)
+    app = _build_app("ws_owner")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk1/native-artifact")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["build_status"] == "queued"
+    assert body["build_job_id"] == "site-preview-pk1-deadbeef"
+    assert body["body_html"] == ""
+
+
+@pytest.mark.asyncio
 async def test_native_artifact_route_non_svelte_is_422(beanie_test_db, monkeypatch):
     """A ripple pocket has no svelte build → 422 (the service ValidationError maps to
     422); no build is triggered (the service raises before constructing a generator)."""

--- a/tests/mutations/site_preview_daytona.json
+++ b/tests/mutations/site_preview_daytona.json
@@ -1,0 +1,68 @@
+[
+  {
+    "label": "preview lane: the cache check no longer short-circuits, so every view queues a sandbox",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    cached = store.read(pocket_id, content_hash)\n    if cached is not None:\n        body_html, css = cached",
+    "replace": "    cached = None\n    if cached is not None:\n        body_html, css = cached",
+    "tests": [
+      "tests/ee/sites/test_preview_build_lane.py",
+      "tests/ee/sites/test_native_artifact.py"
+    ]
+  },
+  {
+    "label": "preview lane: a failed enqueue reads as a pending build the client polls forever",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        logger.exception(\"sites.preview: could not queue the preview build for %s\", pocket_id)\n        raise CloudError(\n            503,\n            \"sites.preview_build_unavailable\",\n            \"The preview build could not be queued. Try again in a moment.\",\n        ) from exc",
+    "replace": "        logger.exception(\"sites.preview: could not queue the preview build for %s\", pocket_id)\n        from pocketpaw_ee.sites.build_job import PreviewBuildEnqueue\n\n        enqueued = PreviewBuildEnqueue(job_id=\"site-preview-unknown\", status=\"queued\")",
+    "tests": [
+      "tests/ee/sites/test_preview_build_lane.py",
+      "tests/ee/sites/test_native_artifact.py"
+    ]
+  },
+  {
+    "label": "preview lane: a refused enqueue is assumed in flight, so a finished failure spins the poller",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "    if job is None:\n        status, reason = await _preview_job_outcome(pool, job_id)",
+    "replace": "    if job is None:\n        status, reason = \"building\", None",
+    "tests": [
+      "tests/ee/sites/test_preview_build_lane.py"
+    ]
+  },
+  {
+    "label": "preview lane: the job id gets a uuid tail, defeating single-flight on the content hash",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "    return f\"site-preview-{pocket_id}-{content_hash}\"",
+    "replace": "    return f\"site-preview-{pocket_id}-{content_hash}-{uuid.uuid4().hex}\"",
+    "tests": [
+      "tests/ee/sites/test_preview_build_lane.py"
+    ]
+  },
+  {
+    "label": "preview lane: a build that failed still has its artifact stored as a served render",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "    if settlement.status != \"built\":\n        # ``settle`` can answer None to keep a publish attempt in flight between retries.",
+    "replace": "    if settlement.status == \"never\":\n        # ``settle`` can answer None to keep a publish attempt in flight between retries.",
+    "tests": [
+      "tests/ee/sites/test_preview_build_lane.py"
+    ]
+  },
+  {
+    "label": "preview lane: the worker stores under its own key instead of the hash the enqueue carried",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "            pocket_id=pocket_id,\n            content_hash=content_hash,\n            output_rel=artifact_rel,",
+    "replace": "            pocket_id=pocket_id,\n            content_hash=\"recomputed\",\n            output_rel=artifact_rel,",
+    "tests": [
+      "tests/ee/sites/test_preview_build_lane.py"
+    ]
+  },
+  {
+    "label": "preview lane: the served-render branch reports a build in progress, badging a finished preview as pending",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            # A served render is not a build in any state. \"none\" is the same value\n            # ``pocket_status`` gives a pocket that has never built, and it is what stops\n            # a client badging a finished preview as mid-build.\n            \"build_status\": \"none\",",
+    "replace": "            \"build_status\": \"building\",",
+    "tests": [
+      "tests/ee/sites/test_preview_build_lane.py",
+      "tests/ee/sites/test_native_artifact.py"
+    ]
+  }
+]

--- a/tests/mutations/sl2_build_job.json
+++ b/tests/mutations/sl2_build_job.json
@@ -114,8 +114,8 @@
   {
     "label": "an empty scaffold is no longer detected, so a sandbox is created, installed and billed to build nothing — and the empty-deploy failure is caught (if at all) only after the money is spent",
     "file": "ee/pocketpaw_ee/sites/build_job.py",
-    "find": "        if not files:",
-    "replace": "        if False:",
+    "find": "        if not files:\n            logger.error(\"sites.build: scaffold of site %s produced no files\", site_id)",
+    "replace": "        if False:\n            logger.error(\"sites.build: scaffold of site %s produced no files\", site_id)",
     "tests": [
       "tests/ee/sites/test_build_job.py::TestTheJobRecordsWhatHappened::test_an_empty_scaffold_costs_no_sandbox"
     ]
@@ -150,8 +150,8 @@
   {
     "label": "the sandbox is held to a budget re-derived from the environment instead of the one the enqueue measured its staleness window against, so a config change mid-flight leaves a live build outside its own window and it gets re-enqueued on top of itself",
     "file": "ee/pocketpaw_ee/sites/build_job.py",
-    "find": "                timeout_seconds=timeout_seconds,",
-    "replace": "                timeout_seconds=resolve_build_timeout_seconds(engine),",
+    "find": "                timeout_seconds=timeout_seconds,\n                client=_client,\n                artifact_rel=artifact_rel,\n            )\n        except Exception:\n            # Nothing ran: Daytona unconfigured, or the sandbox could not be created.",
+    "replace": "                timeout_seconds=resolve_build_timeout_seconds(engine),\n                client=_client,\n                artifact_rel=artifact_rel,\n            )\n        except Exception:\n            # Nothing ran: Daytona unconfigured, or the sandbox could not be created.",
     "tests": [
       "tests/ee/sites/test_build_job.py::TestTheJobRecordsWhatHappened::test_the_sandbox_is_held_to_the_budget_it_was_enqueued_with"
     ]


### PR DESCRIPTION
**Stacked on #2009.** Merge that one first, with `--rebase` rather than `--squash`, then this rebases clean. The two touch the same region of `service.py` and the same section of `api-reference.md`, which is why they are stacked rather than parallel.

A cold `/native-artifact` used to call `generator.build`, which shells out to `bun`. That works on a laptop. The deployed API container has no toolchain, so every cold preview raised and reached users as `sites.generator_failed` on the native-editor path.

The build now goes to the same ephemeral Daytona lane the async publish path has used since SL-3. The API returns immediately with a build-pending shape; a worker scaffolds, installs and builds in a throwaway sandbox and writes `{body_html, css}` into the artifact store under the content hash this call already looked up, so the next view is an ordinary cache hit.

Three things here are load-bearing.

**The cache check stays in front, and it now guards money rather than seconds.** A miss costs a sandbox — 8.70s react, 14.67s svelte in-sandbox, before create, upload and teardown — so a bypassed check would bill one per keystroke in an editing session. There is a mutation for exactly this.

**The pre-warm moved too.** It could not keep building inline: that build fails in the container and `_safe_prewarm` swallows the failure, so the store would never warm and every view would wait on its own build. Sharing the lane also collapses an edit's pre-warm and the view that follows onto one sandbox, because the job id is the content hash.

**A failed enqueue is an error, not a pending build** (`sites.preview_build_unavailable`, 503). Handing back a job id nobody will run makes a client poll forever while the endpoint reports progress.

The `_generator` / `_read_built` seams go away with the inline build; `_pool` is what a test substitutes now. The publish path is untouched.

## Tests

643 lines of new coverage in `test_preview_build_lane.py`. Run on the stacked branch:

```
172 passed in 17.00s
```

Three mutation plans, all green after the rebase:

```
site_preview_daytona      all 7 mutations caught
sl2_build_job             all 24 mutations caught
sites_s3_artifact_store   all 15 mutations caught
```

## About the change to sl2_build_job.json

Two anchors in that existing plan became ambiguous once `build_job.py` grew, so they are extended with trailing context. The mutation payloads are unchanged — `if False:` is still `if False:`, and the timeout substitution is identical. The 24/24 above is that plan re-run, not the old result carried forward.

## Not in scope

Preview exposure is still loopback, so this fixes the build failure and not yet the address. That is the next slice.