### PR TITLE
An employee can ask an admin for a paid site plan

### DIFF
--- a/ee/pocketpaw_ee/cloud/site_plan_requests/__init__.py
+++ b/ee/pocketpaw_ee/cloud/site_plan_requests/__init__.py
@@ -1,0 +1,47 @@
+# ee/cloud/site_plan_requests — an employee asks for a paid site plan; an admin
+# approves it, and the approval is what buys.
+#
+# Created: 2026-09-01 (feat/sites-plan-purchase-request).
+#
+# The gap this fills. ``sites.buy_plan`` (ADMIN) stopped a member charging the
+# company card for a site plan, which was the right refusal and a dead end: the
+# employee who builds the site gets a 403 and no way forward except finding an
+# admin and describing what they wanted. This turns that refusal into a request.
+#
+# The blob is the 14th gated proposal kind, alongside ``_admin_action`` and
+# ``_artifact_change``. Its shape mirrors ``_admin_action`` closely because the
+# problem is the same one — gate a privileged write behind a human — with ONE
+# inversion that is the entire point of this module:
+#
+#   ``_admin_action`` re-checks the PROPOSER's role at execute time. Here the
+#   proposer is, by construction, NOT authorized: a member asking for a plan is
+#   exactly who this exists for. So the execute-time RBAC check runs against the
+#   APPROVER (``Action.approved_by``, the authenticated identity the router
+#   records — never a free-text field). Re-checking the proposer would refuse
+#   every request this feature creates; omitting the check entirely would let any
+#   pending request buy the moment anyone approved it.
+#
+# That inversion is safe because ``instinct.approve`` is itself ADMIN — the same
+# minimum as ``sites.buy_plan`` — so an approver has already cleared the bar the
+# purchase needs. The executor re-checks anyway rather than inferring it: the two
+# rules live in different files and can drift, and "the approve endpoint already
+# checked something similar" is not a control.
+#
+# See ``propose.py`` for the blob shape and ``executor.py`` for what approving
+# actually does.
+
+from pocketpaw_ee.cloud.site_plan_requests.propose import (
+    SITE_PLAN_REQUEST_KIND,
+    SITE_PLAN_REQUEST_PARAM_KEY,
+    SITE_PLAN_REQUEST_SCHEMA,
+    compute_request_hash,
+    propose_site_plan_request,
+)
+
+__all__ = [
+    "SITE_PLAN_REQUEST_KIND",
+    "SITE_PLAN_REQUEST_PARAM_KEY",
+    "SITE_PLAN_REQUEST_SCHEMA",
+    "compute_request_hash",
+    "propose_site_plan_request",
+]

