### PR TITLE
Files that know what they are

### DIFF
--- a/ee/pocketpaw_ee/cloud/files/dto.py
+++ b/ee/pocketpaw_ee/cloud/files/dto.py
@@ -1,5 +1,13 @@
 """Public schemas for the files module.
 
+2026-08-28 (FC-1 "File comprehension"): ``FileEntry`` grew ``summary``
+(``str | None``, default ``None``) — one or two sentences saying what the file
+IS, written by the comprehension pass on ingest. Only the uploads provider
+sets it; every other provider keeps the default, so no provider had to change.
+``None`` reads as "nothing understood about this file yet", which is also what
+a legacy row, a hidden file, or a file that arrived after the daily cap looks
+like — the UI does not need to tell those apart.
+
 2026-07-03 (FL-1 "Library metadata"): ``FileEntry`` grew ``collections``
 (list[str]) and ``hide_from_ai`` (bool) alongside the existing ``tags`` so a
 file's library metadata surfaces in the unified /files listing. Both default
@@ -57,6 +65,8 @@ class FileEntry(BaseModel):
     # other providers leave the defaults (empty list / False).
     collections: list[str] = Field(default_factory=list)
     hide_from_ai: bool = False
+    # FC-1: what the file IS, in a sentence or two. ``None`` = not comprehended.
+    summary: str | None = None
     created_at: datetime
     updated_at: datetime
     source_ref: dict[str, Any] = Field(default_factory=dict)

--- a/ee/pocketpaw_ee/cloud/files/providers/uploads.py
+++ b/ee/pocketpaw_ee/cloud/files/providers/uploads.py
@@ -4,6 +4,11 @@ Scope is personal to the current user within the current workspace. Ownership
 drives RBAC: the owner has full CRUD; workspace admins get manage; everyone
 else is read-only.
 
+2026-08-28 (FC-1 "File comprehension"): ``_to_entry`` also surfaces ``summary``
+— the one-or-two-sentence statement of what the file IS, written by the
+comprehension pass on ingest. Same defensive ``doc.get`` read as the FL-1
+fields, for the same reason: rows written before the column exists.
+
 2026-07-03 (FL-1 "Library metadata"): ``_to_entry`` now surfaces the file's
 ``collections`` and ``hide_from_ai`` metadata (alongside the pre-existing
 ``tags``) onto the ``FileEntry`` so the unified /files listing carries them.
@@ -152,6 +157,9 @@ class UploadsProvider(BaseFolderProvider):
             tags=list(doc.get("tags", [])),
             collections=list(doc.get("collections", [])),
             hide_from_ai=bool(doc.get("hide_from_ai", False)),
+            # FC-1. ``.get`` not ``["summary"]``: the store row predates the
+            # column on legacy documents and on any dict a test hand-builds.
+            summary=doc.get("summary"),
             created_at=doc["created_at"],
             updated_at=doc.get("updated_at", doc["created_at"]),
             source_ref={},

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,12 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-08-28 (FC-3 "File comprehension") — added
+``FileComprehensionUsage`` (one row per workspace per UTC day, the atomic
+counter behind the comprehension daily cap) to the imports and
+``get_all_documents()`` so the ``file_comprehension_usage`` collection is
+wired into ``init_beanie``. Kept out of ``__all__``: only
+``ee.cloud.uploads.comprehension_budget`` imports the doc class directly.
+
 Updated: 2026-07-27 (integration/growth-v1) — G-6's ``WhatsAppSendLog`` is
 gone: it and G-5's ``MessageLog`` were the same send record built in parallel
 under two names, unified onto ``MessageLog`` (which gained the ``sending`` /
@@ -186,6 +193,7 @@ from pocketpaw_ee.cloud.models.fabric_ingest_state import (
     FabricIngestState,
 )
 from pocketpaw_ee.cloud.models.file import FileObj
+from pocketpaw_ee.cloud.models.file_comprehension_usage import FileComprehensionUsage
 from pocketpaw_ee.cloud.models.file_version import FileVersionDoc
 from pocketpaw_ee.cloud.models.foresight_backtest import ForesightBacktest
 from pocketpaw_ee.cloud.models.foresight_prediction_record import (
@@ -456,6 +464,9 @@ def get_all_documents():
         # Public file share links (FL-12b). Only ``uploads.share_store``
         # writes these; the public GET /share/{token} route reads by token.
         ShareLink,
+        # Per-workspace/day file-comprehension spend counter (FC-3). Only
+        # ``ee.cloud.uploads.comprehension_budget`` reads/writes this.
+        FileComprehensionUsage,
         # file_versions edit history (ART-1). Only ``file_versions.service``
         # imports this class (import-linter "FileVersions" contract).
         FileVersionDoc,

--- a/ee/pocketpaw_ee/cloud/models/file_comprehension_usage.py
+++ b/ee/pocketpaw_ee/cloud/models/file_comprehension_usage.py
@@ -1,0 +1,45 @@
+# ee/pocketpaw_ee/cloud/models/file_comprehension_usage.py — the file-comprehension
+# spend counter.
+#
+# Created 2026-08-28 (FC-3 "File comprehension"). Registered in
+# ``cloud.models.__init__`` so ``init_beanie`` wires the collection.
+#
+# One row per workspace per UTC day, keyed by a compound natural key
+# (``<workspace>:<YYYY-MM-DD>``) so the only operation it ever serves — "claim
+# one comprehension for this workspace today" — is a single atomic upsert
+# rather than a read followed by a write. Two uploads landing in the same
+# second must not both read 499 and both decide they are under the cap.
+#
+# WHY IT LIVES HERE and not beside its service: the cloud rules keep Beanie
+# documents in ``cloud.models`` and let exactly one module import each one.
+# ``models.other_hand_usage`` records what happens otherwise — a document
+# declared in its own service file imports ``models.base`` while
+# ``models.__init__`` imports the class back, and the cycle surfaces as an
+# unrelated-looking import error somewhere else entirely. The convention is
+# load-bearing, not decorative.
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class FileComprehensionUsage(TimestampedDocument):
+    """How many uploads one workspace has had comprehended today.
+
+    ``used`` rather than ``count``: ``count`` shadows a query method on the
+    parent Document and Pydantic warns about the collision. That matters more
+    than tidiness here — the field the whole cap depends on silently resolving
+    to a method is exactly the shape of bug that reads as "the ceiling works
+    most of the time".
+    """
+
+    #: ``<workspace>:<YYYY-MM-DD>``. UNIQUE — the upsert keys on it.
+    key: Indexed(str, unique=True)  # type: ignore[valid-type]
+    workspace: str
+    day: str
+    used: int = 0
+
+    class Settings:
+        name = "file_comprehension_usage"

--- a/ee/pocketpaw_ee/cloud/uploads/comprehension.py
+++ b/ee/pocketpaw_ee/cloud/uploads/comprehension.py
@@ -198,7 +198,7 @@ _SYSTEM_PROMPT = (
     "Reply with JSON only, no prose and no code fence:\n"
     '{"summary": "<one or two sentences>", "categories": ["<category>", ...]}\n\n'
     f"categories must be chosen from exactly this list: {', '.join(CATEGORIES)}.\n"
-    f"Use at most {MAX_CATEGORIES}, most fitting first. Use \"other\" when none "
+    f'Use at most {MAX_CATEGORIES}, most fitting first. Use "other" when none '
     "of the rest fit rather than stretching one.\n"
     "The summary names the kind of document and what it covers, e.g. "
     '"A board deck reviewing Q3 revenue and the 2027 hiring plan." Never begin '

--- a/ee/pocketpaw_ee/cloud/uploads/comprehension.py
+++ b/ee/pocketpaw_ee/cloud/uploads/comprehension.py
@@ -95,26 +95,35 @@ narrating. Trimmed rather than rejected — a too-long summary is still useful."
 
 _ENV_MODEL = "POCKETPAW_FILE_COMPREHENSION_MODEL"
 
-_FALLBACK_MODEL = "deepseek/deepseek-chat"
+_FALLBACK_MODEL = "deepseek/deepseek-v4-flash"
 """Last-resort model id when neither the env var nor ``settings.litellm_model``
 names one.
 
-A model id that the proxy does not serve is the WORST outcome available here:
-every call 404s, every ``comprehend`` returns ``None``, the fail-open path
-swallows it, and the feature looks installed while never once running. So the
-resolution order below prefers, in turn, (1) what the operator set explicitly,
-(2) what this deployment ALREADY talks to — ``settings.litellm_model`` is by
-definition a group that resolves on this operator's own proxy — and only then
-(3) this constant.
+A model id the proxy does not serve is the WORST outcome available here: every
+call fails, every ``comprehend`` returns ``None``, the fail-open path swallows
+it, and the feature looks installed while never once running. So the resolution
+order below prefers, in turn, (1) what the operator set explicitly, (2) what
+this deployment ALREADY talks to — ``settings.litellm_model`` is by definition
+a group that resolves on this operator's own proxy — and only then (3) this
+constant.
 
