### PR TITLE
Make an agent of this book

### DIFF
--- a/ee/pocketpaw_ee/cloud/files/dto.py
+++ b/ee/pocketpaw_ee/cloud/files/dto.py
@@ -1,5 +1,12 @@
 """Public schemas for the files module.
 
+2026-08-29 (BA-1 "Make an agent of this book"): ``FileEntry`` grew
+``agent_id`` (``str | None``) — the dedicated co-reader agent made from this
+file. Only the uploads provider sets it (it is the only provider whose rows
+can be turned into an agent); every other provider leaves the ``None``
+default. The listing needs it to decide between "Make an agent of this book"
+and "Open the agent" without a per-row round trip.
+
 2026-07-03 (FL-1 "Library metadata"): ``FileEntry`` grew ``collections``
 (list[str]) and ``hide_from_ai`` (bool) alongside the existing ``tags`` so a
 file's library metadata surfaces in the unified /files listing. Both default
@@ -57,6 +64,9 @@ class FileEntry(BaseModel):
     # other providers leave the defaults (empty list / False).
     collections: list[str] = Field(default_factory=list)
     hide_from_ai: bool = False
+    # BA-1 book-agent bind. ``None`` means no agent has been made from this
+    # file yet. Uploads-provider only; other providers keep the default.
+    agent_id: str | None = None
     created_at: datetime
     updated_at: datetime
     source_ref: dict[str, Any] = Field(default_factory=dict)

--- a/ee/pocketpaw_ee/cloud/files/providers/uploads.py
+++ b/ee/pocketpaw_ee/cloud/files/providers/uploads.py
@@ -4,6 +4,12 @@ Scope is personal to the current user within the current workspace. Ownership
 drives RBAC: the owner has full CRUD; workspace admins get manage; everyone
 else is read-only.
 
+2026-08-29 (BA-1 "Make an agent of this book"): ``_to_entry`` also surfaces
+``agent_id`` — the dedicated co-reader agent made from this file — so the
+library can render "Open the agent" instead of "Make an agent of this book"
+without asking per row. Defensive read like the FL-1 fields: a dict row
+without the key maps to ``None``. Folder entries never carry one.
+
 2026-07-03 (FL-1 "Library metadata"): ``_to_entry`` now surfaces the file's
 ``collections`` and ``hide_from_ai`` metadata (alongside the pre-existing
 ``tags``) onto the ``FileEntry`` so the unified /files listing carries them.
@@ -152,6 +158,7 @@ class UploadsProvider(BaseFolderProvider):
             tags=list(doc.get("tags", [])),
             collections=list(doc.get("collections", [])),
             hide_from_ai=bool(doc.get("hide_from_ai", False)),
+            agent_id=doc.get("agent_id"),
             created_at=doc["created_at"],
             updated_at=doc.get("updated_at", doc["created_at"]),
             source_ref={},

--- a/ee/pocketpaw_ee/cloud/uploads/book_agent.py
+++ b/ee/pocketpaw_ee/cloud/uploads/book_agent.py
@@ -274,12 +274,17 @@ async def ensure_book_agent(
             await agents_service.get(existing_id)
             return BookAgentResult(agent_id=existing_id, created=False, indexed=True)
         except NotFound:
-            # Stale bind (agent deleted) — fall through and re-provision.
+            # Stale bind (agent deleted) — fall through and re-provision. Clear
+            # it FIRST: if the re-provision then fails (unreadable file, ingest
+            # error), the row would otherwise keep pointing at a deleted agent
+            # and the library would offer "open" on a dead id. The invariant is
+            # that a bind always names a live agent that has read the book.
             logger.info(
                 "book agent: file %s bound to missing agent %s; re-provisioning",
                 file_id,
                 existing_id,
             )
+            await store.set_book_agent(file_id, file_workspace, agent_id=None)
 
     # (4) Extract first — the name comes from the title, and a file we cannot
     # read must not leave an agent behind.
@@ -326,6 +331,10 @@ async def ensure_book_agent(
         return BookAgentResult(agent_id=agent.id, created=created, indexed=False)
 
     # (7) Bind the file to the agent — the idempotency key for the next press.
+    # no-event: the visible artifact is the agent, and ``agents.service.create``
+    # already emitted ``AgentCreated`` for it. This write is uploads-internal
+    # bookkeeping on a row nothing subscribes to; an event here would announce
+    # the same thing twice, and on the adopt path announce nothing new at all.
     bound = await store.set_book_agent(file_id, file_workspace, agent_id=agent.id)
     if bound is None:
         # The row vanished under us (deleted mid-provision). The agent read the

--- a/ee/pocketpaw_ee/cloud/uploads/book_agent.py
+++ b/ee/pocketpaw_ee/cloud/uploads/book_agent.py
@@ -1,0 +1,374 @@
+# book_agent.py — provision ONE dedicated co-reader agent per uploaded book.
+#
+# Created 2026-08-29 (BA-2, "Make an agent of this book"): a user opens a PDF
+# in /files, presses one button, and gets an agent that has READ that book and
+# can talk about it. This module is the whole provisioning path.
+#
+# It is deliberately the same idiom as ``paw_bar.agent_provisioning.
+# ensure_site_agent`` (the site-concierge provisioner) rather than a second
+# one: idempotent, tenant-filtered, one dedicated agent, a deterministic slug
+# as the backstop against duplicates, and an existing LIVE bind that is never
+# overwritten. Read that function before changing this one.
+#
+# NOTHING TO WIRE ON THE CHAT SIDE. ``chat.agent_service._kb_scopes_for_context``
+# already searches ``agent:{id}`` on every turn, so ingesting the book into that
+# scope is the entire "it has read the book" mechanic.
+#
+# ORDER MATTERS — extract BEFORE create. The spec's numbered steps read
+# create-then-extract, but the agent's NAME comes from the extracted title, and
+# extracting first means an unreadable file leaves ZERO artifacts behind instead
+# of a nameless agent nobody asked for.
+#
+# FAILURE POLICY (each failure is chosen, not inherited):
+#   * File missing / wrong workspace  -> NotFound. The tenant filter is the
+#     read itself, so a cross-tenant press is indistinguishable from a typo.
+#   * ``hide_from_ai`` set            -> Forbidden. FL-11b made the upload
+#     listener fail CLOSED on hidden files; ingesting the same bytes into an
+#     ``agent:{id}`` scope through a different door would walk straight around
+#     that privacy gate. Same gate, same answer.
+#   * Extraction fails / no text      -> raise, nothing created. A co-reader
+#     that has read nothing is not a degraded feature, it is a broken one.
+#   * Agent creation fails            -> raise, and the file is NOT bound. The
+#     feature failed; leaving a half-bound row would make the next press return
+#     a dangling id.
+#   * INGEST fails after the agent exists -> do NOT raise and do NOT delete the
+#     agent — the user can already see it in their agent list, and deleting a
+#     visible thing is worse than an honest partial. Return ``indexed=False``
+#     and leave the file UNBOUND: the bind is written only on the success path,
+#     so the next press retries the ingest, and the deterministic slug makes
+#     that retry ADOPT the same agent instead of minting a second one. That is
+#     why ``indexed`` is on the result at all — the caller has to tell the user
+#     "your agent is here but it hasn't finished reading."
+#
+# KNOWN COST: the text is extracted AGAIN here. The upload listener already
+# extracted this exact file at upload time, but it only persisted the derived
+# kb-go article, never the raw text, so there is nothing to reuse — see the
+# module's ``_extract_text`` note.
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pocketpaw_ee.cloud._core.errors import Forbidden, Internal, NotFound, ValidationError
+from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+from pocketpaw_ee.cloud.uploads.resolver import materialize_to_local_path
+
+logger = logging.getLogger(__name__)
+
+# Agent.name is capped at 100 by the create DTO; truncate rather than 422.
+_MAX_AGENT_NAME = 100
+
+# The soul archetype every book agent carries. Mirrors the concierge's
+# ``_CONCIERGE_ARCHETYPE`` — one archetype per provisioned agent species.
+_BOOK_ARCHETYPE = "The Co-Reader"
+
+# Separators a filename uses where a title would use a space.
+_FILENAME_SEPARATORS = re.compile(r"[_\-.]+")
+_WHITESPACE = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class BookAgentResult:
+    """Outcome of one ``ensure_book_agent`` call.
+
+    ``created`` — this call minted the agent (False when an existing live bind
+    was returned unchanged, or when a retry adopted an agent left behind by an
+    earlier failed ingest).
+
+    ``indexed`` — the book's text is in the agent's knowledge scope. True on a
+    successful ingest AND on the idempotent early return: the bind is only ever
+    written after an ingest succeeds, so a bind's existence IS the proof. False
+    means the agent exists but has not read the book yet — the caller must say
+    so rather than pretending it is ready.
+    """
+
+    agent_id: str
+    created: bool
+    indexed: bool
+
+
+def book_agent_slug(file_id: str) -> str:
+    """Deterministic, workspace-unique slug for a file's co-reader agent.
+
+    Deterministic on the file id so a retry after a partial provision (agent
+    created, ingest failed, bind withheld) RESOLVES the same agent by slug
+    instead of minting a duplicate. This is the second half of the duplicate
+    guard — the persisted ``agent_id`` bind is the first. ``book-`` + a 32-char
+    uuid4 hex fits the DTO's 50-char slug cap.
+    """
+    return f"book-{file_id}"
+
+
+def book_agent_name(title: str | None, filename: str) -> str:
+    """The agent's display name: the BOOK's name, never the file's.
+
+    A user thinks of "Thinking, Fast and Slow", not
+    ``thinking-fast-and-slow_final_v2.pdf``. Prefer the title extraction
+    detected; otherwise clean the filename into something a human would
+    recognise — drop the extension, turn separators into spaces, collapse
+    runs of whitespace. Falls back to a generic name when there is nothing
+    left (a file called ``.pdf``), because ``Agent.name`` has a min_length of 1.
+    """
+    detected = (title or "").strip()
+    if detected:
+        return detected[:_MAX_AGENT_NAME]
+
+    stem = Path(filename or "").stem
+    cleaned = _WHITESPACE.sub(" ", _FILENAME_SEPARATORS.sub(" ", stem)).strip()
+    return (cleaned or "This Book")[:_MAX_AGENT_NAME]
+
+
+def book_agent_persona(book_name: str) -> str:
+    """The soul persona seeded on the agent — a CO-READER, not an assistant.
+
+    The distinction is the product: this agent has read one book and talks
+    about that book with someone else who is reading it. Saying so in the
+    persona is what keeps it from answering as a general-purpose helper that
+    happens to have a document attached.
+    """
+    subject = (book_name or "").strip() or "this book"
+    return (
+        f'You are a co-reader of "{subject}". You have read it closely and you '
+        "discuss it with the person reading it now — what it argues, where it "
+        "goes, what a passage means, how one part answers another. Ground every "
+        "answer in the book itself and quote it where that helps. When something "
+        "falls outside the book, say so plainly rather than filling the gap."
+    )
+
+
+def _resolve_adapter() -> Any | None:
+    """The EE upload singleton's storage adapter, or ``None``.
+
+    Imported inside the function (not at module scope) for the same reason the
+    upload listener does it: the router owns the singleton, so an import-time
+    dependency here would invert that and freeze the adapter for tests that
+    monkeypatch it.
+    """
+    try:
+        from pocketpaw_ee.cloud.uploads.router import _ADAPTER
+
+        return _ADAPTER
+    except Exception:
+        logger.exception("book agent: upload adapter import failed")
+        return None
+
+
+async def _extract_text(doc: Any) -> tuple[str, str | None]:
+    """Return ``(text, title)`` for the file, or raise.
+
+    THE RE-EXTRACTION NOTE. This runs the same chain the FileReady listener ran
+    at upload time. The listener persists the compiled kb-go article and the
+    article id, never the raw extracted text, so there is genuinely nothing
+    cheaper to read back — reusing the workspace-scope article would hand the
+    agent kb's lossy summary instead of the book. Re-extraction is therefore
+    correct here, just not free: a large PDF pays the full chain again
+    (seconds to tens of seconds locally; a cloud extractor adds its round trip).
+    If this ever needs to be fast, the fix is upstream — persist the extracted
+    text at upload — not a shortcut here.
+    """
+    adapter = _resolve_adapter()
+    storage_key = getattr(doc, "storage_key", "") or ""
+    if adapter is None or not storage_key:
+        raise Internal(
+            "file.extraction_unavailable",
+            "This file's storage is not reachable, so its text cannot be read.",
+        )
+
+    filename = getattr(doc, "filename", "") or "upload"
+    mime = getattr(doc, "mime", "") or "application/octet-stream"
+
+    async with materialize_to_local_path(
+        adapter, storage_key, mime=mime, filename=filename
+    ) as path:
+        if path is None:
+            raise Internal(
+                "file.extraction_unavailable",
+                "This file's bytes could not be read from storage.",
+            )
+        try:
+            from pocketpaw.config import get_settings
+            from pocketpaw_ee.cloud.extraction import build_chain
+
+            chain = build_chain(get_settings())
+            result = await chain.run(path, mime)
+        except Exception as exc:
+            logger.exception("book agent: extraction failed for file_id=%s", doc.file_id)
+            raise Internal(
+                "file.extraction_failed",
+                "This file's text could not be extracted.",
+            ) from exc
+
+    text = (result.text or "").strip()
+    if not text:
+        # An image-only scan, or a format the chain can't read. Refused BEFORE
+        # anything is created — a co-reader with nothing to read is not a
+        # partial success. (The upload listener skips indexing in the same
+        # case; this is the interactive equivalent of that skip.)
+        raise ValidationError(
+            "file.no_text",
+            "No readable text was found in this file, so no agent was made from it.",
+        )
+    return text, result.title
+
+
+async def ensure_book_agent(
+    file_id: str,
+    workspace_id: str,
+    user_id: str,
+) -> BookAgentResult:
+    """Idempotently ensure ``file_id`` has a dedicated co-reader agent.
+
+    Returns the bound agent's id plus whether THIS call created it and whether
+    the book's text is in its knowledge scope. Raises ``NotFound`` for a file
+    that does not exist in ``workspace_id`` (a cross-tenant press is a 404, not
+    a 403 — the caller learns nothing about another tenant's rows).
+
+    One agent per file, guaranteed twice over: by the persisted ``agent_id``
+    bind and, if that is absent, by the deterministic slug. Never overwrites a
+    live bind; a STALE bind (the agent was deleted) is not a permanent failure
+    and re-provisions.
+    """
+    # Lazy imports, exactly as the concierge provisioner does it: the agents
+    # service and the knowledge service pull in heavy trees, and keeping them
+    # inside the call is what keeps this module's import edges inside the
+    # existing import-linter contracts.
+    from pocketpaw_ee.cloud._core.errors import ConflictError
+    from pocketpaw_ee.cloud.agents import service as agents_service
+    from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+
+    if not file_id or not workspace_id:
+        raise ValidationError("file.invalid", "A file id and workspace are required.")
+
+    store = MongoFileStore()
+
+    # (1) Load the file THROUGH the tenant filter. ``get_doc_scoped`` applies
+    # workspace + not-deleted, so another workspace's file simply isn't found.
+    doc = await store.get_doc_scoped(file_id, workspace_id)
+    if doc is None:
+        raise NotFound("file", file_id)
+
+    # (2) FL-11b's privacy gate, enforced on this door too. A file the owner
+    # has hidden from AI must not reach a KB scope by any route.
+    if getattr(doc, "hide_from_ai", False):
+        raise Forbidden(
+            "file.hidden_from_ai",
+            "This file is hidden from AI, so no agent can be made from it.",
+        )
+
+    # The FILE's workspace is authoritative for everything that follows — it
+    # equals ``workspace_id`` by construction of the read above, and using the
+    # row's own value keeps a future refactor of the read from widening tenancy.
+    file_workspace = doc.workspace
+    filename = doc.filename or "upload"
+
+    # (3) Respect an existing LIVE bind — press twice, get the same agent, and
+    # do no work at all (no re-extraction, no re-ingest). A bind is only ever
+    # written after a successful ingest, so a live bind means indexed.
+    existing_id = getattr(doc, "agent_id", "") or ""
+    if existing_id:
+        try:
+            await agents_service.get(existing_id)
+            return BookAgentResult(agent_id=existing_id, created=False, indexed=True)
+        except NotFound:
+            # Stale bind (agent deleted) — fall through and re-provision.
+            logger.info(
+                "book agent: file %s bound to missing agent %s; re-provisioning",
+                file_id,
+                existing_id,
+            )
+
+    # (4) Extract first — the name comes from the title, and a file we cannot
+    # read must not leave an agent behind.
+    text, title = await _extract_text(doc)
+    book_name = book_agent_name(title, filename)
+
+    # (5) Resolve-or-create the dedicated agent on the deterministic slug, so a
+    # retry after a failed ingest adopts the agent already made rather than
+    # minting a second one for the same book.
+    slug = book_agent_slug(file_id)
+    ctx = agents_service.legacy_ctx(user_id, file_workspace)
+
+    created = False
+    try:
+        agent = await agents_service.get_by_slug(file_workspace, slug)
+    except NotFound:
+        agent = None
+
+    if agent is None:
+        body = CreateAgentRequest(
+            name=book_name,
+            slug=slug,
+            # Workspace-visible like the concierge: the file's owner and the
+            # admin who may have pressed the button both need to reach it.
+            visibility="workspace",
+            persona=book_agent_persona(book_name),
+            soul_archetype=_BOOK_ARCHETYPE,
+            # soul_enabled defaults True — a co-reader carries a soul.
+        )
+        try:
+            agent = await agents_service.create(ctx, file_workspace, body)
+            created = True
+        except ConflictError:
+            # Lost a create race on the deterministic slug — adopt the winner.
+            agent = await agents_service.get_by_slug(file_workspace, slug)
+
+    # (6) Give it the book. ``agent:{id}`` is the scope every turn of that
+    # agent's chat already searches, so this one call is what "it has read the
+    # book" means. Failure here is NOT fatal: the agent exists and the user can
+    # see it, so we keep it, report ``indexed=False``, and leave the file
+    # unbound so the next press retries the ingest against this same agent.
+    indexed = await _ingest_book(agent.id, text, filename)
+    if not indexed:
+        return BookAgentResult(agent_id=agent.id, created=created, indexed=False)
+
+    # (7) Bind the file to the agent — the idempotency key for the next press.
+    bound = await store.set_book_agent(file_id, file_workspace, agent_id=agent.id)
+    if bound is None:
+        # The row vanished under us (deleted mid-provision). The agent read the
+        # book and still works; only the shortcut back to it is lost.
+        logger.warning(
+            "book agent: agent %s ingested %s but the file row was gone at bind time",
+            agent.id,
+            file_id,
+        )
+    return BookAgentResult(agent_id=agent.id, created=created, indexed=True)
+
+
+async def _ingest_book(agent_id: str, text: str, filename: str) -> bool:
+    """Ingest the book into ``agent:{id}``; ``True`` on success.
+
+    Swallows the failure ON PURPOSE (see the module's failure policy): the
+    caller has an agent it must not throw away, and the boolean is how that
+    partial state travels back to the user instead of a 500.
+    """
+    from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+    try:
+        await KnowledgeService.ingest_text_to_scope(
+            scope=f"agent:{agent_id}",
+            text=text,
+            source=filename,
+        )
+        return True
+    except Exception:
+        logger.exception(
+            "book agent: KB ingest failed for agent %s (source=%s); the agent "
+            "exists but has not read the book — the file stays unbound so the "
+            "next press retries",
+            agent_id,
+            filename,
+        )
+        return False
+
+
+__all__ = [
+    "BookAgentResult",
+    "book_agent_name",
+    "book_agent_persona",
+    "book_agent_slug",
+    "ensure_book_agent",
+]

--- a/ee/pocketpaw_ee/cloud/uploads/models.py
+++ b/ee/pocketpaw_ee/cloud/uploads/models.py
@@ -1,5 +1,16 @@
 """EE FileUpload document — Mongo metadata for blobs stored via StorageAdapter.
 
+2026-08-29 — BA-1 "Make an agent of this book". Added ``agent_id``
+(``str | None``, default ``None``) so a file REMEMBERS the dedicated
+co-reader agent provisioned from it. Without the column, pressing "Make an
+agent of this book" twice would mint two agents for one book. The bind is
+written by ``uploads.book_agent`` only AFTER the book text lands in the
+agent's KB scope — an agent that exists but hasn't read the book yet stays
+unbound on purpose, so the next press retries the ingest instead of
+returning a co-reader that knows nothing. Legacy rows read back ``None``
+via the default (Beanie field-add, no migration). Not indexed: it's read
+only after a row has already been resolved by ``file_id``.
+
 2026-07-03 — FL-11b "hide-from-AI purge". Added ``kb_article_id`` and
 ``kb_scope`` (both ``str | None``, default ``None``) so a row remembers the
 kb-go article it was ingested into. The FileReady listener records them after a
@@ -84,6 +95,13 @@ class FileUpload(TimestampedDocument):
     # a later re-index re-populates these. Legacy rows read ``None``.
     kb_article_id: str | None = None
     kb_scope: str | None = None
+    # Book-agent bind (BA-1). The id of the dedicated co-reader agent made
+    # from this file, or ``None`` when none has been made. This is the
+    # idempotency key for "Make an agent of this book": a live bind short-
+    # circuits the whole provision path. Written only after a successful
+    # ingest — see the module docstring for why a half-provisioned agent
+    # deliberately leaves this ``None``.
+    agent_id: str | None = None
 
     class Settings:
         name = "file_uploads"

--- a/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
@@ -1,5 +1,15 @@
 """Mongo-backed metadata store, workspace-scoped.
 
+2026-08-29 (BA-1 "Make an agent of this book"): added ``set_book_agent`` —
+the workspace-scoped setter ``uploads.book_agent`` uses to bind a file to the
+dedicated co-reader agent made from it, shaped exactly like ``set_kb_article``
+(read the row through the workspace filter, then write). ``book_agent`` never
+touches Beanie itself; this store stays the only owner of ``FileUpload``
+writes in the package. The ``iter_by_workspace`` / ``iter_by_pocket`` dict rows
+also carry ``agent_id`` now, so the /files listing can render "open the agent"
+instead of "make one" without a second query — the same way ``tags`` is
+threaded.
+
 2026-08-04 (Living-wiki API): ``iter_by_workspace`` rows now also carry
 ``kb_article_id`` and ``kb_scope`` (the FL-11b ingest-tracking columns) so
 GET /knowledge/uploads can derive ``has_article`` without a second query,
@@ -146,6 +156,28 @@ class MongoFileStore:
             return None
         doc.kb_article_id = article_id
         doc.kb_scope = scope
+        await doc.save()
+        return doc
+
+    async def set_book_agent(
+        self,
+        file_id: str,
+        workspace: str,
+        *,
+        agent_id: str | None,
+    ) -> FileUpload | None:
+        """Bind (or clear) this file's dedicated book agent (BA-1).
+
+        Workspace-scoped like every other write here — the filter is applied on
+        the read, so a caller cannot bind another tenant's row. Pass an agent id
+        after the book's text has landed in that agent's KB scope; pass ``None``
+        to clear a bind (e.g. the agent was deleted). Returns the updated doc,
+        or ``None`` if no live row matches ``(file_id, workspace)``.
+        """
+        doc = await self.get_doc_scoped(file_id, workspace)
+        if doc is None:
+            return None
+        doc.agent_id = agent_id
         await doc.save()
         return doc
 
@@ -320,6 +352,9 @@ class MongoFileStore:
                 "kb_article_id": getattr(doc, "kb_article_id", None),
                 "kb_scope": getattr(doc, "kb_scope", None),
                 "pocket_id": getattr(doc, "pocket_id", None),
+                # BA-1: the dedicated co-reader agent made from this file, so
+                # the listing can offer "open" vs "make" without a second read.
+                "agent_id": getattr(doc, "agent_id", None),
             }
 
     async def list_by_workspace(
@@ -427,6 +462,9 @@ class MongoFileStore:
                 "tags": list(getattr(doc, "tags", []) or []),
                 "collections": list(getattr(doc, "collections", []) or []),
                 "hide_from_ai": bool(getattr(doc, "hide_from_ai", False)),
+                # BA-1: same bind the workspace listing carries — a pocket's
+                # Files panel offers the book agent on the same terms.
+                "agent_id": getattr(doc, "agent_id", None),
             }
 
     async def count_by_pocket(self, workspace: str, pocket_id: str) -> int:

--- a/ee/pocketpaw_ee/cloud/uploads/router.py
+++ b/ee/pocketpaw_ee/cloud/uploads/router.py
@@ -1,5 +1,17 @@
 """EE /uploads router — workspace-scoped upload endpoints.
 
+2026-08-29 (BA-3 "Make an agent of this book"): added
+``POST /uploads/{file_id}/agent`` — press once, get a dedicated co-reader
+agent that has read this file. All the provisioning logic lives in
+``uploads.book_agent``; the route is the tenant boundary and nothing else.
+PATH NOTE: the feature is pressed from the /files library, but the endpoint
+lives under this router's ``/uploads`` prefix because that is where the
+native ``file_id``, the tenant deps and the write ACL already are — the
+/files surface addresses the same row as ``uploads:<file_id>``. Unlike its
+neighbours here (which predate the rule), this route raises ``CloudError``
+subclasses, never ``HTTPException``, per the ee/cloud error convention;
+``_core.http.cloud_error_handler`` renders them.
+
 2026-07-03 (FL-11b "hide-from-AI purge"): ``PATCH /uploads/{file_id}`` now
 retroactively purges a file's KB content when ``hide_from_ai`` flips false→true
 AND the row tracks a kb-go article (``kb_article_id`` + ``kb_scope`` recorded on
@@ -452,6 +464,56 @@ async def patch_upload(
         "tags": list(doc.tags or []),
         "collections": list(doc.collections or []),
         "hide_from_ai": bool(doc.hide_from_ai),
+    }
+
+
+@router.post(
+    "/{file_id}/agent",
+    dependencies=[Depends(require_action_any_workspace("uploads.write"))],
+)
+async def make_book_agent(
+    file_id: str,
+    workspace: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Make (or return) the dedicated co-reader agent for this file.
+
+    Idempotent — pressing twice returns the same agent with ``created:
+    false``. ``indexed`` reports whether the book's text is actually in the
+    agent's knowledge scope: ``false`` means the agent exists but the ingest
+    failed, and the caller should say so rather than presenting a co-reader
+    that has read nothing (pressing again retries the ingest against that
+    same agent).
+
+    Gated as a WRITE: it mutates the file row's ``agent_id`` bind, so it takes
+    the same ``uploads.write`` membership check as upload, plus the
+    owner-or-workspace-admin ACL the PATCH route uses. Everything below that
+    — tenancy, idempotency, failure policy — lives in ``book_agent``.
+    """
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.cloud._core.errors import NotFound as CloudNotFound
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    doc = await _META.get_doc_scoped(file_id, workspace=workspace)
+    if doc is None:
+        raise CloudNotFound("file", file_id)
+
+    # Write-side ACL — owner OR workspace admin, matching PATCH /uploads/{id}.
+    # Chat membership does NOT grant it: making an agent of someone's book is
+    # a write on their library row, not a read of a shared attachment.
+    if doc.owner != user_id:
+        try:
+            is_admin = await _is_workspace_admin(user_id, workspace)
+        except Exception:
+            is_admin = False
+        if not is_admin:
+            raise Forbidden("files.forbidden")
+
+    result = await ensure_book_agent(file_id, workspace, user_id)
+    return {
+        "agent_id": result.agent_id,
+        "created": result.created,
+        "indexed": result.indexed,
     }
 
 

--- a/tests/cloud/uploads/test_book_agent.py
+++ b/tests/cloud/uploads/test_book_agent.py
@@ -220,6 +220,28 @@ async def test_a_stale_bind_reprovisions(beanie_upload_db, store, wiring):
     assert doc.agent_id == result.agent_id
 
 
+async def test_a_stale_bind_is_cleared_even_if_the_reprovision_fails(
+    beanie_upload_db, store, wiring
+):
+    """A bind must never outlive the agent it names.
+
+    Stale bind + a re-provision that can't finish its ingest: the row must not
+    keep pointing at the deleted agent, or the library offers "open the agent"
+    on a dead id.
+    """
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    wiring.ingest.fail = True
+    await store.save_scoped(_record(), "w1")
+    await store.set_book_agent("f1", "w1", agent_id="agent-that-was-deleted")
+
+    result = await ensure_book_agent("f1", "w1", "u1")
+
+    assert result.indexed is False
+    doc = await store.get_doc_scoped("f1", "w1")
+    assert doc.agent_id is None
+
+
 # --- tenancy ---------------------------------------------------------------
 
 

--- a/tests/cloud/uploads/test_book_agent.py
+++ b/tests/cloud/uploads/test_book_agent.py
@@ -1,0 +1,401 @@
+# test_book_agent.py — BA-4. Tests for "Make an agent of this book".
+# Created: 2026-08-29 (BA-4). Covers the provisioning slice end to end against
+# real (mongomock) FileUpload rows, with the agents service, the extraction
+# chain and kb-go faked:
+#   (1) pressing twice returns the SAME agent, and does no work the second
+#       time — one create, one extraction, one ingest across both presses.
+#       The call COUNTS are the point: the deterministic slug means a missing
+#       idempotency check would still yield one agent, so counting creates
+#       alone cannot see the bug. Re-extracting a 400-page PDF on every press
+#       is the bug.
+#   (2) a stale bind (agent deleted out from under the file) re-provisions
+#       rather than failing forever.
+#   (3) another workspace's file is NotFound — the tenant filter is the read.
+#   (4) an ingest failure keeps the agent, reports indexed=False, and leaves
+#       the file unbound so the next press retries against that same agent.
+#   (5) the agent is named after the BOOK — extraction's title first, a
+#       cleaned-up filename otherwise.
+#   (6) the book lands in exactly ``agent:{id}`` — the scope the chat path
+#       already searches. Any other scope means the agent never read it.
+#   (7) a file hidden from AI is refused (FL-11b's gate, same answer here).
+#   (8) a file with no readable text makes no agent at all.
+#
+# Mutations that must break these tests live in tests/mutations/book_agent.json.
+"""Provisioning a dedicated co-reader agent from an uploaded book."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud.extraction.adapter import ExtractionResult
+
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- doubles ---------------------------------------------------------------
+
+
+class _FakeChain:
+    """Extraction chain that records how many times it actually ran."""
+
+    def __init__(self, result: ExtractionResult):
+        self._result = result
+        self.runs: list[tuple[Path, str]] = []
+
+    async def run(self, path: Path, mime: str) -> ExtractionResult:
+        self.runs.append((path, mime))
+        return self._result
+
+
+class _FakeAdapter:
+    def __init__(self, local_path_value: Path):
+        self._local = local_path_value
+
+    def local_path(self, key: str) -> Path | None:
+        return self._local
+
+    async def open(self, key: str):  # pragma: no cover — local path wins
+        yield b""
+
+
+class _FakeAgents:
+    """In-memory stand-in for the agents service.
+
+    Only the three functions the provisioner calls: ``create``, ``get`` and
+    ``get_by_slug``. ``creates`` is the list the duplicate tests assert on.
+    """
+
+    def __init__(self) -> None:
+        self.by_id: dict[str, SimpleNamespace] = {}
+        self.by_slug: dict[tuple[str, str], SimpleNamespace] = {}
+        self.creates: list[SimpleNamespace] = []
+        self._seq = 0
+
+    async def create(self, ctx, workspace_id, body):
+        self._seq += 1
+        agent = SimpleNamespace(
+            id=f"agent-{self._seq}",
+            name=body.name,
+            slug=body.slug,
+            persona=body.persona,
+            visibility=body.visibility,
+            workspace=workspace_id,
+            owner=ctx.user_id,
+        )
+        self.by_id[agent.id] = agent
+        self.by_slug[(workspace_id, body.slug)] = agent
+        self.creates.append(agent)
+        return agent
+
+    async def get(self, agent_id):
+        agent = self.by_id.get(agent_id)
+        if agent is None:
+            raise NotFound("agent", agent_id)
+        return agent
+
+    async def get_by_slug(self, workspace_id, slug):
+        agent = self.by_slug.get((workspace_id, slug))
+        if agent is None:
+            raise NotFound("agent", slug)
+        return agent
+
+
+class _FakeIngest:
+    """kb-go ingest double. Records every call; can be made to fail."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.calls: list[dict] = []
+        self.fail = fail
+
+    async def __call__(self, *, scope: str, text: str, source: str) -> dict:
+        self.calls.append({"scope": scope, "text": text, "source": source})
+        if self.fail:
+            raise RuntimeError("kb ingest exploded")
+        return {"article": "art-1"}
+
+
+def _record(**overrides) -> FileRecord:
+    defaults = {
+        "id": "f1",
+        "storage_key": "chat/202608/book.pdf",
+        "filename": "book.pdf",
+        "mime": "application/pdf",
+        "size": 1,
+        "owner_id": "u1",
+        "chat_id": None,
+        "created": datetime.now(UTC),
+    }
+    defaults.update(overrides)
+    return FileRecord(**defaults)
+
+
+@pytest.fixture()
+def wiring(monkeypatch, tmp_path):
+    """Patch the three seams ``ensure_book_agent`` reaches out through.
+
+    Patched at their SOURCE modules, because the provisioner imports them
+    lazily inside the call — patching a name it never binds would silently
+    do nothing and the tests would exercise the real services.
+    """
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads import book_agent
+
+    blob = tmp_path / "book.pdf"
+    blob.write_bytes(b"unused; the chain is faked")
+
+    chain = _FakeChain(ExtractionResult(text="the whole book", title=None, backend="local"))
+    agents = _FakeAgents()
+    ingest = _FakeIngest()
+
+    monkeypatch.setattr(book_agent, "_resolve_adapter", lambda: _FakeAdapter(blob))
+    monkeypatch.setattr("pocketpaw_ee.cloud.extraction.build_chain", lambda settings: chain)
+    monkeypatch.setattr("pocketpaw_ee.cloud.agents.service.create", agents.create)
+    monkeypatch.setattr("pocketpaw_ee.cloud.agents.service.get", agents.get)
+    monkeypatch.setattr("pocketpaw_ee.cloud.agents.service.get_by_slug", agents.get_by_slug)
+    monkeypatch.setattr(kn.KnowledgeService, "ingest_text_to_scope", ingest)
+
+    return SimpleNamespace(chain=chain, agents=agents, ingest=ingest, blob=blob)
+
+
+# --- idempotency -----------------------------------------------------------
+
+
+async def test_pressing_twice_returns_the_same_agent_and_does_no_work_twice(
+    beanie_upload_db, store, wiring
+):
+    """Two presses, one agent — and the second press re-reads nothing.
+
+    Mutation: delete the ``file.agent_id`` early return in
+    ``ensure_book_agent``. The create COUNT stays 1 (the deterministic slug
+    adopts the existing agent), so only the extraction / ingest counts catch
+    it — which is exactly the cost the early return exists to avoid.
+    """
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    await store.save_scoped(_record(), "w1")
+
+    first = await ensure_book_agent("f1", "w1", "u1")
+    second = await ensure_book_agent("f1", "w1", "u1")
+
+    assert first.agent_id == second.agent_id
+    assert first.created is True
+    assert second.created is False
+    assert second.indexed is True
+
+    assert len(wiring.agents.creates) == 1
+    assert len(wiring.chain.runs) == 1
+    assert len(wiring.ingest.calls) == 1
+
+
+async def test_the_bind_is_persisted_on_the_file(beanie_upload_db, store, wiring):
+    """The file remembers its agent — that bind IS the idempotency key."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    await store.save_scoped(_record(), "w1")
+    result = await ensure_book_agent("f1", "w1", "u1")
+
+    doc = await store.get_doc_scoped("f1", "w1")
+    assert doc.agent_id == result.agent_id
+
+
+async def test_a_stale_bind_reprovisions(beanie_upload_db, store, wiring):
+    """A bind pointing at a DELETED agent is not a permanent failure."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    await store.save_scoped(_record(), "w1")
+    await store.set_book_agent("f1", "w1", agent_id="agent-that-was-deleted")
+
+    result = await ensure_book_agent("f1", "w1", "u1")
+
+    assert result.created is True
+    assert result.indexed is True
+    assert result.agent_id != "agent-that-was-deleted"
+    doc = await store.get_doc_scoped("f1", "w1")
+    assert doc.agent_id == result.agent_id
+
+
+# --- tenancy ---------------------------------------------------------------
+
+
+async def test_another_workspaces_file_is_not_found(beanie_upload_db, store, wiring):
+    """Cross-tenant press → NotFound, and nothing is created."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    await store.save_scoped(_record(), "w1")
+
+    with pytest.raises(NotFound):
+        await ensure_book_agent("f1", "w2", "u2")
+
+    assert wiring.agents.creates == []
+    assert wiring.ingest.calls == []
+
+
+async def test_a_file_hidden_from_ai_is_refused(beanie_upload_db, store, wiring):
+    """FL-11b's privacy gate holds on this door too (no KB end-run)."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    await store.save_scoped(_record(), "w1")
+    await store.set_library_metadata("f1", "w1", hide_from_ai=True)
+
+    with pytest.raises(Forbidden):
+        await ensure_book_agent("f1", "w1", "u1")
+
+    assert wiring.agents.creates == []
+    assert wiring.ingest.calls == []
+
+
+# --- the ingest ------------------------------------------------------------
+
+
+async def test_the_book_lands_in_the_agents_own_scope(beanie_upload_db, store, wiring):
+    """Scope must be exactly ``agent:{id}`` — what the chat path searches."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    await store.save_scoped(_record(), "w1")
+    result = await ensure_book_agent("f1", "w1", "u1")
+
+    assert wiring.ingest.calls == [
+        {
+            "scope": f"agent:{result.agent_id}",
+            "text": "the whole book",
+            "source": "book.pdf",
+        }
+    ]
+
+
+async def test_a_failed_ingest_keeps_the_agent_and_says_it_is_unread(
+    beanie_upload_db, store, wiring
+):
+    """The agent survives a KB failure; the file stays unbound on purpose."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    wiring.ingest.fail = True
+    await store.save_scoped(_record(), "w1")
+
+    result = await ensure_book_agent("f1", "w1", "u1")
+
+    assert result.created is True
+    assert result.indexed is False
+    # The agent the user can see is still there — never deleted to tidy up.
+    assert await wiring.agents.get(result.agent_id) is not None
+    # ...and the file is NOT bound, so the next press retries the ingest.
+    doc = await store.get_doc_scoped("f1", "w1")
+    assert doc.agent_id is None
+
+
+async def test_a_retry_after_a_failed_ingest_adopts_the_same_agent(beanie_upload_db, store, wiring):
+    """The unbound retry must not mint a second agent for the same book."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    wiring.ingest.fail = True
+    await store.save_scoped(_record(), "w1")
+    first = await ensure_book_agent("f1", "w1", "u1")
+
+    wiring.ingest.fail = False
+    second = await ensure_book_agent("f1", "w1", "u1")
+
+    assert second.agent_id == first.agent_id
+    assert second.created is False
+    assert second.indexed is True
+    assert len(wiring.agents.creates) == 1
+
+
+async def test_no_readable_text_makes_no_agent(beanie_upload_db, store, wiring, monkeypatch):
+    """An image-only scan is refused BEFORE anything is created."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    empty = _FakeChain(ExtractionResult(text="   ", title="Scanned", backend="local"))
+    monkeypatch.setattr("pocketpaw_ee.cloud.extraction.build_chain", lambda settings: empty)
+    await store.save_scoped(_record(), "w1")
+
+    with pytest.raises(ValidationError):
+        await ensure_book_agent("f1", "w1", "u1")
+
+    assert wiring.agents.creates == []
+
+
+# --- the name --------------------------------------------------------------
+
+
+async def test_the_agent_is_named_after_the_book_when_extraction_finds_a_title(
+    beanie_upload_db, store, wiring, monkeypatch
+):
+    """A detected title beats the filename — the user thinks in book names."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    titled = _FakeChain(
+        ExtractionResult(text="call me ishmael", title="Moby-Dick", backend="local")
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.extraction.build_chain", lambda settings: titled)
+    await store.save_scoped(_record(filename="mobydick_ocr_FINAL_v2.pdf"), "w1")
+
+    await ensure_book_agent("f1", "w1", "u1")
+
+    assert wiring.agents.creates[0].name == "Moby-Dick"
+
+
+async def test_the_agent_falls_back_to_a_cleaned_up_filename(beanie_upload_db, store, wiring):
+    """No title → the filename, minus the extension and the separators."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    await store.save_scoped(_record(filename="thinking-fast_and.slow.pdf"), "w1")
+
+    await ensure_book_agent("f1", "w1", "u1")
+
+    assert wiring.agents.creates[0].name == "thinking fast and slow"
+
+
+async def test_the_agent_is_a_co_reader_not_a_generic_assistant(beanie_upload_db, store, wiring):
+    """The persona names the book and the co-reading job — that IS the feature."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    await store.save_scoped(_record(filename="Dune.pdf"), "w1")
+
+    await ensure_book_agent("f1", "w1", "u1")
+
+    persona = wiring.agents.creates[0].persona
+    assert "co-reader" in persona.lower()
+    assert "Dune" in persona
+
+
+async def test_the_agent_is_made_in_the_files_own_workspace(beanie_upload_db, store, wiring):
+    """Never cross-tenant: the agent lands in the file's workspace."""
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+
+    await store.save_scoped(_record(), "w1")
+    await ensure_book_agent("f1", "w1", "u1")
+
+    assert wiring.agents.creates[0].workspace == "w1"
+    assert wiring.agents.creates[0].slug == "book-f1"
+
+
+async def test_the_agent_follows_the_file_even_if_the_read_stops_filtering(
+    beanie_upload_db, store, wiring, monkeypatch
+):
+    """Defense in depth: the FILE's workspace decides, not the caller's claim.
+
+    Today the two are equal by construction — ``get_doc_scoped`` filters on
+    exactly that — so this forces the case the tenant filter normally makes
+    impossible: a read that hands back a foreign row. The book's contents must
+    still land in the workspace that owns the book, never in the caller's.
+    """
+    from pocketpaw_ee.cloud.uploads.book_agent import ensure_book_agent
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    await store.save_scoped(_record(), "w1")
+    leaked = await store.get_doc_scoped("f1", "w1")
+
+    async def _unfiltered(self, file_id, workspace):
+        return leaked
+
+    monkeypatch.setattr(MongoFileStore, "get_doc_scoped", _unfiltered)
+
+    await ensure_book_agent("f1", "w2", "u2")
+
+    assert wiring.agents.creates[0].workspace == "w1"

--- a/tests/mutations/book_agent.json
+++ b/tests/mutations/book_agent.json
@@ -117,6 +117,15 @@
     ]
   },
   {
+    "label": "a stale bind survives a failed re-provision — the library offers a dead agent",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "            await store.set_book_agent(file_id, file_workspace, agent_id=None)",
+    "replace": "            pass",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_a_stale_bind_is_cleared_even_if_the_reprovision_fails"
+    ]
+  },
+  {
     "label": "the bind is never written — the file forgets its agent",
     "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
     "find": "    bound = await store.set_book_agent(file_id, file_workspace, agent_id=agent.id)",

--- a/tests/mutations/book_agent.json
+++ b/tests/mutations/book_agent.json
@@ -1,0 +1,128 @@
+[
+  {
+    "label": "the idempotency check is deleted — every press re-reads the whole book",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "    existing_id = getattr(doc, \"agent_id\", \"\") or \"\"\n    if existing_id:",
+    "replace": "    existing_id = getattr(doc, \"agent_id\", \"\") or \"\"\n    if False:",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_pressing_twice_returns_the_same_agent_and_does_no_work_twice"
+    ]
+  },
+  {
+    "label": "the tenant filter is dropped — another workspace's book becomes an agent",
+    "file": "ee/pocketpaw_ee/cloud/uploads/mongo_store.py",
+    "find": "    async def get_doc_scoped(self, file_id: str, workspace: str) -> FileUpload | None:\n        return await FileUpload.find_one(\n            FileUpload.file_id == file_id,\n            FileUpload.workspace == workspace,",
+    "replace": "    async def get_doc_scoped(self, file_id: str, workspace: str) -> FileUpload | None:\n        return await FileUpload.find_one(\n            FileUpload.file_id == file_id,",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_another_workspaces_file_is_not_found"
+    ]
+  },
+  {
+    "label": "the book is ingested into the workspace scope — the agent never reads it",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "            scope=f\"agent:{agent_id}\",",
+    "replace": "            scope=f\"workspace:{agent_id}\",",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_the_book_lands_in_the_agents_own_scope"
+    ]
+  },
+  {
+    "label": "the file is bound even when the ingest failed — the retry never happens",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "    indexed = await _ingest_book(agent.id, text, filename)\n    if not indexed:\n        return BookAgentResult(agent_id=agent.id, created=created, indexed=False)",
+    "replace": "    indexed = await _ingest_book(agent.id, text, filename)",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_a_failed_ingest_keeps_the_agent_and_says_it_is_unread"
+    ]
+  },
+  {
+    "label": "the hide-from-AI gate is removed — a hidden file reaches a KB scope anyway",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "    if getattr(doc, \"hide_from_ai\", False):\n        raise Forbidden(",
+    "replace": "    if False:\n        raise Forbidden(",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_a_file_hidden_from_ai_is_refused"
+    ]
+  },
+  {
+    "label": "an unreadable file still mints an agent that has read nothing",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "    if not text:\n        # An image-only scan",
+    "replace": "    if False:\n        # An image-only scan",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_no_readable_text_makes_no_agent"
+    ]
+  },
+  {
+    "label": "the detected title is ignored — the agent is named after the file",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "    detected = (title or \"\").strip()\n    if detected:",
+    "replace": "    detected = (title or \"\").strip()\n    if False:",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_the_agent_is_named_after_the_book_when_extraction_finds_a_title"
+    ]
+  },
+  {
+    "label": "the filename is used raw — separators and all",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "    cleaned = _WHITESPACE.sub(\" \", _FILENAME_SEPARATORS.sub(\" \", stem)).strip()",
+    "replace": "    cleaned = stem",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_the_agent_falls_back_to_a_cleaned_up_filename"
+    ]
+  },
+  {
+    "label": "the slug stops being deterministic — a retry mints a second agent",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "    return f\"book-{file_id}\"",
+    "replace": "    import uuid\n\n    return f\"book-{file_id}-{uuid.uuid4().hex}\"",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_a_retry_after_a_failed_ingest_adopts_the_same_agent"
+    ]
+  },
+  {
+    "label": "the idempotent return claims the agent has not read the book",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "            return BookAgentResult(agent_id=existing_id, created=False, indexed=True)",
+    "replace": "            return BookAgentResult(agent_id=existing_id, created=False, indexed=False)",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_pressing_twice_returns_the_same_agent_and_does_no_work_twice"
+    ]
+  },
+  {
+    "label": "an adopted agent is reported as freshly created",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "    created = False\n    try:\n        agent = await agents_service.get_by_slug(file_workspace, slug)",
+    "replace": "    created = True\n    try:\n        agent = await agents_service.get_by_slug(file_workspace, slug)",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_a_retry_after_a_failed_ingest_adopts_the_same_agent"
+    ]
+  },
+  {
+    "label": "the agent is made in the CALLER's claimed workspace, not the file's",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "    file_workspace = doc.workspace",
+    "replace": "    file_workspace = workspace_id",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_the_agent_follows_the_file_even_if_the_read_stops_filtering"
+    ]
+  },
+  {
+    "label": "the persona reverts to a generic assistant — the co-reader framing is lost",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "        f'You are a co-reader of \"{subject}\". You have read it closely and you '",
+    "replace": "        f'You are a helpful assistant. A document called \"{subject}\" is attached. '",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_the_agent_is_a_co_reader_not_a_generic_assistant"
+    ]
+  },
+  {
+    "label": "the bind is never written — the file forgets its agent",
+    "file": "ee/pocketpaw_ee/cloud/uploads/book_agent.py",
+    "find": "    bound = await store.set_book_agent(file_id, file_workspace, agent_id=agent.id)",
+    "replace": "    bound = await store.set_book_agent(file_id, file_workspace, agent_id=None)",
+    "tests": [
+      "tests/cloud/uploads/test_book_agent.py::test_the_bind_is_persisted_on_the_file"
+    ]
+  }
+]