--- a/ee/pocketpaw_ee/cloud/site_plan_requests/executor.py
+++ b/ee/pocketpaw_ee/cloud/site_plan_requests/executor.py
@@ -1,0 +1,492 @@
+# ee/cloud/site_plan_requests/executor.py — an admin approved the request, so
+# buy the plan and publish the site.
+#
+# Created: 2026-09-01 (feat/sites-plan-purchase-request).
+#
+# The apply-on-approve half. Called best-effort from the instinct router's
+# approve / bulk-approve after ``store.approve()`` succeeds, exactly like
+# ``admin_proposals.executor``. Never raises — a failure here must not break the
+# approve response; it is captured as a ``failed`` outcome the Tray card shows.
+#
+# THE ONE INVERSION, and the reason this is its own module rather than another
+# ``_DISPATCH`` row in ``admin_proposals``:
+#
+#   ``_admin_action`` re-checks the PROPOSER's current role at execute time,
+#   because there the proposer is an admin whose rights might have been revoked
+#   since. Here the proposer is a MEMBER who never had the right — that is the
+#   entire premise of the feature — so re-checking them would refuse every
+#   request this exists to serve. The check runs against the APPROVER instead:
+#   ``Action.approved_by``, which the instinct router writes from the
+#   authenticated identity (``str(user.id)``), never from a request body field.
+#
+# That is safe because ``instinct.approve`` is ADMIN and ``sites.buy_plan`` is
+# ADMIN — an approver has necessarily cleared the purchase bar already. The check
+# is re-run anyway rather than inferred: those two rules live in different files
+# and can drift, and "the approve endpoint checked something similar" is not a
+# control. If ``sites.buy_plan`` is ever raised to OWNER, this keeps working and
+# an ADMIN's approval starts failing closed with a legible reason — which is the
+# correct behaviour and the reason the check is explicit.
+#
+# The order of guards is load-bearing and mirrors admin_proposals: blob present →
+# schema → tenancy → approver identity → identity-hash → idempotency (under a
+# per-action lock, re-read fresh) → RBAC re-check → the write. Nothing that
+# charges runs before all of them.
+#
+# PRICE DRIFT is reported, not enforced. The blob records the price the requester
+# saw; the purchase prices from the live catalog, because the catalog is the
+# truth about money and a week-old snapshot is not. When they differ the outcome
+# says so, so an admin who approved "$7/month" can see they were charged $9. The
+# alternative — refusing on any drift — turns an ordinary price change into a
+# pile of dead Tray cards, and the identity hash already covers the thing that
+# must not move (which workspace, which site, which tier).
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.site_plan_requests.propose import (
+    SITE_PLAN_REQUEST_PARAM_KEY,
+    SITE_PLAN_REQUEST_SCHEMA,
+    compute_request_hash,
+)
+
+logger = logging.getLogger(__name__)
+
+# Bound on an outcome summary, matching admin_proposals.
+_OUTCOME_SUMMARY_MAX = 500
+
+# Per-action locks so two concurrent invocations for the SAME Action cannot
+# interleave between the idempotency guard and the outcome back-write. Keyed on
+# the action id, so different actions never contend.
+_action_locks: dict[str, asyncio.Lock] = {}
+
+
+def _lock_for(action_id: str) -> asyncio.Lock:
+    """Return the process-wide lock for ``action_id`` (minted on first use)."""
+    lock = _action_locks.get(action_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _action_locks[action_id] = lock
+    return lock
+
+
+def site_plan_request_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_site_plan_request`` blob on an Action, or ``None``."""
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get(SITE_PLAN_REQUEST_PARAM_KEY)
+    return blob if isinstance(blob, dict) else None
+
+
+def _coerce_uuid(raw: Any) -> UUID | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be."""
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except (ValueError, AttributeError, TypeError):
+            return None
+    return None
+
+
+def _summarize(text: str) -> str:
+    """Bound + single-line an outcome summary."""
+    text = str(text).replace("\n", " ").strip()
+    if len(text) > _OUTCOME_SUMMARY_MAX:
+        text = text[:_OUTCOME_SUMMARY_MAX] + "…"
+    return text
+
+
+def _approver_id(action: Any) -> str:
+    """The AUTHENTICATED approver recorded on the Action.
+
+    ``approved_by`` is written by ``store.approve(action_id, approver=...)``, and
+    the instinct router passes ``str(user.id)`` — never ``req.approver``, which
+    is a free-text display label a client controls. This is the identity whose
+    role decides whether the purchase may happen, so reading the wrong field here
+    would be the whole vulnerability.
+    """
+    return str(getattr(action, "approved_by", "") or "")
+
+
+async def _persist_outcome(
+    *,
+    store: Any,
+    action_id: str,
+    status: str,
+    response_summary: str,
+    executed_at: str,
+) -> None:
+    """Back-write the structured outcome onto the persisted blob.
+
+    Also the idempotency signal ``_already_executed`` reads. Best-effort: on
+    failure the free-text ``mark_executed`` / ``mark_failed`` outcome still
+    records what happened.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(SITE_PLAN_REQUEST_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["outcome"] = {
+            "status": status,
+            "response_summary": response_summary,
+            "executed_at": executed_at,
+        }
+        params[SITE_PLAN_REQUEST_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — back-write is best-effort
+        logger.warning(
+            "site_plan_request: failed to persist outcome onto action %s",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: UUID | None,
+    response_summary: str | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close.
+
+    The executor owns the close on the approve path (the router owns it on
+    reject), so exactly one terminal lands. Best-effort.
+    """
+    if correlation_id is None:
+        return
+
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {"passed": passed, "action_outcome": action_outcome}
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if response_summary:
+        payload["response_summary"] = response_summary
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "site_plan_request decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+def _already_executed(action: Any, blob: dict[str, Any]) -> bool:
+    """Idempotency guard — True when this purchase already fired.
+
+    Either signal suffices: the blob carries an ``outcome``, or the Action is
+    terminal. A re-approve must never buy the plan twice.
+    """
+    if isinstance(blob.get("outcome"), dict):
+        return True
+    status = getattr(action, "status", None)
+    status_value = getattr(status, "value", status)
+    return str(status_value) in ("executed", "failed")
+
+
+async def _recheck_approver_may_buy(workspace_id: str, approver_user_id: str) -> None:
+    """RE-CHECK the APPROVER's CURRENT right to buy a site plan. FAIL-CLOSED.
+
+    Loads the approver's User doc FRESH (so ``.workspaces`` reflects their role
+    right now) and runs ``check_workspace_action`` for ``sites.buy_plan`` — the
+    same rule the publish router applies to a direct purchase. A missing user, a
+    user who is not a member of this workspace, or one below ADMIN raises
+    ``Forbidden``; the caller turns that into a ``failed`` outcome and the
+    purchase never fires.
+
+    The approver rather than the proposer — see the module header. This is the
+    load-bearing security rule of the whole feature: without it, a pending
+    request would buy the moment ANY approver touched it, and with the wrong
+    identity in it, the check would refuse every legitimate request.
+    """
+    from beanie import PydanticObjectId
+
+    from pocketpaw_ee.cloud.models.user import User as _UserDoc
+    from pocketpaw_ee.guards.deps import check_workspace_action
+    from pocketpaw_ee.guards.rbac import Forbidden
+
+    try:
+        approver = await _UserDoc.get(PydanticObjectId(approver_user_id))
+    except Exception as exc:  # noqa: BLE001 — a bad id is a denial, not a crash
+        raise Forbidden(
+            "sites.plan_purchase_forbidden",
+            f"could not resolve the approving user {approver_user_id}",
+        ) from exc
+    if approver is None:
+        raise Forbidden(
+            "sites.plan_purchase_forbidden",
+            f"the approving user {approver_user_id} no longer exists",
+        )
+    check_workspace_action(approver, workspace_id, "sites.buy_plan")
+
+
+async def execute_approved_site_plan_request(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """Buy the requested plan and publish the site, after an admin approved it.
+
+    Never raises. The Action is marked executed on a successful publish, or
+    failed (with a legible outcome) on any of: a malformed/stale blob, a missing
+    or unauthorized approver, an identity-hash mismatch, or a publish error.
+
+    The whole body runs under a per-action lock so two concurrent invocations on
+    the same Action cannot interleave between the idempotency guard and the
+    back-write — the loser re-reads the winner's committed outcome and no-ops.
+    """
+    action_id = str(getattr(action, "id", "") or "")
+    if not action_id:
+        await _execute_locked(action, human_event_id=human_event_id)
+        return
+    async with _lock_for(action_id):
+        await _execute_locked(action, human_event_id=human_event_id)
+
+
+async def _execute_locked(action: Any, *, human_event_id: Any | None = None) -> None:
+    """The body of ``execute_approved_site_plan_request``, under the lock."""
+    from pocketpaw.stores import get_instinct_store
+
+    blob = site_plan_request_blob(action)
+    if blob is None:
+        # Not a plan-request Action — no chain was opened, and there is no
+        # workspace to scope a store to.
+        logger.warning(
+            "approved action %s carries no _site_plan_request blob",
+            getattr(action, "id", "?"),
+        )
+        return
+
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    pocket_id = str(blob.get("pocket_id") or "")
+    site_plan_key = str(blob.get("site_plan_key") or "")
+    requested_by = str(blob.get("requested_by") or "")
+    approver_user_id = _approver_id(action)
+    action_id = str(getattr(action, "id", "") or "")
+    causation = _coerce_uuid(human_event_id)
+
+    # HTTP approve path (no ``current_workspace`` ContextVar) — scope the store to
+    # the blob's workspace so the terminal audit row lands in the tenant's file.
+    store = get_instinct_store(workspace_id=workspace_id or None)
+
+    async def _fail(reason: str, *, error_class: str, response_summary: str | None = None) -> None:
+        """Mark failed AND close the chain through one terminal."""
+        await store.mark_failed(action.id, reason)
+        await _persist_outcome(
+            store=store,
+            action_id=str(action.id),
+            status="failed",
+            response_summary=_summarize(response_summary or reason),
+            executed_at=datetime.now(UTC).isoformat(),
+        )
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            # The chain actor is the REQUESTER — this is their request's story,
+            # and the approver appears in the outcome summary.
+            user_id=requested_by,
+            causation_id=causation,
+            response_summary=_summarize(response_summary or reason),
+        )
+
+    # Schema — a stale blob from an incompatible build fails loud rather than
+    # buying a misread tier.
+    if blob.get("schema") != SITE_PLAN_REQUEST_SCHEMA:
+        await _fail(
+            "site-plan-request schema mismatch — the blob is from an incompatible "
+            "build and cannot be executed",
+            error_class="SchemaMismatch",
+        )
+        return
+
+    if not (workspace_id and pocket_id and site_plan_key):
+        await _fail(
+            "site-plan-request blob is missing workspace_id / pocket_id / site_plan_key",
+            error_class="MalformedBlob",
+        )
+        return
+
+    # No approver recorded means nothing proves a human with rights accepted this.
+    # Refuse rather than fall back to the requester, who by construction may not buy.
+    if not approver_user_id:
+        await _fail(
+            "site-plan-request carries no approved_by — cannot verify who authorized "
+            "the purchase; refusing to charge the workspace",
+            error_class="MissingApprover",
+        )
+        return
+
+    # Identity hash — the admin approved a SPECIFIC site on a SPECIFIC tier. An
+    # approve-with-edits that moved either must not buy something else.
+    stored_hash = str(blob.get("params_hash") or "")
+    recomputed = compute_request_hash(workspace_id, pocket_id, site_plan_key)
+    if stored_hash and stored_hash != recomputed:
+        await _fail(
+            "site-plan-request identity hash mismatch — the workspace, site or tier "
+            "changed after the request was approved; refusing to buy a different plan",
+            error_class="RequestHashMismatch",
+        )
+        return
+
+    # Idempotency — read the FRESH persisted state so a concurrent loser sees the
+    # winner's committed outcome. The tamper guards above deliberately stay on the
+    # passed-in blob (a re-read would mask a mutated in-flight object).
+    guard_action = action
+    guard_blob = blob
+    if action_id:
+        fresh = await store.get_action(action_id)
+        if fresh is not None:
+            guard_action = fresh
+            fresh_blob = site_plan_request_blob(fresh)
+            if fresh_blob is not None:
+                guard_blob = fresh_blob
+    if _already_executed(guard_action, guard_blob):
+        logger.info(
+            "site_plan_request: action %s already executed (idempotency guard) — "
+            "not buying the plan twice",
+            action.id,
+        )
+        return
+
+    # EXECUTE-TIME RBAC RE-CHECK against the APPROVER (the load-bearing rule).
+    try:
+        await _recheck_approver_may_buy(workspace_id, approver_user_id)
+    except Exception as exc:  # noqa: BLE001 — Forbidden or a resolve error → fail closed
+        await _fail(
+            f"the approving user {approver_user_id} does not hold 'sites.buy_plan' in "
+            f"this workspace — refusing to charge for the site plan: {exc}",
+            error_class=type(exc).__name__,
+            response_summary=str(exc),
+        )
+        return
+
+    # Price the purchase from the LIVE catalog, and report drift rather than
+    # enforcing it — see the module header for why.
+    from pocketpaw_ee.cloud.billing import site_plans
+
+    tier = site_plans.site_scoped_tier(site_plan_key)
+    if tier is None:
+        await _fail(
+            f"'{site_plan_key}' is no longer a plan a single site can be put on — "
+            "the catalog changed since this was requested",
+            error_class="TierNoLongerAvailable",
+        )
+        return
+    live_price = int(tier.monthly_price_usd or 0)
+    quoted_price = int(blob.get("monthly_price_usd") or 0)
+    drift_note = (
+        ""
+        if live_price == quoted_price
+        else f" (price changed since the request: ${quoted_price} → ${live_price}/month)"
+    )
+
+    # THE PURCHASE. ``purchase_authorized=True`` is earned by the RBAC re-check
+    # above and by nothing else — it is the one place in the codebase outside the
+    # publish router that may pass it, which is why the check sits immediately
+    # before it with no branch in between.
+    try:
+        from pocketpaw_ee.sites import service as sites_service
+
+        await sites_service.publish_pocket(
+            workspace_id=workspace_id,
+            # The REQUESTER remains the author of the publish — they built the
+            # site. The approver authorized the spend, which the outcome records.
+            user_id=requested_by,
+            pocket_id=pocket_id,
+            site_plan_key=site_plan_key,
+            purchase_authorized=True,
+        )
+    except Exception as exc:  # noqa: BLE001 — never let a publish failure break approve
+        logger.warning(
+            "site_plan_request: publish failed for action %s (pocket=%s, tier=%s)",
+            action.id,
+            pocket_id,
+            site_plan_key,
+            exc_info=True,
+        )
+        await _fail(
+            f"the site plan purchase failed: {exc}",
+            error_class=type(exc).__name__,
+            response_summary=str(exc),
+        )
+        return
+
+    summary = _summarize(
+        f"Published on the '{site_plan_key}' plan at ${live_price}/month, "
+        f"approved by {approver_user_id}{drift_note}."
+    )
+    await store.mark_executed(action.id, summary)
+    await _persist_outcome(
+        store=store,
+        action_id=str(action.id),
+        status="executed",
+        response_summary=summary,
+        executed_at=datetime.now(UTC).isoformat(),
+    )
+    _emit_chain_close(
+        passed=True,
+        action_outcome="executed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=requested_by,
+        causation_id=causation,
+        response_summary=summary,
+    )
+
+
+__all__ = ["execute_approved_site_plan_request", "site_plan_request_blob"]

--- a/ee/pocketpaw_ee/cloud/site_plan_requests/propose.py
+++ b/ee/pocketpaw_ee/cloud/site_plan_requests/propose.py
@@ -1,0 +1,352 @@
+# ee/cloud/site_plan_requests/propose.py — file an employee's request to put a
+# site on a paid plan.
+#
+# Created: 2026-09-01 (feat/sites-plan-purchase-request).
+#
+# The propose half of the site-plan request gate. A member publishes and asks for
+# a paid tier; ``sites.buy_plan`` (ADMIN) refuses them; instead of ending there,
+# the router files THIS — an Instinct Action carrying a ``_site_plan_request``
+# blob — and tells them it is waiting on an admin. An admin approves it in The
+# Tray and the executor performs the publish that was refused.
+#
+# This module does NOT charge, publish, or grant anything. It only records what
+# was asked for, by whom, at what price.
+#
+# The blob (schema 1):
+#   * ``kind`` / ``schema``    — discriminator + version;
+#   * ``workspace_id``         — the tenant. The router's tenancy gate reads it
+#                                HERE, and the executor re-validates it;
+#   * ``pocket_id``            — the pocket whose site is being published;
+#   * ``site_plan_key``        — the CANONICAL tier key being requested. Stored
+#                                canonicalized so an approval a week later cannot
+#                                resolve a legacy alias to a different rung than
+#                                the one the admin read on the card;
+#   * ``monthly_price_usd``    — the price AT PROPOSE TIME, recorded for the
+#                                approver to read. Never used to charge: the
+#                                executor prices from the live catalog, because
+#                                the truth about money is the catalog's, not a
+#                                week-old snapshot's. It exists so a price that
+#                                MOVED between propose and approve is visible
+#                                rather than silent (see the executor's drift
+#                                check);
+#   * ``requested_by``         — the member who asked. Attribution only: this
+#                                user is NOT re-checked for purchase rights,
+#                                because not having them is the premise;
+#   * ``params_hash``          — a stable hash of the request's identity fields,
+#                                re-checked at execute time so an approve-with-
+#                                edits cannot swap the tier or the pocket out
+#                                from under what the admin actually read;
+#   * ``idempotency_key``      — so a re-approve never double-publishes;
+#   * ``summary``              — one human line for the Tray card;
+#   * ``correlation_id`` / ``proposed_event_id`` — the Decision-Graph chain ids.
+#
+# Security:
+#   * Proposing grants NOTHING. The executor checks the APPROVER's current role
+#     (see the package docstring for why the approver and not the proposer).
+#   * The identity hash is re-checked at execution, so the write that fires is
+#     the write that was displayed.
+#   * Tenancy is bound on the router's approve / reject paths via
+#     ``_assert_site_plan_request_workspace`` and re-validated at execution.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# The Instinct Action kind discriminator. The blob also carries this as ``kind``
+# for readers that introspect it.
+SITE_PLAN_REQUEST_KIND = "site_plan_request"
+
+# The parameters key the blob rides under — peer of ``_admin_action``. The
+# router + executor dispatch on this key being present.
+SITE_PLAN_REQUEST_PARAM_KEY = "_site_plan_request"
+
+# Schema version. Bump when the blob shape changes so a stale pending request
+# approved after a deploy fails loud rather than buying a misread tier.
+SITE_PLAN_REQUEST_SCHEMA = 1
+
+
+def compute_request_hash(workspace_id: str, pocket_id: str, site_plan_key: str) -> str:
+    """Return a stable SHA-256 digest of the request's IDENTITY fields.
+
+    Identity, deliberately — not the whole blob. The three fields here are what
+    the approver is actually agreeing to: this workspace, this site, this tier.
+    The price is excluded on purpose: it is allowed to move between propose and
+    approve (the catalog is the source of truth for money), and hashing it would
+    turn an ordinary price change into a hard failure instead of the visible
+    drift the executor reports.
+
+    Canonical JSON (sorted keys, no whitespace) so ordering cannot change the
+    digest.
+    """
+    canonical = json.dumps(
+        {
+            "workspace_id": workspace_id,
+            "pocket_id": pocket_id,
+            "site_plan_key": site_plan_key,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    workspace_id: str,
+    pocket_id: str,
+    site_plan_key: str,
+    user_id: str,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for a plan request.
+
+    Mirrors ``admin_proposals.propose._emit_agent_proposed``: the requesting
+    member is the actor. Unlike an admin action, this proposal IS bound to a
+    pocket, so the chain's ``pocket_id`` carries the real pocket rather than
+    standing in with the workspace.
+
+    Returns the emitted event id for the blob's ``proposed_event_id`` (the
+    ``human.corrected`` causation handle), or ``None`` when the emit raised —
+    best-effort; the reconciler picks up orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "intent": f"put this site on the '{site_plan_key}' plan",
+        "action": "site_plan_request",
+        "pocket_id": pocket_id,
+        "inputs": [],
+        "proposal_kind": "site_plan_request",
+        "proposal": {"site_plan_key": site_plan_key, "pocket_id": pocket_id},
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "site_plan_request agent.proposed emit failed for correlation_id=%s "
+            "(action_id=%s) — reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Write the chain ids onto the persisted blob after ``agent.proposed`` fired.
+
+    Direct SQL update, the same pattern ``admin_proposals.propose`` uses.
+    Best-effort: a failure leaves ``proposed_event_id`` None and the eventual
+    ``human.corrected`` emits without a causation_id (the chain still folds).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(SITE_PLAN_REQUEST_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[SITE_PLAN_REQUEST_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "site_plan_request: failed to persist chain ids onto action %s — the "
+            "chain's human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+async def propose_site_plan_request(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    site_plan_key: str,
+    requested_by: str,
+    site_name: str = "",
+    idempotency_key: str | None = None,
+    correlation_id: str | None = None,
+    assignee: str | None = None,
+) -> str:
+    """File an Instinct Action asking an admin to put this site on a paid plan.
+
+    Returns the proposed Action id. Grants nothing: the executor re-checks the
+    APPROVER's role and re-prices from the live catalog before it publishes.
+
+    ``site_plan_key`` is canonicalized here rather than at execute time. A tier
+    key can be a legacy alias (``business`` → ``staff``), and the alias table is
+    allowed to change; resolving it at propose time means the blob records the
+    rung the requester actually saw, and the Tray card, the hash, and the
+    eventual purchase all name the same one.
+
+    Raises ``ValueError`` for a missing tenant / pocket / requester, for a tier
+    the catalog does not know, and for a tier that is not a per-site rung — an
+    org-scoped flat (``studio`` / ``agency``) is not a legal ``site_plan_key`` on
+    a publish, so a request for one could never be executed and must not become a
+    Tray card that fails on approval.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+    from pocketpaw_ee.cloud.billing import site_plans
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("propose_site_plan_request requires a non-empty workspace_id")
+    pocket_id = str(pocket_id or "")
+    if not pocket_id:
+        raise ValueError("propose_site_plan_request requires a non-empty pocket_id")
+    requested_by = str(requested_by or "")
+    if not requested_by:
+        raise ValueError("propose_site_plan_request requires a non-empty requested_by")
+
+    # ``site_scoped_tier`` rather than ``get_site_plan``: it resolves a legacy
+    # alias AND returns None for an ORG-scoped flat (studio / agency), which is
+    # exactly the refusal wanted here. An org key is not a legal ``site_plan_key``
+    # on a publish, so a request for one could only ever become a Tray card that
+    # fails on approval — refuse it at the door, where the requester is present to
+    # be told why. Using the same helper the entitlement seams use also means this
+    # cannot drift from their idea of what a per-site rung is.
+    canonical_key = site_plans.canonical_site_tier_key(str(site_plan_key or ""))
+    tier = site_plans.site_scoped_tier(canonical_key)
+    if tier is None:
+        raise ValueError(f"'{site_plan_key}' is not a plan a single site can be put on")
+    monthly_price_usd = int(tier.monthly_price_usd or 0)
+
+    request_hash = compute_request_hash(workspace_id, pocket_id, canonical_key)
+    idem = idempotency_key or f"{workspace_id}:{pocket_id}:{request_hash[:16]}"
+    corr = correlation_id or str(uuid4())
+
+    tier_label = getattr(tier, "display_name", "") or canonical_key
+    subject = site_name or "this site"
+    human_summary = (
+        f"Put {subject} on the {tier_label} plan "
+        f"(${monthly_price_usd}/month, added to this workspace's subscription)."
+    )
+
+    blob: dict[str, Any] = {
+        "kind": SITE_PLAN_REQUEST_KIND,
+        "schema": SITE_PLAN_REQUEST_SCHEMA,
+        "workspace_id": workspace_id,
+        "pocket_id": pocket_id,
+        "site_plan_key": canonical_key,
+        "monthly_price_usd": monthly_price_usd,
+        "requested_by": requested_by,
+        "params_hash": request_hash,
+        "idempotency_key": idem,
+        "summary": human_summary,
+        "correlation_id": corr,
+        "proposed_event_id": None,
+    }
+
+    recommendation = (
+        f"Approving adds ${monthly_price_usd}/month to this workspace's "
+        f"subscription and publishes {subject} on the {tier_label} plan. "
+        "Rejecting leaves the site on its current plan."
+    )
+    trigger = ActionTrigger(
+        type="user",
+        source=requested_by,
+        reason="a workspace member asked to put a site on a paid plan",
+    )
+
+    # Scope the store to the tenant — this path has no ``current_workspace``
+    # ContextVar set.
+    store = get_instinct_store(workspace_id=workspace_id or None)
+    action_obj = await store.propose(
+        pocket_id=pocket_id,
+        title=f"Site plan request — {tier_label}",
+        description=human_summary,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.WORKFLOW,
+        # HIGH, like an admin action: someone is blocked on the answer. A request
+        # that sits in the Tray unnoticed is the 403 again, only slower.
+        priority=ActionPriority.HIGH,
+        parameters={SITE_PLAN_REQUEST_PARAM_KEY: blob},
+        # NOT the requester: they cannot approve this (that is the premise). Left
+        # unassigned so it reaches the workspace's admins rather than sitting in
+        # the inbox of the one person who is known to be unable to act on it.
+        assignee=assignee,
+        workspace_id=workspace_id,
+    )
+
+    logger.info(
+        "site_plan_request: proposed tier '%s' for pocket %s → Instinct action %s "
+        "(workspace=%s, requested_by=%s, correlation_id=%s)",
+        canonical_key,
+        pocket_id,
+        action_obj.id,
+        workspace_id,
+        requested_by,
+        corr,
+    )
+
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=UUID(corr),
+        action_id=action_obj.id,
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        site_plan_key=canonical_key,
+        user_id=requested_by,
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action_obj.id,
+            correlation_id=corr,
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    return action_obj.id
+
+
+__all__ = [
+    "SITE_PLAN_REQUEST_KIND",
+    "SITE_PLAN_REQUEST_PARAM_KEY",
+    "SITE_PLAN_REQUEST_SCHEMA",
+    "compute_request_hash",
+    "propose_site_plan_request",
+]

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1072,6 +1072,7 @@ RESERVED_GATED_PARAM_KEYS: frozenset[str] = frozenset(
         "_artifact_change",
         "_admin_action",
         "_customer_reply",
+        "_site_plan_request",
     }
 )
 
@@ -1209,6 +1210,54 @@ def _assert_gated_workspaces(action: Any, current_workspace: str) -> None:
     # was written; folded in at the growth-v1 rebase so the chokepoint keeps its
     # every-gated-kind guarantee.
     _assert_customer_reply_workspace(action, current_workspace)
+    # A site-plan request — approving it BUYS a plan on this workspace's
+    # subscription, so it needs the same tenancy binding as every other kind.
+    _assert_site_plan_request_workspace(action, current_workspace)
+
+
+def _site_plan_request_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_site_plan_request`` blob on an Action, or ``None``.
+
+    The blob is an employee's request to put a site on a PAID plan — approving it
+    charges the workspace's subscription. See ``ee/cloud/site_plan_requests/``
+    for the propose + execute halves.
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_site_plan_request")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_site_plan_request_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting a site-plan request from another workspace.
+
+    SECURITY — approving one BUYS A PLAN against the blob's workspace
+    subscription. ``require_action_any_workspace("instinct.approve")`` only proves
+    the caller holds the role SOMEWHERE; this binds the request to their active
+    workspace, on BOTH the approve and the reject side (asymmetric tenant scope is
+    no tenant scope — pocketpaw#1183 / #1250).
+
+    FAIL-CLOSED on an empty claim, for the reason the artifact-change guard
+    already documents: a workspace-less blob aimed at a victim's pocket must not
+    be approvable by any operator in any workspace. A plan request's tenancy is
+    mandatory — ``propose_site_plan_request`` refuses to build one without it — so
+    an empty claim is a tampered or corrupt blob, never a legitimate case.
+    """
+    blob = _site_plan_request_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if not blob_workspace:
+        raise Forbidden(
+            "instinct.missing_workspace_in_blob",
+            "This site plan request has no workspace claim — cannot verify tenancy",
+        )
+    if blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_action",
+            "This site plan request belongs to another workspace",
+        )
 
 
 def _growth_send_blob(action: Any) -> dict[str, Any] | None:
@@ -2653,6 +2702,12 @@ async def approve_action(
     # blob's workspace, so a cross-workspace approve would deliver a decision into
     # another tenant's paw-bar surface. Gate it like every other blob kind.
     _assert_customer_reply_workspace(before, workspace_id)
+    # A ``_site_plan_request`` — approving it BUYS a site plan against this
+    # workspace's subscription, so it is bound to the caller's workspace exactly
+    # like every other spending kind. (``_assert_gated_workspaces`` below runs it
+    # too; this line keeps the explicit sweep complete rather than relying on the
+    # chokepoint alone, matching every sibling above.)
+    _assert_site_plan_request_workspace(before, workspace_id)
     # BLOCKER 1 — reject a cross-workspace gated approval before any state
     # mutation. ``require_action_any_workspace`` only proved the caller holds
     # ``instinct.approve`` somewhere; this binds the Action to the caller's
@@ -3135,6 +3190,37 @@ async def approve_action(
             )
         except Exception:
             logger.exception("admin-action execution after approval failed (non-fatal)")
+
+    # A ``_site_plan_request`` — an employee asked to put a site on a paid plan
+    # and an admin has now approved it. The executor re-checks the APPROVER's
+    # ``sites.buy_plan`` (NOT the proposer's — the proposer is a member who never
+    # had it, which is the premise of the feature) and then performs the publish
+    # that was refused. Same best-effort, lazy-import,
+    # never-break-the-approve-response shape as the hooks above; the EXECUTOR owns
+    # the chain close, so the router emits only ``human.corrected`` here.
+    site_plan_request = _site_plan_request_blob(approved)
+    if site_plan_request is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=site_plan_request,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(site_plan_request),
+        )
+        try:
+            from pocketpaw_ee.cloud.site_plan_requests import (
+                executor as site_plan_request_executor,
+            )
+
+            await site_plan_request_executor.execute_approved_site_plan_request(
+                approved, human_event_id=human_event_id
+            )
+        except Exception:
+            logger.exception("site-plan-request execution after approval failed (non-fatal)")
 
     # gap2 — when the approved Action carries a ``_customer_reply`` blob (a
     # paw-bar customer event awaiting a decision), deliver the owner's reply

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -192,6 +192,29 @@ class PublishRequest(BaseModel):
     site_plan_key: str | None = None
 
 
+class SitePlanRequestBody(BaseModel):
+    """Body for POST /sites/plan-requests — ask an admin to put a site on a paid
+    plan. Same two fields a publish takes, because it describes the same
+    purchase; the difference is who is allowed to make it happen."""
+
+    pocket_id: str
+    site_plan_key: str
+
+
+class SitePlanRequestResponse(BaseModel):
+    """Ack for a filed site-plan request.
+
+    ``action_id`` is the pending Instinct Action an admin approves in The Tray —
+    returned so a client can link straight to it rather than telling the employee
+    to go looking. Deliberately carries NO site fields: nothing was published and
+    nothing was charged, and a SiteResponse here would read like it had been."""
+
+    action_id: str
+    status: str
+    site_plan_key: str
+    monthly_price_usd: int
+
+
 class MakeEditableRequest(BaseModel):
     """Body for POST /sites/by-pocket/{pocket_id}/editable (SE-2b). The builder
     origin is optional — the service falls back to the configured dashboard

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -257,6 +257,8 @@ from pocketpaw_ee.sites.dto import (
     SiteDataTablesResponse,
     SiteEntitlementsResponse,
     SiteInvoiceCreate,
+    SitePlanRequestBody,
+    SitePlanRequestResponse,
     SitePreviewRefreshResponse,
     SitePreviewResponse,
     SiteResponse,
@@ -341,6 +343,78 @@ async def publish_site(
         origin=request.headers.get("origin") or None,
     )
     return sites_service._to_response(doc)
+
+
+@router.post("/sites/plan-requests", response_model=SitePlanRequestResponse)
+async def request_site_plan(
+    body: SitePlanRequestBody,
+    ctx: RequestContext = Depends(request_context),
+    user: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SitePlanRequestResponse:
+    """Ask a workspace admin to put this site on a paid plan.
+
+    The other side of ``sites.plan_purchase_forbidden``. A member who publishes
+    and picks a paid tier is refused, correctly — a paid site is an add-on line
+    on the workspace's own subscription, so choosing one spends company money.
+    Before this endpoint the refusal was also a dead end: the employee who built
+    the site had no route forward except finding an admin out-of-band and
+    describing what they wanted.
+
+    This files an Instinct Action instead. An admin approves it in The Tray and
+    the executor performs the publish that was refused — re-checking the
+    APPROVER's ``sites.buy_plan`` at that moment, so approving is what authorizes
+    the spend and nothing here does.
+
+    Gated on ``fabric.write`` (MEMBER), the same action publishing needs: asking
+    is not spending, and a gate above MEMBER would refuse exactly the people this
+    exists for. An ADMIN may also call it — a request they can approve themselves
+    is a slower path to the same place, not a wrong one, and refusing it would
+    make the client's job harder for no benefit.
+
+    Returns the pending Action so the caller can link to it. NOTHING is published
+    and NOTHING is charged on this path.
+    """
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+    from pocketpaw_ee.cloud.billing import site_plans
+    from pocketpaw_ee.cloud.site_plan_requests import propose_site_plan_request
+
+    # Resolve the tier here as well as inside the propose helper — the response
+    # quotes a price, and a client showing "$0/month" for a tier we could not
+    # resolve would be worse than the refusal it replaced.
+    tier = site_plans.site_scoped_tier(site_plans.canonical_site_tier_key(body.site_plan_key))
+    if tier is None:
+        raise ValidationError(
+            "sites.unknown_plan_tier",
+            f"'{body.site_plan_key}' is not a plan a single site can be put on",
+        )
+
+    # The site's name for the Tray card, best-effort: an admin reading "Put
+    # Acme Dental on the Staff plan" can decide; one reading a pocket id cannot.
+    # A failure to resolve it must not block the request.
+    # Imported locally, like every other cross-entity read in this module: the
+    # sites service owns Site reads and reaches into pockets the same way.
+    site_name = ""
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        pocket = await pockets_service.get(body.pocket_id, ctx.user_id)
+        site_name = str((pocket or {}).get("name") or "")
+    except Exception:  # noqa: BLE001 — a nicer card is not worth failing the ask
+        pass
+
+    action_id = await propose_site_plan_request(
+        workspace_id=ctx.workspace_id,
+        pocket_id=body.pocket_id,
+        site_plan_key=body.site_plan_key,
+        requested_by=ctx.user_id,
+        site_name=site_name,
+    )
+    return SitePlanRequestResponse(
+        action_id=action_id,
+        status="pending",
+        site_plan_key=tier.key,
+        monthly_price_usd=int(tier.monthly_price_usd or 0),
+    )
 
 
 @router.post("/sites/reserve", response_model=list[SiteResponse])

--- a/tests/cloud/sites/test_site_plan_request_gate.py
+++ b/tests/cloud/sites/test_site_plan_request_gate.py
@@ -1,0 +1,479 @@
+# tests/cloud/sites/test_site_plan_request_gate.py — an employee asks for a paid
+# site plan; approving is what buys it.
+#
+# Created 2026-09-01 (feat/sites-plan-purchase-request). Stacked on the
+# ``sites.buy_plan`` gate (fix/sites-plan-purchase-authz), which stopped a member
+# charging the company card and left them with a 403 and nowhere to go. This is
+# the other half: the refusal becomes a request an admin approves.
+#
+# THE SECURITY PROPERTY, and the reason most of this file exists. Every other
+# gated proposal kind re-checks the PROPOSER's role at execute time. This one
+# cannot: the proposer is a member who never had the right, which is the premise.
+# So the check runs against the APPROVER — ``Action.approved_by``, which the
+# instinct router writes from the authenticated identity. Get that backwards and
+# the feature refuses every request it exists to serve; leave it out and any
+# pending request buys the moment anyone touches it. Both failure modes are
+# pinned below.
+#
+# What each group covers:
+#   * propose — records what was asked, canonicalizes the tier, refuses an
+#     org-scoped flat at the door (it could only ever fail on approval);
+#   * the approver check — the inversion above, in both directions;
+#   * the tamper guards — schema, identity hash, missing approver, idempotency;
+#   * price drift — reported, never silently charged, and never enforced.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+# --------------------------------------------------------------------------- #
+# Doubles
+# --------------------------------------------------------------------------- #
+
+
+class _FakeStore:
+    """Enough of the instinct store for the executor's guards + back-writes.
+
+    ``_db_path`` points nowhere: the outcome back-write is best-effort and
+    swallows its own failure, so the executor's behaviour is unchanged by it and
+    a test does not need a real SQLite file to observe the decisions.
+    """
+
+    def __init__(self, action: Any):
+        self._db_path = "/nonexistent/instinct.db"
+        self._action = action
+        self.failed: list[str] = []
+        self.executed: list[str] = []
+
+    async def get_action(self, action_id: str) -> Any:  # noqa: ARG002
+        return self._action
+
+    async def mark_failed(self, action_id: str, error: str) -> None:  # noqa: ARG002
+        self.failed.append(error)
+
+    async def mark_executed(self, action_id: str, outcome: str = "") -> None:  # noqa: ARG002
+        self.executed.append(outcome)
+
+
+def _action(blob: dict[str, Any], *, approved_by: str = "admin-1", status: str = "approved"):
+    return SimpleNamespace(
+        id="act-1",
+        parameters={"_site_plan_request": blob},
+        approved_by=approved_by,
+        status=status,
+    )
+
+
+def _blob(**over: Any) -> dict[str, Any]:
+    """A well-formed blob, with the identity hash computed to match."""
+    from pocketpaw_ee.cloud.site_plan_requests.propose import (
+        SITE_PLAN_REQUEST_SCHEMA,
+        compute_request_hash,
+    )
+
+    base = {
+        "kind": "site_plan_request",
+        "schema": SITE_PLAN_REQUEST_SCHEMA,
+        "workspace_id": "ws-1",
+        "pocket_id": "pkt-1",
+        "site_plan_key": "staff",
+        "monthly_price_usd": 19,
+        "requested_by": "member-1",
+        "idempotency_key": "k",
+        "summary": "s",
+        "correlation_id": None,
+        "proposed_event_id": None,
+    }
+    base.update(over)
+    base.setdefault(
+        "params_hash",
+        compute_request_hash(
+            str(base["workspace_id"]), str(base["pocket_id"]), str(base["site_plan_key"])
+        ),
+    )
+    return base
+
+
+def _arm(monkeypatch, *, action, may_buy: bool = True, publish=None) -> dict[str, Any]:
+    """Point the executor at doubles and record what reached the purchase.
+
+    Returns a dict the test reads: ``published`` is the kwargs of the publish
+    call, or absent when it never happened — which is the assertion that matters
+    for every refusal case.
+    """
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    seen: dict[str, Any] = {}
+    store = _FakeStore(action)
+    monkeypatch.setattr(ex, "get_instinct_store", lambda **kw: store, raising=False)
+    import pocketpaw.stores as _stores
+
+    monkeypatch.setattr(_stores, "get_instinct_store", lambda **kw: store)
+
+    async def _recheck(workspace_id: str, approver_user_id: str) -> None:
+        seen["rechecked"] = (workspace_id, approver_user_id)
+        if not may_buy:
+            from pocketpaw_ee.guards.rbac import Forbidden
+
+            raise Forbidden("sites.plan_purchase_forbidden", "not an admin")
+
+    monkeypatch.setattr(ex, "_recheck_approver_may_buy", _recheck)
+
+    async def _publish(**kwargs: Any) -> Any:
+        seen["published"] = kwargs
+        if publish is not None:
+            return publish()
+        return SimpleNamespace(id="site-1")
+
+    from pocketpaw_ee.sites import service as sites_service
+
+    monkeypatch.setattr(sites_service, "publish_pocket", _publish)
+    seen["store"] = store
+    return seen
+
+
+# --------------------------------------------------------------------------- #
+# Propose — what gets recorded, and what is refused before a card exists
+# --------------------------------------------------------------------------- #
+
+
+def test_the_request_hash_covers_identity_and_not_price():
+    """The admin agrees to a site and a tier. The PRICE is allowed to move (the
+    catalog owns money), so hashing it would turn an ordinary price change into a
+    pile of dead Tray cards — while the three fields that must not move are
+    exactly what the hash pins."""
+    from pocketpaw_ee.cloud.site_plan_requests.propose import compute_request_hash
+
+    base = compute_request_hash("ws-1", "pkt-1", "staff")
+    assert compute_request_hash("ws-1", "pkt-1", "staff") == base
+    assert compute_request_hash("ws-2", "pkt-1", "staff") != base
+    assert compute_request_hash("ws-1", "pkt-2", "staff") != base
+    assert compute_request_hash("ws-1", "pkt-1", "site") != base
+
+
+async def test_an_org_scoped_flat_cannot_be_requested_for_one_site():
+    """``studio`` / ``agency`` cover a whole workspace and are refused by
+    ``publish_pocket`` as a ``site_plan_key``. A request for one could only ever
+    become a Tray card that fails on approval, so it is refused at the door —
+    where the requester is present to be told why."""
+    from pocketpaw_ee.cloud.site_plan_requests import propose_site_plan_request
+
+    with pytest.raises(ValueError, match="not a plan a single site"):
+        await propose_site_plan_request(
+            workspace_id="ws-1",
+            pocket_id="pkt-1",
+            site_plan_key="agency",
+            requested_by="member-1",
+        )
+
+
+async def test_an_unknown_tier_is_refused():
+    from pocketpaw_ee.cloud.site_plan_requests import propose_site_plan_request
+
+    with pytest.raises(ValueError, match="not a plan a single site"):
+        await propose_site_plan_request(
+            workspace_id="ws-1",
+            pocket_id="pkt-1",
+            site_plan_key="platinum",
+            requested_by="member-1",
+        )
+
+
+async def test_tenancy_and_requester_are_mandatory():
+    """A blob with no workspace is unexecutable AND ungated — the router's
+    tenancy guard fails closed on an empty claim, so a request that could produce
+    one must never be built."""
+    from pocketpaw_ee.cloud.site_plan_requests import propose_site_plan_request
+
+    with pytest.raises(ValueError, match="workspace_id"):
+        await propose_site_plan_request(
+            workspace_id="", pocket_id="pkt-1", site_plan_key="site", requested_by="m"
+        )
+    with pytest.raises(ValueError, match="pocket_id"):
+        await propose_site_plan_request(
+            workspace_id="ws-1", pocket_id="", site_plan_key="site", requested_by="m"
+        )
+    with pytest.raises(ValueError, match="requested_by"):
+        await propose_site_plan_request(
+            workspace_id="ws-1", pocket_id="pkt-1", site_plan_key="site", requested_by=""
+        )
+
+
+# --------------------------------------------------------------------------- #
+# THE INVERSION — the approver is checked, not the proposer
+# --------------------------------------------------------------------------- #
+
+
+async def test_approving_checks_the_APPROVER_not_the_requester(monkeypatch):
+    """The load-bearing rule. The requester is a member who may not buy — that is
+    the premise — so a proposer-side re-check would refuse every request this
+    feature creates. The identity put to the check must be the approver's."""
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    action = _action(_blob(requested_by="member-1"), approved_by="admin-9")
+    seen = _arm(monkeypatch, action=action)
+
+    await ex.execute_approved_site_plan_request(action)
+
+    assert seen["rechecked"] == ("ws-1", "admin-9"), "the APPROVER's rights decide"
+    assert seen["published"]["purchase_authorized"] is True
+    assert seen["published"]["site_plan_key"] == "staff"
+    # The publish is still attributed to the person who built the site.
+    assert seen["published"]["user_id"] == "member-1"
+
+
+async def test_an_approver_without_buy_rights_does_not_charge(monkeypatch):
+    """A cleared ``instinct.approve`` is not by itself a licence to spend. If the
+    approver cannot buy, nothing reaches the publish path."""
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    action = _action(_blob())
+    seen = _arm(monkeypatch, action=action, may_buy=False)
+
+    await ex.execute_approved_site_plan_request(action)
+
+    assert "published" not in seen, "a denied approver must not buy"
+    assert seen["store"].failed, "and the refusal is recorded on the Action"
+    assert "sites.buy_plan" in seen["store"].failed[0]
+
+
+async def test_an_action_with_no_approver_never_buys(monkeypatch):
+    """``approved_by`` empty means nothing proves a human with rights accepted
+    this. Falling back to the requester would be the whole vulnerability — they
+    are, by construction, the person who may not buy."""
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    action = _action(_blob(), approved_by="")
+    seen = _arm(monkeypatch, action=action)
+
+    await ex.execute_approved_site_plan_request(action)
+
+    assert "published" not in seen
+    assert "rechecked" not in seen, "it must refuse before it even asks"
+    assert any("approved_by" in f for f in seen["store"].failed)
+
+
+def test_the_approver_id_is_read_from_the_authenticated_field():
+    """``approved_by`` is written by the router from ``str(user.id)``. A client
+    can put anything in ``ApproveRequest.approver``; if the executor ever read
+    THAT, a member could approve their own request by naming themselves.
+
+    The decisive case is the FIRST assertion, and it took a mutation to get
+    right. An Action carrying BOTH fields with different values is the only
+    input that separates the two readings — asserting on an object that has only
+    ``approved_by`` passes just as happily against
+    ``getattr(action, "approver", ...) or getattr(action, "approved_by", ...)``,
+    which is precisely the vulnerable version. That mutation escaped this test
+    until this line existed.
+    """
+    from pocketpaw_ee.cloud.site_plan_requests.executor import _approver_id
+
+    # A forged display label alongside the authenticated field: the authenticated
+    # one must win, and the forgery must not appear anywhere in the answer.
+    both = SimpleNamespace(approved_by="admin-1", approver="member-1")
+    assert _approver_id(both) == "admin-1"
+
+    assert _approver_id(SimpleNamespace(approved_by="admin-1")) == "admin-1"
+    assert _approver_id(SimpleNamespace(approved_by=None)) == ""
+    # No such attribute at all → empty, which the caller turns into a refusal.
+    assert _approver_id(SimpleNamespace()) == ""
+    # And a client-controlled field ALONE is never an approver: an Action with no
+    # ``approved_by`` was not approved, whatever else it carries.
+    assert _approver_id(SimpleNamespace(approver="member-1")) == ""
+
+
+def test_buying_and_approving_sit_at_the_same_height():
+    """The inversion is only safe while an approver necessarily clears the
+    purchase bar. If ``sites.buy_plan`` is ever raised above ``instinct.approve``,
+    the executor's re-check starts refusing ADMIN approvals — correct, but a
+    surprise worth failing a test over rather than discovering in production."""
+    from pocketpaw_ee.guards.actions import ACTIONS
+
+    assert ACTIONS["sites.buy_plan"].minimum.level <= ACTIONS["instinct.approve"].minimum.level
+
+
+# --------------------------------------------------------------------------- #
+# Tamper guards
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_moved_tier_after_approval_does_not_buy(monkeypatch):
+    """The admin approved a SPECIFIC site on a SPECIFIC tier. An approve-with-
+    edits that swapped either must not buy something else — the identity hash is
+    recomputed and refuses."""
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    blob = _blob(site_plan_key="site")  # hash computed for 'site'…
+    blob["site_plan_key"] = "staff"  # …then the tier was moved under it
+    action = _action(blob)
+    seen = _arm(monkeypatch, action=action)
+
+    await ex.execute_approved_site_plan_request(action)
+
+    assert "published" not in seen
+    assert any("hash mismatch" in f for f in seen["store"].failed)
+
+
+async def test_a_stale_schema_fails_loud(monkeypatch):
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    action = _action(_blob(schema=99))
+    seen = _arm(monkeypatch, action=action)
+
+    await ex.execute_approved_site_plan_request(action)
+
+    assert "published" not in seen
+    assert any("schema mismatch" in f for f in seen["store"].failed)
+
+
+async def test_a_second_approval_does_not_buy_twice(monkeypatch):
+    """Bulk re-approve and retries are ordinary. Charging twice for one request
+    is not."""
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    blob = _blob()
+    blob["outcome"] = {"status": "executed", "response_summary": "done", "executed_at": "t"}
+    action = _action(blob)
+    seen = _arm(monkeypatch, action=action)
+
+    await ex.execute_approved_site_plan_request(action)
+
+    assert "published" not in seen
+    assert not seen["store"].failed, "an idempotent no-op is not a failure"
+
+
+async def test_a_terminal_action_does_not_re_buy(monkeypatch):
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    action = _action(_blob(), status="executed")
+    seen = _arm(monkeypatch, action=action)
+
+    await ex.execute_approved_site_plan_request(action)
+
+    assert "published" not in seen
+
+
+async def test_a_failed_publish_is_recorded_not_raised(monkeypatch):
+    """The executor runs inside the approve response. A publish failure must
+    surface on the Action, never as a 500 on the admin's approve click."""
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    def _boom():
+        raise RuntimeError("gateway said no")
+
+    action = _action(_blob())
+    seen = _arm(monkeypatch, action=action, publish=_boom)
+
+    await ex.execute_approved_site_plan_request(action)  # must not raise
+
+    assert any("gateway said no" in f for f in seen["store"].failed)
+
+
+# --------------------------------------------------------------------------- #
+# Price drift — reported, never enforced, never silent
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_price_that_moved_is_charged_live_and_reported(monkeypatch):
+    """The catalog owns the truth about money, so the purchase prices from it —
+    but an admin who approved "$7/month" must be able to see they were charged
+    something else. Refusing on drift instead would leave a workspace's requests
+    dead every time a price changed."""
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    # Quoted at a price the catalog no longer has.
+    action = _action(_blob(monthly_price_usd=3))
+    seen = _arm(monkeypatch, action=action)
+
+    await ex.execute_approved_site_plan_request(action)
+
+    assert seen["published"]["site_plan_key"] == "staff"
+    summary = seen["store"].executed[0]
+    assert "price changed since the request" in summary
+    assert "$3" in summary
+
+
+async def test_a_matching_price_says_nothing_about_drift(monkeypatch):
+    from pocketpaw_ee.cloud.billing import site_plans
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    live = int(site_plans.site_scoped_tier("staff").monthly_price_usd or 0)
+    action = _action(_blob(monthly_price_usd=live))
+    seen = _arm(monkeypatch, action=action)
+
+    await ex.execute_approved_site_plan_request(action)
+
+    assert "price changed" not in seen["store"].executed[0]
+
+
+async def test_a_tier_the_catalog_dropped_does_not_buy(monkeypatch):
+    """A request can outlive its tier. Publishing on a rung that no longer exists
+    would stamp a plan nothing can price."""
+    from pocketpaw_ee.cloud.site_plan_requests import executor as ex
+
+    blob = _blob(site_plan_key="staff")
+    action = _action(blob)
+    seen = _arm(monkeypatch, action=action)
+    monkeypatch.setattr("pocketpaw_ee.cloud.billing.site_plans.site_scoped_tier", lambda k: None)
+
+    await ex.execute_approved_site_plan_request(action)
+
+    assert "published" not in seen
+    assert any("no longer a plan" in f for f in seen["store"].failed)
+
+
+# --------------------------------------------------------------------------- #
+# The router's tenancy binding
+# --------------------------------------------------------------------------- #
+
+
+def test_a_request_from_another_workspace_cannot_be_approved():
+    """Approving BUYS on the blob's workspace. ``instinct.approve`` only proves
+    the caller holds the role SOMEWHERE."""
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.instinct.router import _assert_site_plan_request_workspace
+
+    action = _action(_blob(workspace_id="ws-victim"))
+    with pytest.raises(Forbidden):
+        _assert_site_plan_request_workspace(action, "ws-attacker")
+    # The owning workspace passes.
+    _assert_site_plan_request_workspace(action, "ws-victim")
+
+
+def test_a_workspace_less_request_is_refused_rather_than_waved_through():
+    """FAIL-CLOSED on an empty claim. A pass-through would let anyone propose a
+    blob with no workspace aimed at a victim's pocket and have any operator in
+    any workspace approve the purchase."""
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.instinct.router import _assert_site_plan_request_workspace
+
+    action = _action(_blob(workspace_id=""))
+    with pytest.raises(Forbidden):
+        _assert_site_plan_request_workspace(action, "ws-1")
+
+
+def test_the_kind_is_registered_so_edits_cannot_mint_or_move_it():
+    """``RESERVED_GATED_PARAM_KEYS`` is what stops an approve-time edit ADDING
+    this blob to an innocuous Tray card, or rewriting its tenancy. A gated kind
+    that is not in the set is a gated kind in name only."""
+    from pocketpaw_ee.instinct.router import RESERVED_GATED_PARAM_KEYS
+
+    assert "_site_plan_request" in RESERVED_GATED_PARAM_KEYS
+
+
+def test_every_gated_kind_guard_runs_on_the_shared_chokepoint():
+    """``_assert_gated_workspaces`` is the one place all four dispatch paths
+    (approve / bulk-approve / reject / bulk-reject) call, so a kind wired into
+    three of them and missed on the fourth is the bug it exists to prevent."""
+    import inspect
+
+    from pocketpaw_ee.instinct import router
+
+    src = inspect.getsource(router._assert_gated_workspaces)
+    assert "_assert_site_plan_request_workspace" in src

--- a/tests/mutations/site_plan_request_gate.json
+++ b/tests/mutations/site_plan_request_gate.json
@@ -1,0 +1,147 @@
+[
+  {
+    "label": "the executor checks the REQUESTER instead of the approver — every legitimate request now fails, and a member's own id decides",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/executor.py",
+    "find": "        await _recheck_approver_may_buy(workspace_id, approver_user_id)",
+    "replace": "        await _recheck_approver_may_buy(workspace_id, requested_by)",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_approving_checks_the_APPROVER_not_the_requester"
+    ]
+  },
+  {
+    "label": "the RBAC re-check is skipped entirely — any approval buys, whatever the approver's role",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/executor.py",
+    "find": "    try:\n        await _recheck_approver_may_buy(workspace_id, approver_user_id)\n    except Exception as exc:",
+    "replace": "    try:\n        pass\n    except Exception as exc:",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_an_approver_without_buy_rights_does_not_charge"
+    ]
+  },
+  {
+    "label": "a missing approver falls back to the requester — the member approves their own purchase",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/executor.py",
+    "find": "    if not approver_user_id:\n        await _fail(",
+    "replace": "    if False:\n        await _fail(",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_an_action_with_no_approver_never_buys"
+    ]
+  },
+  {
+    "label": "the approver id is read from a client-controlled field instead of the authenticated one",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/executor.py",
+    "find": "    return str(getattr(action, \"approved_by\", \"\") or \"\")",
+    "replace": "    return str(getattr(action, \"approver\", \"\") or getattr(action, \"approved_by\", \"\") or \"\")",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_the_approver_id_is_read_from_the_authenticated_field"
+    ]
+  },
+  {
+    "label": "the identity hash stops being checked — an approve-time edit buys a different tier",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/executor.py",
+    "find": "    if stored_hash and stored_hash != recomputed:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_a_moved_tier_after_approval_does_not_buy"
+    ]
+  },
+  {
+    "label": "the schema guard is dropped — a stale blob from an old build buys a misread tier",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/executor.py",
+    "find": "    if blob.get(\"schema\") != SITE_PLAN_REQUEST_SCHEMA:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_a_stale_schema_fails_loud"
+    ]
+  },
+  {
+    "label": "the idempotency guard is dropped — a bulk re-approve charges twice",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/executor.py",
+    "find": "    if _already_executed(guard_action, guard_blob):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_a_second_approval_does_not_buy_twice",
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_a_terminal_action_does_not_re_buy"
+    ]
+  },
+  {
+    "label": "price drift stops being reported — the admin never learns they were charged more than they approved",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/executor.py",
+    "find": "        else f\" (price changed since the request: ${quoted_price} → ${live_price}/month)\"",
+    "replace": "        else \"\"",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_a_price_that_moved_is_charged_live_and_reported"
+    ]
+  },
+  {
+    "label": "the executor prices from the STALE blob instead of the live catalog",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/executor.py",
+    "find": "    live_price = int(tier.monthly_price_usd or 0)",
+    "replace": "    live_price = int(blob.get(\"monthly_price_usd\") or 0)",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_a_price_that_moved_is_charged_live_and_reported"
+    ]
+  },
+  {
+    "label": "a dropped tier still publishes — the site is stamped with a plan nothing can price",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/executor.py",
+    "find": "    if tier is None:\n        await _fail(\n            f\"'{site_plan_key}' is no longer a plan a single site can be put on — \"",
+    "replace": "    if False:\n        await _fail(\n            f\"'{site_plan_key}' is no longer a plan a single site can be put on — \"",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_a_tier_the_catalog_dropped_does_not_buy"
+    ]
+  },
+  {
+    "label": "an org-scoped flat can be requested for one site — the card can only fail on approval",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/propose.py",
+    "find": "    tier = site_plans.site_scoped_tier(canonical_key)",
+    "replace": "    tier = site_plans.get_site_plan(canonical_key)",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_an_org_scoped_flat_cannot_be_requested_for_one_site"
+    ]
+  },
+  {
+    "label": "the identity hash stops covering the tier — two different tiers hash alike",
+    "file": "ee/pocketpaw_ee/cloud/site_plan_requests/propose.py",
+    "find": "            \"site_plan_key\": site_plan_key,\n        },\n        sort_keys=True,",
+    "replace": "        },\n        sort_keys=True,",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_the_request_hash_covers_identity_and_not_price"
+    ]
+  },
+  {
+    "label": "the router's tenancy guard waves through an empty workspace claim",
+    "file": "ee/pocketpaw_ee/instinct/router.py",
+    "find": "    blob_workspace = str(blob.get(\"workspace_id\") or \"\")\n    if not blob_workspace:\n        raise Forbidden(\n            \"instinct.missing_workspace_in_blob\",\n            \"This site plan request has no workspace claim — cannot verify tenancy\",\n        )",
+    "replace": "    blob_workspace = str(blob.get(\"workspace_id\") or \"\")\n    if not blob_workspace:\n        return",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_a_workspace_less_request_is_refused_rather_than_waved_through"
+    ]
+  },
+  {
+    "label": "a cross-workspace request can be approved — an attacker's card buys on a victim's subscription",
+    "file": "ee/pocketpaw_ee/instinct/router.py",
+    "find": "    if blob_workspace != current_workspace:\n        raise Forbidden(\n            \"instinct.cross_workspace_action\",\n            \"This site plan request belongs to another workspace\",\n        )",
+    "replace": "    if False:\n        raise Forbidden(\n            \"instinct.cross_workspace_action\",\n            \"This site plan request belongs to another workspace\",\n        )",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_a_request_from_another_workspace_cannot_be_approved"
+    ]
+  },
+  {
+    "label": "the kind leaves the reserved set — an approve-time edit can ADD this blob to an innocuous card",
+    "file": "ee/pocketpaw_ee/instinct/router.py",
+    "find": "        \"_customer_reply\",\n        \"_site_plan_request\",",
+    "replace": "        \"_customer_reply\",",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_the_kind_is_registered_so_edits_cannot_mint_or_move_it"
+    ]
+  },
+  {
+    "label": "the guard leaves the shared chokepoint — reject and bulk paths lose their tenancy binding",
+    "file": "ee/pocketpaw_ee/instinct/router.py",
+    "find": "    _assert_site_plan_request_workspace(action, current_workspace)",
+    "replace": "    pass",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_request_gate.py::test_every_gated_kind_guard_runs_on_the_shared_chokepoint"
+    ]
+  }
+]