-The constant is chosen from the evidence in-repo, not from a guess: the
-2026-06-26 gateway probe (``docs/handoff/2026-06-26-mcg2-gateway-probe.md``)
-recorded ``deepseek/deepseek-chat`` serving successfully through the proxy
-while every ``claude-*``/``anthropic/*`` group returned 401 on a bad upstream
-credential and the OpenAI group was quota-exhausted. That was two months ago
-and may well have been fixed since; it is still the most recent DIRECT
-observation this repo contains. Anyone with proxy access should confirm with
-``GET {POCKETPAW_LITELLM_API_BASE}/v1/models`` and correct this line.
+VERIFIED AGAINST THE LIVE PROXY 2026-08-28, which is the only evidence worth
+having for this particular constant: ``GET /v1/models`` on the gateway returns
+80 ids, and a chat completion against this one answers 200.
+
+The previous value was ``deepseek/deepseek-chat``, taken from the 2026-06-26
+gateway-probe handoff. It is NOT served any more — the proxy returns 400 and
+the deployment has moved to the v4 line. That is precisely the silent-nothing
+failure this docstring warns about, and it survived a whole build because no
+test can reach a live proxy. Re-check it with the gateway service's own
+``SERVICE_PASSWORD_MASTERKEY``:
+
+    curl -s -H "Authorization: Bearer $KEY" {BASE}/v1/models
+
+Chat-capable groups there today: ``deepseek/deepseek-v4-flash`` (this one —
+flash is the cheap tier, and a 2-3 sentence summary is what it is for),
+``deepseek/deepseek-v4-pro``, ``Qwen3.8-27B``, ``hetzner/Qwen3.8-27B``. Every
+other id the proxy lists is an image model.
 """
 
 _TIMEOUT_SECONDS = 30.0

--- a/ee/pocketpaw_ee/cloud/uploads/comprehension.py
+++ b/ee/pocketpaw_ee/cloud/uploads/comprehension.py
@@ -1,0 +1,363 @@
+# ee/pocketpaw_ee/cloud/uploads/comprehension.py — one model call that says what
+# an uploaded file IS.
+#
+# Created 2026-08-28 (FC-2 "File comprehension").
+#
+# WHY THIS EXISTS. ``uploads/tagging.py`` ranks words by frequency, on purpose:
+# FL-6's rule was "reuse what extraction already produced, never call a new
+# external LLM". That buys a board deck the tags ``q3``, ``revenue``, ``slide``
+# — every one of them true, and not one of them the answer to "what is this
+# file". Frequency counting cannot produce "a board deck", because the phrase
+# does not appear in the deck. Understanding what a document IS needs a model
+# that has read documents. So this module is the deliberate exception to FL-6's
+# no-LLM rule, and it is scoped to exactly that: one short call, one summary,
+# up to three categories from a fixed list.
+#
+# THE VOCABULARY IS CONTROLLED AND ``tags`` STAYS FREE-FORM. They answer
+# different questions. ``tags`` is "what words are in here" and benefits from
+# being open; ``collections`` is "which shelf does this go on" and is worthless
+# unless two files that belong together get the SAME value. A model asked for
+# free-form shelf names returns "board deck", "board-deck", "Board Presentation"
+# and "quarterly deck" for four copies of the same thing, and the filter that
+# rides on it silently shows one of the four.
+#
+# THE BEARER, AND ONLY THE BEARER. This is a PLATFORM call: it runs on ingest,
+# nobody asked for it, and the platform pays. The LiteLLM proxy in front of us
+# runs with ``forward_llm_provider_auth_headers: true`` (shipped 2026-08-28 for
+# BYOK), which means an ``x-api-key`` header on a request is FORWARDED UPSTREAM
+# and the holder of that key is billed. Attaching one here — even by copying a
+# header dict from the turn path — would quietly charge a user's own Anthropic
+# account to summarise their own uploads. ``_headers()`` therefore builds its
+# dict from nothing and carries exactly ``Authorization`` + ``Content-Type``,
+# and a test asserts the absence, because "we just won't add it" is not a
+# control.
+#
+# EVERY FAILURE IS ``None``. The caller's contract is fail-OPEN: the user asked
+# to store a file, not to have it understood. A 404 model id, a dead proxy, a
+# model that answers in prose instead of JSON, a category nobody has ever heard
+# of — all of it collapses to ``None`` and the file stays indexed, tagged and
+# usable. The only thing this module must never do is raise into an upload.
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+CATEGORIES: tuple[str, ...] = (
+    "contract",
+    "invoice",
+    "deck",
+    "spec",
+    "research",
+    "design",
+    "correspondence",
+    "data",
+    "media",
+    "other",
+)
+"""The controlled vocabulary for ``collections``.
+
+APPEND-ONLY. Removing or renaming a value STRANDS every row already carrying
+it: the string stays in Mongo, the library filter stops offering it, and those
+files quietly drop out of a shelf they are still on. Adding a value is free —
+old rows simply never carry it. If a category turns out to be wrong, add the
+right one and leave the wrong one in place; a migration that rewrites rows is a
+deliberate, separate act, not a side effect of editing this tuple.
+
+``other`` is here so the model has somewhere to put a file that genuinely is
+none of the rest. Without it the pressure is to pick the nearest wrong shelf.
+"""
+
+MAX_CATEGORIES = 3
+"""At most three shelves per file. A file on eight shelves is on none of them."""
+
+MAX_INPUT_CHARS = 6000
+"""How much extracted text the model sees.
+
+A 400-page PDF extracts to megabytes. Sending it would cost more than the
+feature is worth and, on a long document, tells the model nothing the first few
+pages did not — what a file IS is established in its opening, not its
+appendices. Truncation happens BEFORE the request is built, so the cap is a
+property of the payload rather than a hope about the model's context window.
+"""
+
+MAX_SUMMARY_CHARS = 600
+"""Hard ceiling on the returned summary. The prompt asks for one or two
+sentences; this is the backstop for a model that ignores it and starts
+narrating. Trimmed rather than rejected — a too-long summary is still useful."""
+
+_ENV_MODEL = "POCKETPAW_FILE_COMPREHENSION_MODEL"
+
+_FALLBACK_MODEL = "deepseek/deepseek-chat"
+"""Last-resort model id when neither the env var nor ``settings.litellm_model``
+names one.
+
+A model id that the proxy does not serve is the WORST outcome available here:
+every call 404s, every ``comprehend`` returns ``None``, the fail-open path
+swallows it, and the feature looks installed while never once running. So the
+resolution order below prefers, in turn, (1) what the operator set explicitly,
+(2) what this deployment ALREADY talks to — ``settings.litellm_model`` is by
+definition a group that resolves on this operator's own proxy — and only then
+(3) this constant.
+
+The constant is chosen from the evidence in-repo, not from a guess: the
+2026-06-26 gateway probe (``docs/handoff/2026-06-26-mcg2-gateway-probe.md``)
+recorded ``deepseek/deepseek-chat`` serving successfully through the proxy
+while every ``claude-*``/``anthropic/*`` group returned 401 on a bad upstream
+credential and the OpenAI group was quota-exhausted. That was two months ago
+and may well have been fixed since; it is still the most recent DIRECT
+observation this repo contains. Anyone with proxy access should confirm with
+``GET {POCKETPAW_LITELLM_API_BASE}/v1/models`` and correct this line.
+"""
+
+_TIMEOUT_SECONDS = 30.0
+"""One short completion. A slow proxy must not hold an ingest open for minutes;
+the timeout expiring is just another ``None``."""
+
+_PROXY_TRANSPORT: httpx.BaseTransport | None = None
+"""Test seam, mirroring ``agent/mcp_servers/media.py``. Tests assign an
+``httpx.MockTransport`` so the real request-building code runs — headers,
+payload, truncation and all — without a live proxy. Production leaves it
+``None`` and httpx uses the network."""
+
+
+@dataclass(frozen=True)
+class Comprehension:
+    """What one model call understood about one file.
+
+    Frozen because the caller merges it into existing row state; a mutable
+    result invites "fix it up in place" at the call site, which is where the
+    validation this module performs would get quietly undone.
+    """
+
+    summary: str
+    categories: list[str]
+
+
+def model_id() -> str:
+    """Resolve the model this deployment should comprehend with.
+
+    Order: the explicit env var, then whatever LiteLLM model group this
+    deployment is already configured to talk to, then the fallback constant.
+    See ``_FALLBACK_MODEL`` for why the middle step is worth the branch.
+    """
+    explicit = (os.environ.get(_ENV_MODEL) or "").strip()
+    if explicit:
+        return explicit
+    try:
+        from pocketpaw.config import get_settings
+
+        configured = (get_settings().litellm_model or "").strip()
+    except Exception:  # noqa: BLE001 — settings must never break an ingest
+        configured = ""
+    return configured or _FALLBACK_MODEL
+
+
+def _proxy_base() -> str:
+    """The LiteLLM proxy base URL, from catalog config — the same accessor the
+    media MCP server uses, so there is one place a deployment points the proxy."""
+    from pocketpaw_ee.catalog import config
+
+    return config.litellm_proxy_url()
+
+
+def _proxy_key() -> str | None:
+    """The deployment's LiteLLM master/admin key, or None on a keyless proxy."""
+    from pocketpaw_ee.catalog import config
+
+    return config.litellm_proxy_api_key()
+
+
+def _headers() -> dict[str, str]:
+    """The complete header set for a PLATFORM proxy call.
+
+    Built from an empty dict on purpose. The one header that must never appear
+    is ``x-api-key``: the proxy forwards it upstream (BYOK header-forwarding),
+    so setting it would bill whoever owns that key for a summary they never
+    asked for. There is no code path here that could add it, and
+    ``tests/cloud/uploads/test_comprehension.py`` asserts it stays that way.
+    """
+    headers = {"Content-Type": "application/json"}
+    key = _proxy_key()
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    return headers
+
+
+_SYSTEM_PROMPT = (
+    "You classify uploaded files for a document library. Given a file's name, "
+    "type, and an excerpt of its contents, say what the file IS — not what it "
+    "mentions.\n\n"
+    "Reply with JSON only, no prose and no code fence:\n"
+    '{"summary": "<one or two sentences>", "categories": ["<category>", ...]}\n\n'
+    f"categories must be chosen from exactly this list: {', '.join(CATEGORIES)}.\n"
+    f"Use at most {MAX_CATEGORIES}, most fitting first. Use \"other\" when none "
+    "of the rest fit rather than stretching one.\n"
+    "The summary names the kind of document and what it covers, e.g. "
+    '"A board deck reviewing Q3 revenue and the 2027 hiring plan." Never begin '
+    'with "This file" or "This document".'
+)
+
+
+def _truncate(text: str | None) -> str:
+    """Cap the extracted text at :data:`MAX_INPUT_CHARS`, from the front."""
+    if not text:
+        return ""
+    stripped = text.strip()
+    if len(stripped) <= MAX_INPUT_CHARS:
+        return stripped
+    return stripped[:MAX_INPUT_CHARS]
+
+
+def _build_user_message(
+    *, title: str | None, text: str | None, captions: list[str] | None, mime: str
+) -> str:
+    """Assemble the one user turn. Captions carry the only signal an image has."""
+    parts = [f"File type: {mime}"]
+    if title:
+        parts.append(f"Title: {title.strip()[:200]}")
+    caption_blob = " ".join(c.strip() for c in (captions or []) if isinstance(c, str) and c.strip())
+    if caption_blob:
+        parts.append(f"Captions: {caption_blob[:1000]}")
+    excerpt = _truncate(text)
+    if excerpt:
+        parts.append(f"Contents excerpt:\n{excerpt}")
+    return "\n\n".join(parts)
+
+
+def _parse_json_object(raw: str) -> dict[str, Any] | None:
+    """Pull a JSON object out of a model reply, tolerating a code fence.
+
+    Models fence JSON even when told not to. Rather than fail a whole
+    comprehension on a pair of backticks, slice from the first ``{`` to the
+    last ``}`` and parse that. Anything still unparseable is ``None``.
+    """
+    if not raw:
+        return None
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start == -1 or end <= start:
+        return None
+    try:
+        parsed = json.loads(raw[start : end + 1])
+    except (ValueError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def validate_categories(raw: Any) -> list[str]:
+    """Keep only real categories, deduped, in order, capped at the maximum.
+
+    DROP, never map. A category outside :data:`CATEGORIES` is worse than no
+    category at all: it renders in the library as a shelf that looks like every
+    other shelf, and the filter behind it matches one file forever. Guessing
+    the nearest legal value would be worse still — a deck filed under
+    ``contract`` because the model said "board contract" is a wrong answer
+    presented with the same confidence as a right one.
+    """
+    if not isinstance(raw, (list, tuple)):
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            continue
+        value = item.strip().lower()
+        if value not in CATEGORIES or value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+        if len(out) >= MAX_CATEGORIES:
+            break
+    return out
+
+
+async def comprehend(
+    title: str | None,
+    text: str | None,
+    captions: list[str] | None,
+    *,
+    mime: str,
+) -> Comprehension | None:
+    """Ask the proxy what this file is. ``None`` on anything less than success.
+
+    ``None`` covers: nothing to send, a proxy that is down or slow, a non-2xx
+    response, a reply that is not JSON, a reply with no usable summary. The
+    caller treats every one of them identically and leaves the file alone, so
+    there is nothing to gain from distinguishing them beyond the log line.
+    """
+    user_message = _build_user_message(title=title, text=text, captions=captions, mime=mime)
+    # Nothing but the mime line means there is no signal to classify on. The
+    # model would confidently invent one; skip the spend instead.
+    if not (title or (text or "").strip() or captions):
+        return None
+
+    payload = {
+        "model": model_id(),
+        "messages": [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user_message},
+        ],
+        "max_tokens": 400,
+        "temperature": 0,
+    }
+
+    base = _proxy_base().rstrip("/")
+    try:
+        async with httpx.AsyncClient(
+            transport=_PROXY_TRANSPORT, timeout=_TIMEOUT_SECONDS
+        ) as client:
+            resp = await client.post(
+                f"{base}/v1/chat/completions",
+                headers=_headers(),
+                json=payload,
+            )
+            resp.raise_for_status()
+            body = resp.json()
+    except Exception:  # noqa: BLE001 — every failure is the same failure here
+        logger.info(
+            "file comprehension call failed (model=%r); the file stays indexed "
+            "and tagged, it just carries no summary",
+            payload["model"],
+            exc_info=True,
+        )
+        return None
+
+    try:
+        content = body["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError):
+        logger.info("file comprehension: proxy returned an unexpected body shape")
+        return None
+
+    parsed = _parse_json_object(content if isinstance(content, str) else "")
+    if parsed is None:
+        logger.info("file comprehension: model reply was not JSON; skipping")
+        return None
+
+    summary = parsed.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        # Categories without a summary is not worth a write — the summary is
+        # the part a person reads.
+        return None
+    summary = summary.strip()[:MAX_SUMMARY_CHARS]
+
+    return Comprehension(summary=summary, categories=validate_categories(parsed.get("categories")))
+
+
+__all__ = [
+    "CATEGORIES",
+    "MAX_CATEGORIES",
+    "MAX_INPUT_CHARS",
+    "MAX_SUMMARY_CHARS",
+    "Comprehension",
+    "comprehend",
+    "model_id",
+    "validate_categories",
+]

--- a/ee/pocketpaw_ee/cloud/uploads/comprehension_budget.py
+++ b/ee/pocketpaw_ee/cloud/uploads/comprehension_budget.py
@@ -1,0 +1,130 @@
+# ee/pocketpaw_ee/cloud/uploads/comprehension_budget.py — a hard daily ceiling on
+# file comprehension.
+#
+# Created 2026-08-28 (FC-3 "File comprehension").
+#
+# Comprehension is triggered by an UPLOAD, not by a request — nobody asks for
+# it, and each one costs real money on the PLATFORM's account (a user's own
+# BYOK key pays for their turns and deliberately not for this; see the header
+# of ``comprehension.py``). A bulk import of ten thousand files would therefore
+# be ten thousand unrequested model calls charged to us, and the person doing
+# it would experience it as "the upload worked". That is the hole this closes.
+#
+# Deliberately coarse: one counter per workspace per UTC day, checked and
+# incremented in ONE atomic update. It is a cost ceiling, not billing — it does
+# not need to be exact under concurrency, it needs to be impossible to blow
+# past by an order of magnitude.
+#
+# It fails CLOSED, which is the opposite of how the rest of the comprehension
+# path behaves, and the asymmetry is the point. Everything downstream of this
+# gate fails OPEN, because the cost of skipping a summary is a file with no
+# summary. THIS gate fails closed, because the cost of being wrong here is an
+# unbounded bill. A degraded database must not become an open tab.
+#
+# Structure copied from ``cloud/other_hand/illustration_budget.py``, including
+# the increment-then-compare ordering and the rollback of an over-cap claim.
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+
+from pymongo import ReturnDocument
+
+from pocketpaw_ee.cloud.models.file_comprehension_usage import FileComprehensionUsage
+
+logger = logging.getLogger(__name__)
+
+_ENV_CAP = "POCKETPAW_FILE_COMPREHENSION_DAILY"
+_DEFAULT_CAP = 500
+
+
+def daily_cap() -> int:
+    """Comprehensions per workspace per UTC day. 0 disables the feature.
+
+    A non-integer value is a misconfiguration, not an instruction: we warn and
+    use the default rather than reading ``"five hundred"`` as zero and silently
+    switching comprehension off for the whole deployment.
+    """
+    raw = (os.environ.get(_ENV_CAP) or "").strip()
+    if not raw:
+        return _DEFAULT_CAP
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning("%s is not an integer (%r) — using the default", _ENV_CAP, raw)
+        return _DEFAULT_CAP
+
+
+def _today() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+async def try_spend(workspace_id: str | None) -> tuple[bool, int, int]:
+    """Claim one comprehension against today's budget for ``workspace_id``.
+
+    Returns ``(allowed, spent, cap)``. ``spent`` INCLUDES this one when
+    allowed, so a caller can log "3/500" honestly.
+
+    Increments FIRST and compares after. The increment is the atomic part; a
+    check-then-increment would let two concurrent uploads both read 499, both
+    conclude they are under the cap, and both spend. An over-cap claim is
+    rolled back so a refused upload does not hold a slot a later one could
+    have used.
+
+    ``workspace_id`` is passed in rather than resolved from context: the
+    FileReady listener already has it, and a budget that silently charges "no
+    tenant" is a budget with a hole in it.
+    """
+    cap = daily_cap()
+    if cap <= 0:
+        return False, 0, 0
+
+    if not workspace_id:
+        # No tenant means no counter to charge, and an uncharged comprehension
+        # is exactly what this file exists to prevent.
+        logger.warning("file comprehension refused — no workspace on the event")
+        return False, 0, cap
+
+    day = _today()
+    key = f"{workspace_id}:{day}"
+    try:
+        coll = FileComprehensionUsage.get_motor_collection()
+        doc = await coll.find_one_and_update(
+            {"key": key},
+            {
+                "$inc": {"used": 1},
+                "$setOnInsert": {
+                    "workspace": workspace_id,
+                    "day": day,
+                    "createdAt": datetime.now(UTC),
+                },
+                "$set": {"updatedAt": datetime.now(UTC)},
+            },
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        # A successful update with no returned document should not happen, but
+        # if it does we must not read it as "0 spent" — that is a permanently
+        # open gate. Treat it as over-cap.
+        spent = int((doc or {}).get("used", cap + 1))
+    except Exception:
+        # Fail closed — see the module note.
+        logger.warning(
+            "file comprehension budget unavailable for workspace=%s; refusing",
+            workspace_id,
+            exc_info=True,
+        )
+        return False, 0, cap
+
+    if spent > cap:
+        try:
+            await coll.update_one({"key": key}, {"$inc": {"used": -1}})
+        except Exception:
+            logger.debug("could not roll back an over-cap comprehension claim", exc_info=True)
+        return False, cap, cap
+    return True, spent, cap
+
+
+__all__ = ["daily_cap", "try_spend"]

--- a/ee/pocketpaw_ee/cloud/uploads/comprehension_budget.py
+++ b/ee/pocketpaw_ee/cloud/uploads/comprehension_budget.py
@@ -90,7 +90,16 @@ async def try_spend(workspace_id: str | None) -> tuple[bool, int, int]:
     day = _today()
     key = f"{workspace_id}:{day}"
     try:
-        coll = FileComprehensionUsage.get_motor_collection()
+        # ``get_pymongo_collection``, NOT ``get_motor_collection`` — the latter
+        # is beanie 1.x and this repo is on 2.1.0, where the attribute does not
+        # exist. Getting it wrong here is invisible in the worst way: the
+        # AttributeError lands in the fail-closed ``except`` below, every claim
+        # is refused, and the feature reads as "comprehension is off" rather
+        # than as a bug. ``pockets/service.py`` was bitten by the same name and
+        # carries the same note. (The one live caller of this pattern that
+        # still says ``get_motor_collection`` is other_hand's illustration
+        # budget, on an unmerged branch — it has the bug.)
+        coll = FileComprehensionUsage.get_pymongo_collection()
         doc = await coll.find_one_and_update(
             {"key": key},
             {

--- a/ee/pocketpaw_ee/cloud/uploads/listeners.py
+++ b/ee/pocketpaw_ee/cloud/uploads/listeners.py
@@ -1,4 +1,20 @@
 # listeners.py — In-process subscribers for upload-related bus events.
+# Updated: 2026-08-28 — FC-3 "File comprehension". After the FL-6 auto-tag pass
+#   the listener now also asks a model what the file IS (``_write_comprehension``,
+#   beside ``_write_auto_tags``) and persists a ``summary`` plus merged
+#   ``collections`` through ``MongoFileStore.set_library_metadata``. Four
+#   properties, three of which the auto-tag path already modelled:
+#   (1) the ``hide_from_ai`` gate above still runs FIRST and returns before any
+#       of this, so a hidden file is never sent to a model — same fail-CLOSED
+#       privacy gate, no second copy of it;
+#   (2) fail-OPEN on everything else: a failed, empty or capped comprehension
+#       leaves the file indexed, tagged and usable. The user asked to store a
+#       file, not to have it understood;
+#   (3) a non-empty ``summary`` is never overwritten, so a human's correction
+#       survives every re-ingest;
+#   (4) a per-workspace daily cap (``uploads.comprehension_budget``) is claimed
+#       BEFORE the call, and that one gate fails CLOSED — the cost of skipping a
+#       summary is a missing summary, the cost of an unbounded ingest is money.
 # Updated: 2026-08-04 (living-wiki review follow-up) — _extract_article_id now
 #   delegates to knowledge.extract_ingest_article_id: kb-go's real ingest
 #   receipt keys the id as "article" (finishIngest), which the inline
@@ -135,6 +151,11 @@ async def index_uploaded_file(event: Event) -> None:
         )
         return
     existing_tags = list(getattr(doc, "tags", []) or [])
+    # FC-3: read the library state the comprehension pass has to respect while
+    # we still hold the row — the shelves it merges into, and the summary it
+    # must not clobber if a person already wrote one.
+    existing_collections = list(getattr(doc, "collections", []) or [])
+    existing_summary = getattr(doc, "summary", None)
 
     adapter = _resolve_adapter()
     if adapter is None or not storage_key:
@@ -173,6 +194,19 @@ async def index_uploaded_file(event: Event) -> None:
             workspace_id=str(workspace_id),
             result=result,
             existing_tags=existing_tags,
+        )
+
+        # FC-3: comprehension, beside auto-tagging and independent of it. Runs
+        # before the KB ingest for the same reason FL-6 does — a file should
+        # still be understood when the KB write later fails — and is contained
+        # the same way, so nothing here can abort the ingest.
+        await _write_comprehension(
+            file_id=file_id,
+            workspace_id=str(workspace_id),
+            result=result,
+            mime=mime,
+            existing_collections=existing_collections,
+            existing_summary=existing_summary,
         )
 
         text = (result.text or "").strip()
@@ -500,6 +534,102 @@ async def _write_auto_tags(
             logger.info("auto-tagged file_id=%s with %d tag(s)", file_id, len(merged))
     except Exception:
         logger.exception("auto-tagging failed for file_id=%s; KB ingest unaffected", file_id)
+
+
+async def _write_comprehension(
+    *,
+    file_id: str,
+    workspace_id: str,
+    result,
+    mime: str,
+    existing_collections: list[str],
+    existing_summary: str | None,
+) -> None:
+    """Ask a model what this file IS and persist the summary + collections.
+
+    The three refusals, in the order they are cheapest to make:
+
+    1. **A summary already written by a person stays.** The comprehension pass
+       is a guess made from the first few thousand characters; a human who has
+       read the file and typed a correction outranks it, every time, forever.
+       We do not track provenance — any non-empty summary is treated as
+       somebody's, and the cost of that simplification is that a stale machine
+       summary also survives. A person can clear it (``PATCH`` with ``""``) and
+       the next ingest re-writes it. ``collections`` still merges, because
+       merging cannot destroy anything.
+    2. **The daily cap is claimed before the call, and refuses fail-CLOSED.**
+       This is the one gate in the whole path that fails closed; see
+       ``comprehension_budget``'s module note for why the asymmetry is
+       deliberate.
+    3. **Everything after that fails OPEN.** A dead proxy, a 404 model id, a
+       model that answers in prose — ``comprehend`` returns None and this
+       function returns quietly. A file the user asked us to STORE must not
+       fail to store because we could not describe it.
+
+    Note what is NOT here: a ``hide_from_ai`` check. That gate lives at the top
+    of ``index_uploaded_file`` and has already returned before this runs.
+    Re-checking it here would create a second copy of a privacy rule, and two
+    copies of a rule is one copy that can drift.
+    """
+    try:
+        if (existing_summary or "").strip():
+            logger.debug("file_id=%s already has a summary; leaving it alone", file_id)
+            return
+
+        from pocketpaw_ee.cloud.uploads import comprehension_budget
+
+        allowed, spent, cap = await comprehension_budget.try_spend(workspace_id)
+        if not allowed:
+            logger.info(
+                "file comprehension skipped for file_id=%s: workspace %s is at "
+                "%d/%d for today (or the counter was unreadable). The file is "
+                "still indexed and tagged.",
+                file_id,
+                workspace_id,
+                spent,
+                cap,
+            )
+            return
+
+        from pocketpaw_ee.cloud.uploads.comprehension import comprehend
+        from pocketpaw_ee.cloud.uploads.tagging import merge_tags
+
+        captions = list(getattr(result, "captions", None) or [])
+        understood = await comprehend(
+            getattr(result, "title", None),
+            getattr(result, "text", None),
+            captions,
+            mime=mime,
+        )
+        if understood is None:
+            return
+
+        # ``collections`` merges on the same terms tags do: existing values
+        # first, order preserved, no clobber. A shelf a person put this file on
+        # is not the model's to remove.
+        merged = merge_tags(existing_collections, understood.categories)
+
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        updated = await MongoFileStore().set_library_metadata(
+            file_id,
+            workspace_id,
+            summary=understood.summary,
+            collections=merged,
+        )
+        if updated is None:
+            logger.debug(
+                "comprehension write found no row for file_id=%s workspace=%s",
+                file_id,
+                workspace_id,
+            )
+        else:
+            logger.info("comprehended file_id=%s into %d collection(s)", file_id, len(merged))
+    except Exception:
+        logger.exception(
+            "file comprehension failed for file_id=%s; the file stays indexed, tagged and usable",
+            file_id,
+        )
 
 
 def _resolve_adapter():

--- a/ee/pocketpaw_ee/cloud/uploads/models.py
+++ b/ee/pocketpaw_ee/cloud/uploads/models.py
@@ -1,5 +1,16 @@
 """EE FileUpload document — Mongo metadata for blobs stored via StorageAdapter.
 
+2026-08-28 — FC-1 "File comprehension". Added ``summary`` (``str | None``,
+default ``None``): one or two sentences saying what the file IS, written by the
+comprehension pass on ingest (``uploads/comprehension.py``) and editable by a
+human through ``PATCH /uploads/{id}``. Legacy rows read back ``None`` via the
+default — the same backward-compatible Beanie field-add FL-1 relied on, so
+there is no migration. Deliberately NOT indexed: nothing filters or sorts on a
+summary, it is only ever read after a row has been resolved by ``file_id``, and
+an index on free text would cost writes for a query nobody makes. The
+comprehension pass also writes ``collections`` (declared by FL-1 but, until
+now, never written by anything).
+
 2026-07-03 — FL-11b "hide-from-AI purge". Added ``kb_article_id`` and
 ``kb_scope`` (both ``str | None``, default ``None``) so a row remembers the
 kb-go article it was ingested into. The FileReady listener records them after a
@@ -77,6 +88,13 @@ class FileUpload(TimestampedDocument):
     tags: list[str] = Field(default_factory=list)
     collections: list[str] = Field(default_factory=list)
     hide_from_ai: bool = False
+    # What this file IS, in a sentence or two (FC-1). Written by the
+    # comprehension pass on ingest and by a human through PATCH. ``None`` on
+    # legacy rows and on files that were never comprehended (hidden from AI,
+    # over the daily cap, or the model call failed) — the library UI treats
+    # ``None`` and "" alike: no summary to show. Not indexed; see the module
+    # docstring for why.
+    summary: str | None = None
     # KB tracking (FL-11b). After a successful ingest the FileReady listener
     # records the kb-go article id and the scope it landed in, so the file can
     # be retroactively purged from the KB if it's later hidden from AI. ``None``

--- a/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
@@ -1,5 +1,12 @@
 """Mongo-backed metadata store, workspace-scoped.
 
+2026-08-28 (FC-1 "File comprehension"): ``summary`` is threaded exactly the way
+``tags`` is — ``set_library_metadata`` grew a ``summary`` keyword, and both
+``iter_by_workspace`` / ``iter_by_pocket`` dict rows now carry it so the
+/files listing can show what a file IS without a second query. Same
+only-touch-what-was-passed rule as the other library fields, and the same
+always-applied workspace filter, so a caller still cannot write across tenants.
+
 2026-08-04 (Living-wiki API): ``iter_by_workspace`` rows now also carry
 ``kb_article_id`` and ``kb_scope`` (the FL-11b ingest-tracking columns) so
 GET /knowledge/uploads can derive ``has_article`` without a second query,
@@ -103,13 +110,20 @@ class MongoFileStore:
         tags: list[str] | None = None,
         collections: list[str] | None = None,
         hide_from_ai: bool | None = None,
+        summary: str | None = None,
     ) -> FileUpload | None:
-        """Set library metadata on one live row, workspace-scoped (FL-1).
+        """Set library metadata on one live row, workspace-scoped (FL-1, FC-1).
 
         Only the fields passed as non-``None`` are updated — omitted fields
         keep their current value. Returns the updated doc, or ``None`` if no
         live row matches ``(file_id, workspace)``. The workspace filter is
         always applied, so a caller cannot mutate another tenant's rows.
+
+        ``summary`` (FC-1) follows the same rule, which means this setter
+        cannot CLEAR a summary — ``None`` is "leave it alone", not "erase it".
+        That is deliberate and matches the other fields; the only writer that
+        would want to erase one is a human, and the PATCH route handles an
+        explicit empty string by writing ``""``.
         """
         doc = await self.get_doc_scoped(file_id, workspace)
         if doc is None:
@@ -120,6 +134,8 @@ class MongoFileStore:
             doc.collections = [str(c) for c in collections]
         if hide_from_ai is not None:
             doc.hide_from_ai = bool(hide_from_ai)
+        if summary is not None:
+            doc.summary = str(summary)
         await doc.save()
         return doc
 
@@ -314,6 +330,8 @@ class MongoFileStore:
                 "tags": list(getattr(doc, "tags", []) or []),
                 "collections": list(getattr(doc, "collections", []) or []),
                 "hide_from_ai": bool(getattr(doc, "hide_from_ai", False)),
+                # FC-1: read defensively — legacy rows predate the field.
+                "summary": getattr(doc, "summary", None),
                 # Living-wiki API: FL-11b ingest tracking, so /knowledge/uploads
                 # can derive has_article without a second query; pocket_id so
                 # workspace-level listings can exclude pocket-private rows.
@@ -427,6 +445,8 @@ class MongoFileStore:
                 "tags": list(getattr(doc, "tags", []) or []),
                 "collections": list(getattr(doc, "collections", []) or []),
                 "hide_from_ai": bool(getattr(doc, "hide_from_ai", False)),
+                # FC-1: read defensively — legacy rows predate the field.
+                "summary": getattr(doc, "summary", None),
             }
 
     async def count_by_pocket(self, workspace: str, pocket_id: str) -> int:

--- a/ee/pocketpaw_ee/cloud/uploads/router.py
+++ b/ee/pocketpaw_ee/cloud/uploads/router.py
@@ -1,5 +1,14 @@
 """EE /uploads router — workspace-scoped upload endpoints.
 
+2026-08-28 (FC-1 "File comprehension"): ``PATCH /uploads/{file_id}`` accepts
+``summary`` (str) so a person can correct or write what a file IS, and the
+response echoes it. This is the half of FC-1 that makes "never overwrite a
+human's edit" mean something — the ingest-time comprehension pass refuses to
+touch a row whose ``summary`` is already non-empty, so without a way for a
+human to SET one, that rule would only ever protect a previous machine
+summary. An explicit ``""`` erases it (and thereby re-opens the file to a
+future comprehension pass); omitting the field leaves it untouched.
+
 2026-07-03 (FL-11b "hide-from-AI purge"): ``PATCH /uploads/{file_id}`` now
 retroactively purges a file's KB content when ``hide_from_ai`` flips false→true
 AND the row tracks a kb-go article (``kb_article_id`` + ``kb_scope`` recorded on
@@ -89,6 +98,11 @@ _CFG = UploadSettings(local_root=_ROOT)
 _ADAPTER = build_adapter(_ROOT)
 _META = MongoFileStore()
 _FOLDERS = FolderStore()
+
+# FC-1: the longest summary PATCH will accept. A library subtitle, not a
+# document — the machine-written ones land well under this, and the ceiling
+# exists so a hand-crafted request cannot put a novel into every listing row.
+_MAX_SUMMARY_CHARS = 1000
 
 
 async def _is_chat_member(chat_id: str, user_id: str, _workspace: str) -> bool:
@@ -365,6 +379,7 @@ async def patch_upload(
     new_tags = body.get("tags")
     new_collections = body.get("collections")
     new_hide = body.get("hide_from_ai")
+    new_summary = body.get("summary")
 
     if new_filename is not None:
         if not isinstance(new_filename, str) or not new_filename.strip():
@@ -395,6 +410,20 @@ async def patch_upload(
         ):
             raise HTTPException(status_code=400, detail="collections must be a list of strings")
         doc.collections = new_collections
+
+    # FC-1: a human writing (or correcting, or erasing) what the file IS.
+    # Capped at _MAX_SUMMARY_CHARS — this is a library subtitle, not a place
+    # to paste a document, and an unbounded string here would be echoed into
+    # every /files listing row.
+    if new_summary is not None:
+        if not isinstance(new_summary, str):
+            raise HTTPException(status_code=400, detail="summary must be a string")
+        if len(new_summary) > _MAX_SUMMARY_CHARS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"summary must be at most {_MAX_SUMMARY_CHARS} characters",
+            )
+        doc.summary = new_summary
 
     # FL-11b: detect a false→true hide transition so we can retroactively
     # purge the file's KB article after the row is saved. Capture the pre-edit
@@ -452,6 +481,7 @@ async def patch_upload(
         "tags": list(doc.tags or []),
         "collections": list(doc.collections or []),
         "hide_from_ai": bool(doc.hide_from_ai),
+        "summary": doc.summary,
     }
 
 

--- a/tests/cloud/uploads/test_comprehension.py
+++ b/tests/cloud/uploads/test_comprehension.py
@@ -1,0 +1,640 @@
+# tests/cloud/uploads/test_comprehension.py — FC-4. What file comprehension must
+# refuse to do.
+#
+# Created 2026-08-28.
+#
+# The happy path here is cheap to get right and cheap to test: a model returns
+# JSON, a summary lands on a row. Everything worth writing a test for is a
+# REFUSAL — the cases where comprehension must not run, must not trust what it
+# got back, and must not take the upload down with it. So the classes below are
+# named for the four things that would actually hurt:
+#
+#   * a category the vocabulary has never heard of reaching a row, where it
+#     renders as a shelf that looks real and matches one file forever;
+#   * a 400-page PDF becoming a 400-page prompt;
+#   * a hidden file being sent to a model at all;
+#   * a failure — of the proxy, of the model, of the counter — turning "your
+#     file is stored" into "your upload failed".
+#
+# Two conventions worth knowing before editing this file:
+#
+# The hide-from-AI test asserts with a client stub that RAISES the moment it is
+# constructed, and then checks that it never was. Asserting on a boolean flag
+# would pass just as happily if a future refactor stopped consulting the flag.
+# The construction record is the evidence; the raise is there so the failure
+# cannot be quiet if the record is ever dropped.
+#
+# The mutation plan for all of this is ``tests/mutations/file_comprehension.json``
+# — every gate below has been observed to break when its guard is removed. A
+# test nobody has watched fail is a claim, not a gate.
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import FileReady
+from pocketpaw_ee.cloud.extraction.adapter import ExtractionResult
+from pocketpaw_ee.cloud.uploads import comprehension, comprehension_budget
+
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def beanie_with_budget():
+    """Beanie bound to the upload docs AND the comprehension counter.
+
+    The package conftest deliberately does not register
+    ``FileComprehensionUsage`` — which means every OTHER listener test runs
+    with an unreadable counter and therefore a fail-CLOSED budget, so no
+    unrelated test ever reaches the network. Tests that need comprehension to
+    actually run ask for this fixture instead.
+    """
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+    from pocketpaw_ee.cloud.models.file_comprehension_usage import FileComprehensionUsage
+    from pocketpaw_ee.cloud.uploads.models import FileFolder, FileUpload
+    from pocketpaw_ee.cloud.uploads.share_models import ShareLink
+
+    client = AsyncMongoMockClient()
+    db = client[f"test_fc_{uuid.uuid4().hex[:8]}"]
+    original = db.list_collection_names
+
+    async def _safe(*_a, **_kw):
+        return await original()
+
+    db.list_collection_names = _safe  # type: ignore[method-assign]
+
+    models = [FileUpload, FileFolder, ShareLink, FileComprehensionUsage]
+    await init_beanie(database=db, document_models=models)
+    try:
+        yield db
+    finally:
+        # Same teardown reason as the package conftest: a leaked Beanie binding
+        # keeps this torn-down mongomock db attached to the Document classes,
+        # and the next test reads rows that no longer exist.
+        for model in models:
+            for attr in ("_document_settings", "_settings"):
+                if hasattr(model, attr):
+                    try:
+                        setattr(model, attr, None)
+                    except Exception:  # pragma: no cover — defensive
+                        pass
+
+
+@pytest.fixture()
+async def budget_store(beanie_with_budget):
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    return MongoFileStore()
+
+
+def _model_reply(summary: str, categories: list) -> dict:
+    """The OpenAI-compatible envelope the proxy returns."""
+    return {
+        "choices": [
+            {"message": {"content": json.dumps({"summary": summary, "categories": categories})}}
+        ]
+    }
+
+
+class _Capture:
+    """Records every proxy request and answers with a canned body."""
+
+    def __init__(self, body: dict | None = None, status: int = 200):
+        self.requests: list[httpx.Request] = []
+        self._body = body if body is not None else _model_reply("A thing.", ["other"])
+        self._status = status
+
+    def transport(self) -> httpx.MockTransport:
+        def _handler(request: httpx.Request) -> httpx.Response:
+            self.requests.append(request)
+            return httpx.Response(self._status, json=self._body)
+
+        return httpx.MockTransport(_handler)
+
+    @property
+    def sent_payload(self) -> dict:
+        return json.loads(self.requests[-1].content)
+
+
+@pytest.fixture()
+def proxy(monkeypatch):
+    """Point the module's transport seam at a capturing stub."""
+
+    def _install(body: dict | None = None, status: int = 200) -> _Capture:
+        cap = _Capture(body, status)
+        monkeypatch.setattr(comprehension, "_PROXY_TRANSPORT", cap.transport())
+        return cap
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# The vocabulary
+# ---------------------------------------------------------------------------
+
+
+class TestTheVocabularyIsClosed:
+    async def test_a_category_outside_the_list_is_dropped(self, proxy):
+        """An unknown category is worse than none — it renders as a shelf that
+        looks exactly like a real one and matches this file alone forever."""
+        proxy(_model_reply("A board deck.", ["deck", "board-materials", "q3"]))
+
+        got = await comprehension.comprehend("Deck", "revenue", [], mime="application/pdf")
+
+        assert got is not None
+        assert got.categories == ["deck"]
+
+    async def test_nothing_is_mapped_to_the_nearest_legal_value(self, proxy):
+        """Dropping is not the same as guessing. "board contract" must not
+        become ``contract``: a wrong shelf is delivered with exactly the same
+        confidence as a right one."""
+        proxy(_model_reply("A deck.", ["board contract", "invoicing"]))
+
+        got = await comprehension.comprehend("Deck", "revenue", [], mime="application/pdf")
+
+        assert got is not None
+        assert got.categories == []
+
+    async def test_more_than_three_categories_are_capped(self, proxy):
+        proxy(
+            _model_reply(
+                "Everything at once.",
+                ["deck", "invoice", "spec", "research", "design", "data"],
+            )
+        )
+
+        got = await comprehension.comprehend("X", "y", [], mime="application/pdf")
+
+        assert got is not None
+        assert got.categories == ["deck", "invoice", "spec"]
+        assert len(got.categories) <= comprehension.MAX_CATEGORIES
+
+    async def test_every_category_is_lowercase_and_unique(self):
+        """The vocabulary is a wire format: ``validate_categories`` compares
+        against it verbatim, so a stray capital would silently reject a value
+        the prompt told the model to use."""
+        assert list(comprehension.CATEGORIES) == [c.lower() for c in comprehension.CATEGORIES]
+        assert len(set(comprehension.CATEGORIES)) == len(comprehension.CATEGORIES)
+
+
+# ---------------------------------------------------------------------------
+# The input cap
+# ---------------------------------------------------------------------------
+
+
+class TestTheInputIsCapped:
+    async def test_oversized_text_is_truncated_before_the_call(self, proxy):
+        """A 400-page PDF must not become a 400-page prompt. Asserted on the
+        bytes that actually left, not on the truncation helper — the helper
+        being correct while the payload is built from the original is exactly
+        the bug this guards."""
+        cap = proxy()
+        huge = "lorem ipsum " * 20_000
+        assert len(huge) > comprehension.MAX_INPUT_CHARS * 5
+
+        await comprehension.comprehend("Big", huge, [], mime="application/pdf")
+
+        sent = cap.sent_payload["messages"][-1]["content"]
+        assert len(sent) < comprehension.MAX_INPUT_CHARS + 2000
+        assert huge not in sent
+
+    async def test_short_text_is_sent_whole(self, proxy):
+        cap = proxy()
+
+        await comprehension.comprehend("Small", "a short memo about parking", [], mime="text/plain")
+
+        assert "a short memo about parking" in cap.sent_payload["messages"][-1]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Who pays
+# ---------------------------------------------------------------------------
+
+
+class TestThePlatformPaysNotTheUser:
+    async def test_the_request_never_carries_an_x_api_key(self, proxy, monkeypatch):
+        """The gateway forwards ``x-api-key`` upstream (BYOK header-forwarding),
+        so one on this request would bill a user's own Anthropic account to
+        summarise their own upload. This is a platform call; it carries the
+        proxy Bearer and nothing else."""
+        monkeypatch.setattr(comprehension, "_proxy_key", lambda: "sk-platform")
+        cap = proxy()
+
+        await comprehension.comprehend("X", "y", [], mime="text/plain")
+
+        headers = cap.requests[-1].headers
+        assert headers["authorization"] == "Bearer sk-platform"
+        assert "x-api-key" not in headers
+
+
+# ---------------------------------------------------------------------------
+# Failure is never the upload's problem
+# ---------------------------------------------------------------------------
+
+
+class TestFailureReturnsNone:
+    async def test_a_non_2xx_is_none(self, proxy):
+        proxy({"error": "model not found"}, status=404)
+        assert await comprehension.comprehend("X", "y", [], mime="text/plain") is None
+
+    async def test_prose_instead_of_json_is_none(self, proxy):
+        proxy({"choices": [{"message": {"content": "Sure! It looks like a deck."}}]})
+        assert await comprehension.comprehend("X", "y", [], mime="text/plain") is None
+
+    async def test_a_missing_summary_is_none_even_with_good_categories(self, proxy):
+        """The summary is the part a person reads; categories alone are not
+        worth a write."""
+        proxy(_model_reply("   ", ["deck"]))
+        assert await comprehension.comprehend("X", "y", [], mime="text/plain") is None
+
+    async def test_a_fenced_reply_still_parses(self, proxy):
+        """Models fence JSON even when told not to. Failing a whole
+        comprehension over two backticks would be a self-inflicted wound."""
+        fenced = '```json\n{"summary": "A spec.", "categories": ["spec"]}\n```'
+        proxy({"choices": [{"message": {"content": fenced}}]})
+
+        got = await comprehension.comprehend("X", "y", [], mime="text/plain")
+
+        assert got is not None
+        assert got.summary == "A spec."
+
+    async def test_no_signal_at_all_never_calls_the_model(self, proxy):
+        """Nothing but a mime type is nothing to classify. The model would
+        confidently invent something; skip the spend instead."""
+        cap = proxy()
+        assert await comprehension.comprehend(None, "   ", [], mime="text/plain") is None
+        assert cap.requests == []
+
+
+# ---------------------------------------------------------------------------
+# The daily cap
+# ---------------------------------------------------------------------------
+
+
+class TestTheDailyCap:
+    async def test_the_cap_refuses_the_next_claim(self, beanie_with_budget, monkeypatch):
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "2")
+
+        first = await comprehension_budget.try_spend("w1")
+        second = await comprehension_budget.try_spend("w1")
+        third = await comprehension_budget.try_spend("w1")
+
+        assert first[0] is True
+        assert second[0] is True
+        assert third[0] is False, "the third claim on a cap of 2 must be refused"
+        assert third[1:] == (2, 2)
+
+    async def test_a_refused_claim_does_not_consume_a_slot(self, beanie_with_budget, monkeypatch):
+        """An over-cap claim is rolled back, so the counter cannot run away to
+        thousands and leave the workspace refused long after midnight."""
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "1")
+
+        await comprehension_budget.try_spend("w1")
+        for _ in range(5):
+            await comprehension_budget.try_spend("w1")
+
+        from pocketpaw_ee.cloud.models.file_comprehension_usage import FileComprehensionUsage
+
+        day = datetime.now(UTC).strftime("%Y-%m-%d")
+        row = await FileComprehensionUsage.find_one(FileComprehensionUsage.key == f"w1:{day}")
+        assert row is not None
+        assert row.used == 1
+
+    async def test_one_workspace_cannot_spend_anothers_budget(
+        self, beanie_with_budget, monkeypatch
+    ):
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "1")
+
+        await comprehension_budget.try_spend("w1")
+        other = await comprehension_budget.try_spend("w2")
+
+        assert other[0] is True
+
+    async def test_an_unreadable_counter_fails_CLOSED(self, monkeypatch):
+        """No Beanie binding in this test, so the collection genuinely cannot
+        be read — the degraded-database case reached honestly rather than
+        simulated. A degraded database must not become an open tab: skipping a
+        summary costs a summary, an ungated ingest costs money."""
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "5")
+
+        allowed, _spent, _cap = await comprehension_budget.try_spend("w1")
+
+        assert allowed is False
+
+    async def test_no_workspace_is_refused(self, beanie_with_budget, monkeypatch):
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "5")
+        assert (await comprehension_budget.try_spend(""))[0] is False
+        assert (await comprehension_budget.try_spend(None))[0] is False
+
+    async def test_a_zero_cap_disables_the_feature(self, beanie_with_budget, monkeypatch):
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "0")
+        allowed, _spent, cap = await comprehension_budget.try_spend("w1")
+        assert allowed is False
+        assert cap == 0
+
+    async def test_a_nonsense_cap_falls_back_to_the_default(self, monkeypatch):
+        """ "five hundred" must not read as zero and switch comprehension off
+        for a whole deployment."""
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "five hundred")
+        assert comprehension_budget.daily_cap() == 500
+
+
+# ---------------------------------------------------------------------------
+# The listener
+# ---------------------------------------------------------------------------
+
+
+class _FakeChain:
+    def __init__(self, result: ExtractionResult):
+        self._result = result
+        self.calls: list[tuple[Path, str]] = []
+
+    async def run(self, path: Path, mime: str) -> ExtractionResult:
+        self.calls.append((path, mime))
+        return self._result
+
+
+class _FakeAdapter:
+    def __init__(self, local_path_value: Path):
+        self._local = local_path_value
+
+    def local_path(self, key: str) -> Path | None:
+        return self._local
+
+    async def open(self, key: str):  # pragma: no cover — local path wins
+        yield b""
+
+
+def _record(**overrides) -> FileRecord:
+    defaults = {
+        "id": "f1",
+        "storage_key": "chat/202608/aaa.pdf",
+        "filename": "deck.pdf",
+        "mime": "application/pdf",
+        "size": 1,
+        "owner_id": "u1",
+        "chat_id": "c1",
+        "created": datetime.now(UTC),
+    }
+    defaults.update(overrides)
+    return FileRecord(**defaults)
+
+
+def _event() -> FileReady:
+    return FileReady(
+        data={
+            "workspace_id": "w1",
+            "file_id": "f1",
+            "filename": "deck.pdf",
+            "mime": "application/pdf",
+            "storage_key": "chat/202608/aaa.pdf",
+        }
+    )
+
+
+def _wire(monkeypatch, *, chain: _FakeChain, adapter: _FakeAdapter, ingest: AsyncMock):
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads import listeners
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.extraction.build_chain", lambda settings: chain)
+    monkeypatch.setattr(listeners, "_resolve_adapter", lambda: adapter)
+    monkeypatch.setattr(kn.KnowledgeService, "ingest_text_to_scope", ingest)
+
+
+class _ExplodingClient:
+    """A stand-in for ``httpx.AsyncClient`` that cannot be built quietly.
+
+    Records the attempt AND raises. The record is what the assertion reads;
+    the raise is there so that if a future refactor drops the record, the
+    failure still cannot pass silently.
+    """
+
+    attempts: list[str] = []
+
+    def __init__(self, *args, **kwargs):
+        _ExplodingClient.attempts.append("constructed")
+        raise AssertionError("a model client was constructed for a hidden file")
+
+
+class TestTheListener:
+    async def test_a_deck_gets_a_summary_and_a_shelf(
+        self, budget_store, monkeypatch, proxy, tmp_path
+    ):
+        from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "10")
+        proxy(_model_reply("A board deck reviewing Q3 revenue.", ["deck"]))
+        await budget_store.save_scoped(_record(), workspace="w1")
+
+        path = tmp_path / "deck.pdf"
+        path.write_bytes(b"unused; chain mocked")
+        chain = _FakeChain(
+            ExtractionResult(title="Q3 Board Deck", text="revenue revenue", backend="local")
+        )
+        _wire(
+            monkeypatch,
+            chain=chain,
+            adapter=_FakeAdapter(path),
+            ingest=AsyncMock(return_value={"article": "a1"}),
+        )
+
+        await index_uploaded_file(_event())
+
+        doc = await budget_store.get_doc_scoped("f1", "w1")
+        assert doc is not None
+        assert doc.summary == "A board deck reviewing Q3 revenue."
+        assert doc.collections == ["deck"]
+        # The FL-6 tag path is untouched by any of this.
+        assert doc.tags
+
+    async def test_hide_from_ai_means_ZERO_model_calls(self, budget_store, monkeypatch, tmp_path):
+        """A hidden file must not reach a model, and the proof is that no
+        client was ever built — not that a flag was consulted."""
+        from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "10")
+        _ExplodingClient.attempts = []
+        monkeypatch.setattr(comprehension.httpx, "AsyncClient", _ExplodingClient)
+
+        await budget_store.save_scoped(_record(), workspace="w1")
+        await budget_store.set_library_metadata("f1", "w1", hide_from_ai=True)
+
+        path = tmp_path / "secret.pdf"
+        path.write_bytes(b"unused")
+        chain = _FakeChain(ExtractionResult(text="confidential", backend="local"))
+        ingest = AsyncMock()
+        _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(path), ingest=ingest)
+
+        await index_uploaded_file(_event())
+
+        assert _ExplodingClient.attempts == [], "a hidden file reached the model"
+        assert chain.calls == [], "a hidden file was extracted"
+        ingest.assert_not_awaited()
+        doc = await budget_store.get_doc_scoped("f1", "w1")
+        assert doc is not None
+        assert doc.summary is None
+        assert doc.collections == []
+
+    async def test_a_raising_comprehension_does_not_take_the_upload_down(
+        self, budget_store, monkeypatch, tmp_path
+    ):
+        """The listener's own containment, tested directly.
+
+        ``comprehend`` swallows its own failures, so a proxy error alone can
+        never reach the listener — which means the listener's try/except is
+        untested by every other case here and could be narrowed or deleted
+        without anything noticing. This drives a raise straight at it. The
+        upload must complete: KB ingest awaited, tags written, no exception
+        out of ``index_uploaded_file``.
+        """
+        from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "10")
+
+        async def _boom(*_a, **_kw):
+            raise RuntimeError("the comprehension path blew up")
+
+        # ``_write_comprehension`` imports ``comprehend`` inside the function,
+        # so the attribute is resolved at call time and this patch lands.
+        monkeypatch.setattr(comprehension, "comprehend", _boom)
+
+        await budget_store.save_scoped(_record(), workspace="w1")
+        path = tmp_path / "deck.pdf"
+        path.write_bytes(b"unused")
+        chain = _FakeChain(
+            ExtractionResult(title="Invoice", text="payment payment due", backend="local")
+        )
+        ingest = AsyncMock(return_value={"article": "a1"})
+        _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(path), ingest=ingest)
+
+        await index_uploaded_file(_event())
+
+        ingest.assert_awaited_once()
+        doc = await budget_store.get_doc_scoped("f1", "w1")
+        assert doc is not None
+        assert doc.summary is None
+        assert doc.tags, "the tag path must survive a raising comprehension"
+
+    async def test_a_human_set_summary_survives_reingest(
+        self, budget_store, monkeypatch, proxy, tmp_path
+    ):
+        """Somebody read the file and typed a correction. A guess made from the
+        first few thousand characters does not get to overwrite it."""
+        from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "10")
+        cap = proxy(_model_reply("A machine guess.", ["invoice"]))
+
+        await budget_store.save_scoped(_record(), workspace="w1")
+        await budget_store.set_library_metadata(
+            "f1", "w1", summary="The 2027 board pack. Ignore the cover date."
+        )
+
+        path = tmp_path / "deck.pdf"
+        path.write_bytes(b"unused")
+        chain = _FakeChain(ExtractionResult(title="Deck", text="revenue", backend="local"))
+        _wire(
+            monkeypatch,
+            chain=chain,
+            adapter=_FakeAdapter(path),
+            ingest=AsyncMock(return_value={"article": "a1"}),
+        )
+
+        await index_uploaded_file(_event())
+
+        doc = await budget_store.get_doc_scoped("f1", "w1")
+        assert doc is not None
+        assert doc.summary == "The 2027 board pack. Ignore the cover date."
+        assert cap.requests == [], "the model was called for a file already summarised"
+
+    async def test_a_model_failure_leaves_the_file_indexed_and_tagged(
+        self, budget_store, monkeypatch, proxy, tmp_path
+    ):
+        """Fail OPEN. Somebody asked us to store a file, not to describe it."""
+        from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "10")
+        proxy({"error": "no such model"}, status=404)
+        await budget_store.save_scoped(_record(), workspace="w1")
+
+        path = tmp_path / "deck.pdf"
+        path.write_bytes(b"unused")
+        chain = _FakeChain(
+            ExtractionResult(title="Invoice", text="payment payment due", backend="local")
+        )
+        ingest = AsyncMock(return_value={"article": "a1"})
+        _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(path), ingest=ingest)
+
+        await index_uploaded_file(_event())
+
+        doc = await budget_store.get_doc_scoped("f1", "w1")
+        assert doc is not None
+        assert doc.summary is None
+        assert doc.tags, "the tag path must survive a comprehension failure"
+        ingest.assert_awaited_once()
+
+    async def test_an_exhausted_cap_leaves_the_file_indexed_and_tagged(
+        self, budget_store, monkeypatch, proxy, tmp_path
+    ):
+        from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "0")
+        cap = proxy(_model_reply("Never sent.", ["deck"]))
+        await budget_store.save_scoped(_record(), workspace="w1")
+
+        path = tmp_path / "deck.pdf"
+        path.write_bytes(b"unused")
+        chain = _FakeChain(ExtractionResult(title="Deck", text="revenue", backend="local"))
+        ingest = AsyncMock(return_value={"article": "a1"})
+        _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(path), ingest=ingest)
+
+        await index_uploaded_file(_event())
+
+        assert cap.requests == [], "a capped workspace still called the model"
+        doc = await budget_store.get_doc_scoped("f1", "w1")
+        assert doc is not None
+        assert doc.summary is None
+        assert doc.tags
+        ingest.assert_awaited_once()
+
+    async def test_an_existing_shelf_is_not_removed_by_comprehension(
+        self, budget_store, monkeypatch, proxy, tmp_path
+    ):
+        """A shelf a person put this file on is not the model's to take away."""
+        from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+        monkeypatch.setenv("POCKETPAW_FILE_COMPREHENSION_DAILY", "10")
+        proxy(_model_reply("A deck.", ["deck"]))
+
+        await budget_store.save_scoped(_record(), workspace="w1")
+        await budget_store.set_library_metadata("f1", "w1", collections=["research"])
+
+        path = tmp_path / "deck.pdf"
+        path.write_bytes(b"unused")
+        chain = _FakeChain(ExtractionResult(title="Deck", text="revenue", backend="local"))
+        _wire(
+            monkeypatch,
+            chain=chain,
+            adapter=_FakeAdapter(path),
+            ingest=AsyncMock(return_value={"article": "a1"}),
+        )
+
+        await index_uploaded_file(_event())
+
+        doc = await budget_store.get_doc_scoped("f1", "w1")
+        assert doc is not None
+        assert doc.collections == ["research", "deck"]

--- a/tests/mutations/file_comprehension.json
+++ b/tests/mutations/file_comprehension.json
@@ -1,0 +1,130 @@
+[
+  {
+    "label": "the controlled vocabulary stops being controlled — anything the model invents becomes a shelf",
+    "file": "ee/pocketpaw_ee/cloud/uploads/comprehension.py",
+    "find": "        if value not in CATEGORIES or value in seen:",
+    "replace": "        if value in seen:",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheVocabularyIsClosed::test_a_category_outside_the_list_is_dropped",
+      "tests/cloud/uploads/test_comprehension.py::TestTheVocabularyIsClosed::test_nothing_is_mapped_to_the_nearest_legal_value"
+    ]
+  },
+  {
+    "label": "the three-category cap is removed — a file lands on every shelf and therefore on none",
+    "file": "ee/pocketpaw_ee/cloud/uploads/comprehension.py",
+    "find": "        if len(out) >= MAX_CATEGORIES:\n            break",
+    "replace": "        if False:\n            break",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheVocabularyIsClosed::test_more_than_three_categories_are_capped"
+    ]
+  },
+  {
+    "label": "the input cap is removed — a 400-page PDF becomes a 400-page prompt",
+    "find": "    if len(stripped) <= MAX_INPUT_CHARS:\n        return stripped",
+    "file": "ee/pocketpaw_ee/cloud/uploads/comprehension.py",
+    "replace": "    if True:\n        return stripped",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheInputIsCapped::test_oversized_text_is_truncated_before_the_call"
+    ]
+  },
+  {
+    "label": "an x-api-key rides along — the gateway forwards it upstream and a user's own key pays to summarise their upload",
+    "file": "ee/pocketpaw_ee/cloud/uploads/comprehension.py",
+    "find": "    headers = {\"Content-Type\": \"application/json\"}",
+    "replace": "    headers = {\"Content-Type\": \"application/json\", \"x-api-key\": \"a-tenants-own-key\"}",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestThePlatformPaysNotTheUser::test_the_request_never_carries_an_x_api_key"
+    ]
+  },
+  {
+    "label": "the model call stops failing open — a dead proxy raises out of comprehend instead of returning None",
+    "file": "ee/pocketpaw_ee/cloud/uploads/comprehension.py",
+    "find": "            payload[\"model\"],\n            exc_info=True,\n        )\n        return None",
+    "replace": "            payload[\"model\"],\n            exc_info=True,\n        )\n        raise",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestFailureReturnsNone::test_a_non_2xx_is_none"
+    ]
+  },
+  {
+    "label": "the listener stops containing comprehension — a raise in the pass takes the whole upload down with it",
+    "file": "ee/pocketpaw_ee/cloud/uploads/listeners.py",
+    "find": "    except Exception:\n        logger.exception(\n            \"file comprehension failed for file_id=%s; the file stays indexed, tagged and usable\",",
+    "replace": "    except KeyboardInterrupt:\n        logger.exception(\n            \"file comprehension failed for file_id=%s; the file stays indexed, tagged and usable\",",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheListener::test_a_raising_comprehension_does_not_take_the_upload_down"
+    ]
+  },
+  {
+    "label": "the hide-from-AI gate is removed — a file the user hid from AI is sent to a model",
+    "file": "ee/pocketpaw_ee/cloud/uploads/listeners.py",
+    "find": "    if getattr(doc, \"hide_from_ai\", False):",
+    "replace": "    if False and getattr(doc, \"hide_from_ai\", False):",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheListener::test_hide_from_ai_means_ZERO_model_calls",
+      "tests/cloud/uploads/test_listener_auto_tag.py::test_hide_from_ai_skips_ingest_and_tags"
+    ]
+  },
+  {
+    "label": "the daily cap is ignored at the call site — a refused claim generates anyway",
+    "file": "ee/pocketpaw_ee/cloud/uploads/listeners.py",
+    "find": "        allowed, spent, cap = await comprehension_budget.try_spend(workspace_id)\n        if not allowed:",
+    "replace": "        allowed, spent, cap = await comprehension_budget.try_spend(workspace_id)\n        if False:",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheListener::test_an_exhausted_cap_leaves_the_file_indexed_and_tagged"
+    ]
+  },
+  {
+    "label": "the counter fails OPEN — a degraded database becomes an open tab at the model",
+    "file": "ee/pocketpaw_ee/cloud/uploads/comprehension_budget.py",
+    "find": "            exc_info=True,\n        )\n        return False, 0, cap",
+    "replace": "            exc_info=True,\n        )\n        return True, 0, cap",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheDailyCap::test_an_unreadable_counter_fails_CLOSED"
+    ]
+  },
+  {
+    "label": "off by one at the ceiling — a cap of 2 serves 3",
+    "file": "ee/pocketpaw_ee/cloud/uploads/comprehension_budget.py",
+    "find": "    if spent > cap:",
+    "replace": "    if spent > cap + 1:",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheDailyCap::test_the_cap_refuses_the_next_claim"
+    ]
+  },
+  {
+    "label": "a workspace with no tenancy is charged to nobody and served anyway",
+    "file": "ee/pocketpaw_ee/cloud/uploads/comprehension_budget.py",
+    "find": "        logger.warning(\"file comprehension refused — no workspace on the event\")\n        return False, 0, cap",
+    "replace": "        logger.warning(\"file comprehension refused — no workspace on the event\")\n        return True, 0, cap",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheDailyCap::test_no_workspace_is_refused"
+    ]
+  },
+  {
+    "label": "a human's summary is overwritten by the next ingest's guess",
+    "file": "ee/pocketpaw_ee/cloud/uploads/listeners.py",
+    "find": "        if (existing_summary or \"\").strip():",
+    "replace": "        if False:",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheListener::test_a_human_set_summary_survives_reingest"
+    ]
+  },
+  {
+    "label": "collections stops merging — the model's shelves replace the ones a person chose",
+    "file": "ee/pocketpaw_ee/cloud/uploads/listeners.py",
+    "find": "        merged = merge_tags(existing_collections, understood.categories)",
+    "replace": "        merged = list(understood.categories)",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestTheListener::test_an_existing_shelf_is_not_removed_by_comprehension"
+    ]
+  },
+  {
+    "label": "a reply with no summary is written anyway — the row grows an empty subtitle",
+    "file": "ee/pocketpaw_ee/cloud/uploads/comprehension.py",
+    "find": "    if not isinstance(summary, str) or not summary.strip():",
+    "replace": "    if not isinstance(summary, str):",
+    "tests": [
+      "tests/cloud/uploads/test_comprehension.py::TestFailureReturnsNone::test_a_missing_summary_is_none_even_with_good_categories"
+    ]
+  }
+]


### PR DESCRIPTION
`/files` already stores tags, collections and `hide_from_ai`, already runs an
extraction pass on upload, and already exposes agent verbs. What it could not do
is understand anything.

`derive_tags` ranks keywords by frequency — its own docstring says it never calls
a model. It tags a board deck `q3`, `revenue`, `slide`. It cannot say it IS a
board deck. `collections` has existed on the document since the Library shipped
and nothing has ever written to it. There was no summary field at all.

So the library was a filing cabinet with the labels torn off: BM25 over raw
extracted text, and finding a file meant already knowing its name.

This adds one cheap model call to the extraction pass that already runs, with
the text already in hand. It writes a 2-3 sentence summary of what the file is,
and up to three categories from a fixed vocabulary.

## The vocabulary is controlled on purpose

contract, invoice, deck, spec, research, design, correspondence, data, media,
other. Append-only — removing a value strands existing rows.

Free-form was the tempting choice and it is exactly why today's tags do not make
a usable filter: two invoices become `invoice`, `billing` and `finance`, and
nothing groups. A category outside the list is dropped rather than mapped to the
nearest legal value, because a wrong category is worse than no category — it
looks like a filter that works.

Tags are untouched. Replacing keyword-frequency tags with model-suggested ones
is a separate change and is deliberately not bundled here.

## It cannot cost you a file

Failure is one-directional throughout. A dead proxy, a 404 model id, a model
answering in prose instead of JSON, a category nobody has heard of — every one
returns None and the file is still stored, still indexed, still tagged, still
usable. The user asked to store a file, not to have it understood.

`hide_from_ai` is checked before any of it. A summary a person wrote is never
overwritten by a later guess, and collections merge rather than replace.

## The header that must never appear

The gateway now forwards a client `x-api-key` upstream so a user's own key pays
for their turns. This is a platform call, not a turn: attaching one — even by
copying a header dict from the turn path — would quietly bill a user's Anthropic
account to summarise their own uploads. The header builder starts from an empty
dict and carries only Authorization and Content-Type, and a test asserts the
absence, because "we just won't add it" is not a control.

## Cost ceiling

`POCKETPAW_FILE_COMPREHENSION_DAILY`, default 500 per workspace per UTC day.
Atomic upsert, incremented before the comparison because check-then-increment
lets two concurrent uploads both pass. Fails closed: an unreadable counter means
no, since being wrong that way costs a file its summary and the other way is an
open tab.

## A live bug this found

The sibling illustration budget on `feat/other-hand-illustrate-tool` called
`get_motor_collection()`, which is beanie 1.x against this repo's 2.1.0. The
AttributeError landed in its fail-closed handler, so that budget refused every
claim and the feature read as switched off rather than broken. Fixed on that
branch, in its own commit, with a test that asserts the accessor exists.

## Verification

26 new tests. 14 mutations, all caught — the vocabulary un-controlled, the caps
removed, `hide_from_ai` gone, fail-open flipped, the counter failing open, an
off-by-one at the ceiling, a workspace with no tenancy served free, a human's
summary overwritten, an `x-api-key` riding along.

`tests/cloud/uploads` runs 23 failed / 196 passed. Those 23 are pre-existing:
checking the modified files out at the base commit reproduces exactly 23 failed
/ 170 passed. All are `test_router*` returning 401 on POST /uploads, an
auth-plumbing issue in the test app upstream of anything here. This branch moves
the pass count 170 to 196.

import-linter: 1 kept and 36 kept, 0 broken. ruff clean.

## Not verified

**The default model id.** The proxy config lives in Coolify file storage, not in
this repo, and the documented host returned 503 on two probes today. Resolution
is `POCKETPAW_FILE_COMPREHENSION_MODEL`, then `settings.litellm_model`, then a
constant traced to a gateway probe from June. That observation is two months old.
Someone with proxy access should run `GET {BASE}/v1/models` and correct the
fallback — the instruction is in the constant's docstring. A model id that 404s
makes the feature silently never run, which is the failure mode worth catching
before merge.

No real upload has been through a live proxy; every model interaction in the
tests is a mock transport. Cap atomicity rests on Mongo's find_one_and_update
semantics and is asserted by construction, not observed under concurrent load.

The two new env vars are documented in-module but not yet in the root CLAUDE.md
Files-as-Knowledge list.