### PR DESCRIPTION
Open a PDF in the Library, press one button, and you get an agent that has read
that book and can talk about it while you read.

Almost none of this is new machinery. Agent creation, extraction, `agent:{id}`
knowledge scopes and agent chat all shipped already, and `_kb_scopes_for_context`
searches `user > pocket > agent > workspace` on every turn — so an agent reads
its own scope without anything being wired for it. What was missing was the one
call that ties them together.

`ensure_book_agent` follows `paw_bar.agent_provisioning.ensure_site_agent`
rather than inventing a second provisioning idiom: site concierges are the same
shape wearing a different hat — one dedicated agent, bound to one resource, its
knowledge in its own scope, never cross-tenant.

## Pressing twice gives you the same agent

The file remembers its agent. A live bind is returned untouched; a stale one
(the agent was deleted) re-provisions rather than failing forever. A
deterministic `book-{file_id}` slug backstops both.

That backstop is why the obvious test is not enough. Deleting the idempotency
check still yields exactly ONE agent, because the slug adopts the existing one —
counting agents cannot see the bug. The real cost of a second press is
re-reading a 400-page PDF, so the test asserts the extraction and ingest counts
across two presses, which is where the damage actually lands.

## Four deliberate deviations from the task, each vetoable

**The route is `POST /uploads/{file_id}/agent`, not `/files/...`.** The brief
asked for `/files/{file_id}/agent` *in the uploads router*, which contradicts
itself — that router is mounted at `/uploads`. Keeping it there means native
`file_id`, the tenant deps and the write ACL are all already present; moving it
to the files router means namespaced `uploads:<id>` entry ids and the provider
abstraction. (The UI half took the brief's literal path and would have 404'd;
fixed on that branch.)

