### PR TITLE
Bill site plans as add-ons on the workspace subscription

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -32,6 +32,13 @@ Changed 2026-07-08 (feat/billing-smb-caps): added ``PocketLimitError`` (402,
 prompt a plan upgrade. Both enforce at create/enable time only (never retroactive)
 and only when ``billing_enforced`` is on.
 
+Changed 2026-08-26 (feat/site-plans-as-addons): ``NoActiveSubscription`` now takes
+an optional ``message``. It gained a SECOND caller — the site add-on rail, where a
+workspace with no subscription cannot be sold a paid site because an add-on has
+nothing to attach to — and the hardcoded "no active subscription to cancel"
+described an action that buyer never attempted. Status, code and default message
+are unchanged, so the cancel path and any client keyed on the code are untouched.
+
 Changed 2026-08-15 (fix/sites-custom-domain-entitlement): added
 ``CustomDomainNotEntitled`` (402, ``billing.custom_domain_not_entitled``) — the
 domain-attach sibling of the two above, and the first of this family keyed to a
@@ -324,13 +331,23 @@ class NoActiveSubscription(CloudError):
     subscribed. 402 (the same family as ``InsufficientCredits`` / ``QuotaExceeded``,
     "you can't do the money action right now") so the client prompts a
     not-subscribed state rather than treating it as a 404-style missing resource.
+
+    ``message`` is overridable because there are now TWO callers and the default
+    names only one of them. The site add-on rail raises this when a workspace with
+    no subscription tries to buy a paid site — the same 402, the same code, and a
+    client that reads the code keeps working — but telling that buyer there is
+    "no active subscription to cancel" describes an action they did not attempt.
+    The default is unchanged, so the cancel path and every existing test are
+    untouched.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self, message: str = "No active subscription to cancel for this workspace"
+    ) -> None:
         super().__init__(
             402,
             "billing.no_active_subscription",
-            "No active subscription to cancel for this workspace",
+            message,
         )
 
 

--- a/ee/pocketpaw_ee/cloud/billing/providers/base.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/base.py
@@ -22,7 +22,13 @@
 #   ``create_subscription`` + ``cancel_subscription``, and documented that
 #   ``verify_and_parse_webhook`` now also returns a ``SubscriptionEvent`` for a
 #   verified subscription.* delivery.
-
+#
+# Updated 2026-08-26 (feat/site-plans-as-addons): ``change_plan`` gained a
+#   REQUIRED ``addons`` argument carrying the subscription's COMPLETE add-on cart.
+#   Required, not defaulted, because the gateway treats the list as declarative —
+#   omitting it removes every add-on the subscription holds. A default would make
+#   the destructive case the quiet one, and the destruction is invisible until the
+#   next invoice.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -129,8 +135,28 @@ class IPaymentsProvider(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def change_plan(self, *, subscription_id: str, product_id: str, plan_key: str) -> None:
-        """Move an EXISTING gateway subscription onto a different product.
+    async def change_plan(
+        self,
+        *,
+        subscription_id: str,
+        product_id: str,
+        plan_key: str,
+        addons: list[dict],
+    ) -> None:
+        """Move an EXISTING gateway subscription onto a different product, and set
+        its COMPLETE add-on cart.
+
+        ``addons`` IS NOT OPTIONAL AND IS NOT A DELTA. The gateway treats the
+        add-on list as declarative: what you send becomes the whole cart, and
+        sending nothing REMOVES every add-on the subscription holds. Dodo's own
+        wording is "leaving this empty would remove any existing addons". So a
+        caller that only means to move the plan must still pass the full cart it
+        wants preserved, and ``[]`` must be written deliberately rather than
+        reached by omission. It is a required keyword for exactly that reason — a
+        default would make the destructive case the quiet one, and the destruction
+        is invisible until the next invoice.
+
+        Each entry is ``{"addon_id": str, "quantity": int}``.
 
         The alternative — cancel the old subscription and create a new one — is
         wrong in both directions for a term subscription: the buyer forfeits the

--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -97,7 +97,13 @@
 #   subscription is created at payment; the response ``session_id`` is carried on
 #   ``SubscriptionCheckout.subscription_id``. The webhook grant is untouched (it
 #   reads the subscription_id + metadata off the event body, not this response).
-
+#
+# Updated 2026-08-26 (feat/site-plans-as-addons): ``change_plan`` now forwards an
+#   ``addons`` cart to ``subscriptions.change_plan``, ALWAYS — including when it is
+#   empty. The SDK omits an unset parameter, and an omitted add-on list is not
+#   "leave the cart alone" at this gateway, it is "empty the cart". Forwarding
+#   unconditionally means the destructive case only happens when a caller asked
+#   for it.
 from __future__ import annotations
 
 import json
@@ -359,7 +365,14 @@ class DodoProvider:
         client = self._client()
         await client.subscriptions.update(subscription_id, status="cancelled")
 
-    async def change_plan(self, *, subscription_id: str, product_id: str, plan_key: str) -> None:
+    async def change_plan(
+        self,
+        *,
+        subscription_id: str,
+        product_id: str,
+        plan_key: str,
+        addons: list[dict],
+    ) -> None:
         if not subscription_id:
             raise ValidationError("billing.invalid_subscription", "subscription_id is required")
         if not product_id:
@@ -376,12 +389,19 @@ class DodoProvider:
         # already paid for. ``prevent_change`` means a declined card leaves the
         # subscription on its CURRENT plan rather than moving it and then failing —
         # the caller's persisted tier and the gateway's stay in agreement.
+        #
+        # ``addons`` is forwarded ALWAYS, including when empty. The SDK omits an
+        # unset parameter, and an omitted add-on list is not "leave the cart
+        # alone" at this gateway — it is "empty the cart". Passing the caller's
+        # list through unconditionally means the destructive case only happens
+        # when a caller actually asked for it.
         await client.subscriptions.change_plan(
             subscription_id,
             product_id=product_id,
             quantity=1,
             proration_billing_mode="difference_immediately",
             on_payment_failure="prevent_change",
+            addons=list(addons),
         )
 
     # ------------------------------------------------------------------ #

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -101,7 +101,27 @@
 #   cancel is logged and skipped. Credits are still never clawed back. See the
 #   ``subscribe`` body for the STILL-OPEN downgrade lag-window (checkout→active
 #   webhook) that only the atomic Dodo ``change_plan`` closes.
-
+#
+# Updated 2026-08-26 (feat/site-plans-as-addons): added ``_site_addon_cart`` +
+#   ``sync_site_addons`` — a paid SITE is now a LINE on the workspace's existing
+#   subscription instead of a subscription of its own. One bill, one renewal date,
+#   one payment method, however many sites the workspace runs.
+#
+#   THE CART IS DECLARATIVE, WHICH IS THE ONLY THing worth knowing before touching
+#   this. Dodo's ``change_plan`` REPLACES the add-on list; sending nothing removes
+#   every add-on the subscription holds. So the cart is rebuilt from the ``Site``
+#   documents on every call and pushed WHOLE — never appended to, never diffed
+#   against gateway state. That also makes cancellation fall out for free: a site
+#   that stops being active stops appearing in the cart, and the next sync drops
+#   its line.
+#
+#   Sites still holding a per-site ``subscription_id`` are EXCLUDED from the cart.
+#   Those are the subscriptions the old rail sold, Dodo is already billing them,
+#   and counting one here too would charge the customer twice for one site.
+#
+#   A workspace with no active subscription is REFUSED (``NoActiveSubscription``)
+#   rather than being sold a standalone per-site subscription — that standalone
+#   subscription is exactly the separate payment this change removes.
 from __future__ import annotations
 
 import logging
@@ -256,6 +276,128 @@ async def _active_subscription(workspace_id: str) -> Subscription | None:
         .sort("-createdAt")
         .first_or_none()
     )