### PR DESCRIPTION
Stacked on #2024 (`feat/sites-plan-purchase-authz`), which owns `purchase_authorized` and the `sites.buy_plan` rule. Merge that one first.

## Why

#2024 stopped a member charging the company card for a site plan. That was the right refusal, and it was also a dead end: the employee who built the site got a 403 and no route forward except finding an admin out-of-band and describing what they wanted.

This gives the refusal an answer. `POST /sites/plan-requests` files an Instinct Action; an admin approves it in The Tray and the executor performs the publish that was refused. **Filing the request publishes nothing and charges nothing.**

## The inversion

The design mirrors the `_admin_action` gate closely, with one deliberate difference that is the whole point of the module.

Every other gated proposal kind re-checks the **proposer's** role at execute time — right there, because the proposer is an admin whose rights might have been revoked since. Here the proposer is a member who *never had the right*; that is the premise. So the check runs against the **approver**, read from `Action.approved_by`, which the instinct router writes from the authenticated identity (`str(user.id)`) and never from a request body field.

Get it backwards and the feature refuses every request it exists to serve. Leave it out and any pending request buys the moment anyone touches it. Both failure modes have a test.

This is safe because `instinct.approve` and `sites.buy_plan` are both ADMIN — an approver has necessarily cleared the purchase bar already. The check runs anyway rather than being inferred: those two rules live in different files and can drift, and "the approve endpoint already checked something similar" is not a control. A test fails if the two ever separate, so raising `sites.buy_plan` to OWNER later is a caught change rather than a silent one.

