### PR TITLE
Enforce the concierge's monthly conversation allowance

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/enforcement.py
+++ b/ee/pocketpaw_ee/cloud/billing/enforcement.py
@@ -27,7 +27,22 @@
 # badge from every OSS / self-host site the moment this shipped, which is a
 # product decision, not a refactor. Named here so the omission is visibly a choice.
 
+# Updated 2026-08-26 (feat/concierge-conversation-quota): added
+# ``concierge_conversation_quota_exceeded`` — the "200 conversations a month"
+# allowance on the ``staff`` tier stops being a catalog claim and starts being a
+# gate. It lives beside ``sites_enforced`` because it is the same family (a
+# per-site billing seam) and because it needs that function; the module comment
+# above already explains why ``billing`` rather than ``sites`` is the home.
+#
+# It is ASYNC and touches a store, which nothing else in the per-site entitlement
+# path does. That is why it is not in ``entitlements.service``: the resolver there
+# is deliberately pure so every branch runs without a database, and a quota is a
+# question about history, not about a plan.
+
 from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
 
 
 def sites_enforced() -> bool:
@@ -52,4 +67,87 @@ def sites_enforced() -> bool:
     )
 
 
-__all__ = ["sites_enforced"]
+def _month_start() -> datetime:
+    """Midnight on the 1st of the current month, on the clock the store writes.
+
+    NAIVE LOCAL, deliberately, and it must stay that way. ``created_at`` on a
+    conversation row is written with ``datetime.now().isoformat()`` — no timezone,
+    local clock — and the count compares ISO strings. A UTC or aware boundary
+    renders with an offset suffix that sorts after every stored value, so the
+    count would come back 0 and the quota would never fire. Same clock, same shape.
+    """
+    now = datetime.now()
+    return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+async def concierge_conversation_quota_exceeded(
+    site: Any,
+    *,
+    widget_id: str,
+    workspace_id: str,
+    store: Any | None = None,
+) -> bool:
+    """Would STARTING another concierge conversation exceed this site's month?
+
+    Asked only when a visitor's turn would begin a NEW conversation. A thread
+    already in progress is never cut off part-way through: it was counted on the
+    turn that started it, and refusing its next message would strand a visitor
+    mid-sentence for a number they cannot see.
+
+    Returns False (allow) in four cases, each for its own reason:
+
+      * Billing is not enforced. OSS and self-host have no paywall, and this
+        returns before it reads anything.
+      * The site's tier is unresolvable, or is an org flat. The entitlement gate
+        upstream has already decided whether a concierge is served at all; this
+        function's job is only the ceiling.
+      * The tier's allowance is 0. That is NOT "no conversations" — 0 means the
+        tier sells no allowance, and reading it as a ceiling would refuse every
+        conversation on a tier that is meant to be metered from the first one.
+        ``agency`` is the tier designed that way, at its pooled rate; note it
+        cannot actually reach this line today, because it is an ORG flat and
+        ``site_scoped_tier`` refuses it above. The branch is what keeps a future
+        metered per-site rung from being silently capped at zero.
+      * The store read fails. A bookkeeping error must not silence a paying
+        customer's concierge, so the failure direction is to serve.
+
+    Fail-OPEN on error is the opposite of the entitlement gate's posture, and
+    deliberately so: that gate answers "has this been paid for", where the safe
+    error is refuse. This one answers "has a paid allowance been used up", where
+    the safe error is allow — the alternative charges a customer for a tier and
+    then withholds it because a count did not load.
+    """
+    if not sites_enforced():
+        return False
+
+    from pocketpaw_ee.cloud.billing import site_plans
+
+    tier = site_plans.site_scoped_tier(getattr(site, "plan_tier", None))
+    if tier is None:
+        return False
+    allowance = tier.conversation_allowance
+    if allowance <= 0:
+        return False
+
+    if store is None:
+        from pocketpaw_ee.api import get_paw_bar_store
+
+        store = get_paw_bar_store()
+    try:
+        used = await store.count_conversations_started_since(
+            widget_id, _month_start(), workspace_id
+        )
+    except Exception:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "billing.concierge_quota: could not count conversations for widget %s — "
+            "serving the concierge rather than refusing on a bookkeeping error",
+            widget_id,
+            exc_info=True,
+        )
+        return False
+    return used >= allowance
+
+
+__all__ = ["concierge_conversation_quota_exceeded", "sites_enforced"]

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -482,7 +482,24 @@
 # widget can read the owner's decision back out — the back-half of the loop. The
 # approve/reject delivery hook lives in the instinct router (it owns the human
 # decision); see decision_loop.deliver_customer_decision.
