### PR TITLE
The preview build ships the site's own JavaScript

### DIFF
--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -970,9 +970,7 @@ def _generator_build_id() -> str:
     # real files and taking the FIRST fingerprints node.exe, whose mtime never moves
     # on a generator rebuild. That would leave this function returning a constant and
     # the bug entirely unfixed, while looking like it worked.
-    entry: str | None = next(
-        (tok for tok in reversed(argv) if Path(tok).is_file()), None
-    )
+    entry: str | None = next((tok for tok in reversed(argv) if Path(tok).is_file()), None)
     if entry is None and argv:
         entry = shutil.which(argv[0])
     if not entry:

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -935,16 +935,76 @@ def artifact_home() -> Path:
 _ARTIFACT_FORMAT_EPOCH = "v1"
 
 
+def _generator_build_id() -> str:
+    """Identity of the paw-sites BUILD currently on disk — ``mtime_ns:size`` of the
+    resolved generator entry file, or ``"unresolved"`` when it cannot be located.
+
+    Added 2026-08-25. :func:`generator_version` claimed to identify "the paw-sites
+    GENERATOR", but every term of it was a hand-maintained constant or a dep version
+    string: rebuilding ``paw-sites/dist/cli.js`` did not move the cache key at all.
+    So a generator change that alters the built HTML — exactly what RX-2's react
+    ``data-uid`` stamping is — kept serving the render made by the OLD generator,
+    forever. Observed: two react pockets cached with ZERO ``data-uid``, which the
+    native editor reads as ``uids.size === 0`` and answers by falling back to the
+    section-level iframe editor. The symptom reaches the operator as "react selection
+    is coarse and stays armed in Browse mode", nowhere near the cache that caused it,
+    and no amount of rebuilding the generator clears it.
+
+    Stat, not hash: the bundled ``cli.js`` is ~10MB and this rides a per-view code
+    path, so a content hash would cost more than the rebuild it guards against.
+    ``mtime_ns`` moves on every rebuild, which is precisely the event that must
+    invalidate.
+
+    NOT memoised, deliberately. A module-level cache would pin the value at import
+    and reintroduce the bug for the case that matters most — a generator rebuilt
+    while the server is running, which is the normal inner loop when someone is
+    iterating on the generator itself.
+
+    ``"unresolved"`` (a CONSTANT, never a changing value) is the honest degrade: it
+    restores exactly today's behaviour rather than making the key unstable, which
+    would defeat the cache on every call."""
+    argv = _gen_cmd_argv()
+    # LAST existing-file token wins, and the direction is load-bearing. The documented
+    # local override is an INTERPRETER plus a script — the shipped one on this box is
+    # "C:/PROGRA~1/nodejs/node.exe D:/…/paw-sites/dist/cli.js" — so both tokens are
+    # real files and taking the FIRST fingerprints node.exe, whose mtime never moves
+    # on a generator rebuild. That would leave this function returning a constant and
+    # the bug entirely unfixed, while looking like it worked.
+    entry: str | None = next(
+        (tok for tok in reversed(argv) if Path(tok).is_file()), None
+    )
+    if entry is None and argv:
+        entry = shutil.which(argv[0])
+    if not entry:
+        return "unresolved"
+    try:
+        st = Path(entry).stat()
+    except OSError:
+        return "unresolved"
+    return f"{st.st_mtime_ns}:{st.st_size}"
+
+
 def generator_version() -> str:
     """A stable identifier of the paw-sites GENERATOR + artifact-format the cache is
     keyed on, so a generator/dep upgrade (which changes the built output) invalidates
     the native-artifact store rather than serving a render from the old toolchain.
 
-    Combines the artifact-format epoch with the pinned ripple + motion dep specs —
-    the inputs that most directly move the built HTML/CSS. It rides the content hash
-    in ``service._artifact_content_hash``; a bump to any of these yields a fresh key,
-    so the next preview rebuilds once and re-caches."""
-    return f"{_ARTIFACT_FORMAT_EPOCH}|{_ripple_dep_source()}|{_ripple_motion_dep()}"
+    Combines the artifact-format epoch, the BUILD IDENTITY of the generator actually
+    on disk (see :func:`_generator_build_id`), and the pinned ripple + motion dep
+    specs — the inputs that most directly move the built HTML/CSS. It rides the
+    content hash in ``service._artifact_content_hash``; a change to any of these
+    yields a fresh key, so the next preview rebuilds once and re-caches.
+
+    The build-id term is what makes the docstring's first sentence true. Without it
+    the only generator-identifying inputs were a hand-bumped epoch and two dep
+    strings, so shipping a generator change and forgetting the manual bump served
+    stale renders indefinitely. ``_ARTIFACT_FORMAT_EPOCH`` stays for what it is
+    actually good at: invalidating when the EXTRACTION shape changes on the Python
+    side, which no amount of watching the generator file can detect."""
+    return (
+        f"{_ARTIFACT_FORMAT_EPOCH}|{_generator_build_id()}"
+        f"|{_ripple_dep_source()}|{_ripple_motion_dep()}"
+    )
 
 
 def _ripple_dep_source() -> str:

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1084,6 +1084,44 @@ def _read_native_artifact(project_dir: str, engine: str = "svelte") -> tuple[str
 # ---------------------------------------------------------------------------
 
 
+def _resolve_keeps_client_bundle(pocket: dict[str, Any]) -> bool:
+    """Collapse a pocket's ``keepsClientBundle`` TRI-STATE to the bool the generator
+    takes — the same resolution ``publish_pocket`` performs.
+
+    Added 2026-08-26. This lived only inline in ``publish_pocket``, so the PREVIEW lane
+    never asked the question and its build fell to ``build_generator_input``'s
+    ``keeps_client_bundle=False`` default. paw-sites' ``reactPrerenderScript`` branches
+    hard on that flag: False STRIPS Vite's module script and the modulepreload hints
+    from dist/index.html, leaving the emitted chunk on disk unreferenced. So the editor
+    previewed a JavaScript-less variant of a site that ships JavaScript when published —
+    no hydration, no scroll reveals, no menu toggle — which the operator reads as broken
+    CSS. Observed on a real react site: a 215KB ``index-*.js`` in ``dist/assets`` that
+    ``index.html`` never referenced.
+
+    SP-2 moved the preview build out to the Daytona lane but did not carry the flag, so
+    the divergence survived that rewrite; it now rides ``generator_input`` like every
+    other build input.
+
+    ``None`` means the author declared nothing (every legacy pocket) and resolves to
+    ``sites_keep_client_bundle_default``, which is **True**: sites ship their own
+    JavaScript unless told otherwise. An explicit True/False is authorial and beats the
+    setting in both directions.
+
+    A shared helper rather than a second copy of the logic, because the failure mode
+    here was exactly two call sites answering the same question differently — and a
+    divergence between what you preview and what you publish stays invisible until
+    someone diffs two builds byte by byte.
+
+    ``pocket`` is the pocket WIRE dict, so the key is camelCase
+    (``keeps_client_bundle`` is the Beanie/domain name)."""
+    from pocketpaw.config import get_settings
+
+    declared = pocket.get("keepsClientBundle")
+    if declared is None:
+        return bool(get_settings().sites_keep_client_bundle_default)
+    return bool(declared)
+
+
 def _artifact_content_hash(
     *,
     source: dict[str, Any],
@@ -1091,6 +1129,7 @@ def _artifact_content_hash(
     builder_origin: str,
     gen_version: str,
     engine: str = "svelte",
+    keeps_client_bundle: bool = False,
 ) -> str:
     """Fingerprint the inputs that determine a native artifact's rendered output — the
     source map, the theme, the builder origin (it changes the stamped
@@ -1108,6 +1147,10 @@ def _artifact_content_hash(
         gen_version,
         engine,
         builder_origin or "",
+        # Materially different HTML: with it false the prerender strips Vite's module
+        # script, so the two variants differ by the whole JavaScript layer. A hash blind
+        # to it would serve whichever variant was built first, forever.
+        f"kcb={int(bool(keeps_client_bundle))}",
         json.dumps(source, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
         json.dumps(theme, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
     ):
@@ -1245,6 +1288,7 @@ async def _build_native_artifact(
     pocket_id: str,
     content_hash: str,
     engine: str = "svelte",
+    keeps_client_bundle: bool = False,
     _pool: Any | None = None,
 ) -> Any:
     """QUEUE the ARMED build for a native artifact in the ephemeral Daytona lane.
@@ -1301,6 +1345,9 @@ async def _build_native_artifact(
         ripple_spec={},
         source=source,
         builder_origin=builder_origin,
+        # The site's own declaration that its client JS is load-bearing. Without it the
+        # sandbox builds the no-JS variant of a site that ships JS when published.
+        keeps_client_bundle=keeps_client_bundle,
     )
     return await build_job.enqueue_preview_build(
         pocket_id=pocket_id,
@@ -1361,6 +1408,11 @@ async def _prewarm_native_artifact(
     site_name = (pocket.get("name") or "").strip() or "Untitled site"
     origin = (builder_origin or "").strip() or _builder_origin()
 
+    # MT-1: the site's own declaration that its client JS is load-bearing, resolved the
+    # SAME way publish resolves it. It rides BOTH the hash and the build below — the hash
+    # because the two variants are different HTML, the build because that is the bug: this
+    # lane passed nothing and silently built the no-JS variant of a site that ships JS.
+    keeps_client_bundle = _resolve_keeps_client_bundle(pocket)
     store = _store or _default_artifact_store()
     content_hash = _artifact_content_hash(
         source=source,
@@ -1368,6 +1420,7 @@ async def _prewarm_native_artifact(
         builder_origin=origin,
         gen_version=generator_client.generator_version(),
         engine=engine,
+        keeps_client_bundle=keeps_client_bundle,
     )
     if store.read(pocket_id, content_hash) is not None:
         return  # already warm — no rebuild
@@ -1379,6 +1432,7 @@ async def _prewarm_native_artifact(
         pocket_id=pocket_id,
         content_hash=content_hash,
         engine=engine,
+        keeps_client_bundle=keeps_client_bundle,
         _pool=_pool,
     )
 
@@ -6184,6 +6238,11 @@ async def get_native_artifact(
     # data-uid + embed the manifest. Default to the configured dashboard origin when
     # the caller passes none, exactly like make_site_editable.
     origin = (builder_origin or "").strip() or _builder_origin()
+    # MT-1: the site's own declaration that its client JS is load-bearing, resolved the
+    # SAME way publish resolves it. It rides BOTH the hash and the build below — the hash
+    # because the two variants are different HTML, the build because that is the bug: this
+    # lane passed nothing and silently built the no-JS variant of a site that ships JS.
+    keeps_client_bundle = _resolve_keeps_client_bundle(pocket)
     store = _store or _default_artifact_store()
     content_hash = _artifact_content_hash(
         source=source,
@@ -6191,6 +6250,7 @@ async def get_native_artifact(
         builder_origin=origin,
         gen_version=generator_client.generator_version(),
         engine=engine,
+        keeps_client_bundle=keeps_client_bundle,
     )
     # READ-THROUGH: a hit serves the prior render straight off disk — no queue, no
     # sandbox, no build. This is what makes a VIEW instant, and since SP-2 it is also
@@ -6221,6 +6281,7 @@ async def get_native_artifact(
             pocket_id=pocket_id,
             content_hash=content_hash,
             engine=engine,
+            keeps_client_bundle=keeps_client_bundle,
             _pool=_pool,
         )
     except Exception as exc:

--- a/tests/ee/sites/test_generator_version_build_id.py
+++ b/tests/ee/sites/test_generator_version_build_id.py
@@ -63,9 +63,7 @@ def test_the_script_is_fingerprinted_not_the_interpreter(
     script = tmp_path / "dist" / "cli.js"
     script.parent.mkdir(parents=True)
     script.write_text("// generator build A", encoding="utf-8")
-    monkeypatch.setenv(
-        "PAW_SITES_GEN_CMD", f"{interpreter.as_posix()} {script.as_posix()}"
-    )
+    monkeypatch.setenv("PAW_SITES_GEN_CMD", f"{interpreter.as_posix()} {script.as_posix()}")
 
     before = _generator_build_id()
     # Rebuild ONLY the script; the interpreter is untouched, as on a real rebuild.

--- a/tests/ee/sites/test_generator_version_build_id.py
+++ b/tests/ee/sites/test_generator_version_build_id.py
@@ -1,0 +1,156 @@
+# tests/ee/sites/test_generator_version_build_id.py
+# Created: 2026-08-25 (fix/sites-artifact-cache-tracks-generator-build).
+#
+# THE BUG. ``generator_version()`` is the term in the native-artifact cache key that
+# is supposed to mean "which paw-sites generator built this render". It did not: every
+# term was a hand-bumped constant (``_ARTIFACT_FORMAT_EPOCH``) or a dep VERSION string
+# (ripple, motion). Rebuilding ``paw-sites/dist/cli.js`` moved none of them, so the
+# store kept serving a render made by the previous generator with no way to evict it.
+#
+# How it surfaced, which is why this deserves a test rather than a comment: RX-2 taught
+# the generator to stamp ``data-uid`` on react leaves. After the rebuild, every react
+# preview still served the pre-RX-2 cached render with ZERO uids. NativeSiteEditor reads
+# ``uids.size === 0`` as "nothing editable here" and falls back to the section-level
+# iframe editor — which, unlike the native one, takes no editMode prop and therefore
+# arms in Browse too. The operator sees "react selection is coarse and stays on in
+# Browse mode"; the cause is a cache key three layers away, and rebuilding the generator
+# (the obvious move) changes nothing. That loop is what the build-id term ends.
+#
+# The tests pin all four properties the fix has to hold at once — it must invalidate on
+# a rebuild WITHOUT becoming unstable, or it would defeat the cache it is guarding.
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.sites import generator_client
+from pocketpaw_ee.sites.generator_client import (
+    _generator_build_id,
+    generator_version,
+)
+
+
+@pytest.fixture
+def fake_generator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A stand-in ``dist/cli.js`` that PAW_SITES_GEN_CMD points at, interpreter-prefixed
+    — the documented local override shape, so the entry is NOT argv[0].
+
+    POSIX separators, because ``_gen_cmd_argv`` runs the value through ``shlex.split``
+    in POSIX mode: a Windows path written with backslashes comes out with them eaten
+    ("D:\\paw-workspace\\…" → "D:paw-workspace…") and resolves to nothing. The real
+    override on this box is written with forward slashes for exactly that reason, so
+    the fixture matches the shape that actually works rather than one that cannot.
+    """
+    entry = tmp_path / "dist" / "cli.js"
+    entry.parent.mkdir(parents=True)
+    entry.write_text("// generator build A", encoding="utf-8")
+    monkeypatch.setenv("PAW_SITES_GEN_CMD", f"node {entry.as_posix()}")
+    return entry
+
+
+def test_the_script_is_fingerprinted_not_the_interpreter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The trap this fix nearly fell into. The shipped override names a real
+    interpreter AND a real script — "C:/PROGRA~1/nodejs/node.exe D:/…/dist/cli.js" —
+    so BOTH tokens resolve as files. Fingerprinting the first one takes node.exe,
+    whose mtime does not move when the generator is rebuilt: the version would be a
+    constant and the cache would stay stale, with the fix appearing to be in place.
+    """
+    interpreter = tmp_path / "node.exe"
+    interpreter.write_text("binary-ish", encoding="utf-8")
+    script = tmp_path / "dist" / "cli.js"
+    script.parent.mkdir(parents=True)
+    script.write_text("// generator build A", encoding="utf-8")
+    monkeypatch.setenv(
+        "PAW_SITES_GEN_CMD", f"{interpreter.as_posix()} {script.as_posix()}"
+    )
+
+    before = _generator_build_id()
+    # Rebuild ONLY the script; the interpreter is untouched, as on a real rebuild.
+    script.write_text("// generator build B, now a different length", encoding="utf-8")
+
+    assert _generator_build_id() != before
+
+
+def test_rebuilding_the_generator_changes_the_version(fake_generator: Path) -> None:
+    """The regression. A rebuilt generator must yield a different cache key."""
+    before = generator_version()
+
+    # A rebuild that also changes the bundle size — the ordinary case.
+    fake_generator.write_text("// generator build B, now longer", encoding="utf-8")
+
+    assert generator_version() != before
+
+
+def test_a_same_size_rebuild_still_changes_the_version(fake_generator: Path) -> None:
+    """mtime carries the rebuild even when the bundle size lands identical.
+
+    mtime is set explicitly rather than by writing twice: Windows' ~15.6ms clock
+    granularity can hand two quick writes the SAME mtime_ns, which would make this
+    assertion flaky for a reason that has nothing to do with the behaviour.
+    """
+    before = generator_version()
+
+    fake_generator.write_text("// generator build C", encoding="utf-8")  # same length
+    st = fake_generator.stat()
+    os.utime(fake_generator, ns=(st.st_atime_ns, st.st_mtime_ns + 5_000_000_000))
+
+    assert generator_version() != before
+
+
+def test_an_unchanged_generator_is_stable(fake_generator: Path) -> None:
+    """The other half, and the one that matters more: an unchanged generator must
+    produce a STABLE key across calls. A version that moved on its own would turn
+    every view into a cache miss and a full rebuild — worse than the bug."""
+    assert generator_version() == generator_version() == generator_version()
+
+
+def test_an_unresolvable_generator_degrades_to_a_constant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No generator on disk and none on PATH: report a fixed sentinel, never a
+    changing value. This restores exactly the pre-fix behaviour (no auto-invalidation)
+    instead of making the key unstable."""
+    monkeypatch.setenv("PAW_SITES_GEN_CMD", "definitely-not-a-real-bin-xyz")
+
+    assert _generator_build_id() == "unresolved"
+    assert generator_version() == generator_version()
+
+
+def test_the_build_id_reaches_the_artifact_cache_key(fake_generator: Path) -> None:
+    """End to end: the term has to actually ride the hash the store is keyed on,
+    with every OTHER input held identical. This is the assertion that would have
+    caught the original bug — the two react pockets differed by generator alone."""
+    from pocketpaw_ee.sites.service import _artifact_content_hash
+
+    inputs = {
+        "source": {"src/App.tsx": "export default () => <div>hi</div>;"},
+        "theme": {},
+        "builder_origin": "http://localhost:1420",
+        "engine": "react",
+    }
+    before = _artifact_content_hash(gen_version=generator_version(), **inputs)
+
+    fake_generator.write_text("// rebuilt with react uid stamping", encoding="utf-8")
+    after = _artifact_content_hash(gen_version=generator_version(), **inputs)
+
+    assert before != after, (
+        "a generator rebuild must change the artifact cache key, or a render built "
+        "by the old generator is served forever"
+    )
+
+
+def test_the_format_epoch_still_participates(fake_generator: Path) -> None:
+    """The build id ADDS to the key, it does not replace the epoch — the epoch is
+    still the only lever for a change to the Python-side extraction shape, which
+    watching the generator file cannot detect."""
+    before = generator_version()
+    monkeypatch_epoch = "v-next"
+    original = generator_client._ARTIFACT_FORMAT_EPOCH
+    try:
+        generator_client._ARTIFACT_FORMAT_EPOCH = monkeypatch_epoch
+        assert generator_version() != before
+    finally:
+        generator_client._ARTIFACT_FORMAT_EPOCH = original

--- a/tests/ee/sites/test_native_artifact.py
+++ b/tests/ee/sites/test_native_artifact.py
@@ -167,6 +167,10 @@ async def _hash_for(pocket_id: str, *, origin: str, engine: str = "svelte") -> s
         builder_origin=origin,
         gen_version=generator_client.generator_version(),
         engine=engine,
+        # Resolved the same way the service resolves it, not hardcoded: the flag joined
+        # the hash when the preview lane started carrying it, and a literal here would
+        # drift silently the moment the default moves.
+        keeps_client_bundle=sites_service._resolve_keeps_client_bundle(wire),
     )
 
 
@@ -449,6 +453,7 @@ async def test_native_artifact_store_hit_skips_build(beanie_test_db):
         theme={},
         builder_origin="https://dash.paw.example",
         gen_version=generator_client.generator_version(),
+        keeps_client_bundle=sites_service._resolve_keeps_client_bundle(wire),
     )
     store.data[(pocket_id, content_hash)] = ("<h1>cached</h1>", ".x{color:red}")
 

--- a/tests/ee/sites/test_native_artifact_keeps_client_bundle.py
+++ b/tests/ee/sites/test_native_artifact_keeps_client_bundle.py
@@ -1,0 +1,145 @@
+# tests/ee/sites/test_native_artifact_keeps_client_bundle.py
+# Created 2026-08-26 (fix/sites-preview-ships-client-js).
+#
+# THE BUG, reported as "the site's CSS looks broken in preview — maybe because the JS
+# isn't shipped in the native artifact". It is the JS, and the cause is a dropped
+# argument.
+#
+# `keeps_client_bundle` is the per-site declaration that a site's own client JavaScript
+# is load-bearing. It is a TRI-STATE on the pocket: an explicit True/False is authorial,
+# and `None` — every legacy pocket — resolves to `sites_keep_client_bundle_default`,
+# which is True. Sites ship their JavaScript unless told otherwise.
+#
+# `publish_pocket` resolves that tri-state and threads it to the generator. The PREVIEW
+# lane never asked the question at all, so its build fell to `build_generator_input`'s
+# `keeps_client_bundle=False` default.
+#
+# Downstream that is not subtle. paw-sites' `reactPrerenderScript` branches on the flag:
+# with it False it STRIPS Vite's module script and the modulepreload hints from
+# dist/index.html, leaving the emitted chunk on disk unreferenced. Observed on a real
+# react site: a 215KB index-*.js in dist/assets that index.html never referenced. So the
+# preview rendered a JavaScript-less variant of a site that ships JavaScript when
+# published — no hydration, no scroll reveals, no menu toggle — and the operator sees a
+# broken page and reasonably blames the CSS.
+#
+# SP-2 moved the preview build out of this process into the ephemeral Daytona lane, and
+# the flag did not come along, so the divergence survived that rewrite. These tests pin
+# it where it now lives: on the generator_input the JOB carries, not an inline build.
+#
+# The flag also has to ride the artifact CONTENT HASH. Without that, flipping the
+# declaration would keep serving the previously-cached variant forever — the same class
+# of staleness that made this hard to see in the first place.
+#
+# Engine-agnostic on purpose: the lane is shared, so svelte sites that declare a client
+# bundle were mis-built the same way. React is simply where it was caught.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+
+_REACT_SOURCE = {
+    "src/App.tsx": "export default function App() { return <main><h1>Hi</h1></main>; }\n",
+    "src/index.css": ":root{--brand:#0A84FF}",
+}
+
+
+class _RecordingPool:
+    """An arq pool that records the enqueue instead of performing it."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def enqueue_job(self, function: str, *args, _job_id: str | None = None, **kw):
+        self.calls.append({"function": function, "args": args, "job_id": _job_id})
+        return object()
+
+
+async def _make_pocket(keeps_client_bundle: bool | None) -> str:
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="react",
+        source=dict(_REACT_SOURCE),
+        keeps_client_bundle=keeps_client_bundle,
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+async def _queued_site_config(pocket_id: str) -> dict[str, Any]:
+    """Drive a cache MISS and return the siteConfig the QUEUED job carries.
+
+    The generator input is positional arg 2 of the enqueue — see
+    ``build_job.enqueue_preview_build``.
+    """
+    pool = _RecordingPool()
+    await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="https://dash.paw.example",
+        _pool=pool,
+    )
+    assert pool.calls, "a cache miss must queue exactly one build"
+    generator_input = pool.calls[0]["args"][2]
+    return generator_input.get("siteConfig") or {}
+
+
+@pytest.mark.asyncio
+async def test_an_undeclared_pocket_keeps_its_client_bundle(beanie_test_db):
+    """The reported bug. An undeclared pocket resolves to the settings default — True —
+    exactly as publish resolves it. Before the fix nothing was passed, so the sandbox
+    built with generator_client's False and stripped the module script the PUBLISHED
+    site keeps."""
+    pocket_id = await _make_pocket(None)
+
+    assert (await _queued_site_config(pocket_id)).get("keepsClientBundle") is True
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_false_still_drops_the_bundle(beanie_test_db):
+    """The other direction, and it must not be lost in the fix: a site that DECLARES it
+    ships no JavaScript still gets none. Passing a hardcoded True would be as wrong as
+    the hardcoded False, just less visibly. The key is omitted rather than set False —
+    build_generator_input only writes it when True."""
+    pocket_id = await _make_pocket(False)
+
+    assert not (await _queued_site_config(pocket_id)).get("keepsClientBundle")
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_true_keeps_the_bundle(beanie_test_db):
+    pocket_id = await _make_pocket(True)
+
+    assert (await _queued_site_config(pocket_id)).get("keepsClientBundle") is True
+
+
+def test_the_flag_rides_the_artifact_cache_key():
+    """Flipping the declaration must invalidate the cached render. The two variants are
+    materially different HTML — one references the module script, one has it stripped —
+    so a hash blind to the flag would serve whichever was built first and make the fix
+    appear not to work."""
+    from pocketpaw_ee.sites.service import _artifact_content_hash
+
+    common = {
+        "source": {"src/App.tsx": "export default () => <div>hi</div>;"},
+        "theme": {},
+        "builder_origin": "https://dash.paw.example",
+        "gen_version": "v1|abc|0.2.0|^12.40.0",
+        "engine": "react",
+    }
+
+    with_js = _artifact_content_hash(keeps_client_bundle=True, **common)
+    without_js = _artifact_content_hash(keeps_client_bundle=False, **common)
+
+    assert with_js != without_js

--- a/tests/ee/sites/test_preview_build_lane.py
+++ b/tests/ee/sites/test_preview_build_lane.py
@@ -140,6 +140,10 @@ async def _content_hash(pocket_id: str, *, engine: str = "svelte", origin: str =
         builder_origin=origin,
         gen_version=generator_client.generator_version(),
         engine=engine,
+        # Resolved the same way the service resolves it, not hardcoded: the flag joined
+        # the hash when the preview lane started carrying it, and a literal here would
+        # drift silently the moment the default moves.
+        keeps_client_bundle=sites_service._resolve_keeps_client_bundle(wire),
     )
 
 


### PR DESCRIPTION
Reported as "the preview CSS is broken". It was the JavaScript, and two bugs were hiding each other.

## The preview build never got keeps_client_bundle

It is the per-site declaration that a site's client JS is load-bearing. A tri-state, where `None` (every legacy pocket) resolves to `sites_keep_client_bundle_default`, which is True. Sites ship their JavaScript unless told otherwise.

`publish_pocket` resolves it and threads it to the generator. The preview lane never asked, so its build took `build_generator_input`'s `False` default.

paw-sites' `reactPrerenderScript` branches hard on that flag. With it False it strips Vite's module script and the modulepreload hints from `dist/index.html` and leaves the emitted chunk on disk unreferenced. On a real react site here that was a 215KB `index-*.js` in `dist/assets` that `index.html` never referenced. The editor previewed a JavaScript-less variant of a site that ships JavaScript when published, and the missing hydration reads as broken styling.

SP-2 moved this build out to the Daytona lane and the flag did not come along, so the divergence survived that rewrite. It now rides `generator_input` like every other build input, and the tri-state resolution lives in one helper both callers share. Two call sites answering the same question differently is what caused this, and a preview/publish divergence stays invisible until someone diffs two builds byte by byte.

## generator_version did not identify the generator

It is the term in the artifact cache key that is supposed to mean "which paw-sites build made this render". Every part of it was a hand-bumped constant or a dep version string, so rebuilding paw-sites moved none of them and the store kept serving a render made by the previous generator with no way to evict it.

That is how a generator fix could ship and change nothing, repeatedly, which is most of why the bug above took so long to find.

It now includes the on-disk build identity of the resolved entry, `mtime_ns:size`.

One detail worth reviewing: it fingerprints the script, not the interpreter. The documented override is `node /path/dist/cli.js`, so both tokens resolve as real files, and taking the first match pins `node.exe`, whose mtime never moves on a rebuild. It scans in reverse and a test pins that case, because the wrong version would have looked correct and done nothing.

It is also deliberately not memoised. A generator rebuilt while the server runs is the normal inner loop when someone is iterating on the generator, and that is exactly the case that has to invalidate.

The flag joins the content hash too, or flipping the declaration would keep serving the previously-cached variant.

## Testing

11 new tests: 7 for the build id (including the interpreter-vs-script trap and the unresolvable degrade) and 4 for the flag, asserting on the `siteConfig` the queued job actually carries.

Three existing test files needed their seeded content hash to resolve the flag the same way the service does, since the hash gained a term. Their assertions are unchanged.

Sites suite is 1341 passed, 4 skipped. That excludes `test_capture_readiness`, `test_draft_screenshot`, `test_screenshot_capture` and `test_preview_refresh`, which fail on this machine against a live S3 `PutObject` returning ServiceUnavailable. Nothing here touches that path, but I have not seen them green.