## Price drift: reported, not enforced

The blob records the price the requester saw. The purchase prices from the **live catalog**, because the catalog is the truth about money and a week-old snapshot is not — and the outcome names the difference, so an admin who approved "$7/month" can see they were charged $9.

Refusing on any drift would turn an ordinary price change into a pile of dead Tray cards. The identity hash already pins what must not move: workspace, site, tier. Price is deliberately excluded from it.

## Guards

Ordered so nothing that charges runs before all of them: blob present → schema → tenancy → approver identity → identity hash → idempotency (under a per-action lock, re-read fresh) → RBAC re-check → the write. Tenancy joins `_assert_gated_workspaces`, so all four dispatch paths (approve / bulk-approve / reject / bulk-reject) inherit it, and `_site_plan_request` joins `RESERVED_GATED_PARAM_KEYS` so an approve-time edit can neither mint the blob on an innocuous card nor move its tenancy.

## The mutation run

All 16 caught (`tests/mutations/site_plan_request_gate.json`). One escaped first, and it was the most security-relevant one: my test asserted the approver id came from `approved_by`, but the fixture only carried that field — so it passed just as happily against a version preferring a client-controlled `approver`. The fix was an Action carrying **both** with different values, which is the only input that separates the two readings.

Two other things the run caught: a `site_scoped_tier` → `get_site_plan` swap (org-scoped flats become requestable, producing cards that can only fail on approval), and pricing from the stale blob instead of the catalog.

## Tests

363 pass across every suite this touches — `tests/cloud/sites/`, `tests/instinct/`, plus the instinct approval-security, bulk-action, dispatch and fail-closed-tenancy suites. 21 new. Ruff clean, import-linter contract kept.

The UI half (the refusal offering "ask an admin") is a separate paw-enterprise PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