-
+#
+# Updated 2026-08-26 (feat/concierge-conversation-quota): POST /paw-bar/chat gained
+#   gate 7c — the site's MONTHLY CONVERSATION ALLOWANCE (403
+#   ``concierge_quota_exceeded``). The ``staff`` tier sells "200 conversations a
+#   month" and until now nothing counted and nothing refused.
+#
+#   IT ONLY REFUSES A TURN THAT WOULD START A CONVERSATION. A thread already under
+#   way was counted when it began, and cutting it off part-way strands a visitor
+#   mid-sentence over a number they cannot see — which an owner reads as the bot
+#   breaking, not as a plan limit. That is why the check sits here, beside
+#   ``is_new_conversation``, and not in the shared key gate that runs every turn.
+#
+#   It is placed BEFORE ``upsert_conversation_on_visitor_turn``, which is what
+#   mints the row: refusing after it would spend the allowance on a conversation
+#   nobody was allowed to have and carry the ghost into the next month.
+#
+#   The refusal has its OWN detail. A visitor sees the same silence as a disabled
+#   or unentitled concierge, but the three are different conversations in support.
 from __future__ import annotations
 
 import asyncio
@@ -4765,6 +4782,10 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
       7b. The pocket must expose NO connectors (409) — public-safe lockdown until
           the claude_sdk untrusted-mode GA fix (a static deny can't strip dynamic
           composio connector ids). Fail-closed on a lookup error too.
