### PR TITLE
feat(studio): expose per-model fal.ai edit params on curated image models

### DIFF
--- a/ee/pocketpaw_ee/cloud/studio/fal_image.py
+++ b/ee/pocketpaw_ee/cloud/studio/fal_image.py
@@ -89,6 +89,7 @@ EDIT_ENDPOINTS: dict[str, str] = {
     "nano_banana": "fal-ai/nano-banana-2/edit",
     "gpt_image_2": "openai/gpt-image-2/edit",
     "seedream_2k": "bytedance/seedream/v5/pro/edit",
+    "grok_imagine": "xai/grok-imagine-image/v2.0/edit",
 }
 
 # Per-model ceiling on ``image_urls`` for the reference-based edit endpoints.
@@ -96,6 +97,181 @@ EDIT_ENDPOINTS: dict[str, str] = {
 # truncate). Absent = no known cap.
 EDIT_REFERENCE_LIMITS: dict[str, int] = {
     "grok_imagine": 3,
+}
+
+# ── Per-model edit parameters ────────────────────────────────────────────────
+# The declarative knobs the edit composer surfaces PER MODEL, keyed by the
+# curated registry key. Each entry mirrors that model's actual fal.ai edit
+# schema (what the endpoint exposes — quality, size, background, number of
+# images, resolution, output format, safety tolerance, seed), so the rail
+# composer shows exactly what the model provides. Values the backend forwards on
+# the edit path (``build_edit_arguments`` below) are the same keys.
+#
+# ``recraft_v3`` has no edit variant, so it carries no params. Serialized into
+# ``StudioModel.params`` by ``service._curated_image_models()``.
+
+MODEL_PARAMS: dict[str, list[dict[str, Any]]] = {
+    "nano_banana": [
+        {
+            "key": "num_images",
+            "label": "Number of images",
+            "type": "stepper",
+            "default": 1,
+            "min": 1,
+            "max": 4,
+        },
+        {
+            "key": "seed",
+            "label": "Seed",
+            "type": "text",
+            "default": "",
+            "hint": "Optional — fixed seed for reproducible edits",
+            "advanced": True,
+        },
+        {
+            "key": "output_format",
+            "label": "Output format",
+            "type": "select",
+            "default": "png",
+            "options": ["png", "jpeg", "webp"],
+            "advanced": True,
+        },
+        {
+            "key": "safety_tolerance",
+            "label": "Safety tolerance",
+            "type": "slider",
+            "default": 4,
+            "min": 1,
+            "max": 6,
+            "step": 1,
+            "hint": "API only",
+            "advanced": True,
+        },
+    ],
+    "gpt_image_2": [
+        {
+            "key": "quality",
+            "label": "Quality",
+            "type": "select",
+            "default": "medium",
+            "options": ["low", "medium", "high"],
+        },
+        {
+            "key": "num_images",
+            "label": "Number of images",
+            "type": "stepper",
+            "default": 1,
+            "min": 1,
+            "max": 4,
+        },
+        {
+            "key": "size",
+            "label": "Image size",
+            "type": "select",
+            "default": "auto",
+            "options": ["auto", "1024x1024", "1536x1024", "1024x1536"],
+            "advanced": True,
+        },
+        {
+            "key": "background",
+            "label": "Background",
+            "type": "select",
+            "default": "auto",
+            "options": ["auto", "transparent", "opaque"],
+            "advanced": True,
+        },
+        {
+            "key": "output_format",
+            "label": "Output format",
+            "type": "select",
+            "default": "jpeg",
+            "options": ["jpeg", "png", "webp"],
+            "advanced": True,
+        },
+        {
+            "key": "seed",
+            "label": "Seed",
+            "type": "text",
+            "default": "",
+            "hint": "Optional — fixed seed for reproducible edits",
+            "advanced": True,
+        },
+    ],
+    "seedream_2k": [
+        {
+            "key": "num_images",
+            "label": "Number of images",
+            "type": "stepper",
+            "default": 1,
+            "min": 1,
+            "max": 4,
+        },
+        {
+            "key": "resolution",
+            "label": "Image size",
+            "type": "select",
+            "default": "auto",
+            "options": ["auto", "1K", "2K", "4K"],
+            "hint": "Determined automatically from the input when 'auto'",
+            "advanced": True,
+        },
+        {
+            "key": "output_format",
+            "label": "Output format",
+            "type": "select",
+            "default": "jpeg",
+            "options": ["jpeg", "png"],
+            "advanced": True,
+        },
+        {
+            "key": "seed",
+            "label": "Seed",
+            "type": "text",
+            "default": "",
+            "hint": "Optional — fixed seed for reproducible edits",
+            "advanced": True,
+        },
+    ],
+    "grok_imagine": [
+        {
+            "key": "resolution",
+            "label": "Resolution",
+            "type": "select",
+            "default": "2k",
+            "options": ["1k", "2k"],
+        },
+        {
+            "key": "quality",
+            "label": "Quality",
+            "type": "select",
+            "default": "medium",
+            "options": ["low", "medium", "high"],
+        },
+        {
+            "key": "num_images",
+            "label": "Number of images",
+            "type": "stepper",
+            "default": 1,
+            "min": 1,
+            "max": 4,
+        },
+        {
+            "key": "output_format",
+            "label": "Output format",
+            "type": "select",
+            "default": "jpeg",
+            "options": ["jpeg", "png"],
+            "advanced": True,
+        },
+        {
+            "key": "seed",
+            "label": "Seed",
+            "type": "text",
+            "default": "",
+            "hint": "Optional — fixed seed for reproducible edits",
+            "advanced": True,
+        },
+    ],
 }
 
 # ── Aspect ratio → image_size ────────────────────────────────────────────────
@@ -199,36 +375,91 @@ def build_edit_arguments(
     aspect_ratio: str | None = None,
     count: int = 1,
     seed: int | None = None,
+    quality: str | None = None,
+    size: str | None = None,
+    background: str | None = None,
+    output_format: str | None = None,
+    resolution: str | None = None,
+    safety_tolerance: int | None = None,
 ) -> dict[str, Any]:
     """Build the fal ``arguments`` dict for a reference-based edit call.
 
-    nano-banana / gpt-image-2 take the references as ``image_urls`` (capped per
-    model) + prompt; seedream's edit endpoint is a SINGLE-image op, so a single
-    reference is sent as ``image_url`` (same shape as fal_edit's sketch-to-image
-    op). Pure + side-effect free; raises ValueError when no references were
-    supplied.
+    nano-banana / gpt-image-2 / grok take the references as ``image_urls``
+    (capped per model) + prompt; seedream's edit endpoint is a SINGLE-image op,
+    so a single reference is sent as ``image_url`` (same shape as fal_edit's
+    sketch-to-image op). Each model's own knobs (quality / size / background /
+    resolution / output_format / safety_tolerance / seed / num_images) are
+    forwarded only when provided — the shapes mirror each endpoint's fal schema.
+    Pure + side-effect free; raises ValueError when no references were supplied.
     """
     refs = [u for u in (image_urls or []) if u and u.strip()]
     if not refs:
         raise ValueError("at least one reference image is required for image edit")
     refs = cap_reference_images(model_key, refs)
+    num_images = max(1, min(int(count), 4))
 
     if model_key == "seedream_2k":
-        args = {
+        args: dict[str, Any] = {
             "prompt": prompt,
             "image_url": refs[0],
+            "num_images": num_images,
         }
+        if resolution:
+            args["resolution"] = resolution
+        if output_format:
+            args["output_format"] = output_format
+        if seed is not None:
+            args["seed"] = int(seed)
         return args
 
+    if model_key == "gpt_image_2":
+        args = {
+            "prompt": prompt,
+            "image_urls": refs,
+            "num_images": num_images,
+        }
+        if quality:
+            args["quality"] = quality
+        if size:
+            args["size"] = size
+        if background:
+            args["background"] = background
+        if output_format:
+            args["output_format"] = output_format
+        if seed is not None:
+            args["seed"] = int(seed)
+        return args
+
+    if model_key == "grok_imagine":
+        args = {
+            "prompt": prompt,
+            "image_urls": refs,
+            "num_images": num_images,
+        }
+        if resolution:
+            args["resolution"] = resolution
+        if quality:
+            args["quality"] = quality
+        if output_format:
+            args["output_format"] = output_format
+        if seed is not None:
+            args["seed"] = int(seed)
+        return args
+
+    # nano_banana (and any other reference-based edit endpoint): the generic
+    # fal image-edit shape. Keeps the legacy ``output_format``/``sync_mode``
+    # defaults unless the composer overrides them.
     args = {
         "prompt": prompt,
         "image_urls": refs,
-        "num_images": max(1, min(int(count), 4)),
-        "output_format": "jpeg",
+        "num_images": num_images,
+        "output_format": output_format or "jpeg",
         "sync_mode": False,
     }
     if seed is not None:
         args["seed"] = int(seed)
+    if safety_tolerance is not None:
+        args["safety_tolerance"] = int(safety_tolerance)
     return args
 
 
@@ -347,6 +578,12 @@ async def run_fal_image_edit(
     aspect_ratio: str | None = None,
     count: int = 1,
     seed: int | None = None,
+    quality: str | None = None,
+    size: str | None = None,
+    background: str | None = None,
+    output_format: str | None = None,
+    resolution: str | None = None,
+    safety_tolerance: int | None = None,
     key: str | None = None,
 ) -> list[tuple[bytes, str]]:
     """Run a reference-based image edit and return ``[(bytes, mime), …]``.
@@ -354,8 +591,10 @@ async def run_fal_image_edit(
     ``image_urls`` are the reference images (character/location/element) the edit
     endpoint conditions on; the model is resolved to its edit variant via
     ``EDIT_ENDPOINTS`` (seedream resolves to its single-image edit endpoint).
-    Raises ValueError (no references / no edit endpoint for the model) and
-    FalImageError (upstream / no output).
+    The optional per-model knobs (``quality``/``size``/``background``/
+    ``resolution``/``output_format``/``safety_tolerance``/``seed``/``count``) are
+    forwarded onto the endpoint's own schema. Raises ValueError (no references /
+    no edit endpoint for the model) and FalImageError (upstream / no output).
     """
     text = (prompt or "").strip()
     if not text:
@@ -376,6 +615,12 @@ async def run_fal_image_edit(
         aspect_ratio=aspect_ratio,
         count=count,
         seed=seed,
+        quality=quality,
+        size=size,
+        background=background,
+        output_format=output_format,
+        resolution=resolution,
+        safety_tolerance=safety_tolerance,
     )
 
     api_key = key if key is not None else fal_edit.fal_api_key()
@@ -396,6 +641,7 @@ __all__ = [
     "IMAGE_MODEL_LABELS",
     "EDIT_ENDPOINTS",
     "EDIT_REFERENCE_LIMITS",
+    "MODEL_PARAMS",
     "IMAGE_SIZE_MAP",
     "GPT_IMAGE_SIZE_MAP",
     "FalImageError",

--- a/ee/pocketpaw_ee/cloud/studio/schemas.py
+++ b/ee/pocketpaw_ee/cloud/studio/schemas.py
@@ -17,6 +17,26 @@ from pydantic import BaseModel, Field
 # ── Model / style catalog ───────────────────────────────────────────────────
 
 
+class StudioModelParam(BaseModel):
+    """One declarative per-model parameter knob (the edit composer renders a
+    control for each). Mirrors paw-enterprise ``core/studio/types.ts``
+    ``StudioModelParam`` — ``key``/``label``/``type``/``default`` plus the
+    optional ``min``/``max``/``step``/``options``/``hint``/``advanced`` fields.
+    ``type`` is one of ``stepper`` | ``text`` | ``select`` | ``slider`` |
+    ``toggle``; ``default`` is the value the knob resets to."""
+
+    key: str
+    label: str
+    type: str
+    default: Any = None
+    hint: str | None = None
+    min: int | float | None = None
+    max: int | float | None = None
+    step: int | float | None = None
+    options: list[str] | None = None
+    advanced: bool = False
+
+
 class StudioModel(BaseModel):
     """One selectable generation model in the composer picker."""
 
@@ -33,6 +53,9 @@ class StudioModel(BaseModel):
     credits: int | None = None
     tags: list[str] = Field(default_factory=list)
     default: bool | None = None
+    # Per-model declarative knobs the edit composer surfaces (empty for models
+    # that expose no extra edit controls).
+    params: list[StudioModelParam] = Field(default_factory=list)
 
 
 class StudioStyleLook(BaseModel):
@@ -181,6 +204,10 @@ class EditRequest(BaseModel):
     direction: str | None = None
     factor: float | None = None
     model: str | None = None
+    # The rail edit composer's per-model parameter values (keyed by the model's
+    # ``params`` keys — e.g. ``num_images`` / ``seed``). Only the ``edit`` op
+    # reads them today.
+    params: dict[str, Any] | None = None
 
 
 class VideoElementsRequest(BaseModel):
@@ -317,6 +344,7 @@ class MediaListResponse(BaseModel):
 
 __all__ = [
     "StudioModel",
+    "StudioModelParam",
     "StudioStyle",
     "StudioStyleLook",
     "StudioStyleMotion",

--- a/ee/pocketpaw_ee/cloud/studio/service.py
+++ b/ee/pocketpaw_ee/cloud/studio/service.py
@@ -267,6 +267,12 @@ def _curated_image_models() -> list[schemas.StudioModel]:
                 credits=1,
                 tags=[cfg.get("vendor", "fal").lower(), "image", "curated"],
                 default=(key == fal_image.DEFAULT_IMAGE_MODEL),
+                # Per-model edit knobs (what each fal model's edit endpoint
+                # actually accepts) — declared in fal_image.MODEL_PARAMS.
+                params=[
+                    schemas.StudioModelParam.model_validate(p)
+                    for p in fal_image.MODEL_PARAMS.get(key, [])
+                ],
             )
         )
     return models
@@ -1246,6 +1252,44 @@ def _fit_character_image(data_url: str, mime: str) -> tuple[str, str]:
     )
 
 
+def _coerce_param_int(value: Any, *, default: int, lo: int, hi: int) -> int:
+    """Coerce a rail-composer param value to an int clamped to ``[lo, hi]``.
+
+    The composer may send numbers, numeric strings, or ``None`` (an untouched
+    knob). Anything unparsable falls back to ``default`` so a malformed value
+    never 500s the request."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(n, hi))
+
+
+def _coerce_param_seed(value: Any) -> int | None:
+    """Coerce a rail-composer seed param to an int, or None when unset/blank.
+
+    The composer's seed knob defaults to an empty string (meaning "unset");
+    ``False`` (a cleared toggle-like value) is treated the same. A literal 0 is a
+    valid seed and passes through."""
+    if value is None or value == "" or value is False:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_param_str(value: Any) -> str | None:
+    """Coerce a rail-composer select/text param to a non-empty string, or None.
+
+    Select knobs default to a chosen option (always a non-empty string); a
+    cleared/absent value becomes None so it is omitted from the fal arguments."""
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
 async def edit(req: schemas.EditRequest, *, workspace_id: str) -> schemas.Generation:
     """Run a canvas edit op (inpaint/expand/upscale/variations/remove-bg/edit/
     sketch-to-image) DIRECTLY against fal.ai — the LiteLLM gateway serves
@@ -1268,19 +1312,64 @@ async def edit(req: schemas.EditRequest, *, workspace_id: str) -> schemas.Genera
         raise ValueError("sourceUrl is required for an edit")
 
     source_data_url, _ = await _resolve_source_data_url(req.sourceUrl)
+    model_id = (req.model or "").strip()
 
-    try:
-        results = await fal_edit.run_fal_edit(
-            op=op,
-            image_data_url=source_data_url,
-            mask_data_url=req.maskDataUrl,
-            prompt=req.prompt,
-            direction=req.direction,
-            factor=req.factor,
-            model=req.model,
+    # The rail edit composer sends ``op='edit'`` with a CURATED image model id
+    # (e.g. ``fal-ai/nano-banana-2`` — the text-to-image id, not its /edit
+    # endpoint) plus the model's per-model params. Route those through the
+    # model's own edit variant (fal_image), forwarding ``num_images`` / ``seed``.
+    # Canvas ops and non-curated models keep the generic fal_edit path.
+    is_curated_edit = (
+        op == "edit"
+        and model_id
+        and fal_image.model_key_for_id(model_id) in fal_image.EDIT_ENDPOINTS
+    )
+    if is_curated_edit:
+        composer_params = req.params or {}
+        count = _coerce_param_int(
+            composer_params.get("num_images"), default=1, lo=1, hi=_MAX_GENERATED_ASSETS
         )
-    except fal_edit.FalEditError as exc:
-        raise StudioUpstreamError(str(exc)) from exc
+        seed = _coerce_param_seed(composer_params.get("seed"))
+        quality = _coerce_param_str(composer_params.get("quality"))
+        size = _coerce_param_str(composer_params.get("size"))
+        background = _coerce_param_str(composer_params.get("background"))
+        output_format = _coerce_param_str(composer_params.get("output_format"))
+        resolution = _coerce_param_str(composer_params.get("resolution"))
+        raw_tolerance = composer_params.get("safety_tolerance")
+        safety_tolerance = (
+            _coerce_param_int(raw_tolerance, default=4, lo=1, hi=6)
+            if raw_tolerance is not None
+            else None
+        )
+        try:
+            results = await fal_image.run_fal_image_edit(
+                prompt=req.prompt,
+                image_urls=[source_data_url],
+                model=model_id,
+                count=count,
+                seed=seed,
+                quality=quality,
+                size=size,
+                background=background,
+                output_format=output_format,
+                resolution=resolution,
+                safety_tolerance=safety_tolerance,
+            )
+        except fal_image.FalImageError as exc:
+            raise StudioUpstreamError(str(exc)) from exc
+    else:
+        try:
+            results = await fal_edit.run_fal_edit(
+                op=op,
+                image_data_url=source_data_url,
+                mask_data_url=req.maskDataUrl,
+                prompt=req.prompt,
+                direction=req.direction,
+                factor=req.factor,
+                model=model_id,
+            )
+        except fal_edit.FalEditError as exc:
+            raise StudioUpstreamError(str(exc)) from exc
 
     if not results:
         raise StudioUpstreamError("fal edit produced no output images")
@@ -1290,7 +1379,7 @@ async def edit(req: schemas.EditRequest, *, workspace_id: str) -> schemas.Genera
         url = await _save_image_bytes(data, mime=mime, ext=fal_edit.mime_to_ext(mime))
         assets.append({"id": _seq_id("asset"), "url": url, "mime": mime})
 
-    model = (req.model or "").strip() or fal_edit.DEFAULT_EDIT_MODELS[op]
+    model = model_id or fal_edit.DEFAULT_EDIT_MODELS[op]
     params: dict[str, Any] = {
         "kind": "image",
         "model": model,

--- a/tests/cloud/studio/test_service.py
+++ b/tests/cloud/studio/test_service.py
@@ -243,6 +243,59 @@ async def test_list_models_upstream_failure_propagates(monkeypatch) -> None:
         await service.list_models()
 
 
+async def test_curated_image_models_expose_edit_params(monkeypatch) -> None:
+    """Curated image models surface their per-model edit knobs from
+    ``fal_image.MODEL_PARAMS`` — only the edit-capable models carry any."""
+
+    async def _list(**kw):
+        return []
+
+    monkeypatch.setattr(catalog_service, "list_models", _list)
+
+    models = await service.list_models()
+    by_id = {m.id: m for m in models}
+
+    nana = by_id["fal-ai/nano-banana-2"]
+    assert {p.key for p in nana.params} == {
+        "num_images",
+        "seed",
+        "output_format",
+        "safety_tolerance",
+    }
+    num = next(p for p in nana.params if p.key == "num_images")
+    assert num.type == "stepper" and num.min == 1 and num.max == 4
+
+    gpt = by_id["openai/gpt-image-2"]
+    assert {p.key for p in gpt.params} == {
+        "quality",
+        "num_images",
+        "size",
+        "background",
+        "output_format",
+        "seed",
+    }
+
+    seedream = by_id["bytedance/seedream/v5/pro/text-to-image"]
+    assert {p.key for p in seedream.params} == {
+        "num_images",
+        "resolution",
+        "output_format",
+        "seed",
+    }
+
+    grok = by_id["xai/grok-imagine-image/v2.0/text-to-image"]
+    assert {p.key for p in grok.params} == {
+        "resolution",
+        "quality",
+        "num_images",
+        "output_format",
+        "seed",
+    }
+
+    # Non-edit curated image models expose no params.
+    assert by_id["fal-ai/recraft/v3/text-to-image"].params == []
+
+
 # ── generate (image) ─────────────────────────────────────────────────────────
 
 
@@ -651,6 +704,94 @@ async def test_edit_happy_path(monkeypatch, studio_env) -> None:
     assert len(records) == 1
     assert records[0]["_workspace"] == "ws-1"
     assert name in service.tracked_generation_filenames()
+
+
+async def test_edit_op_routes_curated_model_through_fal_image(monkeypatch, studio_env) -> None:
+    """``op='edit'`` with a curated image model id + per-model params dispatches
+    through the model's own /edit variant (fal_image), forwarding ``num_images``
+    and ``seed`` instead of the generic canvas op."""
+    png = b"\x89PNG\r\n\x1a\nedited"
+    seen: dict = {}
+
+    async def _fake_fal_image_edit(**kwargs):
+        seen.update(kwargs)
+        return [(png, "image/png")]
+
+    monkeypatch.setattr(fal_image, "run_fal_image_edit", _fake_fal_image_edit)
+
+    req = schemas.EditRequest(
+        op="edit",
+        sourceUrl=_DATA_URL,
+        prompt="turn the sky purple",
+        model="fal-ai/nano-banana-2",
+        params={"num_images": 3, "seed": "42"},
+    )
+    gen = await service.edit(req, workspace_id="ws-1")
+
+    assert gen.status == "succeeded"
+    assert seen["model"] == "fal-ai/nano-banana-2"
+    assert seen["count"] == 3
+    assert seen["seed"] == 42
+    assert seen["image_urls"] == [_DATA_URL]
+    assert gen.assets[0].url.startswith("/api/v1/media/")
+
+
+async def test_edit_op_forwards_gpt_image_2_knobs(monkeypatch, studio_env) -> None:
+    """gpt-image-2 edit forwards its own knobs (quality / size / background /
+    output_format) onto the fal arguments."""
+    png = b"\x89PNG\r\n\x1a\nedited"
+    seen: dict = {}
+
+    async def _fake_fal_image_edit(**kwargs):
+        seen.update(kwargs)
+        return [(png, "image/png")]
+
+    monkeypatch.setattr(fal_image, "run_fal_image_edit", _fake_fal_image_edit)
+
+    req = schemas.EditRequest(
+        op="edit",
+        sourceUrl=_DATA_URL,
+        prompt="livery",
+        model="openai/gpt-image-2",
+        params={
+            "quality": "high",
+            "size": "1536x1024",
+            "background": "transparent",
+            "output_format": "png",
+            "num_images": 2,
+        },
+    )
+    gen = await service.edit(req, workspace_id="ws-1")
+    assert gen.status == "succeeded"
+    assert seen["quality"] == "high"
+    assert seen["size"] == "1536x1024"
+    assert seen["background"] == "transparent"
+    assert seen["output_format"] == "png"
+    assert seen["count"] == 2
+
+
+async def test_edit_op_curated_params_blank_seed_is_none(monkeypatch, studio_env) -> None:
+    """A blank ``seed`` from the composer's untouched text knob coerces to None
+    (never ``int('')`` → 400/500)."""
+    png = b"\x89PNG\r\n\x1a\nedited"
+    seen: dict = {}
+
+    async def _fake_fal_image_edit(**kwargs):
+        seen.update(kwargs)
+        return [(png, "image/png")]
+
+    monkeypatch.setattr(fal_image, "run_fal_image_edit", _fake_fal_image_edit)
+
+    req = schemas.EditRequest(
+        op="edit",
+        sourceUrl=_DATA_URL,
+        prompt="recolor",
+        model="bytedance/seedream/v5/pro/text-to-image",
+        params={"seed": ""},
+    )
+    gen = await service.edit(req, workspace_id="ws-1")
+    assert gen.status == "succeeded"
+    assert seen["seed"] is None
 
 
 async def test_edit_resolves_stored_media_source(monkeypatch, studio_env) -> None:


### PR DESCRIPTION
## Summary

The rail image-edit composer now renders each curated image model's own edit options, sourced from the backend (`fal_image.MODEL_PARAMS`) rather than a hard-coded frontend registry — matching what each fal.ai edit endpoint actually accepts.

## Per-model edit params

- **Nano Banana 2** — number of images, seed, output format, safety tolerance
- **GPT Image 2** — quality, number of images, image size, background, output format, seed
- **Seedream 2K** — number of images, image size, output format, seed
- **Grok Imagine 2.0** — resolution, quality, number of images, output format, seed

## Changes

- `schemas`: add `StudioModelParam` + `StudioModel.params` + `EditRequest.params`
- `fal_image`: per-model params + Grok edit endpoint; `build_edit_arguments`/`run_fal_image_edit` forward quality/size/background/resolution/output_format/safety_tolerance/num_images/seed
- `service`: serialize params into the curated model rows; route the rail composer's `op='edit'` through the model's own `/edit` variant, forwarding the collected params

## Tests

`tests/cloud/studio/` → 190 passed; `ruff check` clean.