**Extraction runs before creation.** The agent is named from the book's own
title, which only exists after extraction — and an unreadable file then leaves
no artifacts behind instead of an orphan agent.

**The bind is withheld when the ingest fails.** The agent still exists and the
response says `indexed=False`, but the file stays unbound. That makes a re-press
self-healing: the slug adopts the same agent and the ingest retries. It also
makes a live bind mean something — it proves the book is in the scope, so the
idempotent path can honestly return `indexed=True` without re-checking.

**The agent is owned by whoever pressed the button**, not by the file's owner.
Visibility is workspace-scoped, so both reach it either way.

## Refusals

Empty extracted text is a 422 before anything is created — an image-only scan
makes no agent. A `hide_from_ai` file is a 403: the upload listener already fails
closed on those, and ingesting the same bytes into `agent:{id}` would walk around
that gate.

## Verification

15 tests. 15 mutations, all caught — the idempotency check, the tenant filter,
the scope string, the ACL, the refusals. One escaped on the first pass
(`doc.workspace` to `workspace_id`, equal by construction in the fixtures);
rather than dropping it, a test now forces the unfiltered-read case.

`tests/cloud/uploads` goes from 23 failed / 170 passed to 23 failed / 185
passed. The 23 are pre-existing `test_router*` / `test_folders` 401s, reproduced
at the base commit with these files reverted. Zero skipped in every run, so the
ee group really installed and EE tests really ran.

import-linter 1 kept and 36 kept, 0 broken. ruff clean.

## Not verified

**Nothing ran over HTTP.** `tests/cloud/uploads` has a pre-existing harness gap
where guarded POSTs return 401 — the same gap behind those 23 failures — so the
route registration and ACL were verified by reading, not by exercising.

**Extraction and kb-go are faked in every test.** That the ingest lands in
`agent:{id}` is proven; that kb-go accepts a book-sized payload on a real
deployment is not.

**Extraction runs a second time here**, because the text extracted at upload is
never persisted — only the compiled article and its id. The alternative would be
feeding the agent kb's lossy summary instead of the book, which defeats the
point. The real fix is upstream (persist extracted text at upload) and would
speed up file comprehension in #2020 too. Cost is estimated, not measured:
seconds to tens of seconds on the local pypdf chain, more with a network
captioning adapter.