+      7c. If this turn would START a conversation, the site's monthly conversation
+          allowance must not already be used up (403
+          ``concierge_quota_exceeded``). Only new conversations are refused — a
+          thread under way was counted when it began.
       8. Dispatch a CONCIERGE-scoped run over the shared machinery and stream its
          frames back as SSE.
     """
@@ -4916,6 +4937,43 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
             "a human",
             body.widget_id,
         )
+
+    # MONTHLY CONVERSATION ALLOWANCE. Asked HERE and not in the shared key gate,
+    # because the gate runs on every turn and this must only refuse a turn that
+    # would START a conversation. A thread already under way was counted when it
+    # began; cutting it off part-way would strand a visitor mid-sentence over a
+    # number they cannot see, and the owner would read it as the bot breaking.
+    #
+    # Before the upsert, which is what mints the row — refusing after it would
+    # spend the allowance on a conversation nobody was allowed to have, and the
+    # next month's count would carry the ghost.
+    #
+    # 403 with its OWN detail, like every refusal in this family: an owner who
+    # switched the concierge off, one whose plan does not sell it, and one who has
+    # used the month all read differently in support even though the visitor sees
+    # the same silence.
+    #
+    # A LOST READ SERVES THE VISITOR. ``is_new_conversation`` stays False when the
+    # read above throws (the fail-closed mute arm keeps it that way), so a storage
+    # hiccup lets a new conversation through rather than refusing one. That is the
+    # same direction the quota function takes on its own errors and the opposite of
+    # the entitlement gate's: "has this been paid for" fails to refuse, "has a paid
+    # allowance been used up" fails to serve. Charging for a tier and then
+    # withholding it because a count did not load is the worse outcome.
+    if is_new_conversation:
+        from pocketpaw_ee.cloud.billing.enforcement import (
+            concierge_conversation_quota_exceeded,
+        )
+
+        if await concierge_conversation_quota_exceeded(
+            site, widget_id=body.widget_id, workspace_id=ctx.workspace_id, store=store
+        ):
+            logger.info(
+                "paw-bar: refusing a NEW conversation for widget %s — the site's "
+                "monthly conversation allowance is used up",
+                body.widget_id,
+            )
+            raise HTTPException(403, "concierge_quota_exceeded")
 
     try:
         await store.auto_resume_bot_if_idle(body.widget_id, body.customer_ref, ctx.workspace_id)

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -113,7 +113,23 @@
 # nothing. The hot-lookup indexes the decision-loop needs already ship in
 # SCHEMA_SQL: idx_pp_decisions_action covers the instinct_action_id lookup and
 # idx_pp_decisions_customer covers the (widget_id, customer_ref) poll.
-
+#
+# Updated: 2026-08-26 (feat/concierge-conversation-quota) — added
+#   count_conversations_started_since(widget_id, since, workspace_id): how many
+#   conversations this widget STARTED at or after a boundary, counted by
+#   created_at. The enterprise layer's monthly concierge allowance is built on it;
+#   the counting lives here because the rows do, and no billing knowledge crosses
+#   into the OSS core.
+#
+#   TWO THINGS IT DELIBERATELY DOES NOT DO. It does not filter on ``active``: a
+#   retired row is a conversation that happened, and excluding them would make
+#   "start over" a way to loop for free. And it does not count messages or runs —
+#   the ladder sells CONVERSATIONS, so a thread carrying fifty turns is one.
+#
+#   ``since`` is compared as a NAIVE LOCAL ISO string because that is what
+#   ``created_at`` holds (the writers use ``datetime.now().isoformat()``). An
+#   aware boundary renders with an offset that sorts after every stored value and
+#   makes the count 0 — a quota that silently never fires.
 from __future__ import annotations
 
 import json
@@ -1675,6 +1691,52 @@ class PawBarStore:
                     if row[0] in counts:
                         counts[row[0]] = row[1]
         return counts
+
+    async def count_conversations_started_since(
+        self,
+        widget_id: str,
+        since: datetime,
+        workspace_id: str | None = None,
+    ) -> int:
+        """How many conversations this widget STARTED at or after ``since``.
+
+        Counts rows by ``created_at``, which is the moment
+        :meth:`upsert_conversation_on_visitor_turn` minted the row — a visitor's
+        first message. A conversation is therefore counted ONCE, on the turn that
+        began it, however long it then runs or however many messages it carries.
+        That is the unit the site-plan ladder sells ("200 conversations a month"),
+        and it is why this counts rows rather than messages or runs.
+
+        Finished conversations still count. ``active`` goes to 0 when a visitor
+        starts over, and the new thread mints a NEW row with a NEW ``created_at``
+        — so "start over" costs one from the allowance, which is correct, and
+        excluding inactive rows here would let a visitor loop for free.
+
+        ``since`` IS COMPARED AS A NAIVE LOCAL ISO STRING, because that is what
+        ``created_at`` holds: the writers use ``datetime.now().isoformat()``, not
+        UTC and not a zoned value. Passing an aware datetime produces a string
+        with an offset suffix, which sorts after every stored value and makes this
+        return 0 — a silent "never over quota". Callers build the boundary with
+        ``datetime.now()``, same clock, same shape.
+
+        No billing knowledge lives here. This is a count; whether some number of
+        conversations is too many is a question the enterprise layer asks, and
+        this module is the OSS core and cannot import it.
+        """
+        conditions = "widget_id = ? AND created_at >= ?"
+        params: list[Any] = [widget_id, since.isoformat()]
+        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
+        if ws_cond:
+            conditions += f" AND {ws_cond}"
+            params.extend(ws_params)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(
+                f"SELECT COUNT(*) FROM paw_bar_conversations WHERE {conditions}",
+                params,
+            ) as cur:
+                row = await cur.fetchone()
+        return int(row[0]) if row else 0
 
     async def auto_resume_bot_if_idle(
         self, widget_id: str, customer_ref: str, workspace_id: str | None = None

--- a/tests/cloud/test_concierge_conversation_quota.py
+++ b/tests/cloud/test_concierge_conversation_quota.py
@@ -1,0 +1,252 @@
+# tests/cloud/test_concierge_conversation_quota.py — the Staff tier's "200
+# conversations a month" stops being a catalog claim and becomes a ceiling.
+#
+# Created 2026-08-26 (feat/concierge-conversation-quota). Until now
+# ``conversation_allowance`` was read by exactly one thing: a DTO that renders a
+# plan card. Nothing counted, nothing refused, and a site on the $19 rung could
+# serve unlimited conversations forever.
+#
+# What this pins, and why each one is a way to get it wrong:
+#
+#   * The unit is a CONVERSATION, not a message and not a run. The ladder sells
+#     "200 conversations a month" and the storefront shows that sentence to
+#     buyers, so counting messages would silently sell a tenth of what was
+#     advertised.
+#   * Only a turn that STARTS a conversation is refused. Cutting a thread off
+#     part-way strands a visitor mid-sentence over a number they cannot see.
+#   * An allowance of 0 is NOT a cap. ``agency`` sells the concierge with a 0
+#     allowance because it is metered from the first conversation at a pooled
+#     rate; reading 0 as a ceiling refuses every conversation on the tier that
+#     pays per conversation.
+#   * The quota fails OPEN. This is the opposite of the entitlement gate next to
+#     it, on purpose: "has this been paid for" fails to refuse, "has a paid
+#     allowance been used up" fails to serve.
+#   * The month boundary is NAIVE LOCAL, because ``created_at`` is. An aware
+#     boundary renders with an offset that sorts after every stored row, so the
+#     count comes back 0 and the ceiling silently never fires.
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from pocketpaw_ee.cloud.billing.enforcement import (
+    _month_start,
+    concierge_conversation_quota_exceeded,
+)
+
+from pocketpaw.paw_bar.store import PawBarStore
+
+pytestmark = pytest.mark.anyio
+
+WIDGET = "w-quota"
+WORKSPACE = "ws-quota"
+
+
+@pytest.fixture
+async def store(tmp_path):
+    return PawBarStore(str(tmp_path / "paw_bar.db"))
+
+
+def _enforce(monkeypatch, *, on: bool) -> None:
+    monkeypatch.setattr(
+        "pocketpaw.config.get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, sites_billing_enforced=on),
+    )
+
+
+def _site(tier: str | None):
+    return SimpleNamespace(plan_tier=tier)
+
+
+async def _start_conversations(store: PawBarStore, n: int) -> None:
+    """Mint n distinct conversations by giving each visitor its own ref."""
+    for i in range(n):
+        await store.upsert_conversation_on_visitor_turn(WIDGET, f"visitor-{i}", WORKSPACE)
+
+
+# --------------------------------------------------------------------------- #
+# The count
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_conversation_counts_once_however_many_messages_it_carries(store):
+    """The unit is the conversation. Ten turns from one visitor is one row and
+    one count — counting turns would sell a tenth of what the ladder advertises."""
+    for _ in range(10):
+        await store.upsert_conversation_on_visitor_turn(WIDGET, "visitor-a", WORKSPACE)
+
+    assert await store.count_conversations_started_since(WIDGET, _month_start(), WORKSPACE) == 1
+
+
+async def test_distinct_visitors_are_distinct_conversations(store):
+    await _start_conversations(store, 3)
+
+    assert await store.count_conversations_started_since(WIDGET, _month_start(), WORKSPACE) == 3
+
+
+async def test_the_count_is_scoped_to_one_widget_and_workspace(store):
+    await _start_conversations(store, 2)
+    await store.upsert_conversation_on_visitor_turn("w-other", "visitor-x", WORKSPACE)
+
+    assert await store.count_conversations_started_since(WIDGET, _month_start(), WORKSPACE) == 2
+
+
+async def test_a_retired_conversation_still_counts(store):
+    """ "Start over" retires the row (``active = 0``) and mints a new one. Both
+    count: excluding retired rows would let one visitor loop "start over"
+    indefinitely and never spend the allowance, which is the obvious way to get
+    unlimited conversations on a capped tier."""
+    await store.upsert_conversation_on_visitor_turn(WIDGET, "visitor-a", WORKSPACE)
+    await store.open_conversation(WIDGET, "visitor-a", WORKSPACE)
+
+    assert await store.count_conversations_started_since(WIDGET, _month_start(), WORKSPACE) == 2
+
+
+async def test_conversations_before_the_boundary_do_not_count(store):
+    """Last month's traffic must not spend this month's allowance."""
+    await _start_conversations(store, 2)
+    future = datetime.now() + timedelta(days=1)
+
+    assert await store.count_conversations_started_since(WIDGET, future, WORKSPACE) == 0
+
+
+async def test_the_month_boundary_is_naive_local(store):
+    """``created_at`` is written with ``datetime.now().isoformat()`` — no zone.
+
+    An aware boundary renders as '...+00:00', which sorts AFTER every stored
+    value, so the count returns 0 and the ceiling never fires. The bug would be
+    invisible: no error, just a quota that silently does nothing."""
+    boundary = _month_start()
+
+    assert boundary.tzinfo is None
+    assert "+" not in boundary.isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# The ceiling
+# --------------------------------------------------------------------------- #
+
+
+async def test_under_the_allowance_is_allowed(store, monkeypatch):
+    _enforce(monkeypatch, on=True)
+    await _start_conversations(store, 199)
+
+    assert (
+        await concierge_conversation_quota_exceeded(
+            _site("staff"), widget_id=WIDGET, workspace_id=WORKSPACE, store=store
+        )
+        is False
+    )
+
+
+async def test_at_the_allowance_the_next_conversation_is_refused(store, monkeypatch):
+    """200 included means the 201st is refused, so the ceiling trips AT 200."""
+    _enforce(monkeypatch, on=True)
+    await _start_conversations(store, 200)
+
+    assert (
+        await concierge_conversation_quota_exceeded(
+            _site("staff"), widget_id=WIDGET, workspace_id=WORKSPACE, store=store
+        )
+        is True
+    )
+
+
+async def test_a_zero_allowance_is_not_a_ceiling(store, monkeypatch):
+    """0 means "this tier does not sell an allowance", never "zero conversations".
+
+    Uses ``site`` — a SITE-SCOPED tier whose allowance is 0 — because that is the
+    only shape that actually reaches this branch. The first version of this test
+    used ``agency``, the tier the design comment cites as the metered case, and it
+    passed without ever getting here: an org flat is refused by
+    ``site_scoped_tier`` two lines earlier, so the assertion held for a reason
+    that had nothing to do with the allowance. The mutation plan caught it.
+    """
+    _enforce(monkeypatch, on=True)
+    await _start_conversations(store, 50)
+
+    assert (
+        await concierge_conversation_quota_exceeded(
+            _site("site"), widget_id=WIDGET, workspace_id=WORKSPACE, store=store
+        )
+        is False
+    )
+
+
+async def test_an_org_flat_never_reaches_the_allowance_branch(store, monkeypatch):
+    """``agency`` is the tier that is genuinely metered-from-zero, and it can never
+    be a single site's plan: it is an org-wide flat, so ``site_scoped_tier``
+    refuses it before any allowance is read. Pinned so the design comment about
+    the metered case is read as forward-looking rather than as describing
+    something reachable today."""
+    from pocketpaw_ee.cloud.billing import site_plans
+
+    _enforce(monkeypatch, on=True)
+    await _start_conversations(store, 50)
+
+    assert site_plans.get_site_plan("agency").is_org_scoped is True
+    assert site_plans.site_scoped_tier("agency") is None
+    assert (
+        await concierge_conversation_quota_exceeded(
+            _site("agency"), widget_id=WIDGET, workspace_id=WORKSPACE, store=store
+        )
+        is False
+    )
+
+
+async def test_an_unenforced_deployment_has_no_ceiling(store, monkeypatch):
+    """OSS and self-host see no paywall, and this returns before reading anything."""
+    _enforce(monkeypatch, on=False)
+    await _start_conversations(store, 500)
+
+    assert (
+        await concierge_conversation_quota_exceeded(
+            _site("staff"), widget_id=WIDGET, workspace_id=WORKSPACE, store=store
+        )
+        is False
+    )
+
+
+async def test_an_unresolvable_tier_is_left_to_the_entitlement_gate(store, monkeypatch):
+    _enforce(monkeypatch, on=True)
+    await _start_conversations(store, 500)
+
+    for tier in (None, "not_a_tier"):
+        assert (
+            await concierge_conversation_quota_exceeded(
+                _site(tier), widget_id=WIDGET, workspace_id=WORKSPACE, store=store
+            )
+            is False
+        )
+
+
+async def test_a_broken_store_serves_rather_than_refuses(monkeypatch):
+    """FAIL OPEN, and the opposite of the entitlement gate beside it.
+
+    That gate answers "has this been paid for", where the safe error is refuse.
+    This one answers "has a paid allowance been used up", where the safe error is
+    serve — charging a customer for the tier and then withholding it because a
+    count did not load is the worse outcome."""
+    _enforce(monkeypatch, on=True)
+
+    class _Broken:
+        async def count_conversations_started_since(self, *a, **kw):
+            raise RuntimeError("store is down")
+
+    assert (
+        await concierge_conversation_quota_exceeded(
+            _site("staff"), widget_id=WIDGET, workspace_id=WORKSPACE, store=_Broken()
+        )
+        is False
+    )
+
+
+async def test_the_allowance_comes_from_the_catalog_not_a_literal():
+    """If the ladder re-prices, the ceiling moves with it. A hardcoded 200 here
+    would keep enforcing the old number after the catalog changed."""
+    from pocketpaw_ee.cloud.billing import site_plans
+
+    assert site_plans.get_site_plan("staff").conversation_allowance == 200
+    assert site_plans.get_site_plan("site").conversation_allowance == 0

--- a/tests/cloud/test_paw_bar_concierge_chat.py
+++ b/tests/cloud/test_paw_bar_concierge_chat.py
@@ -1069,3 +1069,116 @@ async def test_chat_does_not_replay_the_current_message_into_history(concierge_c
 
     next_turn = await _load_concierge_history("pocket-1", "cust-1", "ws-1", session_key=key)
     assert {"role": "user", "content": message} in next_turn
+
+
+# ---------------------------------------------------------------------------
+# The monthly conversation allowance (feat/concierge-conversation-quota).
+#
+# The unit tests in test_concierge_conversation_quota.py prove the counter and
+# the ceiling in isolation. These two prove the GATE is actually wired into the
+# handler and refuses the right turn — a quota nothing calls is a quota that does
+# not exist, and the reachability is the half that silently rots.
+# ---------------------------------------------------------------------------
+
+
+def _enforce_sites_billing(monkeypatch) -> None:
+    """Turn the per-site paywall on for both gates that read it.
+
+    Patches the enforcement module's attribute rather than the settings object:
+    ``concierge_available`` and the quota both resolve ``sites_enforced`` lazily
+    from this module, and a stubbed settings namespace would also be read by
+    unrelated machinery in the chat path.
+    """
+    monkeypatch.setattr("pocketpaw_ee.cloud.billing.enforcement.sites_enforced", lambda: True)
+
+
+def _mock_run_machinery(monkeypatch):
+    """The same dispatch stubs the happy path uses, so a 200 means the handler ran
+    to completion rather than that nothing was wired."""
+    from pocketpaw_ee.cloud.chat.runs.memory_stream import InMemoryStreamTransport
+
+    transport = InMemoryStreamTransport()
+    fake_exec = _FakeExecutor(transport)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.transport.get_stream_transport", lambda: transport
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.executor.get_executor", lambda: fake_exec)
+
+    async def _fake_create_run(spec):
+        return SimpleNamespace(run_id=spec.run_id)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.create_run", _fake_create_run)
+
+
+@pytest.mark.asyncio
+async def test_a_used_up_month_refuses_a_NEW_conversation(concierge_client, monkeypatch):
+    """The 201st conversation on a 200-conversation tier is refused, with its own
+    detail so support can tell it from a disabled or unentitled concierge."""
+    client, store = concierge_client
+    _enforce_sites_billing(monkeypatch)
+    _mock_run_machinery(monkeypatch)
+    await _site(plan_tier="staff", subscription_status="active")
+    widget = await store.create_widget(_widget(agent_id="agent-xyz"))
+
+    for i in range(200):
+        await store.upsert_conversation_on_visitor_turn(widget.id, f"spent-{i}", "ws-1")
+
+    res = await client.post(
+        "/paw-bar/chat",
+        json=_payload(widget.id, customer_ref="brand-new-visitor"),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert res.status_code == 403
+    # Its OWN detail, distinct from the two refusals beside it. A visitor sees the
+    # same silence for all three; support needs to tell "the owner switched it
+    # off" from "the plan does not sell it" from "the month is used up", because
+    # the remedies are three different conversations.
+    assert res.json()["detail"] == "concierge_quota_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_a_conversation_already_under_way_is_not_cut_off(concierge_client, monkeypatch):
+    """THE HALF THAT MATTERS TO A VISITOR. The month is spent, but this thread was
+    counted when it began — refusing its next message would strand someone
+    mid-sentence over a number they cannot see, and the owner would read it as the
+    bot breaking rather than as a plan limit."""
+    client, store = concierge_client
+    _enforce_sites_billing(monkeypatch)
+    _mock_run_machinery(monkeypatch)
+    await _site(plan_tier="staff", subscription_status="active")
+    widget = await store.create_widget(_widget(agent_id="agent-xyz"))
+
+    for i in range(200):
+        await store.upsert_conversation_on_visitor_turn(widget.id, f"spent-{i}", "ws-1")
+
+    # spent-0 is one of the 200 already counted, so this turn continues a
+    # conversation rather than starting one.
+    res = await client.post(
+        "/paw-bar/chat",
+        json=_payload(widget.id, customer_ref="spent-0"),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert res.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_an_unenforced_deployment_serves_past_the_allowance(concierge_client, monkeypatch):
+    """OSS / self-host has no paywall, so the ceiling must not appear there."""
+    client, store = concierge_client
+    monkeypatch.setattr("pocketpaw_ee.cloud.billing.enforcement.sites_enforced", lambda: False)
+    _mock_run_machinery(monkeypatch)
+    await _site(plan_tier="staff", subscription_status="active")
+    widget = await store.create_widget(_widget(agent_id="agent-xyz"))
+
+    for i in range(250):
+        await store.upsert_conversation_on_visitor_turn(widget.id, f"spent-{i}", "ws-1")
+
+    res = await client.post(
+        "/paw-bar/chat",
+        json=_payload(widget.id, customer_ref="brand-new-visitor"),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert res.status_code == 200

--- a/tests/mutations/concierge_conversation_quota.json
+++ b/tests/mutations/concierge_conversation_quota.json
@@ -1,0 +1,102 @@
+[
+  {
+    "label": "the quota gate is deleted — the 201st conversation is served free",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        if await concierge_conversation_quota_exceeded(",
+    "replace": "        if False and await concierge_conversation_quota_exceeded(",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_chat.py::test_a_used_up_month_refuses_a_NEW_conversation"
+    ]
+  },
+  {
+    "label": "the gate stops asking whether the turn STARTS a conversation — a thread in progress is cut off mid-sentence",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "    if is_new_conversation:\n        from pocketpaw_ee.cloud.billing.enforcement import (",
+    "replace": "    if True:\n        from pocketpaw_ee.cloud.billing.enforcement import (",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_chat.py::test_a_conversation_already_under_way_is_not_cut_off"
+    ]
+  },
+  {
+    "label": "the refusal loses its own detail and reads as an unentitled plan",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "            raise HTTPException(403, \"concierge_quota_exceeded\")",
+    "replace": "            raise HTTPException(403, \"concierge_not_entitled\")",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_chat.py::test_a_used_up_month_refuses_a_NEW_conversation"
+    ]
+  },
+  {
+    "label": "a 0 allowance becomes a cap — every conversation on the metered tier is refused",
+    "file": "ee/pocketpaw_ee/cloud/billing/enforcement.py",
+    "find": "    if allowance <= 0:\n        return False",
+    "replace": "    if allowance < 0:\n        return False",
+    "tests": [
+      "tests/cloud/test_concierge_conversation_quota.py::test_a_zero_allowance_is_not_a_ceiling"
+    ]
+  },
+  {
+    "label": "off by one — the tier serves 201 conversations on a 200 allowance",
+    "file": "ee/pocketpaw_ee/cloud/billing/enforcement.py",
+    "find": "    return used >= allowance",
+    "replace": "    return used > allowance",
+    "tests": [
+      "tests/cloud/test_concierge_conversation_quota.py::test_at_the_allowance_the_next_conversation_is_refused"
+    ]
+  },
+  {
+    "label": "the paywall flag is ignored — OSS and self-host get a ceiling they never bought",
+    "file": "ee/pocketpaw_ee/cloud/billing/enforcement.py",
+    "find": "    if not sites_enforced():\n        return False\n\n    from pocketpaw_ee.cloud.billing import site_plans",
+    "replace": "    from pocketpaw_ee.cloud.billing import site_plans",
+    "tests": [
+      "tests/cloud/test_concierge_conversation_quota.py::test_an_unenforced_deployment_has_no_ceiling"
+    ]
+  },
+  {
+    "label": "a broken store refuses instead of serving — a paying customer is silenced by a bookkeeping error",
+    "file": "ee/pocketpaw_ee/cloud/billing/enforcement.py",
+    "find": "            exc_info=True,\n        )\n        return False\n    return used >= allowance",
+    "replace": "            exc_info=True,\n        )\n        return True\n    return used >= allowance",
+    "tests": [
+      "tests/cloud/test_concierge_conversation_quota.py::test_a_broken_store_serves_rather_than_refuses"
+    ]
+  },
+  {
+    "label": "the month boundary goes UTC-aware — the ISO compare sorts wrong and the quota silently never fires",
+    "file": "ee/pocketpaw_ee/cloud/billing/enforcement.py",
+    "find": "    now = datetime.now()\n    return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)",
+    "replace": "    from datetime import UTC\n\n    now = datetime.now(UTC)\n    return now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)",
+    "tests": [
+      "tests/cloud/test_concierge_conversation_quota.py::test_the_month_boundary_is_naive_local",
+      "tests/cloud/test_concierge_conversation_quota.py::test_at_the_allowance_the_next_conversation_is_refused"
+    ]
+  },
+  {
+    "label": "the count ignores the boundary — last month's traffic spends this month's allowance",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "        conditions = \"widget_id = ? AND created_at >= ?\"\n        params: list[Any] = [widget_id, since.isoformat()]",
+    "replace": "        conditions = \"widget_id = ? AND created_at >= ''\"\n        params: list[Any] = [widget_id]",
+    "tests": [
+      "tests/cloud/test_concierge_conversation_quota.py::test_conversations_before_the_boundary_do_not_count"
+    ]
+  },
+  {
+    "label": "the count excludes retired rows — \"start over\" becomes unlimited free conversations",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "        conditions = \"widget_id = ? AND created_at >= ?\"",
+    "replace": "        conditions = \"widget_id = ? AND active = 1 AND created_at >= ?\"",
+    "tests": [
+      "tests/cloud/test_concierge_conversation_quota.py::test_a_retired_conversation_still_counts"
+    ]
+  },
+  {
+    "label": "the count loses its widget scope — one widget spends another's allowance",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "                f\"SELECT COUNT(*) FROM paw_bar_conversations WHERE {conditions}\",",
+    "replace": "                \"SELECT COUNT(*) FROM paw_bar_conversations WHERE created_at >= ?\",",
+    "tests": [
+      "tests/cloud/test_concierge_conversation_quota.py::test_the_count_is_scoped_to_one_widget_and_workspace"
+    ]
+  }
+]


### PR DESCRIPTION
The Staff tier sells **"200 conversations a month"** and the storefront shows that sentence to buyers. Nothing counted and nothing refused — a site on the $19 rung served unlimited conversations indefinitely. `conversation_allowance` was read by exactly one thing: a DTO that renders a plan card.

## The unit is a conversation

Not a message, not a run. A thread carrying fifty turns is **one** conversation, counted on the turn that began it. That's what the ladder sells, so counting messages would have quietly delivered a tenth of what was advertised.

Counting works out to be cheap: `paw_bar_conversations` already mints exactly one row per conversation on the first visitor turn, and it already has a `created_at`. No new schema, no counter to keep in sync — a `COUNT(*)` over rows the inbox already writes.

## Only a *new* conversation is refused

A thread already under way was counted when it began. Cutting it off part-way strands a visitor mid-sentence over a number they can't see, and the owner reads it as the bot breaking rather than as a plan limit.

So the gate sits beside `is_new_conversation` in the chat handler — not in the shared key gate that runs on every turn — and **before** the upsert that mints the row. Refusing after it would spend the allowance on a conversation nobody was allowed to have and carry the ghost into next month.

The refusal has its own detail, `concierge_quota_exceeded`. A visitor sees the same silence as a disabled or unentitled concierge, but those are three different conversations in support.

## Two deliberate choices, both opposite to the gate beside it

**It fails open.** The entitlement gate answers *"has this been paid for"*, where the safe error is refuse. This one answers *"has a paid allowance been used up"*, where the safe error is serve. Charging for a tier and then withholding it because a count didn't load is the worse outcome. Applies to a store error, and to a lost `is_new_conversation` read.

**An allowance of 0 is not a ceiling.** It means the tier sells no allowance — how a metered-from-zero rung is expressed. Reading it as a cap would refuse every conversation on a tier meant to bill per conversation.

## The timestamp coupling

The month boundary is **naive local**, because `created_at` is: the store writes `datetime.now().isoformat()` and the count compares ISO strings. A UTC-aware boundary renders with an offset that sorts after every stored row, so the count comes back 0 and the quota silently never fires — no error, just a ceiling that does nothing. There's a test pinning it, and a mutation proving the test works.

## Layering

Counting lives in the OSS store because the rows do — `count_conversations_started_since` carries no billing knowledge, and the core can't import the enterprise layer anyway. Whether some number is too many is asked in `billing/enforcement.py`, beside `sites_enforced`.

Retired rows still count. `active` goes to 0 when a visitor hits "start over" and a new row is minted, so excluding them would make "start over" an unlimited-conversation loop.

## Testing

15 new tests across two modules — the counter and ceiling in isolation, plus three driving the real `POST /paw-bar/chat` handler, because a quota nothing calls is a quota that doesn't exist.

**All 11 mutations caught.** One of them found a bug in my own test: the 0-allowance case used `agency`, which is org-scoped and refused two lines earlier by `site_scoped_tier`, so it passed without ever reaching the branch it named. Now uses `site`, and there's a separate test pinning why `agency` can't reach it.

`mutate.py --validate` green repo-wide: 772 anchors, 63 plans.

**Pre-existing red, not from this branch:** 11 tests in `test_paw_bar_actions.py`, `test_paw_bar_agent_provisioning.py` and `test_paw_bar_escape_hatch.py` fail on `dev`. I verified this by reverting my source changes to HEAD and re-running — identical 11 failures. They're preamble/identity assertions, unrelated to conversations.

## Not in scope

Overage billing. The catalog carries `conversation_rate_cents` ($0.10, and $0.05 pooled for agency), but there's no debit path and nothing charges per conversation. This is the ceiling only — at 200 the concierge stops taking new conversations rather than metering past it. Worth saying out loud because the tier's tagline says "then metered", which is why I left that clause off the Dodo add-on description.
