### PR TITLE
 fix: clear progressive-summary Redis key after fetch so back-to-back meetings don't reuse old notes

### DIFF
--- a/ee/pocketpaw_ee/cloud/livekit/agent.py
+++ b/ee/pocketpaw_ee/cloud/livekit/agent.py
@@ -1207,12 +1207,23 @@ class CallMeetingAgent:
 
         Tries Redis first; falls back to the in-memory list if Redis is
         unavailable or the call was short (no Redis entries).
+
+        The Redis key is deleted as soon as it has been read
+        (consume-once) so a back-to-back meeting on the same group never
+        picks up the previous call's stale summaries.  The in-memory list
+        still covers this agent for the rest of its lifecycle.
         """
         redis = await self._get_redis()
         if redis is not None:
             try:
                 key = _REDIS_PROGRESSIVE_KEY.format(group_id=self.group_id)
                 raw_list = await redis.lrange(key, 0, -1)
+                # Consume-once: drop the key immediately after reading it
+                # so the next meeting on this group starts clean.
+                await redis.delete(key)
+                logger.info(
+                    "Agent: cleared progressive summaries key %s after fetch", key
+                )
                 if raw_list:
                     summaries = []
                     for raw in raw_list:

--- a/ee/pocketpaw_ee/cloud/livekit/agent.py
+++ b/ee/pocketpaw_ee/cloud/livekit/agent.py
@@ -1221,9 +1221,7 @@ class CallMeetingAgent:
                 # Consume-once: drop the key immediately after reading it
                 # so the next meeting on this group starts clean.
                 await redis.delete(key)
-                logger.info(
-                    "Agent: cleared progressive summaries key %s after fetch", key
-                )
+                logger.info("Agent: cleared progressive summaries key %s after fetch", key)
                 if raw_list:
                     summaries = []
                     for raw in raw_list:

--- a/tests/ee/test_livekit_service.py
+++ b/tests/ee/test_livekit_service.py
@@ -880,6 +880,8 @@ class TestProgressiveSummarization:
             assert len(fetched) == 1
             assert fetched[0]["segment_summary"] == "From Redis"
             mock_redis.lrange.assert_awaited_once()
+            # Consume-once: the key must be deleted right after reading
+            mock_redis.delete.assert_awaited_once_with("livekit:progressive:g")
 
     @pytest.mark.asyncio
     async def test_store_pushes_to_redis_with_ttl(self):
@@ -958,6 +960,69 @@ class TestProgressiveSummarization:
             assert len(fetched) == 1
             assert fetched[0]["segment_summary"] == "From Redis"
             assert fetched[0]["action_items"] == ["Redis task"]
+            mock_redis.delete.assert_awaited_once_with("livekit:progressive:g")
+
+    @pytest.mark.asyncio
+    async def test_fetch_deletes_redis_key_for_next_meeting(self):
+        """Regression: a back-to-back meeting on the same group must not
+        pick up the previous call's progressive summaries from Redis.
+
+        Simulates two sequential agent runs sharing one Redis: the first
+        run fetches (and must delete) the key, so the second run — with a
+        fresh in-memory list — sees nothing stale.
+        """
+        from pocketpaw_ee.cloud.livekit.agent import CallMeetingAgent
+
+        # Tiny fake Redis with a real list under the hood.
+        class _FakeRedis:
+            def __init__(self):
+                self.lists: dict[str, list[str]] = {}
+
+            async def rpush(self, key, value):
+                self.lists.setdefault(key, []).append(value)
+
+            async def expire(self, key, ttl):
+                pass
+
+            async def lrange(self, key, start, end):
+                return list(self.lists.get(key, []))
+
+            async def delete(self, key):
+                self.lists.pop(key, None)
+
+        fake_redis = _FakeRedis()
+        stale_summary = {
+            "segment_summary": "Old call discussion",
+            "action_items": ["Stale task"],
+            "topics": [],
+            "participants": ["Alice"],
+            "timestamp": 1000.0,
+        }
+
+        # ── First meeting: stores summaries, then finalizes ──
+        first_agent = CallMeetingAgent(
+            group_id="g",
+            room_name="group-call-g",
+            bot_token="tok",
+        )
+        with patch.object(first_agent, "_get_redis", AsyncMock(return_value=fake_redis)):
+            await first_agent._store_progressive_summary(stale_summary)
+            fetched = await first_agent._fetch_progressive_summaries()
+            assert len(fetched) == 1
+            assert fetched[0]["segment_summary"] == "Old call discussion"
+
+        # Key must be gone from Redis after the fetch
+        assert "livekit:progressive:g" not in fake_redis.lists
+
+        # ── Second meeting one minute later: fresh agent, same group ──
+        second_agent = CallMeetingAgent(
+            group_id="g",
+            room_name="group-call-g",
+            bot_token="tok",
+        )
+        assert second_agent._progressive_summaries == []
+        fetched = await second_agent._fetch_progressive_summaries()
+        assert fetched == [], "stale summaries from previous call leaked into new meeting"
 
     @pytest.mark.asyncio
     async def test_fetch_returns_empty_when_nothing_stored(self):


### PR DESCRIPTION
## Problem

Meeting notes are built from progressive summaries stored in Redis under
`livekit:progressive:{group_id}` (6h TTL). That key was never deleted after
`_finalize_notes()` read it, so when a new meeting started on the same group
shortly after the previous one ended, `_fetch_progressive_summaries()` picked
up the previous call's stale summaries and merged them into the new meeting's
notes — regenerating essentially the same notes for a call where nothing was
discussed.

## Fix

Consume-once semantics in `_fetch_progressive_summaries()`: delete the Redis
key immediately after reading it. The current agent's in-memory summary list
still covers it for the rest of its lifecycle, so nothing is lost within a
call — but the next meeting on the same group now starts with a clean slate.

## Testing

- New regression test `test_fetch_deletes_redis_key_for_next_meeting`
  simulates two back-to-back meetings sharing one Redis: first run consumes
  and clears the key; second run gets `[]` instead of the stale summaries.
- Existing store/fetch tests updated to assert `delete` is called with the
  correct key.
- `uv run pytest tests/ee/test_livekit_service.py` — 57 passed
- `uv run ruff check` on changed files — clean

## Files changed

- `ee/pocketpaw_ee/cloud/livekit/agent.py` — consume-once delete + logging in `_fetch_progressive_summaries`
- `tests/ee/test_livekit_service.py` — regression test + delete assertions