### PR TITLE
fix(sites): a created react component that nothing imports now says so

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1913,9 +1913,21 @@ Write ONE file of a react site's `source` map as a reviewable draft.
 | `create` | boolean | Default `false`. Create a NEW file at `component_path`; the path must **not** already exist. |
 
 Returns `{ok: true, status: "draft", is_live: false, pocket_id, component_path,
-created, message}`. To **add a section**, call it twice: once with `create: true`
-for `src/components/<Name>.tsx`, then again with `edits` on `src/App.tsx` to
-import and render it.
+created, unreferenced, message}`. To **add a section**, call it twice: once with
+`create: true` for `src/components/<Name>.tsx`, then again with `edits` on
+`src/App.tsx` to import and render it.
+
+**`unreferenced` is the second call's reminder.** It is `true` when this call
+*created* a file that nothing else in the source map reaches — no import specifier
+resolves to it, or, under `public/`, no file mentions its URL. Such a file is not
+in the bundle: the page renders exactly as it did before. The `message` then leads
+with the outstanding step and an explicit instruction not to report the section as
+added yet, because a create that stops after call 1 otherwise returns an
+unqualified success and the agent tells the user about a component they cannot
+find. It is advisory and never blocking — call 1 of two is unreferenced at the
+instant it lands, every time, so refusing it would make adding a section
+impossible. `unreferenced` is always `false` for an ordinary edit; the scan is
+scoped to `create` so the common path stays quiet.
 
 **It does not publish and does not enqueue a build**, and that is a deliberate
 divergence from the svelte tool rather than an omission. `build_runs_async("react")`

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,6 +1,15 @@
 # sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
 # create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
 #
+# Updated: 2026-09-01 (fix/sites-react-orphan-create — a create that renders nothing
+# stopped narrating as a finished change). ``edit_react_component``'s success body now
+# carries ``unreferenced`` and, when it is true, a ``message`` that LEADS with the
+# outstanding second call and forbids reporting the section as added. The skill already
+# taught the two-call contract in prose; what was missing was feedback inside the loop,
+# so an agent that made call 1 and stopped read an unqualified "Saved to the site's
+# draft" and had no reason to make call 2. Advice, not an error: ``ok`` stays true and
+# the file really was written, so the agent must not retry the create.
+#
 # Updated: 2026-08-19 (fix/sites-read-source-tool — the edit lane could write but not
 # read) — added ``read_site_source`` + ``_read_site_source_handler``, the READ half the
 # three edit tools in this file were written against and never had. Each of them prefers
@@ -2072,6 +2081,35 @@ async def _edit_react_component_handler(args: dict) -> dict:
 
     # The edit is a DRAFT. The chat agent narrates this payload, so — exactly like
     # the svelte edit tool — it must not contain a completed-state publish claim.
+    #
+    # ``unreferenced`` (2026-09-01) makes the SECOND half of the two-call contract
+    # visible on the call that creates the first half. A created component that
+    # nothing imports is not in the bundle: the page renders exactly as it did
+    # before. The old payload said "Saved to the site's draft" for that case too,
+    # which is true and is the whole problem — an agent reading an unqualified
+    # success has no reason to make call 2, and reports a section the user cannot
+    # find. So the message carries the outstanding step and, explicitly, the
+    # instruction NOT to report the work as done yet.
+    #
+    # It is advice, not an error: ``ok`` stays True and the file really was written.
+    # A refusal here would make "add a testimonials section" impossible, since call
+    # 1 is unreferenced at the instant it lands, every time.
+    unreferenced = bool(result.get("unreferenced"))
+    message = (
+        "Saved to the site's draft — it is NOT online yet, and no build was "
+        "started. Tell the user the change is in the draft they can preview "
+        "under /sites, and offer to publish it; only call the publish tool "
+        "when they ask."
+    )
+    if unreferenced:
+        message = (
+            f"HALF DONE — `{result['component_path']}` was created, but NOTHING "
+            "IMPORTS IT, so the page renders exactly as it did before and the user "
+            "will see no change. Make your NEXT call an `edits` call on "
+            "`src/App.tsx` (or whichever component should contain it) that imports "
+            "and renders it. Do NOT tell the user the section/image is added until "
+            "that second call succeeds — the file exists, but nothing shows it.\n"
+        ) + message
     return _success_response(
         {
             "ok": True,
@@ -2080,12 +2118,8 @@ async def _edit_react_component_handler(args: dict) -> dict:
             "pocket_id": result["pocket_id"],
             "component_path": result["component_path"],
             "created": result["created"],
-            "message": (
-                "Saved to the site's draft — it is NOT online yet, and no build was "
-                "started. Tell the user the change is in the draft they can preview "
-                "under /sites, and offer to publish it; only call the publish tool "
-                "when they ask."
-            ),
+            "unreferenced": unreferenced,
+            "message": message,
         }
     )
 
@@ -2140,7 +2174,11 @@ def make_edit_react_component_tool(tool: Any) -> Any:
             "Args: `pocket_id` (the react site pocket), `component_path`, and one "
             "of `edits` / `new_source`, plus optional `create`. Returns {ok, "
             "status:'draft', is_live:false, pocket_id, component_path, created, "
-            "message}. Relay the `message`: the change is in the DRAFT the user can "
+            "unreferenced, message}. `unreferenced:true` means the file you just "
+            "created is imported by NOTHING — it is not in the bundle and the page "
+            "is unchanged, so the second call is still outstanding and you must not "
+            "report the section as added yet. Relay the `message`: the change is in "
+            "the DRAFT the user can "
             "preview under /sites, and publishing is their call — do NOT tell them "
             "it is live. ok=false with an error means NOTHING was saved: an "
             "old_string that matched 0 or >1 times means make it more specific and "

--- a/ee/pocketpaw_ee/sites/react_paths.py
+++ b/ee/pocketpaw_ee/sites/react_paths.py
@@ -1,5 +1,15 @@
 # react_paths.py — the ONE place the react-track source-map path policy lives.
 #
+# Updated: 2026-09-01 (fix/sites-react-orphan-create) — added
+# ``react_path_is_referenced``, which answers "does anything in this source map
+# reach that path". The module was pure POLICY (may this path be written); this is
+# the first question about REACHABILITY, and it lives here because the answer
+# depends on the same two-prefix layout the policy above encodes: ``src/`` is a
+# module tree reached by import specifiers, ``public/`` is copied to the web root
+# and reached by URL. Written for the edit lane's ``create``, which could land a
+# component nothing imports and report a clean success — see the section comment
+# above the function for the incident that produced it.
+#
 # Created: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — extracted from
 # ``agent/mcp_servers/sites_create.py``, which owned ``REACT_RESERVED_FILES`` /
 # ``REACT_RESERVED_PREFIX`` / ``_reserved_react_keys`` because create was the only
@@ -49,6 +59,8 @@ trivial path spelling defeats is not a guard, and ``./package.json`` /
 from __future__ import annotations
 
 import posixpath
+import re
+from collections.abc import Mapping
 from typing import Any
 
 # Paths the generator owns and no source map may write. Mirrors ``RESERVED_FILES``
@@ -139,6 +151,105 @@ def react_path_rejection(path: str) -> str | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# Is this path reached by anything? (the two-call contract's missing half)
+# ---------------------------------------------------------------------------
+#
+# Added 2026-09-01 (fix/sites-react-orphan-create). Adding a section to a react site
+# is TWO calls — ``create=true`` writes ``src/components/<Name>.tsx``, then a second
+# ``edits`` call imports and renders it in ``src/App.tsx`` — and nothing connected
+# the two. A create that landed call 1 and never got call 2 returned a flat success
+# for a file the bundle does not contain: no import, no render, no trace on the page.
+# The agent read the clean success and told the user the work was done, which is how
+# a real incident produced "I added it to a component" over a site that never changed.
+#
+# So a create now ANSWERS the question its own success hides: does anything reach
+# this file yet? The verdict is advisory — call 1 is unreferenced by definition at
+# the instant it happens, and a create that refused or errored on it would close the
+# only lane that can add a section at all.
+#
+# The two prefixes are reached two different ways and a single rule gets one of them
+# wrong. ``src/`` is a MODULE tree: reached by an import specifier, which is resolved
+# here rather than pattern-matched, so `./components/Hero` from `src/App.tsx` and
+# `../components/Hero` from `src/sections/X.tsx` both resolve to the one file they
+# mean. ``public/`` is NOT a module tree: it is copied to the web root and reached by
+# URL (`<img src="/logo.png">`), so an import-only scan would call every correctly
+# used asset an orphan.
+
+# Extensions a specifier may omit. A resolved specifier and a source-map key are
+# compared with these stripped, because `./components/Hero` and
+# `src/components/Hero.tsx` are the same file written two ways.
+_REACT_MODULE_EXTS: tuple[str, ...] = (".tsx", ".ts", ".jsx", ".js", ".mjs", ".css")
+
+# Quoted module specifiers: `from '...'`, a side-effect or dynamic `import '...'` /
+# `import('...')`, and `require('...')`. Deliberately NOT a general string scan —
+# matching any quoted text would let a testimonial mentioning "Testimonials" pass
+# for an import, and a false "it is referenced" is the silence this exists to break.
+_REACT_SPECIFIER_RE = re.compile(
+    r"""(?:\bfrom\s*|\bimport\s*\(?\s*|\brequire\s*\(\s*)['"]([^'"\n]+)['"]"""
+)
+
+
+def _strip_module_ext(path: str) -> str:
+    """Drop a module extension so a specifier and a map key compare equal."""
+    for ext in _REACT_MODULE_EXTS:
+        if path.endswith(ext):
+            return path[: -len(ext)]
+    return path
+
+
+def _resolve_specifier(importer: str, specifier: str) -> str | None:
+    """Resolve one import specifier to a project-relative path, or ``None``.
+
+    ``None`` means "not a local file" — a bare package specifier (``react``,
+    ``react-dom/client``) resolves into node_modules and can never name a source-map
+    key. Relative specifiers resolve against the IMPORTER's directory, which is the
+    whole reason this is a resolver and not a substring search: `./Hero` means a
+    different file depending on who wrote it.
+    """
+    if specifier.startswith("."):
+        return posixpath.normpath(posixpath.join(posixpath.dirname(importer), specifier))
+    if specifier.startswith("/"):
+        return posixpath.normpath(specifier.lstrip("/"))
+    # Vite's conventional root aliases. Neither is configured in the generator's
+    # shell today; resolving them anyway costs nothing and means the day one is,
+    # this reports "referenced" instead of nagging about a wired component.
+    if specifier.startswith(("@/", "~/")):
+        return posixpath.normpath("src/" + specifier[2:])
+    return None
+
+
+def react_path_is_referenced(source: Mapping[str, Any], path: str) -> bool:
+    """Does any OTHER file in ``source`` reach ``path``?
+
+    ``source`` is the source map AFTER the write, so the created file is present and
+    is skipped — a module that imports itself is still unreachable from the page.
+
+    A ``public/`` path is matched on its URL (``public/img/logo.png`` →
+    ``/img/logo.png``) as a substring, because an asset reference is an attribute
+    value in arbitrary markup and there is no grammar to resolve. A ``src/`` path is
+    matched by resolving every import specifier in every other file and comparing
+    extension-stripped paths, so the answer does not depend on how the import was
+    spelled.
+    """
+    norm = normalize_react_path(path)
+
+    if norm.startswith("public/"):
+        url = "/" + norm[len("public/") :]
+        return any(url in str(text) for key, text in source.items() if key != norm)
+
+    target = _strip_module_ext(norm)
+    for key, text in source.items():
+        if normalize_react_path(key) == norm:
+            continue  # the file itself — a self-import reaches nothing
+        importer = normalize_react_path(key)
+        for specifier in _REACT_SPECIFIER_RE.findall(str(text)):
+            resolved = _resolve_specifier(importer, specifier)
+            if resolved is not None and _strip_module_ext(resolved) == target:
+                return True
+    return False
+
+
 __all__ = [
     "REACT_AUTHORABLE_PREFIXES",
     "REACT_RESERVED_FILES",
@@ -146,6 +257,7 @@ __all__ = [
     "is_authorable_react_path",
     "is_reserved_react_path",
     "normalize_react_path",
+    "react_path_is_referenced",
     "react_path_rejection",
     "reserved_react_keys",
 ]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,19 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-09-01 (fix/sites-react-orphan-create): ``edit_react_component`` now
+# returns ``unreferenced`` alongside ``created``. Adding a section to a react site is
+# TWO calls — write ``src/components/<Name>.tsx``, then edit ``src/App.tsx`` to import
+# and render it — and the first call returned a flat success whether or not the second
+# ever came. A component nothing imports is not in the bundle, so the page is byte-for-
+# byte unchanged; the caller could not tell that from a real edit, and reported the work
+# as done over a site that never moved. Reported live: an image attached to a published
+# site, "added to a component", and nowhere to be found. The verdict is ADVISORY (the
+# file is written, ``ok`` stays true) because call 1 is unreferenced by definition at the
+# instant it lands — a refusal would close the only lane that can add a section at all.
+# It is scoped to ``create`` for the same reason the signal exists: a warning on every
+# edit is noise, and noise is how the one that matters gets skimmed.
+#
 # Updated 2026-08-24 (SP-2 — draft preview joins the ephemeral build lane): a cold
 # ``get_native_artifact`` no longer builds in this process. ``_build_native_artifact``
 # used to call ``generator.build``, which shells out to ``bun``; the deployed API
@@ -980,7 +993,11 @@ from pocketpaw_ee.sites.html_paths import (
     is_reserved_html_path,
     normalize_html_path,
 )
-from pocketpaw_ee.sites.react_paths import is_reserved_react_path, react_path_rejection
+from pocketpaw_ee.sites.react_paths import (
+    is_reserved_react_path,
+    react_path_is_referenced,
+    react_path_rejection,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -6845,7 +6862,13 @@ async def edit_react_component(
     ``edit_svelte_component`` only needs the workspace to look up the Site doc whose
     builder origin its republish must re-apply — a republish this lane does not do.
 
-    Returns ``{pocket_id, component_path, created}``.
+    Returns ``{pocket_id, component_path, created, unreferenced}``. ``unreferenced``
+    is the advisory half of the two-call contract: True when this call CREATED a
+    file that no other file in the map imports (or, under ``public/``, that no file
+    references by URL), which means the page renders nothing new until the caller's
+    next edit wires it in. It is never True for a plain edit, and it never blocks —
+    call 1 of two is unreferenced by definition, so refusing it would close the only
+    lane that can add a section at all.
     """
     if _pockets is not None:
         pockets_service = _pockets
@@ -6911,10 +6934,32 @@ async def edit_react_component(
         create=create,
     )
 
+    # Does anything reach the file we just wrote? A create is HALF of adding a
+    # section — the other half is the ``src/App.tsx`` edit that imports and renders
+    # it — and until 2026-09-01 nothing connected the two. A create that landed call
+    # 1 and never got call 2 returned a flat success for a file the bundle does not
+    # contain, so the caller had no way to tell "added" from "added and reachable"
+    # and reported the work as done over a page that never changed.
+    #
+    # Scoped to ``create`` deliberately. An ordinary edit touches a file that is
+    # already part of the site, and re-litigating its wiring on every headline change
+    # is noise on the common path — which is how the signal on the rare path gets
+    # skimmed. The map scanned is the POST-write one: the write sets exactly this one
+    # key, so re-reading the pocket to learn what we just sent it would be a round
+    # trip for an answer we already hold.
+    unreferenced = create and not react_path_is_referenced(
+        {**source_map, component_path: new_source}, component_path
+    )
+
     # NO publish, NO enqueue, NO native pre-warm. The pre-warm serves the svelte
     # native editor's shadow-render, which reads a SvelteKit build; react has no
     # such artifact, so warming one here would build a site nothing reads.
-    return {"pocket_id": pocket_id, "component_path": component_path, "created": create}
+    return {
+        "pocket_id": pocket_id,
+        "component_path": component_path,
+        "created": create,
+        "unreferenced": unreferenced,
+    }
 
 
 async def edit_html_file(

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-edit-react-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-edit-react-site/SKILL.md
@@ -173,6 +173,14 @@ always **two calls**, and stopping after the first is the failure mode:
    adding the `import`, one block placing `<Testimonials />` at the right point
    in the funnel.
 
+**The tool tells you when call 2 is still outstanding.** After a `create`, the
+response carries `unreferenced: true` if nothing in the source map reaches the
+file you just wrote, and the `message` leads with the step you still owe. Treat
+that as "half done", not as a warning to note and move past: the file exists, the
+page is unchanged, and reporting the section as added there is exactly how a user
+ends up hunting for a component that renders nowhere. It is not an error — `ok`
+is still true and the write really happened, so do not retry the create.
+
 Removing a section is the mirror image: edit `src/App.tsx` to drop the import
 and the element. Leaving the now-unused component file behind is harmless (the
 build tree-shakes it), so prefer that over a delete you cannot undo.
@@ -398,7 +406,8 @@ Never fall back to another engine's tool, and never fall back to
 - Exactly one site pocket exists, and it is the one the user was looking at.
 - The change went in as a **diff** unless it was a genuine rewrite.
 - With **all JavaScript disabled**, the edited section still looks finished.
-- A new section was **both** written and rendered from `src/App.tsx`.
+- A new section was **both** written and rendered from `src/App.tsx` — and the
+  last `create` did not come back `unreferenced: true`.
 - No claim was made about a package being added, or about the change being live.
 - The user was told it is a draft, and was not invited to go and look at a
   rendered page that does not exist until a build runs.

--- a/tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py
@@ -44,12 +44,18 @@ def _default_sites_plan():
         yield
 
 
-def _ok_result(*, created: bool = False) -> dict:
-    """What the service returns on a successful edit."""
+def _ok_result(*, created: bool = False, unreferenced: bool = False) -> dict:
+    """What the service returns on a successful edit.
+
+    ``unreferenced`` mirrors the service's own key (see
+    ``sites/service.py::edit_react_component``): True when a CREATE landed a file
+    that nothing imports. The stub carries it so this file pins the real shape —
+    a stub that lags the service tests a payload the handler never receives."""
     return {
         "pocket_id": "pk1",
         "component_path": "src/components/Hero.tsx",
         "created": created,
+        "unreferenced": unreferenced,
     }
 
 
@@ -512,3 +518,122 @@ class TestEditHandler:
             )
         assert out.get("is_error") is True
         assert "edit failed" in out["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# The unreferenced-create warning — the payload the agent narrates
+# ---------------------------------------------------------------------------
+#
+# THE INCIDENT (2026-09-01): a user attached an image to an already-published react
+# site and asked for it in the hero. The agent created a component, this payload
+# came back a clean success, and the agent reported the image as added. Nothing
+# imported the new file, so the page never changed and the user could not find the
+# component anywhere. The service now answers "does anything reach this file"; these
+# pin that the answer reaches the agent as an OUTSTANDING STEP rather than a footnote.
+
+
+class TestUnreferencedCreateWarning:
+    @pytest.mark.asyncio
+    async def test_orphan_create_tells_the_agent_the_page_is_unchanged(self) -> None:
+        """The message must name the next call AND forbid the premature report. A
+        payload that only said "saved to the draft" is what produced the incident.
+
+        THE MUTATION THAT BREAKS THIS: drop the `if unreferenced:` branch. Run: the
+        orphan create narrated as an ordinary success again."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_react_component",
+                new=AsyncMock(return_value=_ok_result(created=True, unreferenced=True)),
+            ),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": "export default function Hero() { return <section/>; }",
+                    "create": True,
+                }
+            )
+
+        # Advice, not a rejection: the file WAS written, so ok stays true and the
+        # agent must not retry the create.
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["ok"] is True
+        assert body["created"] is True
+        assert body["unreferenced"] is True
+
+        message = body["message"]
+        assert "src/App.tsx" in message, "the outstanding call must name where to wire it"
+        assert "NOTHING IMPORTS IT" in message
+        # The half that stops the false report the user actually hit.
+        assert "Do NOT tell the user" in message
+        # The draft/not-live contract is still carried — this is additive.
+        assert "NOT online yet" in message
+
+    @pytest.mark.asyncio
+    async def test_a_wired_create_carries_no_warning(self) -> None:
+        """A warning on every create teaches the agent to skim the field. Only an
+        actually-unreachable file gets one.
+
+        THE MUTATION THAT BREAKS THIS: warn unconditionally on `created`. Run: a
+        create the agent had already wired up still nagged."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_react_component",
+                new=AsyncMock(return_value=_ok_result(created=True, unreferenced=False)),
+            ),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": "x",
+                    "create": True,
+                }
+            )
+
+        body = json.loads(out["content"][0]["text"])
+        assert body["unreferenced"] is False
+        assert "HALF DONE" not in body["message"]
+        assert "NOT online yet" in body["message"]
+
+    @pytest.mark.asyncio
+    async def test_a_service_without_the_key_degrades_to_no_warning(self) -> None:
+        """Forward/backward compatibility: an older service dict (no
+        ``unreferenced``) must not KeyError the handler mid-turn. Absent reads as
+        "nothing to warn about" — the pre-change behaviour — never as a crash that
+        loses an edit the service already persisted."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        legacy = {
+            "pocket_id": "pk1",
+            "component_path": "src/components/Hero.tsx",
+            "created": True,
+        }
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_react_component",
+                new=AsyncMock(return_value=legacy),
+            ),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": "x",
+                    "create": True,
+                }
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["unreferenced"] is False
+        assert "HALF DONE" not in body["message"]

--- a/tests/ee/sites/test_react_component_edit.py
+++ b/tests/ee/sites/test_react_component_edit.py
@@ -110,10 +110,14 @@ async def test_targeted_edits_are_applied_and_persisted(beanie_test_db):
         edits=[{"old_string": "Bright Smile Dental", "new_string": "Bright Smile"}],
     )
 
+    # Whole-dict equality on purpose: the agent narrates this payload, so a key
+    # arriving without a decision is a key it will narrate un-briefed. ``unreferenced``
+    # is False here because this is an edit, not a create — see section (d).
     assert out == {
         "pocket_id": pocket_id,
         "component_path": "src/components/Hero.tsx",
         "created": False,
+        "unreferenced": False,
     }
     source = await _source_of(pocket_id)
     assert "<h1>Bright Smile</h1>" in source["src/components/Hero.tsx"]
@@ -627,3 +631,176 @@ async def test_pockets_service_emits_pocket_updated(beanie_test_db, _recording_b
 
     kinds = [type(e).__name__ for e in _recording_bus_for_sites.events]
     assert "PocketUpdated" in kinds, kinds
+
+
+# ---------------------------------------------------------------------------
+# (d) The UNREFERENCED-CREATE signal — the second half of the two-call contract
+# ---------------------------------------------------------------------------
+#
+# THE INCIDENT (2026-09-01). A user uploaded an image to an already-published react
+# site and asked for it in the hero. The agent created a new component, reported
+# "I added it to a component", and nothing appeared — not on the page, not anywhere
+# the user could find it. Only "just add an img tag with the link" worked, because
+# that edited a component the page ALREADY renders.
+#
+# Adding a section is a TWO-CALL contract: `create=true` writes the file, then a
+# second `edits` call wires it into `src/App.tsx`. Nothing enforced or even
+# mentioned the second call after the first one landed. `create` returned a flat
+# success for a file that nothing imports — dead code in the source map — and the
+# agent, reading a clean success, reported the work as done. The file really was
+# written, so "I added it to a component" was true and useless.
+#
+# The signal is ADVISORY, never blocking: call 1 is unreferenced BY DEFINITION at
+# the moment it happens. It has to read as the next step on a checklist, or agents
+# learn to avoid `create` entirely and the section-adding lane closes again. This
+# mirrors merge_spec's orphan-state warning ("Added state key(s) with no ui widget
+# reading them — renders nothing"), which is the same defect one engine over.
+
+
+@pytest.mark.asyncio
+async def test_create_reports_the_new_file_is_referenced_by_nothing(beanie_test_db):
+    """The bug, in one assertion. A created component that no file imports renders
+    NOTHING, and the caller must be told so on the call that creates it.
+
+    THE MUTATION THAT BREAKS THIS: hardcode ``unreferenced`` to False. Run: the
+    orphan create reported a clean success and the agent had no reason to make the
+    second call."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    out = await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/components/Testimonials.tsx",
+        new_source="export default function Testimonials() { return <section/>; }\n",
+        create=True,
+    )
+
+    assert out["created"] is True
+    assert out["unreferenced"] is True, (
+        "src/App.tsx does not import the new component, so the page renders nothing "
+        "new — the response must say so"
+    )
+    # The file still landed: this is advice about the NEXT call, not a rejection.
+    source = await _source_of(pocket_id)
+    assert "src/components/Testimonials.tsx" in source
+
+
+@pytest.mark.asyncio
+async def test_create_is_silent_once_a_file_imports_the_new_path(beanie_test_db):
+    """The other half — the warning must not cry wolf. An agent that wires the
+    import FIRST (or re-creates a path something already references) has nothing
+    outstanding, and a warning there teaches it to ignore the field.
+
+    THE MUTATION THAT BREAKS THIS: always report ``unreferenced=True``. Run: a
+    correctly-wired create still nagged, which is how a signal gets ignored."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+    # Wire the import BEFORE the component file exists — the order the generator's
+    # own scaffold uses, and legal because App.tsx already exists.
+    await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/App.tsx",
+        edits=[
+            {
+                "old_string": "import Hero from './components/Hero';\n",
+                "new_string": (
+                    "import Hero from './components/Hero';\n"
+                    "import Testimonials from './components/Testimonials';\n"
+                ),
+            }
+        ],
+    )
+
+    out = await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/components/Testimonials.tsx",
+        new_source="export default function Testimonials() { return <section/>; }\n",
+        create=True,
+    )
+
+    assert out["created"] is True
+    assert out["unreferenced"] is False
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_edit_never_reports_unreferenced(beanie_test_db):
+    """Scoped to ``create``. An ordinary edit touches a file that was already part
+    of the site; re-litigating its wiring on every headline change is noise, and
+    noise on the common path is what makes the signal on the rare path get skimmed.
+
+    The file edited here is ``src/index.css``, which NOTHING in the fixture imports —
+    chosen deliberately. Editing ``Hero.tsx`` would prove nothing: it is imported by
+    App.tsx, so it reports False whether the ``create and`` scoping is there or not,
+    and the mutation below would sail past a green test.
+
+    THE MUTATION THAT BREAKS THIS: drop the ``create and`` so the scan runs on every
+    edit. Run: a headline change to any unwired file nagged about wiring the caller
+    never asked to change."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    out = await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/index.css",
+        edits=[{"old_string": "#0A84FF", "new_string": "#111111"}],
+    )
+
+    assert out["created"] is False
+    assert out["unreferenced"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_file_that_only_imports_itself_is_still_unreferenced(beanie_test_db):
+    """A module reaching itself reaches nothing: the page still never renders it.
+    Skipping the created file is what makes that true, and a scan that counted its
+    own contents would report every self-referential component as wired.
+
+    THE MUTATION THAT BREAKS THIS: drop the ``continue`` that skips the file itself.
+    Run: a component importing a sibling constant from its own path reported as
+    referenced, and the outstanding App.tsx call was never suggested."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    out = await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/components/Gallery.tsx",
+        new_source=(
+            "import { SHOTS } from './Gallery';\n"
+            "export default function Gallery() { return <section>{SHOTS.length}</section>; }\n"
+        ),
+        create=True,
+    )
+
+    assert out["created"] is True
+    assert out["unreferenced"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_public_asset_is_referenced_by_its_url_not_an_import(beanie_test_db):
+    """``public/`` is the other authorable prefix and it is NOT a module tree: a
+    file there is reached by URL (``/logo.png``), never by an import specifier. An
+    import-only scan would report every correctly-used asset as an orphan."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+    await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/components/Hero.tsx",
+        edits=[
+            {
+                "old_string": "<h1>Bright Smile Dental</h1>",
+                "new_string": '<h1>Bright Smile Dental</h1>\n      <img src="/logo.png" alt=""/>',
+            }
+        ],
+    )
+
+    out = await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="public/logo.png",
+        new_source="(binary-ish placeholder)",
+        create=True,
+    )
+
+    assert out["created"] is True
+    assert out["unreferenced"] is False

--- a/tests/mutations/react_edit_lane.json
+++ b/tests/mutations/react_edit_lane.json
@@ -178,8 +178,8 @@
   {
     "label": "the success body claims the change is published, so the agent tells the user a draft edit went live",
     "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
-    "find": "                \"Saved to the site's draft — it is NOT online yet, and no build was \"",
-    "replace": "                \"Published — the change is live at the site's url. Also a draft. \"",
+    "find": "        \"Saved to the site's draft — it is NOT online yet, and no build was \"",
+    "replace": "        \"Published — the change is live at the site's url. Also a draft. \"",
     "tests": [
       "tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py::TestEditHandler::test_success_payload_says_draft_and_never_claims_it_is_live"
     ]
@@ -284,6 +284,62 @@
     "replace": "            \"`create_react_site` again with the SAME \"",
     "tests": [
       "tests/cloud/surface/test_sites_handler.py::test_react_create_step_routes_follow_up_changes_to_the_edit_tool"
+    ]
+  },
+  {
+    "label": "the orphan-create signal is hardcoded off: a component nothing imports reports a clean success, which is the 2026-09-01 incident exactly",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    unreferenced = create and not react_path_is_referenced(",
+    "replace": "    unreferenced = False and not react_path_is_referenced(",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_create_reports_the_new_file_is_referenced_by_nothing",
+      "tests/ee/sites/test_react_component_edit.py::test_a_file_that_only_imports_itself_is_still_unreferenced"
+    ]
+  },
+  {
+    "label": "the signal is hardcoded on: every create nags, including one already wired, which is how a warning gets ignored",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    unreferenced = create and not react_path_is_referenced(",
+    "replace": "    unreferenced = create or not react_path_is_referenced(",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_create_is_silent_once_a_file_imports_the_new_path",
+      "tests/ee/sites/test_react_component_edit.py::test_a_public_asset_is_referenced_by_its_url_not_an_import"
+    ]
+  },
+  {
+    "label": "the create scoping is gone: the scan runs on every edit, so an ordinary change to an unwired file nags about wiring nobody asked to change",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    unreferenced = create and not react_path_is_referenced(",
+    "replace": "    unreferenced = not react_path_is_referenced(",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_an_ordinary_edit_never_reports_unreferenced"
+    ]
+  },
+  {
+    "label": "public/ is scanned as a module tree: an asset reached by URL reports as an orphan, so every correctly-used image nags",
+    "file": "ee/pocketpaw_ee/sites/react_paths.py",
+    "find": "    if norm.startswith(\"public/\"):",
+    "replace": "    if False and norm.startswith(\"public/\"):",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_a_public_asset_is_referenced_by_its_url_not_an_import"
+    ]
+  },
+  {
+    "label": "the file no longer skips itself, so a self-import counts as a reference and an unreachable component reports as wired",
+    "file": "ee/pocketpaw_ee/sites/react_paths.py",
+    "find": "            continue  # the file itself — a self-import reaches nothing",
+    "replace": "            pass  # the file itself — a self-import reaches nothing",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_a_file_that_only_imports_itself_is_still_unreferenced"
+    ]
+  },
+  {
+    "label": "the handler drops the outstanding-step warning, so the agent narrates an orphan create as an ordinary success",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
+    "find": "    if unreferenced:\n        message = (",
+    "replace": "    if False and unreferenced:\n        message = (",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py::TestUnreferencedCreateWarning::test_orphan_create_tells_the_agent_the_page_is_unchanged"
     ]
   }
 ]


### PR DESCRIPTION
## What happened

A user attached an image to an already-published react site and asked for it in
the hero. The agent created a component, said it had added it, and the page never
changed. The component was not anywhere they could find. Only "just add an img tag
with the link" worked, because that edited a component the page already renders.

## Why

Adding a section to a react site is two calls. `create=true` writes
`src/components/<Name>.tsx`; a second `edits` call imports and renders it from
`src/App.tsx`. The skill has said so in prose since RX-3.

What was missing was feedback inside the loop. Call 1 returned the same flat
"Saved to the site's draft" whether or not call 2 ever came, so an agent that
stopped after the write had nothing telling it the job was half done, and the
success it read is the success it relayed. The file really was written, which is
why "I added it to a component" was true and useless.

## The change

`edit_react_component` now returns `unreferenced`. When it is true the MCP message
leads with the outstanding call and says not to report the section as added yet.

Reachability is resolved, not pattern matched. Every import/from/require specifier
in every other file resolves against the importing file's own directory, so
`./components/Hero` from App.tsx and `../components/Hero` from a sibling land on
the one file they mean, and a testimonial that happens to say "Testimonials" is
not read as an import. `public/` gets a separate rule because it is not a module
tree: an asset is reached by URL, and an import-only scan would call every
correctly used image an orphan.

Two constraints, both load bearing. It is advisory and never blocks, because call
1 of two is unreferenced at the instant it lands, every time, and refusing it
would close the only lane that can add a section at all. And it is scoped to
`create`, because a warning on every edit is noise, and noise is how the one that
matters gets skimmed.

This mirrors `merge_spec`'s orphan-state warning, which is the same defect one
engine over.

## Verification

- 2553 passed, 4 skipped across `tests/ee/sites`, `tests/ee/agent`,
  `tests/cloud/surface`, `tests/atlas` and the skill suites, run on the rebased
  branch rather than the pre-rebase tree.
- All 37 mutations in `react_edit_lane.json` caught, including the six new ones.
- The mutation pass earned its keep: it caught a weak test of mine. The
  ordinary-edit case used a file App.tsx imports, so it reported False either way
  and dropping the `create` scoping escaped it. Now pinned on an unwired file.
- `mutate.py --validate` clean at 802 anchors, after repointing one anchor this
  change rotted.

## Not fixed here

`edit_html_file` has the identical two-call shape ("add an about page" needs a
link from `index.html`) and no such signal. Same defect, different engine. Left
out to keep this diff on the reported bug.