+
+
+async def _site_addon_cart(workspace_id: str) -> list[dict]:
+    """The COMPLETE Dodo add-on cart a workspace's sites should be billed for.
+
+    Rebuilt from the ``Site`` documents every time, never from what the gateway
+    currently holds. That is not defensiveness, it is the contract:
+    ``change_plan`` REPLACES the whole add-on list, so the only safe thing to
+    send is a full cart derived from our own source of truth. A function that
+    read the gateway's cart and appended to it would inherit any drift already
+    there and make it permanent.
+
+    Three exclusions, each load-bearing:
+
+      * A site holding a ``subscription_id`` is on a LEGACY per-site
+        subscription. Dodo is already billing it on its own rail, and counting it
+        here too would charge the customer twice for one site. Only sites with no
+        per-site subscription of their own ride the add-on rail.
+      * A site whose ``subscription_status`` is not active is not paying — a
+        cancelled site must drop off the next cart, which is precisely how a
+        cancellation stops costing money under this model.
+      * A tier with no configured ``dodo_addon_id`` cannot be expressed as an
+        add-on. It is skipped rather than guessed at; the publish path already
+        refuses to record an unpurchasable tier.
+
+    Quantities aggregate: four sites on ``site`` are one cart line of quantity 4,
+    not four lines. Dodo keys a cart line by add-on id, so emitting the same id
+    twice would be a malformed cart rather than a double charge.
+
+    Sorted by add-on id so the cart is deterministic — two calls with the same
+    sites produce byte-identical payloads, which is what makes a no-op sync
+    genuinely a no-op and keeps test assertions stable.
+    """
+    from pocketpaw_ee.cloud.billing import site_plans
+    from pocketpaw_ee.cloud.models.site import Site
+
+    counts: dict[str, int] = {}
+    async for doc in Site.find(Site.workspace == workspace_id):
+        if getattr(doc, "subscription_id", None):
+            continue
+        if (getattr(doc, "subscription_status", None) or "none") != "active":
+            continue
+        tier = site_plans.site_scoped_tier(getattr(doc, "plan_tier", None))
+        if tier is None or tier.monthly_price_usd == 0:
+            continue
+        addon_id = tier.dodo_addon_id
+        if not addon_id:
+            continue
+        counts[addon_id] = counts.get(addon_id, 0) + 1
+    return [{"addon_id": addon_id, "quantity": qty} for addon_id, qty in sorted(counts.items())]
+
+
+async def sync_site_addons(
+    workspace_id: str,
+    *,
+    provider: IPaymentsProvider | None = None,
+) -> dict:
+    """Push the workspace's full site add-on cart onto its EXISTING subscription.
+
+    This is how a paid site is billed now: as a line on the one subscription the
+    workspace already has, rather than as a subscription of its own. One bill,
+    one renewal date, one payment method, and a per-site charge that prorates
+    against the term the workspace has already paid for.
+
+    Idempotent by construction. The cart is recomputed from the ``Site``
+    documents on every call and sent whole, so calling this twice with no change
+    between sends the same cart twice and the second is a no-op at the gateway.
+    Callers do not need to know whether a sync is "needed".
+
+    RAISES ``NoActiveSubscription`` WHEN THE WORKSPACE HAS NO SUBSCRIPTION, and
+    that refusal is the deliberate shape of the feature rather than a gap in it.
+    An add-on attaches to something; there is no subscription-less add-on at this
+    gateway. A free workspace buying its first site therefore has to start a
+    workspace subscription, and the alternative — quietly opening a standalone
+    per-site subscription for it — is the separate payment this change exists to
+    remove. Reversing that trade is one branch here (create a subscription with
+    the cart attached, rather than refusing), but it needs a target workspace
+    plan that the publish request does not carry today, so it is not guessed.
+    """
+    sub = await _active_subscription(workspace_id)
+    if sub is None:
+        raise NoActiveSubscription(
+            "This workspace has no active subscription to add a site plan to."
+        )
+    # The gateway needs the plan the subscription is ALREADY on: ``change_plan``
+    # is one call that sets both the product and the cart, so "keep the plan,
+    # change the cart" is expressed by re-sending the current product. Prefer the
+    # product recorded on the row over a catalog lookup — the row is what the
+    # gateway actually charged, and a catalog remapped since the sale would
+    # otherwise silently move the workspace's plan as a side effect of publishing
+    # a site.
+    product_id = sub.product_id or _dodo_product_for_plan(sub.plan_key)
+    if not product_id:
+        raise ValidationError(
+            "billing.plan_product_unconfigured",
+            f"No Dodo product is configured for plan '{sub.plan_key}'.",
+        )
+    if not sub.gateway_subscription_id:
+        raise ValidationError(
+            "billing.invalid_subscription",
+            "The active subscription has no gateway id to attach add-ons to.",
+        )
+
+    cart = await _site_addon_cart(workspace_id)
+    prov = provider or _default_provider()
+    await prov.change_plan(
+        subscription_id=sub.gateway_subscription_id,
+        product_id=product_id,
+        plan_key=sub.plan_key,
+        addons=cart,
+    )
+    logger.info(
+        "billing.sync_site_addons: workspace=%s subscription=%s cart=%s",
+        workspace_id,
+        sub.gateway_subscription_id,
+        cart,
+    )
+    return {
+        "subscription_id": sub.gateway_subscription_id,
+        "plan_key": sub.plan_key,
+        "addons": cart,
+    }
 
 
 async def subscribe(

--- a/ee/pocketpaw_ee/cloud/billing/site_plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/site_plans.py
@@ -106,6 +106,24 @@
 # meter fields below are CATALOG CLAIMS — what a tier will sell — and no seam
 # reads them as an entitlement yet. ``SiteEntitlements`` still does not carry
 # them, for the reason its own docstring gives.
+#
+# Updated 2026-08-26 (feat/site-plans-as-addons): added ``dodo_addon_id`` and its
+# resolver ``_dodo_addon_for`` (reading a new ``POCKETPAW_DODO_SITE_ADDONS``
+# map), because a paid site now bills as an ADD-ON LINE on the workspace
+# subscription instead of opening a subscription of its own.
+#
+# THE TWO IDS ARE NOT INTERCHANGEABLE and that is why this is a second field
+# rather than a reinterpretation of the first. A Dodo add-on is its own entity
+# with its own id; ``subscriptions.change_plan`` takes ``addons=[{addon_id,
+# quantity}]`` and a product id is rejected there. So the product map stays, the
+# add-on map is new, and each is read by the rail it belongs to.
+#
+# ``purchasable`` now passes on EITHER id. That is deliberate rollout slack: a
+# deployment that has the product map set and the add-on map not yet would
+# otherwise turn every paid tier unbuyable the moment this shipped, and publish
+# paid selections as the free floor — the exact failure the 2026-08-22 rekey note
+# above describes. Per-site subscriptions already sold stay live and keep
+# renewing through the product half; only NEW purchases take the add-on rail.
 
 from __future__ import annotations
 
@@ -373,6 +391,11 @@ class SitePlanTier:
     monthly_price_usd: int
     dodo_product_id: str | None
     cloudflare_features: frozenset[str]
+    # Sits here rather than next to ``dodo_product_id``, where it belongs by
+    # meaning, because a defaulted dataclass field cannot precede an undefaulted
+    # one and ``cloudflare_features`` has no default. It defaults so the existing
+    # direct constructions (tests, fixtures) keep working unchanged.
+    dodo_addon_id: str | None = None
     scope: str = ORG_SCOPE
     badge_removal: bool = False
     max_domained_sites: int | None = 0
@@ -438,7 +461,17 @@ class SitePlanTier:
         """
         if self.is_org_scoped:
             return False
-        return self.monthly_price_usd == 0 or self.dodo_product_id is not None
+        if self.monthly_price_usd == 0:
+            return True
+        # EITHER rail makes a tier buyable, and the ADD-ON one is the rail new
+        # purchases take. ``dodo_product_id`` is kept in the OR because the
+        # per-site subscriptions it opened are live in production: a deployment
+        # mid-rollout has the product map set and the add-on map not yet, and
+        # returning False there would make every paid tier abruptly unbuyable and
+        # publish paid selections as the free floor. Once the add-on map is
+        # configured everywhere, the product half is only reached by rows that
+        # already hold a per-site subscription.
+        return self.dodo_addon_id is not None or self.dodo_product_id is not None
 
 
 def canonical_site_tier_key(key: str | None) -> str | None:
@@ -493,6 +526,40 @@ def _dodo_product_for(key: str) -> str | None:
     return None
 
 
+def _dodo_addon_for(key: str) -> str | None:
+    """Resolve the Dodo ADD-ON id for a site tier, or None.
+
+    The add-on analogue of ``_dodo_product_for``, and a SEPARATE map because a
+    Dodo add-on is its own entity with its own id — it is not a product id and
+    the two are not interchangeable at the API.
+
+    Reads an optional ``POCKETPAW_DODO_SITE_ADDONS`` mapping
+    (``{tier_key: addon_id}``) off settings when present. None is the correct
+    default: a paid publish then records the tier without a live charge, exactly
+    as it does with no product configured. Lazy ``get_settings`` import and a
+    blanket degrade-to-None for the same reason the product resolver has them —
+    building the catalog must never force a config load or raise.
+
+    THE CANONICAL KEY WINS, THEN ANY LEGACY ALIAS OF IT, identically to the
+    product map. A deployment keyed ``{"pro": ..., "business": ...}`` keeps
+    resolving after the 2026-08-22 rename.
+    """
+    try:
+        from pocketpaw.config import get_settings
+
+        mapping = getattr(get_settings(), "dodo_site_addons", None)
+    except Exception:
+        return None
+    if not isinstance(mapping, dict):
+        return None
+    candidates = [key] + [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key]
+    for candidate in candidates:
+        val = mapping.get(candidate)
+        if isinstance(val, str) and val:
+            return val
+    return None
+
+
 def _build(key: str) -> SitePlanTier:
     """Construct a ``SitePlanTier`` for ``key`` from the catalog constants + config.
 
@@ -506,6 +573,7 @@ def _build(key: str) -> SitePlanTier:
         key=key,
         monthly_price_usd=_SITE_PLAN_MONTHLY_PRICE_USD.get(key, 0),
         dodo_product_id=_dodo_product_for(key),
+        dodo_addon_id=_dodo_addon_for(key),
         cloudflare_features=_SITE_PLAN_CF_FEATURES.get(key, frozenset()),
         scope=_SITE_PLAN_SCOPE.get(key, ORG_SCOPE),
         badge_removal=_SITE_PLAN_BADGE_REMOVAL.get(key, False),

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -888,7 +888,36 @@
 #     apply_edits, and hands that to the UNCHANGED SE-2 persist + preview/republish
 #     + smoke-gate-rollback path. ``new_source`` (full rewrite) is unchanged and
 #     stays the fallback for large rewrites; exactly one of the two must be given.
-
+#
+# Updated 2026-08-26 (feat/site-plans-as-addons): a NEW paid publish bills as an
+#   ADD-ON on the workspace subscription (``_publish_addon_site``) instead of
+#   opening a per-site checkout. The per-site rail is kept for the subscriptions
+#   already sold, and the dispatcher checks the ADD-ON rail FIRST — a deployment
+#   mid-rollout has both maps configured, and checking the old one first would
+#   open exactly the subscription this replaces.
+#
+#   STILL CHARGE-FIRST, WITHOUT THE PENDING/WEBHOOK DANCE. The old rail deferred
+#   the deploy because payment happened on a hosted checkout the buyer left the
+#   app for, so "did they pay" was only answerable later, by a webhook. Attaching
+#   an add-on charges the card already on the subscription synchronously, so the
+#   answer is known inside the request and the site goes live in it. No
+#   ``checkout_url`` is returned on this rail.
+#
+#   TWO THINGS HERE ARE EASY TO GET WRONG AND BOTH COST MONEY:
+#   (1) the site is marked ``active`` BEFORE the charge, because the cart is built
+#       from the ``Site`` documents and a site absent from them is absent from the
+#       cart. A failed charge reverts it; without the revert the site keeps every
+#       paid capability for free, since nothing else rewrites that field.
+#   (2) ``activate_site`` gained ``force`` for the same reason. Its idempotency
+#       guard reads "deployed and active" as "nothing to do" — correct for a
+#       replayed webhook, wrong here, where the site is already active by the time
+#       the deploy runs. Upgrading a LIVE free site would otherwise charge the
+#       customer and ship them none of the new content.
+#
+#   ``already_paying`` now covers BOTH rails. An add-on site deliberately holds no
+#   per-site ``subscription_id`` (that absence is the cart builder's
+#   discriminator), so the old "has a subscription id" test read every add-on site
+#   as unpaid and re-ran the charge on every content edit.
 from __future__ import annotations
 
 import asyncio
@@ -5127,13 +5156,20 @@ async def publish_pocket(
     )
     is_paid = tier is not None and tier.monthly_price_usd > 0
     dodo_configured = tier is not None and bool(tier.dodo_product_id)
+    # THE ADD-ON RAIL, and it WINS over the per-site one when both are configured.
+    # A paid site is a line on the workspace's existing subscription now; the
+    # per-site product only still exists so the subscriptions already sold keep
+    # renewing. Checking the add-on first is what stops a deployment that has both
+    # maps set (the normal state during rollout) from opening exactly the separate
+    # subscription this rail replaces.
+    addon_configured = tier is not None and bool(tier.dodo_addon_id)
 
-    if is_paid and not dodo_configured:
-        # A paid tier whose Dodo product is unconfigured can't open a checkout —
-        # fall back to publishing LIVE immediately so the user is never stranded.
+    if is_paid and not dodo_configured and not addon_configured:
+        # A paid tier with neither rail configured can't charge at all — fall back
+        # to publishing LIVE immediately so the user is never stranded.
         logger.warning(
-            "sites.publish: paid tier %s has no configured Dodo product — publishing "
-            "live immediately (charge-first fallback, no checkout)",
+            "sites.publish: paid tier %s has no configured Dodo add-on or product — "
+            "publishing live immediately (no charge)",
             tier.key if tier is not None else site_plan_key,
         )
 
@@ -5152,11 +5188,59 @@ async def publish_pocket(
     existing_doc = await _SiteDoc.find_one(
         {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
     )
+    # TWO RAILS PAY, AND ONLY ONE OF THEM LEAVES A ``subscription_id``.
+    #
+    # "has an active per-site subscription id" was the whole test until add-ons
+    # existed, and it silently stopped covering half the paying sites: an add-on
+    # site deliberately holds NO per-site id (that absence is the cart builder's
+    # discriminator). Left as it was, every republish of an add-on site read as
+    # "not yet paying", took the purchase branch, and re-ran the charge. The
+    # declarative cart means that re-charge happened to be idempotent — the cart
+    # recomputes to the same quantity — but relying on that is relying on an
+    # accident, and it still churns proration at the gateway on every content
+    # edit. A paid tier with an active status IS the add-on rail's proof of
+    # payment.
+    _existing_tier = (
+        site_plans.site_scoped_tier(getattr(existing_doc, "plan_tier", None))
+        if existing_doc is not None
+        else None
+    )
+    paying_on_addon = (
+        existing_doc is not None
+        and existing_doc.subscription_status == "active"
+        and not existing_doc.subscription_id
+        and _existing_tier is not None
+        and _existing_tier.monthly_price_usd > 0
+    )
     already_paying = (
         existing_doc is not None
         and existing_doc.subscription_status == "active"
-        and bool(existing_doc.subscription_id)
+        and (bool(existing_doc.subscription_id) or paying_on_addon)
     )
+
+    if paying_on_addon and is_paid and addon_configured and existing_doc.plan_tier != tier.key:
+        # A genuine TIER CHANGE on a site paying via an add-on. There is no
+        # per-site subscription to move — the change is expressed as a different
+        # cart on the workspace's subscription, so stamp the new tier first and
+        # then re-sync. Stamp first for the same reason the purchase path does:
+        # the cart is built from the documents.
+        from pocketpaw_ee.cloud.billing import service as _billing_service
+
+        _previous_tier = existing_doc.plan_tier
+        existing_doc.plan_tier = tier.key
+        await existing_doc.save()
+        try:
+            await _billing_service.sync_site_addons(workspace_id, provider=_billing_provider)
+        except Exception:
+            existing_doc.plan_tier = _previous_tier
+            await existing_doc.save()
+            raise
+        logger.info(
+            "sites.publish: site %s moved %s -> %s on the workspace add-on cart",
+            str(existing_doc.id),
+            _previous_tier,
+            tier.key,
+        )
 
     if already_paying and is_paid and dodo_configured and existing_doc.plan_tier != tier.key:
         # A genuine TIER CHANGE on a paying site. Move the existing subscription
@@ -5172,6 +5256,13 @@ async def publish_pocket(
             subscription_id=existing_doc.subscription_id,
             product_id=tier.dodo_product_id,
             plan_key=tier.key,
+            # EMPTY ON PURPOSE, and only safe because of what this subscription is.
+            # ``existing_doc.subscription_id`` is a PER-SITE subscription — one
+            # subscription that buys one site — and nothing ever attaches an add-on
+            # to one. The workspace subscription that DOES carry site add-ons is a
+            # different row and is not touched here. Sending [] to that one would
+            # cancel every paid site in the workspace.
+            addons=[],
         )
         logger.info(
             "sites.publish: site %s moved %s → %s on subscription %s (no new checkout)",
@@ -5181,9 +5272,40 @@ async def publish_pocket(
             existing_doc.subscription_id,
         )
 
+    if is_paid and addon_configured and not already_paying:
+        # PAID + not yet paying → bill it as an ADD-ON on the workspace's own
+        # subscription and deploy in the same request.
+        #
+        # STILL CHARGE-FIRST, without the pending/webhook dance. The old rail had
+        # to defer the deploy because payment happened on a hosted checkout the
+        # buyer wandered off to, so "did they pay" was only answerable later, by a
+        # webhook. Attaching an add-on charges the card already on the
+        # subscription, synchronously, inside this request — so the answer is
+        # known here and the site can go live immediately. The buyer never leaves
+        # the app and there is no ``checkout_url`` in the response.
+        return await _publish_addon_site(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            ripple_spec=ripple_spec,
+            theme=theme,
+            engine=engine,
+            source=source,
+            pattern=pattern,
+            name=name or pocket.get("name", ""),
+            builder_origin=builder_origin,
+            keeps_client_bundle=keeps_client_bundle,
+            tier=tier,
+            provider=_billing_provider,
+            _generator=_generator,
+            _cloudflare=_cloudflare,
+            _bundle_reader=_bundle_reader,
+            _local_deploy=_local_deploy,
+        )
+
     if is_paid and dodo_configured and not already_paying:
-        # PAID + chargeable + not yet paying → defer the deploy until
-        # subscription.active.
+        # PAID + chargeable on the LEGACY per-site rail (no add-on configured for
+        # the tier) → defer the deploy until subscription.active.
         return await _publish_pending_site(
             workspace_id=workspace_id,
             user_id=user_id,
@@ -5384,7 +5506,12 @@ async def _apply_site_plan(
     already_paying = getattr(doc, "subscription_status", None) == "active" and bool(
         getattr(doc, "subscription_id", None)
     )
-    if tier is not None and tier.dodo_product_id and not already_paying:
+    # ``not tier.dodo_addon_id``: a tier that HAS an add-on rail is billed on the
+    # workspace subscription, and this live path must not also open a per-site
+    # subscription for it — that is the double charge the add-on rail removes. The
+    # add-on rail does its own charging in ``_publish_addon_site`` before the
+    # deploy; by the time a site on that rail reaches here it is already paying.
+    if tier is not None and tier.dodo_product_id and not tier.dodo_addon_id and not already_paying:
         try:
             prov = provider or _default_billing_provider()
             checkout = await prov.create_subscription(
@@ -5467,6 +5594,116 @@ def _site_checkout_return_urls(origin: str | None) -> tuple[str | None, str | No
     return (f"{base}/sites?checkout=success", f"{base}/sites?checkout=cancel")
 
 
+async def _publish_addon_site(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    ripple_spec: dict[str, Any] | None,
+    theme: dict[str, Any],
+    engine: str,
+    source: dict[str, str] | None,
+    pattern: str | None,
+    name: str,
+    builder_origin: str | None,
+    keeps_client_bundle: bool,
+    tier: Any,
+    provider: Any | None,
+    _generator: GeneratorClient | None = None,
+    _cloudflare: Any | None = None,
+    _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
+    _local_deploy: Callable[[str, str], str] | None = None,
+) -> _SiteDoc:
+    """Buy a paid site as an ADD-ON on the workspace subscription, then deploy it.
+
+    The add-on half of ``publish_pocket``, and the rail every new paid publish
+    takes. The site is not a subscription of its own: it becomes a line on the
+    subscription the workspace already pays, so the customer gets one bill, one
+    renewal date and one payment method however many sites they run.
+
+    ORDER IS THE WHOLE DESIGN HERE, so it is worth being explicit about:
+
+      1. Create the site PENDING and not deployed, exactly as the per-site rail
+         does, capturing the deploy inputs on the doc.
+      2. Mark it ``active`` BEFORE charging. This looks backwards and is not: the
+         cart is computed from the ``Site`` documents, so the site has to be in
+         the documents to be in the cart. Marking it after the charge would bill
+         the workspace for every site EXCEPT the one being bought.
+      3. Sync the cart, which charges the card on the subscription synchronously.
+      4. Only then deploy, through the SAME ``activate_site`` the per-site
+         webhook uses — one deferred-deploy implementation, not two.
+
+    A FAILED CHARGE REVERTS STEP 2 AND PROPAGATES. Leaving the site ``active``
+    after a refusal would hand it every paid capability — badge off, custom
+    domain, concierge — for free and forever, since nothing else rewrites that
+    field. The revert runs in a ``finally``-shaped except so a gateway refusal,
+    a network error and a bug all take it.
+
+    The site stays PENDING and undeployed on failure rather than being deleted:
+    the buyer can fix their card and republish onto the same deterministic
+    ``site_id``, which is the same recovery the per-site rail offers.
+    """
+    from pocketpaw_ee.cloud.billing import service as billing_service
+
+    doc = await _publish_pending_site(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        ripple_spec=ripple_spec,
+        theme=theme,
+        engine=engine,
+        source=source,
+        pattern=pattern,
+        name=name,
+        builder_origin=builder_origin,
+        keeps_client_bundle=keeps_client_bundle,
+        tier=tier,
+        provider=provider,
+        addon_rail=True,
+    )
+
+    site_id = str(doc.id)
+    previous_status = doc.subscription_status
+    doc.subscription_status = "active"
+    await doc.save()
+    try:
+        # Thread the caller's provider through rather than letting the sync fall
+        # back to the default one. The publish path takes an injectable provider
+        # and every other billing call here honours it; dropping it at this one
+        # call reaches the real gateway from a caller that explicitly supplied a
+        # substitute.
+        result = await billing_service.sync_site_addons(workspace_id, provider=provider)
+    except Exception:
+        doc.subscription_status = previous_status
+        await doc.save()
+        logger.warning(
+            "sites.publish: add-on charge failed for site %s (tier=%s) — left PENDING "
+            "and undeployed, nothing charged",
+            site_id,
+            tier.key,
+            exc_info=True,
+        )
+        raise
+
+    logger.info(
+        "sites.publish: site %s billed as an add-on on subscription %s (tier=%s, cart=%s)",
+        site_id,
+        result.get("subscription_id"),
+        tier.key,
+        result.get("addons"),
+    )
+
+    return await activate_site(
+        workspace_id=workspace_id,
+        site_id=site_id,
+        force=True,
+        _generator=_generator,
+        _cloudflare=_cloudflare,
+        _bundle_reader=_bundle_reader,
+        _local_deploy=_local_deploy,
+    )
+
+
 async def _publish_pending_site(
     *,
     workspace_id: str,
@@ -5483,6 +5720,7 @@ async def _publish_pending_site(
     tier: Any,
     provider: Any | None,
     origin: str | None = None,
+    addon_rail: bool = False,
 ) -> _SiteDoc:
     """Charge-first: create a PAID-tier site as PENDING and open its checkout,
     WITHOUT deploying it live.
@@ -5581,23 +5819,31 @@ async def _publish_pending_site(
     # metadata carries it without the doc existing yet. If opening the checkout
     # raises, it PROPAGATES (no swallow) and NO pending doc is created — never an
     # orphan pending row with no subscription_id. The buyer can simply retry.
-    prov = provider or _default_billing_provider()
-    return_url, cancel_url = _site_checkout_return_urls(origin)
-    checkout = await prov.create_subscription(
-        plan_key=plan_key,
-        product_id=tier.dodo_product_id,
-        workspace_id=workspace_id,
-        customer_email=None,
-        metadata={
-            "workspace_id": workspace_id,
-            "site_id": site_id,
-            "plan_key": plan_key,
-        },
-        return_url=return_url,
-        cancel_url=cancel_url,
-    )
-    checkout_url: str | None = checkout.checkout_url or None
-    subscription_id: str | None = checkout.subscription_id or None
+    checkout_url: str | None = None
+    subscription_id: str | None = None
+    if not addon_rail:
+        prov = provider or _default_billing_provider()
+        return_url, cancel_url = _site_checkout_return_urls(origin)
+        checkout = await prov.create_subscription(
+            plan_key=plan_key,
+            product_id=tier.dodo_product_id,
+            workspace_id=workspace_id,
+            customer_email=None,
+            metadata={
+                "workspace_id": workspace_id,
+                "site_id": site_id,
+                "plan_key": plan_key,
+            },
+            return_url=return_url,
+            cancel_url=cancel_url,
+        )
+        checkout_url = checkout.checkout_url or None
+        subscription_id = checkout.subscription_id or None
+    # ON THE ADD-ON RAIL ``subscription_id`` STAYS None, and that is load-bearing
+    # rather than incidental. It is the discriminator the cart builder reads: a
+    # site holding a per-site subscription id is billed on the old rail and is
+    # EXCLUDED from the workspace cart, so stamping the workspace's subscription
+    # id here to be informative would silently drop the site off its own invoice.
 
     # Checkout opened — NOW upsert the PENDING canonical Site doc with the
     # subscription_id already set (review fix B). The size cap (A) already ran.
@@ -5646,6 +5892,7 @@ async def activate_site(
     workspace_id: str,
     site_id: str,
     subscription_id: str | None = None,
+    force: bool = False,
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
@@ -5677,7 +5924,17 @@ async def activate_site(
 
     # Idempotent: an already-deployed+active site is a no-op (replayed / out-of-order
     # delivery). We treat "deployed and active" as the terminal live state.
-    if doc.deployed and doc.subscription_status == "active":
+    #
+    # ``force`` EXISTS BECAUSE THAT GUARD IS ONLY RIGHT FOR THE WEBHOOK. It reads
+    # "deployed and active" as "nothing left to do", which is true of a replayed
+    # ``subscription.active`` and false of the add-on rail: there the caller marks
+    # the site active BEFORE charging (the cart is built from the documents), so by
+    # the time the deploy runs the doc already looks terminal. An upgrade of a
+    # LIVE free site to a paid tier would hit this line, return early, and ship
+    # the customer a charge with none of the new content — the site would keep
+    # serving what it was serving before. The webhook still passes force=False and
+    # keeps its at-least-once protection unchanged.
+    if doc.deployed and doc.subscription_status == "active" and not force:
         return doc
 
     inputs = doc.pending_deploy_inputs or {}

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -159,6 +159,12 @@ Changes:
     site tier's ``dodo_product_id`` was None, and no per-site plan could be
     purchased on any deployment however it was configured. Declaring it makes the
     env var mean something for the first time.
+  - 2026-08-26: Added ``dodo_site_addons`` (default {}, env
+    POCKETPAW_DODO_SITE_ADDONS as a JSON object) — the tier -> Dodo ADD-ON id map
+    that bills a paid site as a LINE on the workspace subscription instead of a
+    separate per-site subscription. ``dodo_site_products`` is deliberately kept
+    alongside it: per-site subscriptions are live in production and their renewal
+    and cancel webhooks still route through the product map.
   - 2026-08-21: Added ``sites_billing_enforced`` (default False, env
     ``POCKETPAW_SITES_BILLING_ENFORCED``) — the PER-SITE paywall switch, so the
     Paw Sites seams (custom-domain capability + count caps, concierge
@@ -2362,6 +2368,27 @@ class Settings(BaseSettings):
             "var did nothing at all."
         ),
     )
+    dodo_site_addons: Annotated[dict[str, str], NoDecode] = Field(
+        default_factory=dict,
+        description=(
+            "Mapping of PER-SITE plan tier key -> Dodo ADD-ON id, the rails a paid "
+            "site bills on now that it is an add-on LINE on the workspace "
+            "subscription rather than a subscription of its own. An add-on is its "
+            "own Dodo entity with its own id and is NOT a product id, so this "
+            "cannot reuse dodo_site_products (which stays, for the per-site "
+            "subscriptions already live in production). "
+            "``billing.service.sync_site_addons`` reads it to build the workspace's "
+            "full add-on cart and pushes that cart with subscriptions.change_plan. "
+            "Set via POCKETPAW_DODO_SITE_ADDONS as a JSON object keyed by tier, "
+            'e.g. {"site":"adn_...","staff":"adn_..."}. Only the SITE-SCOPED rungs '
+            "belong here — the org flats (studio, agency) are refused by site_plans "
+            'regardless of what this map says. The pre-2026-08-22 keys ("pro", '
+            '"business") are honoured through the same alias lookup the product map '
+            "uses. Default empty means no site tier is purchasable as an add-on, and "
+            "a paid publish records the tier without a charge exactly as it does "
+            "with an unconfigured product."
+        ),
+    )
     dodo_checkout_return_base: str = Field(
         default="",
         description=(
@@ -2838,6 +2865,29 @@ class Settings(BaseSettings):
         The consequence of an empty mapping is milder here and worth knowing: no
         per-site tier is purchasable, so a paid selection publishes live and
         records the tier without a charge. It does not raise.
+        """
+        if v is None or v == "":
+            return {}
+        if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+            except ValueError:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        return v
+
+    @field_validator("dodo_site_addons", mode="before")
+    @classmethod
+    def _parse_dodo_site_addons(cls, v: object) -> object:
+        """Same degrade as the two product maps: a malformed env string becomes an
+        empty mapping rather than crashing settings load at boot.
+
+        Needs ``NoDecode`` on the field for this to run at all — ``EnvSettingsSource``
+        JSON-decodes a complex field at SOURCE time and raises ``SettingsError``
+        before any field validator sees the value. The field carries it.
+
+        An empty mapping means no site tier is purchasable as an add-on: a paid
+        publish records the tier with no charge. It does not raise.
         """
         if v is None or v == "":
             return {}

--- a/tests/cloud/billing/test_change_plan_provider.py
+++ b/tests/cloud/billing/test_change_plan_provider.py
@@ -54,7 +54,7 @@ async def test_the_plan_change_prorates_the_difference(monkeypatch):
     client = _fake_sdk(monkeypatch)
 
     await _provider().change_plan(
-        subscription_id=SUB_ID, product_id="prod_site_business", plan_key="business"
+        subscription_id=SUB_ID, product_id="prod_site_business", plan_key="business", addons=[]
     )
 
     args, kwargs = client.subscriptions.change_plan.call_args
@@ -75,7 +75,7 @@ async def test_a_declined_card_leaves_the_plan_where_it_was(monkeypatch):
     client = _fake_sdk(monkeypatch)
 
     await _provider().change_plan(
-        subscription_id=SUB_ID, product_id="prod_site_business", plan_key="business"
+        subscription_id=SUB_ID, product_id="prod_site_business", plan_key="business", addons=[]
     )
 
     _, kwargs = client.subscriptions.change_plan.call_args
@@ -89,7 +89,7 @@ async def test_an_empty_subscription_id_never_reaches_the_gateway(monkeypatch):
 
     with pytest.raises(ValidationError):
         await _provider().change_plan(
-            subscription_id="", product_id="prod_site_business", plan_key="business"
+            subscription_id="", product_id="prod_site_business", plan_key="business", addons=[]
         )
 
     client.subscriptions.change_plan.assert_not_called()
@@ -101,6 +101,8 @@ async def test_an_unconfigured_product_never_reaches_the_gateway(monkeypatch):
     client = _fake_sdk(monkeypatch)
 
     with pytest.raises(ValidationError):
-        await _provider().change_plan(subscription_id=SUB_ID, product_id="", plan_key="business")
+        await _provider().change_plan(
+            subscription_id=SUB_ID, product_id="", plan_key="business", addons=[]
+        )
 
     client.subscriptions.change_plan.assert_not_called()

--- a/tests/cloud/billing/test_site_plan_addons.py
+++ b/tests/cloud/billing/test_site_plan_addons.py
@@ -1,0 +1,340 @@
+# tests/cloud/billing/test_site_plan_addons.py — the ADD-ON RAIL: a paid site is
+# a LINE on the workspace's existing subscription, not a subscription of its own.
+#
+# What these cover, and why each one is here rather than being obvious:
+#
+#   * The SDK edge — ``change_plan`` forwards ``addons`` ALWAYS, empty included.
+#     Dodo treats the add-on list as declarative ("leaving this empty would remove
+#     any existing addons"), so an OMITTED list is not "leave the cart alone", it
+#     is "empty the cart". A provider that only passed the kwarg when non-empty
+#     would silently cancel every paid site in a workspace the next time anyone
+#     changed the workspace plan, and the only symptom would be a smaller invoice
+#     a month later.
+#   * The cart builder — aggregation, and the three exclusions. The double-billing
+#     one is the expensive bug: a site already on a legacy per-site subscription
+#     that also lands on the workspace cart is charged twice for one site.
+#   * The refusal — a workspace with no subscription has nothing to attach an
+#     add-on to, and must say so rather than quietly opening the separate
+#     subscription this rail exists to remove.
+#
+# Uses the shared ``mongo_db`` fixture (mongomock-motor + Beanie over
+# ALL_DOCUMENTS) from tests/cloud/conftest.py, with REAL ``Site`` and
+# ``Subscription`` documents — the cart is built by querying them, so a stubbed
+# repository would test the stub rather than the query.
+#
+# Created 2026-08-26 (feat/site-plans-as-addons): new test module.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import NoActiveSubscription
+from pocketpaw_ee.cloud.billing import service as billing_service
+from pocketpaw_ee.cloud.billing import site_plans
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.cloud.models.subscription import Subscription
+
+pytestmark = pytest.mark.anyio
+
+WORKSPACE = "ws_addons"
+ADDONS = {"site": "adn_site", "staff": "adn_staff"}
+
+
+def _addons(monkeypatch, mapping: dict[str, str] | None = None) -> None:
+    """Point the lazily-imported ``get_settings`` at an add-on map stub.
+
+    ``_dodo_addon_for`` imports ``get_settings`` inside the call, so the patch has
+    to land on the config module rather than on a name already bound here.
+    """
+    monkeypatch.setattr(
+        "pocketpaw.config.get_settings",
+        lambda: SimpleNamespace(
+            dodo_site_addons=ADDONS if mapping is None else mapping,
+            dodo_site_products=None,
+        ),
+    )
+
+
+async def _site(*, tier: str, status: str = "active", subscription_id: str | None = None) -> Site:
+    doc = Site(
+        workspace=WORKSPACE,
+        pocket_id=f"pocket_{tier}_{status}_{subscription_id or 'none'}",
+        owner="user_1",
+        name="a site",
+        plan_tier=tier,
+        subscription_status=status,
+        subscription_id=subscription_id,
+    )
+    await doc.insert()
+    return doc
+
+
+async def _subscription(*, plan_key: str = "pro", product_id: str = "prod_ws_pro") -> Subscription:
+    doc = Subscription(
+        workspace=WORKSPACE,
+        gateway="dodo",
+        gateway_subscription_id="sub_workspace_1",
+        plan_key=plan_key,
+        product_id=product_id,
+        status="active",
+    )
+    await doc.insert()
+    return doc
+
+
+# --------------------------------------------------------------------------- #
+# The gateway edge
+# --------------------------------------------------------------------------- #
+
+
+async def test_the_provider_forwards_an_empty_cart_rather_than_omitting_it(monkeypatch):
+    """An omitted add-on list EMPTIES the cart at this gateway, so the parameter
+    must be sent on every call — including, and especially, when it is empty.
+
+    If the adapter dropped the kwarg when the list was empty, the SDK would omit
+    it, Dodo would read that as "remove every addon", and a workspace that changed
+    its plan would lose the billing for every paid site it runs while our own
+    documents still said those sites were active."""
+    from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+
+    client = MagicMock()
+    client.subscriptions.change_plan = AsyncMock(return_value=None)
+    provider = DodoProvider(
+        api_key="k",
+        environment="test_mode",
+        webhook_secret="whsec_x",
+        credit_product_id=None,
+        plan_products={},
+    )
+    monkeypatch.setattr(provider, "_client", lambda: client)
+
+    await provider.change_plan(
+        subscription_id="sub_1", product_id="prod_ws_pro", plan_key="pro", addons=[]
+    )
+
+    _, kwargs = client.subscriptions.change_plan.call_args
+    assert "addons" in kwargs, (
+        "the kwarg must be present even when empty — an omitted list is not "
+        "'leave the cart alone', it is 'empty the cart'"
+    )
+    assert kwargs["addons"] == []
+
+
+async def test_the_provider_forwards_the_cart_it_was_given(monkeypatch):
+    from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+
+    client = MagicMock()
+    client.subscriptions.change_plan = AsyncMock(return_value=None)
+    provider = DodoProvider(
+        api_key="k",
+        environment="test_mode",
+        webhook_secret="whsec_x",
+        credit_product_id=None,
+        plan_products={},
+    )
+    monkeypatch.setattr(provider, "_client", lambda: client)
+
+    cart = [{"addon_id": "adn_site", "quantity": 3}]
+    await provider.change_plan(
+        subscription_id="sub_1", product_id="prod_ws_pro", plan_key="pro", addons=cart
+    )
+
+    _, kwargs = client.subscriptions.change_plan.call_args
+    assert kwargs["addons"] == cart
+
+
+# --------------------------------------------------------------------------- #
+# The catalog
+# --------------------------------------------------------------------------- #
+
+
+def test_a_tier_is_purchasable_on_the_addon_id_alone(monkeypatch):
+    """The add-on id is the rail a new purchase takes, so it alone must make a
+    tier buyable — a deployment that has configured add-ons and never configured
+    the per-site products is the intended end state, not a broken one."""
+    _addons(monkeypatch)
+    tier = site_plans.get_site_plan("site")
+    assert tier is not None
+    assert tier.dodo_addon_id == "adn_site"
+    assert tier.dodo_product_id is None
+    assert tier.purchasable is True
+
+
+def test_an_org_flat_is_still_unpurchasable_however_it_is_configured(monkeypatch):
+    """Add-ons make an org flat mechanically chargeable for the first time, which
+    is exactly why this stays asserted: nothing about this change should let a
+    per-site publish buy a plan that covers twenty-five sites."""
+    _addons(monkeypatch, {"studio": "adn_studio", "agency": "adn_agency"})
+    for key in ("studio", "agency"):
+        tier = site_plans.get_site_plan(key)
+        assert tier is not None
+        assert tier.purchasable is False, f"{key} is an org flat and must stay unbuyable here"
+
+
+def test_the_legacy_tier_names_still_resolve_an_addon(monkeypatch):
+    """A deployment keyed by the pre-2026-08-22 names must keep charging. The
+    product map already had this alias lookup; the add-on map needs the same one
+    or a rename turns every paid tier unbuyable on deploy."""
+    _addons(monkeypatch, {"pro": "adn_legacy_pro"})
+    tier = site_plans.get_site_plan("site")
+    assert tier is not None
+    assert tier.dodo_addon_id == "adn_legacy_pro"
+
+
+# --------------------------------------------------------------------------- #
+# The cart
+# --------------------------------------------------------------------------- #
+
+
+async def test_the_cart_aggregates_sites_on_the_same_tier(mongo_db, monkeypatch):  # noqa: ARG001
+    """Dodo keys a cart line by add-on id, so four sites on one tier are one line
+    of quantity four. Emitting the id four times is a malformed cart."""
+    _addons(monkeypatch)
+    for _ in range(3):
+        await _site(tier="site")
+    await _site(tier="staff")
+
+    cart = await billing_service._site_addon_cart(WORKSPACE)
+
+    assert cart == [
+        {"addon_id": "adn_site", "quantity": 3},
+        {"addon_id": "adn_staff", "quantity": 1},
+    ]
+
+
+async def test_a_site_on_a_legacy_per_site_subscription_stays_off_the_cart(
+    mongo_db,  # noqa: ARG001
+    monkeypatch,
+):
+    """THE DOUBLE-BILLING GUARD. Per-site subscriptions are live in production and
+    Dodo is already charging for them on their own rail. Counting one on the
+    workspace cart too would charge the customer twice for a single site, and the
+    only place it would show up is the invoice."""
+    _addons(monkeypatch)
+    await _site(tier="site")
+    await _site(tier="staff", subscription_id="sub_per_site_legacy")
+
+    cart = await billing_service._site_addon_cart(WORKSPACE)
+
+    assert cart == [{"addon_id": "adn_site", "quantity": 1}]
+
+
+async def test_a_cancelled_site_drops_off_the_cart(mongo_db, monkeypatch):  # noqa: ARG001
+    """This IS the cancellation mechanism under the add-on model: the cart is
+    rebuilt from the documents and pushed whole, so a site that stops being active
+    stops being billed on the next sync. Nothing has to remember to detach it."""
+    _addons(monkeypatch)
+    await _site(tier="site")
+    await _site(tier="site", status="cancelled")
+    await _site(tier="staff", status="none")
+
+    cart = await billing_service._site_addon_cart(WORKSPACE)
+
+    assert cart == [{"addon_id": "adn_site", "quantity": 1}]
+
+
+async def test_a_free_site_is_never_a_cart_line(mongo_db, monkeypatch):  # noqa: ARG001
+    _addons(monkeypatch)
+    await _site(tier="free")
+
+    assert await billing_service._site_addon_cart(WORKSPACE) == []
+
+
+async def test_a_tier_with_no_configured_addon_is_skipped(mongo_db, monkeypatch):  # noqa: ARG001
+    """Nothing is guessed for an unconfigured tier. The publish path separately
+    refuses to record a tier it cannot charge for, so this only ever sees a site
+    whose tier lost its configuration after the sale."""
+    _addons(monkeypatch, {"site": "adn_site"})
+    await _site(tier="site")
+    await _site(tier="staff")
+
+    assert await billing_service._site_addon_cart(WORKSPACE) == [
+        {"addon_id": "adn_site", "quantity": 1}
+    ]
+
+
+async def test_the_cart_is_scoped_to_one_workspace(mongo_db, monkeypatch):  # noqa: ARG001
+    _addons(monkeypatch)
+    await _site(tier="site")
+    other = Site(
+        workspace="ws_someone_else",
+        pocket_id="pocket_other",
+        owner="user_2",
+        name="not ours",
+        plan_tier="staff",
+        subscription_status="active",
+    )
+    await other.insert()
+
+    assert await billing_service._site_addon_cart(WORKSPACE) == [
+        {"addon_id": "adn_site", "quantity": 1}
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# The sync
+# --------------------------------------------------------------------------- #
+
+
+async def test_sync_refuses_a_workspace_with_no_subscription(mongo_db, monkeypatch):  # noqa: ARG001
+    """An add-on attaches to something. Refusing here is the deliberate shape of
+    the feature — the alternative is opening a standalone per-site subscription,
+    which is the separate payment this rail replaces."""
+    _addons(monkeypatch)
+    await _site(tier="site")
+    provider = MagicMock()
+    provider.change_plan = AsyncMock()
+
+    with pytest.raises(NoActiveSubscription):
+        await billing_service.sync_site_addons(WORKSPACE, provider=provider)
+
+    provider.change_plan.assert_not_awaited()
+
+
+async def test_sync_pushes_the_full_cart_onto_the_existing_subscription(
+    mongo_db,  # noqa: ARG001
+    monkeypatch,
+):
+    """One subscription, one bill. The site is charged by moving the workspace's
+    OWN subscription onto the same product it already has with a fuller cart —
+    never by creating a second subscription."""
+    _addons(monkeypatch)
+    await _subscription()
+    await _site(tier="site")
+    await _site(tier="staff")
+    provider = MagicMock()
+    provider.change_plan = AsyncMock(return_value=None)
+    provider.create_subscription = AsyncMock()
+
+    result = await billing_service.sync_site_addons(WORKSPACE, provider=provider)
+
+    _, kwargs = provider.change_plan.call_args
+    assert kwargs["subscription_id"] == "sub_workspace_1"
+    assert kwargs["product_id"] == "prod_ws_pro", (
+        "re-send the product the subscription is already on — publishing a site "
+        "must not move the workspace's plan as a side effect"
+    )
+    assert kwargs["addons"] == [
+        {"addon_id": "adn_site", "quantity": 1},
+        {"addon_id": "adn_staff", "quantity": 1},
+    ]
+    provider.create_subscription.assert_not_awaited()
+    assert result["subscription_id"] == "sub_workspace_1"
+
+
+async def test_sync_is_idempotent(mongo_db, monkeypatch):  # noqa: ARG001
+    """The cart is recomputed and sent whole every time, so a second sync with no
+    change between sends a byte-identical payload. Callers never have to work out
+    whether a sync is 'needed'."""
+    _addons(monkeypatch)
+    await _subscription()
+    await _site(tier="site")
+    provider = MagicMock()
+    provider.change_plan = AsyncMock(return_value=None)
+
+    first = await billing_service.sync_site_addons(WORKSPACE, provider=provider)
+    second = await billing_service.sync_site_addons(WORKSPACE, provider=provider)
+
+    assert first["addons"] == second["addons"] == [{"addon_id": "adn_site", "quantity": 1}]

--- a/tests/cloud/sites/test_addon_publish.py
+++ b/tests/cloud/sites/test_addon_publish.py
@@ -1,0 +1,502 @@
+# tests/cloud/sites/test_addon_publish.py — the ADD-ON PUBLISH RAIL end to end:
+# buying a paid site attaches a LINE to the workspace's existing subscription and
+# deploys in the same request, instead of opening a per-site checkout.
+#
+# What separates this from tests/cloud/billing/test_site_plan_addons.py: that one
+# proves the cart and the sync in isolation, this one drives the real
+# ``publish_pocket`` dispatcher and asserts on what the buyer actually gets — a
+# live site and no redirect — and on what they must NOT get, a second
+# subscription.
+#
+# The three that are worth the most:
+#
+#   * ``test_a_paid_publish_deploys_in_the_same_request`` — there is no pending
+#     state and no ``checkout_url`` on this rail. The charge is synchronous, so
+#     the deploy can be too.
+#   * ``test_upgrading_a_live_free_site_ships_the_new_content`` — the regression
+#     that the obvious implementation gets wrong. ``activate_site``'s idempotency
+#     guard returns early for a site that is already deployed+active, and this
+#     rail marks the site active BEFORE charging (the cart is built from the
+#     documents). Without ``force=True`` the customer is charged and keeps seeing
+#     the old site, with every status field claiming success.
+#   * ``test_a_declined_charge_leaves_nothing_paid_for`` — a refusal must not
+#     leave the site holding paid capabilities. Nothing else rewrites
+#     ``subscription_status``, so a missed revert is permanent.
+#
+# Created 2026-08-26 (feat/site-plans-as-addons): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import NoActiveSubscription
+from pocketpaw_ee.cloud.billing import site_plans
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.cloud.models.subscription import Subscription
+from pocketpaw_ee.sites import service as sites_service
+
+pytestmark = pytest.mark.anyio
+
+WS_SUB_ID = "sub_workspace_real"
+
+
+class _RecordingGenerator:
+    def __init__(self):
+        self.build_calls: list[dict] = []
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.build_calls.append(dict(kw))
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _RecordingBillingProvider:
+    """Records what the publish asked the gateway to do.
+
+    ``create_subscription`` is present and recorded precisely so a test can prove
+    it was NOT called — the whole point of this rail is that no second
+    subscription is ever opened.
+    """
+
+    def __init__(self, *, change_plan_raises: Exception | None = None):
+        self.create_calls: list[dict] = []
+        self.change_plan_calls: list[dict] = []
+        self._change_plan_raises = change_plan_raises
+
+    async def create_subscription(self, **kw):
+        from pocketpaw_ee.cloud.billing.domain import SubscriptionCheckout
+
+        self.create_calls.append(dict(kw))
+        return SubscriptionCheckout(checkout_url="https://nope.test", subscription_id="cks_nope")
+
+    async def change_plan(self, *, subscription_id, product_id, plan_key, addons):
+        if self._change_plan_raises is not None:
+            raise self._change_plan_raises
+        self.change_plan_calls.append(
+            {
+                "subscription_id": subscription_id,
+                "product_id": product_id,
+                "plan_key": plan_key,
+                "addons": addons,
+            }
+        )
+
+    async def cancel_subscription(self, subscription_id: str) -> None:  # pragma: no cover
+        raise AssertionError("the add-on rail must never cancel a subscription")
+
+
+async def _make_workspace(plan: str = "pro") -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(
+        name="Acme",
+        slug=f"acme-addon-{datetime.now(UTC).timestamp()}",
+        owner="u1",
+        plan=plan,
+    )
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _make_pocket(*, workspace_id: str, owner: str = "u1") -> str:
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(
+        workspace=workspace_id,
+        name="My Landing",
+        owner=owner,
+        type="site",
+        pattern="landing",
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _make_subscription(workspace_id: str) -> None:
+    doc = Subscription(
+        workspace=workspace_id,
+        gateway="dodo",
+        gateway_subscription_id=WS_SUB_ID,
+        plan_key="pro",
+        product_id="prod_ws_pro",
+        status="active",
+    )
+    await doc.insert()
+
+
+def _addon_rail_only(monkeypatch) -> None:
+    """Configure the ADD-ON map and leave the per-site product map empty.
+
+    The two together are the intended end state; separating them here means a
+    test that asserts "no second subscription" is proving the dispatcher chose
+    the add-on rail rather than proving the old rail happened to be unconfigured.
+    """
+    monkeypatch.setattr(
+        site_plans,
+        "_dodo_addon_for",
+        lambda key: {"site": "adn_site", "staff": "adn_staff"}.get(key),
+    )
+    monkeypatch.setattr(site_plans, "_dodo_product_for", lambda key: None)
+
+
+def _local_deploy(monkeypatch) -> list[str]:
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    gen = _RecordingGenerator()
+    monkeypatch.setattr(sites_service, "GeneratorClient", lambda *a, **k: gen)
+    from pocketpaw_ee.sites import local_server
+
+    deploys: list[str] = []
+
+    def _fake_deploy_local(site_id, project_dir, **kw):
+        deploys.append(site_id)
+        return f"http://local/{site_id}/"
+
+    monkeypatch.setattr(local_server, "deploy_local", _fake_deploy_local)
+    return deploys
+
+
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_paid_publish_deploys_in_the_same_request(mongo_db, monkeypatch):  # noqa: ARG001
+    """No pending state, no checkout_url, no second subscription.
+
+    The old rail had to defer the deploy because payment happened on a hosted
+    checkout the buyer wandered off to. Attaching an add-on charges the card on
+    the subscription synchronously, so the answer to "did they pay" is known
+    inside this request and the site can go live in it."""
+    _addon_rail_only(monkeypatch)
+    deploys = _local_deploy(monkeypatch)
+    ws = await _make_workspace()
+    await _make_subscription(ws)
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="site",
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    assert provider.create_calls == [], (
+        "a paid site must not open a subscription of its own — that is the "
+        "separate payment this rail replaces"
+    )
+    call = provider.change_plan_calls[0]
+    assert call["subscription_id"] == WS_SUB_ID
+    assert call["addons"] == [{"addon_id": "adn_site", "quantity": 1}]
+
+    assert doc.deployed is True
+    assert doc.subscription_status == "active"
+    assert doc.plan_tier == "site"
+    assert deploys, "the site must actually deploy in this request"
+
+    assert doc.subscription_id is None, (
+        "no PER-SITE subscription exists, and the field is the cart builder's "
+        "discriminator — stamping the workspace's id here would drop the site "
+        "off its own invoice"
+    )
+    assert sites_service._to_response(doc).checkout_url is None, (
+        "the buyer never leaves the app on this rail"
+    )
+
+
+async def test_upgrading_a_live_free_site_ships_the_new_content(mongo_db, monkeypatch):  # noqa: ARG001
+    """THE REGRESSION THIS RAIL INVITES. The site is marked active BEFORE the
+    charge, because the cart is built from the documents. ``activate_site``
+    treats "deployed and active" as terminal and returns early — so an upgrade of
+    an already-live free site would charge the customer and redeploy nothing,
+    while every status field reported success."""
+    _addon_rail_only(monkeypatch)
+    deploys = _local_deploy(monkeypatch)
+    ws = await _make_workspace()
+    await _make_subscription(ws)
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    # First publish on the FREE floor — goes live, no charge.
+    free_doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="free",
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+    assert free_doc.deployed is True
+    assert provider.change_plan_calls == []
+    deploys.clear()
+
+    # Now buy a paid tier for the SAME pocket.
+    paid_doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="site",
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    assert provider.change_plan_calls, "the upgrade must actually charge"
+    assert deploys, (
+        "the customer paid for an upgrade and got no redeploy — activate_site's "
+        "idempotency guard swallowed it (this is what force=True exists for)"
+    )
+    assert paid_doc.plan_tier == "site"
+    assert paid_doc.subscription_status == "active"
+    assert paid_doc.deployed is True
+
+
+async def test_a_declined_charge_leaves_nothing_paid_for(mongo_db, monkeypatch):  # noqa: ARG001
+    """A refusal propagates, and the site must not keep the paid status it was
+    optimistically given. Nothing else ever rewrites that field, so a missed
+    revert hands out badge removal, custom domains and the concierge for free and
+    for good."""
+    _addon_rail_only(monkeypatch)
+    _local_deploy(monkeypatch)
+    ws = await _make_workspace()
+    await _make_subscription(ws)
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider(change_plan_raises=RuntimeError("card declined"))
+
+    with pytest.raises(RuntimeError, match="card declined"):
+        await sites_service.publish_pocket(
+            workspace_id=ws,
+            user_id="u1",
+            pocket_id=pocket_id,
+            site_plan_key="site",
+            _bundle_reader=lambda d: b"x",
+            _billing_provider=provider,
+        )
+
+    doc = await Site.find_one(Site.workspace == ws)
+    assert doc is not None
+    assert doc.subscription_status != "active", (
+        "a declined card must not leave the site holding every paid capability"
+    )
+    assert doc.deployed is False, "nothing was paid for, so nothing goes live"
+
+
+async def test_a_workspace_with_no_subscription_cannot_buy_a_site(mongo_db, monkeypatch):  # noqa: ARG001
+    """The deliberate funnel consequence, asserted so it is a decision rather than
+    an accident: an add-on attaches to something. A free workspace has to start a
+    workspace subscription first — the alternative is opening the standalone
+    per-site subscription this rail exists to remove."""
+    _addon_rail_only(monkeypatch)
+    _local_deploy(monkeypatch)
+    ws = await _make_workspace()  # deliberately NO subscription
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    with pytest.raises(NoActiveSubscription):
+        await sites_service.publish_pocket(
+            workspace_id=ws,
+            user_id="u1",
+            pocket_id=pocket_id,
+            site_plan_key="site",
+            _bundle_reader=lambda d: b"x",
+            _billing_provider=provider,
+        )
+
+    assert provider.create_calls == [], (
+        "refusing must not fall back to opening a per-site subscription"
+    )
+
+
+async def test_the_legacy_per_site_rail_still_runs_when_no_addon_is_configured(
+    mongo_db,  # noqa: ARG001
+    monkeypatch,
+):
+    """Grandfathering. Per-site subscriptions are live in production; a tier with a
+    product and no add-on must still take the old charge-first path so a
+    part-configured deployment keeps selling."""
+    monkeypatch.setattr(site_plans, "_dodo_addon_for", lambda key: None)
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
+    )
+    _local_deploy(monkeypatch)
+    ws = await _make_workspace()
+    await _make_subscription(ws)
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="site",
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    assert provider.create_calls, "the legacy rail opens a per-site checkout"
+    assert provider.change_plan_calls == []
+    assert doc.subscription_status == "pending"
+    assert doc.deployed is False
+
+
+async def test_republishing_a_paid_addon_site_does_not_charge_again(mongo_db, monkeypatch):  # noqa: ARG001
+    """A republish is a CONTENT EDIT, not a purchase.
+
+    An add-on site deliberately holds no per-site ``subscription_id`` — that
+    absence is how the cart builder tells the two rails apart — so the old
+    "already paying means it has a subscription id" test read every add-on site as
+    unpaid and re-ran the charge on every content edit."""
+    _addon_rail_only(monkeypatch)
+    deploys = _local_deploy(monkeypatch)
+    ws = await _make_workspace()
+    await _make_subscription(ws)
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="site",
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+    assert len(provider.change_plan_calls) == 1
+    deploys.clear()
+
+    # Same pocket, same tier, new content.
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="site",
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    assert len(provider.change_plan_calls) == 1, (
+        "a content edit must not touch billing — the declarative cart makes a "
+        "re-charge idempotent, but churning proration on every publish is not"
+    )
+    assert provider.create_calls == []
+    assert doc.subscription_status == "active"
+    assert doc.plan_tier == "site"
+    assert deploys, "the new content still has to go live"
+
+
+async def test_a_tier_change_on_the_addon_rail_resyncs_the_cart(mongo_db, monkeypatch):  # noqa: ARG001
+    """There is no per-site subscription to move, so an upgrade is expressed as a
+    different cart on the workspace's subscription."""
+    _addon_rail_only(monkeypatch)
+    _local_deploy(monkeypatch)
+    ws = await _make_workspace()
+    await _make_subscription(ws)
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="site",
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="staff",
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    assert doc.plan_tier == "staff"
+    assert provider.create_calls == []
+    assert provider.change_plan_calls[-1]["addons"] == [{"addon_id": "adn_staff", "quantity": 1}], (
+        "the site moved rungs, so the cart carries the new tier and NOT the old "
+        "one — a cart that kept both would bill the customer for two sites"
+    )
+
+
+async def test_both_rails_configured_still_never_opens_a_per_site_subscription(
+    mongo_db,  # noqa: ARG001
+    monkeypatch,
+):
+    """THE ROLLOUT STATE, and the one where getting this wrong costs money.
+
+    A deployment mid-migration has the per-site product map AND the add-on map
+    set. Every code path that can reach ``create_subscription`` has to check the
+    add-on rail first, or the customer is billed on both at once."""
+    monkeypatch.setattr(site_plans, "_dodo_addon_for", lambda key: {"site": "adn_site"}.get(key))
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
+    )
+    _local_deploy(monkeypatch)
+    ws = await _make_workspace()
+    await _make_subscription(ws)
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="site",
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    assert provider.create_calls == [], (
+        "both maps configured is the normal rollout state — the add-on rail must "
+        "win, or the site is billed twice for one purchase"
+    )
+    assert provider.change_plan_calls
+    assert doc.subscription_id is None
+    assert doc.deployed is True
+
+
+async def test_the_stamp_path_refuses_to_open_a_per_site_sub_for_an_addon_tier(
+    mongo_db,  # noqa: ARG001
+    monkeypatch,
+):
+    """Defence in depth on ``_apply_site_plan``, exercised directly.
+
+    The dispatcher already routes an add-on tier away from this function, so
+    today nothing reaches it with both rails configured — which is exactly why
+    this is called directly rather than through ``publish_pocket``. The guard
+    protects a BILLING path against a future refactor that changes the routing,
+    and an untested guard in a billing path is a guess. Reaching in is the honest
+    way to prove it, and the mutation plan confirms it fails without the check."""
+    monkeypatch.setattr(site_plans, "_dodo_addon_for", lambda key: {"site": "adn_site"}.get(key))
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
+    )
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    doc = Site(
+        workspace=ws,
+        pocket_id=pocket_id,
+        owner="u1",
+        name="direct",
+        plan_tier=None,
+        subscription_status="none",
+    )
+    await doc.insert()
+
+    await sites_service._apply_site_plan(
+        doc=doc,
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="site",
+        provider=provider,
+    )
+
+    assert provider.create_calls == [], (
+        "the tier has an add-on rail, so this path must never open a per-site "
+        "subscription for it — that is a second charge for one site"
+    )

--- a/tests/cloud/sites/test_republish_double_billing.py
+++ b/tests/cloud/sites/test_republish_double_billing.py
@@ -108,7 +108,7 @@ class _RecordingBillingProvider:
         )
         return SubscriptionCheckout(checkout_url=CHECKOUT_URL, subscription_id=SESSION_ID)
 
-    async def change_plan(self, *, subscription_id, product_id, plan_key):
+    async def change_plan(self, *, subscription_id, product_id, plan_key, addons):
         if self._change_plan_raises is not None:
             raise self._change_plan_raises
         self.change_plan_calls.append(
@@ -116,6 +116,7 @@ class _RecordingBillingProvider:
                 "subscription_id": subscription_id,
                 "product_id": product_id,
                 "plan_key": plan_key,
+                "addons": addons,
             }
         )
 
@@ -419,6 +420,12 @@ async def test_moving_a_paying_site_to_another_tier_changes_the_plan(
         "change_plan was handed the checkout session id, not the gateway subscription"
     )
     assert call["product_id"] == "prod_site_staff"
+    assert call["addons"] == [], (
+        "a PER-SITE subscription buys exactly one site and never carries add-ons, "
+        "so an empty cart is correct HERE and only here — sending [] to the "
+        "WORKSPACE subscription would remove the billing for every paid site it "
+        "carries, which is why the provider takes the cart as a required argument"
+    )
 
     # The webhook acks plan_changed without acting, so the new tier has to be
     # written synchronously here or nothing ever records it.

--- a/tests/cloud/test_paw_bar_concierge_entitlement.py
+++ b/tests/cloud/test_paw_bar_concierge_entitlement.py
@@ -15,12 +15,27 @@
 # reason to trigger it, and reuses that path byte for byte — a refused visitor sees
 # exactly what an owner-disabled one sees.
 #
-# The gate rule (captain's call 2026-08-15): any tier above the free floor, with an
-# active subscription. Derived from ``BASE_SITE_PLAN_KEY`` rather than a per-tier
-# catalog flag, because no tier grants concierge today and the one that will
-# (``staff``) does not exist until the pricing-spec rekey. So every criterion below
-# reads the floor out of the catalog instead of hardcoding "basic"/"pro" — the rekey
-# moves these tests with the catalog instead of breaking them.
+# The gate rule (captain's call 2026-08-15): a tier that sells the concierge, with
+# an active subscription. Every criterion below reads that tier out of the catalog
+# rather than hardcoding a key, so the ladder can be re-priced without touching
+# this file.
+#
+# Updated 2026-08-26 (feat/site-plans-as-addons): the derivation was "the cheapest
+# tier above the free floor", chosen in 2026-08-15 because no tier sold the
+# concierge yet and ``staff`` did not exist until the pricing rekey. The stated
+# intent was that "the rekey moves these tests with the catalog instead of breaking
+# them" — but that derivation is not the one that moves. The 2026-08-22 rekey gave
+# the catalog a per-tier ``sells_concierge`` map in which the cheapest paid rung
+# (``site``, $7) sells none, so the helper returned a tier with no concierge:
+#
+#   * four tests asserting an ENTITLED site failed outright, and stayed red;
+#   * two more passed for the wrong reason — "not available" for a LAPSED
+#     subscription and for a flipped OWNER SWITCH both held because the tier said
+#     no before either gate was reached. Neither gate was under test, which the
+#     mutation plan had been reporting as two escapes.
+#
+# ``_concierge_tier`` now reads ``sells_concierge``, which is the derivation the
+# header always described.
 #
 # The two questions stay SEPARATE (``concierge_enabled`` vs ``concierge_entitled``)
 # and that separation is itself pinned below: collapsing them into one boolean makes
@@ -46,12 +61,31 @@ import pocketpaw.config as ppconfig  # noqa: E402
 _VALID_KEY = "site_key_" + "a" * 24
 
 
-def _paid_tier() -> str:
-    """The cheapest catalog tier above the free floor — see the header."""
+def _concierge_tier() -> str:
+    """The cheapest SITE-SCOPED tier that actually SELLS the concierge.
+
+    This used to be "the cheapest tier above the free floor", which was correct
+    exactly as long as the catalog derived ``sells_concierge`` the same way. The
+    2026-08-22 pricing rekey replaced that derivation with a per-tier map in which
+    the cheapest paid rung (``site``, $7) sells NO concierge — the concierge is
+    precisely what separates it from ``staff`` ($19). The helper kept returning
+    ``site``, so four tests asserting an ENTITLED site went red, and two more went
+    quietly useless: they asserted "not available" for a lapsed subscription and a
+    flipped owner switch, and passed because the tier said no first. Neither the
+    subscription gate nor the switch was being tested at all, which the mutation
+    plan reported as two escapes.
+
+    Reading ``sells_concierge`` is what the module header always said this should
+    do — "the rekey moves these tests with the catalog instead of breaking them".
+    The derivation just wasn't the one that moves.
+
+    Site-scoped because an org flat can never be a single site's ``plan_tier``;
+    ``agency`` also sells the concierge and would be a legal answer here otherwise.
+    """
     for tier in site_plans.list_site_plans():
-        if tier.key != site_plans.BASE_SITE_PLAN_KEY:
+        if tier.scope == site_plans.SITE_SCOPE and tier.sells_concierge:
             return tier.key
-    raise AssertionError("catalog has no tier above the floor — catalog changed")
+    raise AssertionError("no site-scoped tier sells the concierge — catalog changed")
 
 
 def _free_tier() -> str:
@@ -71,7 +105,7 @@ def _resolve(**ov):
     kw = {
         "site_id": "6512c1f0e4b0a1b2c3d4e5f6",
         "workspace_id": "ws-1",
-        "plan_tier": _paid_tier(),
+        "plan_tier": _concierge_tier(),
         "subscription_status": "active",
         "concierge_enabled": True,
     }
@@ -108,7 +142,7 @@ def test_an_unknown_tier_is_not_entitled():
 def test_a_paid_tier_without_an_active_subscription_is_not_entitled(status):
     """Cancellation never resets ``plan_tier``, and an unconfigured Dodo product
     records a paid tier with no charge at all. Tier-alone would serve both."""
-    ent = _resolve(plan_tier=_paid_tier(), subscription_status=status)
+    ent = _resolve(plan_tier=_concierge_tier(), subscription_status=status)
 
     assert ent.subscription_active is False
     assert ent.concierge_entitled is False
@@ -117,7 +151,7 @@ def test_a_paid_tier_without_an_active_subscription_is_not_entitled(status):
 
 def test_an_active_paid_site_is_entitled():
     """The paying case still works — the gate must not become the bug."""
-    ent = _resolve(plan_tier=_paid_tier(), subscription_status="active")
+    ent = _resolve(plan_tier=_concierge_tier(), subscription_status="active")
 
     assert ent.concierge_entitled is True
     assert ent.concierge_available is True
@@ -135,7 +169,7 @@ def test_the_owner_switch_and_the_plan_are_distinguishable():
     An owner who switched it off and an owner whose plan lapsed need different
     remedies, so the dashboard has to be able to tell them apart.
     """
-    owner_off = _resolve(plan_tier=_paid_tier(), concierge_enabled=False)
+    owner_off = _resolve(plan_tier=_concierge_tier(), concierge_enabled=False)
     plan_says_no = _resolve(plan_tier=_free_tier(), concierge_enabled=True)
 
     assert owner_off.concierge_available is False
@@ -150,7 +184,8 @@ def test_the_owner_switch_and_the_plan_are_distinguishable():
 def test_an_entitled_site_with_the_switch_off_stays_off():
     """Entitlement never overrides the owner. Paying for a concierge does not force
     one onto a site whose owner silenced it."""
-    assert _resolve(plan_tier=_paid_tier(), concierge_enabled=False).concierge_available is False
+    ent = _resolve(plan_tier=_concierge_tier(), concierge_enabled=False)
+    assert ent.concierge_available is False
 
 
 # --------------------------------------------------------------------------- #
@@ -242,7 +277,7 @@ async def test_the_frame_still_renders_for_an_entitled_site(frame_client, monkey
     """A paying site is untouched — the gate must not take the bar off sites that
     bought it."""
     _enforce(monkeypatch, on=True)
-    await _site(plan_tier=_paid_tier(), subscription_status="active")
+    await _site(plan_tier=_concierge_tier(), subscription_status="active")
 
     res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY, "w": "pp_seed"})
 
@@ -284,7 +319,7 @@ async def test_chat_still_works_for_an_entitled_site(mongo_db, monkeypatch):
     from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
 
     _enforce(monkeypatch, on=True)
-    await _site(plan_tier=_paid_tier(), subscription_status="active")
+    await _site(plan_tier=_concierge_tier(), subscription_status="active")
 
     ctx = await resolve_site_key(_VALID_KEY, "https://brewco.com", "cust_1")
 
@@ -369,7 +404,7 @@ async def test_the_publish_embed_treats_a_pending_subscription_as_paid(bound_wid
     ent = resolve_site_entitlements(
         site_id="6512c1f0e4b0a1b2c3d4e5f6",
         workspace_id="ws-1",
-        plan_tier=_paid_tier(),
+        plan_tier=_concierge_tier(),
         subscription_status="pending",
         concierge_enabled=True,
     )
@@ -400,7 +435,7 @@ async def test_the_runtime_gate_still_refuses_pending(mongo_db, monkeypatch):
     from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
 
     _enforce(monkeypatch, on=True)
-    await _site(plan_tier=_paid_tier(), subscription_status="pending")
+    await _site(plan_tier=_concierge_tier(), subscription_status="pending")
 
     with pytest.raises(HTTPException) as exc:
         await resolve_site_key(_VALID_KEY, "https://brewco.com", "customer_abc123")

--- a/tests/mutations/concierge_entitlement.json
+++ b/tests/mutations/concierge_entitlement.json
@@ -144,8 +144,8 @@
   {
     "label": "activation flips the status AFTER the deploy again (the original P0)",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    doc.subscription_status = \"active\"\n",
-    "replace": "",
+    "find": "    doc.subscription_status = \"active\"\n    # Persist the AUTHORITATIVE gateway subscription id from the verified webhook.",
+    "replace": "    # Persist the AUTHORITATIVE gateway subscription id from the verified webhook.",
     "tests": [
       "tests/cloud/sites/test_charge_first.py::test_the_subscription_reads_active_before_the_activation_deploy_runs"
     ]

--- a/tests/mutations/site_plan_addons.json
+++ b/tests/mutations/site_plan_addons.json
@@ -1,0 +1,92 @@
+[
+  {
+    "label": "activate_site honours its idempotency guard on the add-on rail (drops force)",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if doc.deployed and doc.subscription_status == \"active\" and not force:",
+    "replace": "    if doc.deployed and doc.subscription_status == \"active\":",
+    "tests": [
+      "tests/cloud/sites/test_addon_publish.py::test_upgrading_a_live_free_site_ships_the_new_content"
+    ]
+  },
+  {
+    "label": "a declined add-on charge leaves the site marked active",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        doc.subscription_status = previous_status\n        await doc.save()",
+    "replace": "        pass",
+    "tests": [
+      "tests/cloud/sites/test_addon_publish.py::test_a_declined_charge_leaves_nothing_paid_for"
+    ]
+  },
+  {
+    "label": "the cart counts sites already billed on a per-site subscription (double billing)",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "        if getattr(doc, \"subscription_id\", None):\n            continue",
+    "replace": "        if False:\n            continue",
+    "tests": [
+      "tests/cloud/billing/test_site_plan_addons.py::test_a_site_on_a_legacy_per_site_subscription_stays_off_the_cart"
+    ]
+  },
+  {
+    "label": "the cart keeps billing a cancelled site",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "        if (getattr(doc, \"subscription_status\", None) or \"none\") != \"active\":\n            continue",
+    "replace": "        if False:\n            continue",
+    "tests": [
+      "tests/cloud/billing/test_site_plan_addons.py::test_a_cancelled_site_drops_off_the_cart"
+    ]
+  },
+  {
+    "label": "the provider omits an empty add-on cart (wipes every site add-on)",
+    "file": "ee/pocketpaw_ee/cloud/billing/providers/dodo.py",
+    "find": "            addons=list(addons),",
+    "replace": "            **({\"addons\": list(addons)} if addons else {}),",
+    "tests": [
+      "tests/cloud/billing/test_site_plan_addons.py::test_the_provider_forwards_an_empty_cart_rather_than_omitting_it"
+    ]
+  },
+  {
+    "label": "the add-on rail also opens a per-site subscription on the live path",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if tier is not None and tier.dodo_product_id and not tier.dodo_addon_id and not already_paying:",
+    "replace": "    if tier is not None and tier.dodo_product_id and not already_paying:",
+    "tests": [
+      "tests/cloud/sites/test_addon_publish.py::test_the_stamp_path_refuses_to_open_a_per_site_sub_for_an_addon_tier"
+    ]
+  },
+  {
+    "label": "a workspace with no subscription silently skips the charge",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "        raise NoActiveSubscription(\n            \"This workspace has no active subscription to add a site plan to.\"\n        )",
+    "replace": "        return {\"subscription_id\": None, \"plan_key\": None, \"addons\": []}",
+    "tests": [
+      "tests/cloud/sites/test_addon_publish.py::test_a_workspace_with_no_subscription_cannot_buy_a_site"
+    ]
+  },
+  {
+    "label": "a republish of an add-on site is treated as a fresh purchase",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        and (bool(existing_doc.subscription_id) or paying_on_addon)",
+    "replace": "        and bool(existing_doc.subscription_id)",
+    "tests": [
+      "tests/cloud/sites/test_addon_publish.py::test_republishing_a_paid_addon_site_does_not_charge_again"
+    ]
+  },
+  {
+    "label": "a tier change on the add-on rail never re-syncs the cart",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if paying_on_addon and is_paid and addon_configured and existing_doc.plan_tier != tier.key:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/sites/test_addon_publish.py::test_a_tier_change_on_the_addon_rail_resyncs_the_cart"
+    ]
+  },
+  {
+    "label": "the dispatcher checks the legacy rail before the add-on rail",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if is_paid and addon_configured and not already_paying:",
+    "replace": "    if is_paid and addon_configured and not already_paying and not dodo_configured:",
+    "tests": [
+      "tests/cloud/sites/test_addon_publish.py::test_both_rails_configured_still_never_opens_a_per_site_subscription"
+    ]
+  }
+]

--- a/tests/mutations/site_plan_purchasable.json
+++ b/tests/mutations/site_plan_purchasable.json
@@ -2,7 +2,7 @@
   {
     "label": "purchasable is always true — an unbuyable tier is recorded again",
     "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
-    "find": "        return self.monthly_price_usd == 0 or self.dodo_product_id is not None",
+    "find": "        return self.dodo_addon_id is not None or self.dodo_product_id is not None",
     "replace": "        return True",
     "tests": [
       "tests/cloud/billing/test_site_plan_purchasable.py::test_a_priced_tier_with_no_product_is_not_purchasable",
@@ -12,8 +12,8 @@
   {
     "label": "the free tier reads as unbuyable — its card goes unavailable",
     "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
-    "find": "        return self.monthly_price_usd == 0 or self.dodo_product_id is not None",
-    "replace": "        return self.dodo_product_id is not None",
+    "find": "        if self.monthly_price_usd == 0:\n            return True",
+    "replace": "        if False:\n            return True",
     "tests": [
       "tests/cloud/billing/test_site_plan_purchasable.py::test_the_free_tier_is_always_purchasable",
       "tests/cloud/billing/test_site_plan_purchasable.py::TestThePublishRecordsWhatIsTrue::test_an_explicit_move_to_free_still_works"

--- a/tests/mutations/site_pricing_ladder.json
+++ b/tests/mutations/site_pricing_ladder.json
@@ -23,8 +23,8 @@
   {
     "label": "_dodo_product_for stops looking through the alias — the deployed product map goes dead",
     "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
-    "find": "    candidates = [key] + [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key]",
-    "replace": "    candidates = [key]",
+    "find": "        mapping = getattr(get_settings(), \"dodo_site_products\", None)\n    except Exception:\n        return None\n    if not isinstance(mapping, dict):\n        return None\n    candidates = [key] + [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key]",
+    "replace": "        mapping = getattr(get_settings(), \"dodo_site_products\", None)\n    except Exception:\n        return None\n    if not isinstance(mapping, dict):\n        return None\n    candidates = [key]",
     "tests": [
       "tests/cloud/billing/test_site_pricing_ladder.py::test_the_deployed_legacy_product_map_still_opens_a_checkout"
     ]
@@ -32,8 +32,8 @@
   {
     "label": "the legacy key wins over the canonical one — re-keying the env var does nothing",
     "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
-    "find": "    candidates = [key] + [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key]",
-    "replace": "    candidates = [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key] + [key]",
+    "find": "        mapping = getattr(get_settings(), \"dodo_site_products\", None)\n    except Exception:\n        return None\n    if not isinstance(mapping, dict):\n        return None\n    candidates = [key] + [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key]",
+    "replace": "        mapping = getattr(get_settings(), \"dodo_site_products\", None)\n    except Exception:\n        return None\n    if not isinstance(mapping, dict):\n        return None\n    candidates = [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key] + [key]",
     "tests": [
       "tests/cloud/billing/test_site_pricing_ladder.py::test_the_new_key_wins_over_a_legacy_one_for_the_same_tier"
     ]
@@ -51,8 +51,8 @@
   {
     "label": "purchasable stops excluding org flats — the per-site checkout can charge $149",
     "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
-    "find": "        if self.is_org_scoped:\n            return False\n        return self.monthly_price_usd == 0 or self.dodo_product_id is not None",
-    "replace": "        return self.monthly_price_usd == 0 or self.dodo_product_id is not None",
+    "find": "        if self.is_org_scoped:\n            return False\n        if self.monthly_price_usd == 0:",
+    "replace": "        if False:\n            return False\n        if self.monthly_price_usd == 0:",
     "tests": [
       "tests/cloud/billing/test_site_pricing_ladder.py::test_an_org_flat_is_never_purchasable_however_config_is_set"
     ]

--- a/tests/mutations/site_republish_billing.json
+++ b/tests/mutations/site_republish_billing.json
@@ -12,8 +12,8 @@
   {
     "label": "the stamp path re-charges a paying site one layer below the dispatcher",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    if tier is not None and tier.dodo_product_id and not already_paying:",
-    "replace": "    if tier is not None and tier.dodo_product_id:",
+    "find": "    if tier is not None and tier.dodo_product_id and not tier.dodo_addon_id and not already_paying:",
+    "replace": "    if tier is not None and tier.dodo_product_id and not tier.dodo_addon_id:",
     "tests": [
       "tests/cloud/sites/test_republish_double_billing.py::test_republishing_a_paying_site_opens_no_second_subscription",
       "tests/cloud/sites/test_republish_double_billing.py::test_republishing_a_paying_site_keeps_its_paid_status_and_goes_live"
@@ -22,7 +22,7 @@
   {
     "label": "\"already paying\" accepts a PENDING site — a never-paid site never gets its checkout",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    already_paying = (\n        existing_doc is not None\n        and existing_doc.subscription_status == \"active\"\n        and bool(existing_doc.subscription_id)\n    )",
+    "find": "    already_paying = (\n        existing_doc is not None\n        and existing_doc.subscription_status == \"active\"\n        and (bool(existing_doc.subscription_id) or paying_on_addon)\n    )",
     "replace": "    already_paying = existing_doc is not None and bool(existing_doc.subscription_id)",
     "tests": [
       "tests/cloud/sites/test_republish_double_billing.py::test_republishing_a_site_that_never_paid_still_opens_a_checkout"
@@ -59,8 +59,8 @@
   {
     "label": "a refused plan change falls back to opening a fresh checkout",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "        prov = _billing_provider or _default_billing_provider()\n        await prov.change_plan(\n            subscription_id=existing_doc.subscription_id,\n            product_id=tier.dodo_product_id,\n            plan_key=tier.key,\n        )",
-    "replace": "        prov = _billing_provider or _default_billing_provider()\n        try:\n            await prov.change_plan(\n                subscription_id=existing_doc.subscription_id,\n                product_id=tier.dodo_product_id,\n                plan_key=tier.key,\n            )\n        except Exception:\n            already_paying = False",
+    "find": "        prov = _billing_provider or _default_billing_provider()\n        await prov.change_plan(\n            subscription_id=existing_doc.subscription_id,\n            product_id=tier.dodo_product_id,\n            plan_key=tier.key,",
+    "replace": "        prov = _billing_provider or _default_billing_provider()\n        try:\n            await prov.change_plan(\n                subscription_id=existing_doc.subscription_id,\n                product_id=tier.dodo_product_id,\n                plan_key=tier.key,\n                addons=[],\n            )\n        except Exception:\n            already_paying = False\n        _unused = (\n            existing_doc.subscription_id,\n            tier.dodo_product_id,\n            tier.key,",
     "tests": [
       "tests/cloud/sites/test_republish_double_billing.py::test_a_failed_plan_change_leaves_the_subscription_alone"
     ]
@@ -68,8 +68,8 @@
   {
     "label": "the site checkout stops sending a return url — the buyer is stranded on the gateway",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "        return_url=return_url,\n        cancel_url=cancel_url,\n    )",
-    "replace": "    )",
+    "find": "            return_url=return_url,\n            cancel_url=cancel_url,\n        )",
+    "replace": "        )",
     "tests": [
       "tests/cloud/sites/test_republish_double_billing.py::test_the_site_checkout_sends_the_buyer_back_to_the_app"
     ]
@@ -104,8 +104,8 @@
   {
     "label": "change_plan accepts an empty subscription id and calls the gateway with it",
     "file": "ee/pocketpaw_ee/cloud/billing/providers/dodo.py",
-    "find": "    async def change_plan(self, *, subscription_id: str, product_id: str, plan_key: str) -> None:\n        if not subscription_id:\n            raise ValidationError(\"billing.invalid_subscription\", \"subscription_id is required\")",
-    "replace": "    async def change_plan(self, *, subscription_id: str, product_id: str, plan_key: str) -> None:",
+    "find": "        addons: list[dict],\n    ) -> None:\n        if not subscription_id:\n            raise ValidationError(\"billing.invalid_subscription\", \"subscription_id is required\")",
+    "replace": "        addons: list[dict],\n    ) -> None:",
     "tests": [
       "tests/cloud/billing/test_change_plan_provider.py::test_an_empty_subscription_id_never_reaches_the_gateway"
     ]


### PR DESCRIPTION
A paid site used to be its own payment. Publishing one opened a Dodo checkout and started a subscription for that site alone, so a workspace running four paid sites carried four subscriptions, four renewal dates and four invoices.

Now a paid site is a line on the subscription the workspace already has. Same tiers, same prices — $7 for `site`, $19 for `staff`. What changed is the rails they bill on.

## What the gateway actually supports

Checked against the installed `dodopayments` SDK, not the docs:

| Call | Add-ons |
|---|---|
| `subscriptions.create(addons=[...])` | yes, at checkout time |
| `subscriptions.change_plan(..., addons=[...])` | yes, mid-cycle, with proration |
| `subscriptions.preview_change_plan(...)` | yes, quote before charging |
| `subscriptions.update(...)` | no `addons` param at all |

An add-on is its own Dodo entity with its own `addon_id`, so it can't reuse `POCKETPAW_DODO_SITE_PRODUCTS`. There's a new `POCKETPAW_DODO_SITE_ADDONS` map alongside it.

## The constraint that shapes everything

`change_plan` treats the add-on list as declarative. Its own docstring: *"leaving this empty would remove any existing addons."* There is no attach-one-more.

So nothing here sends a delta. Every push rebuilds the **complete** cart from the `Site` documents and sends it whole. That's also how cancellation works — a site that stops being active stops appearing in the cart, and the next sync drops its line. Nothing has to remember to detach anything.

The provider takes the cart as a **required** argument. A default would make the destructive case the quiet one, and the destruction is invisible until the next invoice.

## Charge-first, without the webhook dance

The old rail had to defer the deploy because the buyer paid on a hosted checkout they'd wandered off to, so "did they pay" was only answerable later. Attaching an add-on charges the card already on the subscription, synchronously, inside the request. The site goes live in that same request and there's no `checkout_url` to redirect to.

## Two things here cost money if they're wrong

Both are covered by tests, and both mutations are caught:

- The site is marked `active` **before** the charge, because the cart is built from the documents and a site absent from them is absent from the cart. A declined card reverts it. Without the revert the site keeps badge removal, custom domains and the concierge permanently, since nothing else writes that field.
- `activate_site` gained a `force` switch. Its idempotency guard reads "deployed and active" as nothing-to-do, which is right for a replayed webhook and wrong here, where the site is already active by the time the deploy runs. Upgrading a live free site would otherwise charge the customer and ship them none of the new content.

## Grandfathering

Per-site subscriptions already sold keep renewing untouched. Sites holding one are excluded from the cart, so nobody is billed on both rails at once. The dispatcher checks the add-on rail first, because a deployment mid-rollout has both maps configured and checking the old one first would open exactly the subscription this replaces. `purchasable` passes on either id for the same reason.

## Decision worth a look

**A workspace with no subscription can't buy a site add-on.** There's nothing to attach to, and Dodo has no add-on-only subscription. It returns a 402 pointing at the workspace upgrade rather than opening the standalone checkout this change exists to remove.

That's a funnel change — a free workspace used to be able to buy a $7 site directly. Reversing it is one branch in `sync_site_addons` (create a subscription with the cart attached instead of refusing), but it needs a target workspace plan the publish request doesn't carry today, so I didn't guess. Happy to add it if you want the old funnel back.

Org tiers (`studio`, `agency`) stay unbuyable. Add-ons make them mechanically possible for the first time, but wiring `white_label` / `included_sites` into the entitlement resolver is its own change.

## Testing

326 pass across `tests/cloud/billing/` and `tests/cloud/sites/`. 24 new tests across two modules.

All 10 mutations in `tests/mutations/site_plan_addons.json` are caught, including the double-billing exclusion, the empty-cart forwarding, the revert on a declined card, and the `force` deploy.

Four existing mutation plans had anchors pointing at lines this touched and are repointed, keeping the harm each label describes. `mutate.py --validate` is green repo-wide: 761 anchors across 62 plans.

**Unrelated red, pre-existing:** `tests/cloud/test_paw_bar_concierge_entitlement.py` has 4 failures on `dev` that predate this branch — they expect the `site` tier to sell the concierge, and the shipped catalog has said `"site": False` since the 2026-08-22 ladder rekey. Two mutations in `concierge_entitlement.json` escape as a result. Nothing in this diff touches the concierge catalog or the entitlements resolver. Worth its own fix.

Design doc: `docs/design/drafts/2026-08-26-site-plans-as-enterprise-addons.md` in paw-workspace.
