### PR TITLE
Make the worker's concurrency ceilings reachable from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -168,6 +168,43 @@
 # POCKETPAW_WEB_HOST=0.0.0.0
 # POCKETPAW_WEB_PORT=8888
 
+# ── Concurrency / capacity ────────────────────────────────
+# Four different ceilings, easy to confuse. In a CLOUD deploy the first one is
+# the only one that bounds how many agent runs execute at once.
+#
+# CLUSTER-WIDE. Concurrent jobs one arq worker will run, shared across every
+# lane it registers: chat runs, workspace jobs, both /ship jobs and both site
+# builds. arq's own default is 10 — so ten concurrent site publishes leave no
+# slot for a chat run, and job 11 is not rejected or retried, it waits in Redis
+# behind a job_timeout of up to 30 minutes. Total concurrency is this value
+# times the number of worker replicas.
+# Raise it WITH the worker container's memory limit: the default
+# claude_agent_sdk backend spawns a Node subprocess per run, so RAM binds first.
+# POCKETPAW_ARQ_MAX_JOBS=10
+#
+# PER-PROCESS. Live agent instances one process's AgentPool holds before it
+# refuses to build another. The web process and each worker each get their own.
+# POCKETPAW_AGENT_POOL_MAX_INSTANCES=20
+#
+# PER-PROCESS. Warm session slots — the per-tenant one is the fairness knob
+# that stops a single workspace holding every slot; over the limit the oldest
+# IDLE slot is evicted (never a busy one). Each warm slot pins a live agent
+# client, so raise the global one with the container's memory limit.
+# POCKETPAW_SESSION_WARM_MAX_PER_TENANT=8
+# POCKETPAW_SESSION_WARM_MAX_GLOBAL=64
+#
+# CHANNEL ADAPTERS ONLY (Telegram/Discord/Slack/WhatsApp). The cloud chat path
+# does not go through the OSS AgentLoop, so raising this does nothing for a
+# cloud deploy — use POCKETPAW_ARQ_MAX_JOBS there.
+# POCKETPAW_MAX_CONCURRENT_CONVERSATIONS=5
+#
+# Per-run budget on the worker. The 10-minute stale-run sweeper is the backstop.
+# POCKETPAW_CLOUD_RUN_JOB_TIMEOUT=1800
+#
+# Leave FALSE on any deploy with more than one worker replica — the boot sweep
+# interrupts sibling workers' in-flight runs.
+# POCKETPAW_CLOUD_WORKER_BOOT_SWEEP=false
+
 # ── Cloud Sandbox (Daytona) ────────────────────────────────
 # DAYTONA_API_URL=https://app.daytona.io/api    # Daytona server API
 # DAYTONA_API_KEY=                               # Daytona API key for auth

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,31 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   env-configurable), marking queued/running `ChatRunDoc`s older than 10 minutes as
   `interrupted` so runs abandoned by a backend restart surface a retry affordance
   instead of leaving clients subscribed forever.
+- **Concurrency / capacity config**: four ceilings that are easy to confuse. In a
+  cloud deploy only the first one bounds how many agent runs execute at once.
+  `POCKETPAW_ARQ_MAX_JOBS` (default `10`, arq's own) — **cluster-wide**: concurrent
+  jobs ONE arq worker runs, shared across every lane it registers (chat runs,
+  workspace jobs, both `/ship` jobs, both site builds). It was unset until
+  2026-09-01, so every earlier deploy ran on arq's default with no way to raise
+  it; ten concurrent site publishes left no slot for a chat run, and job 11 was
+  neither rejected nor retried (`max_tries = 1`) — it waited in Redis behind a
+  30-minute `job_timeout`. Total concurrency is this value x worker replicas.
+  Raise it WITH the container's memory limit: the default `claude_agent_sdk`
+  backend spawns a Node subprocess per run, so RAM binds before CPU.
+  `POCKETPAW_AGENT_POOL_MAX_INSTANCES` (default `20`) — **per-process** AgentPool
+  ceiling; the web process and each worker each hold their own pool.
+  `POCKETPAW_SESSION_WARM_MAX_PER_TENANT` (default `8`) /
+  `POCKETPAW_SESSION_WARM_MAX_GLOBAL` (default `64`) — **per-process** warm
+  session slots. The per-tenant one is the fairness knob that stops one workspace
+  holding every slot; over the limit the oldest IDLE slot is evicted, never a busy
+  one. Each warm slot pins a live agent client, so raise the global one with the
+  container's memory limit.
+  `POCKETPAW_MAX_CONCURRENT_CONVERSATIONS` (default `5`) — the OSS `AgentLoop`
+  semaphore, which gates the CHANNEL adapters only. The cloud chat path
+  (`ee.cloud.chat.runs.run_core`) never imports `AgentLoop`, so raising this does
+  nothing for a cloud deploy. Every default above is the value that was already in
+  force, so shipping these knobs moved no deploy. Sizing guidance:
+  `docs/internal/2026-05-resumable-runs-deploy.md` -> "Sizing the worker".
 - **Growth outbound config (`GROWTH_SENDING_DOMAIN`)**: the secondary domain the
   `/growth` engine sends cold outreach from — **required**, with no default. The
   dispatch worker fails closed when it is unset (nothing goes out), validates the

--- a/docs/internal/2026-05-resumable-runs-deploy.md
+++ b/docs/internal/2026-05-resumable-runs-deploy.md
@@ -57,6 +57,49 @@ POCKETPAW_CLOUD_RUN_EXECUTOR=arq
 Redeploy the web service. POST `/api/v1/cloud/chat/{scope}/{scope_id}/agent`
 will now enqueue an `execute_run_job` instead of spawning an `asyncio.Task`.
 
+## Sizing the worker
+
+`max_jobs` was unset until 2026-09-01, so every deploy before that ran on arq's
+default of **10 concurrent jobs per worker** — and that ceiling is shared by all
+six registered functions, not divided among them. Ten concurrent site publishes
+leave no slot for a chat message. The failure mode is invisible from the outside:
+job 11 is not rejected and, with `max_tries = 1`, not retried either. It waits in
+Redis behind a `job_timeout` of up to 30 minutes, so the user just sees a reply
+that never starts.
+
+Total cluster concurrency is `POCKETPAW_ARQ_MAX_JOBS x worker replicas`. Both
+levers work; they cost different things.
+
+**Raise `max_jobs` when the runs are IO-bound** (waiting on the model API). Costs
+memory in one container, and nothing else.
+
+**Add replicas when the runs are CPU- or memory-bound** (site builds, `/ship`
+deploys). Costs a whole container each, and they are safe to add: arq uses a
+single Redis-backed queue, so each job goes to exactly one worker.
+
+Two constraints bound how far `max_jobs` can go:
+
+- **Memory, not CPU, binds first.** The default `claude_agent_sdk` backend spawns
+  a Node subprocess per run. Raise the container's memory limit in the same change
+  — the Coolify worker ships with a 4G limit, which will not hold 10 concurrent
+  SDK runs, let alone more. The `pydantic_ai` backend runs in-process and is much
+  cheaper per run if you are concurrency-bound rather than capability-bound.
+- **Mongo connections.** Each worker opens its own pool (pymongo's default
+  `maxPoolSize` is 100 and nothing overrides it), so replicas multiply
+  connections against a single-node Mongo.
+
+**Set `POCKETPAW_CLOUD_WORKER_BOOT_SWEEP=false` before adding the second
+replica** — it defaults to false, so this is a "do not turn it on" rather than a
+change, but it is the one setting that is actively unsafe multi-replica: the boot
+sweep marks other workers' in-flight runs as `interrupted`.
+
+The per-process knobs (`POCKETPAW_AGENT_POOL_MAX_INSTANCES`,
+`POCKETPAW_SESSION_WARM_MAX_*`) bound each process independently, so they need to
+clear `max_jobs` on the worker — a worker allowed 40 concurrent jobs but only 20
+pool instances will queue on the pool instead. `SESSION_WARM_MAX_PER_TENANT` is
+the one to keep deliberately low: it is what stops a single busy workspace
+holding every warm slot on the box.
+
 ## Manual end-to-end verification (staging)
 
 Run with worker + web both up and `POCKETPAW_CLOUD_RUN_EXECUTOR=arq` on the web:
@@ -125,6 +168,10 @@ Env vars (all also documented in `backend/CLAUDE.md` → Key Conventions):
 | Var | Default | Purpose |
 |-----|---------|---------|
 | `POCKETPAW_CLOUD_RUN_EXECUTOR` | `inprocess` | Set to `arq` on the web service to enable Tier 2 |
+| `POCKETPAW_ARQ_MAX_JOBS` | `10` | Concurrent jobs ONE worker runs, shared across every registered lane. Set on the **worker**; the web service ignores it. See "Sizing the worker" below |
+| `POCKETPAW_AGENT_POOL_MAX_INSTANCES` | `20` | Per-process AgentPool ceiling. Applies to the web process AND each worker |
+| `POCKETPAW_SESSION_WARM_MAX_PER_TENANT` | `8` | Per-process warm session slots one workspace may hold. The per-tenant fairness knob |
+| `POCKETPAW_SESSION_WARM_MAX_GLOBAL` | `64` | Per-process warm session slots across all workspaces |
 | `POCKETPAW_REDIS_URL` | — | Required for both tiers; web + worker must share |
 | `CLOUD_MONGODB_URI` | `mongodb://localhost:27017/paw-enterprise` | Web + worker must share |
 | `POCKETPAW_CLOUD_RUN_STREAM_TTL` | `3600` | Redis Stream retention after a run terminates |

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -1,5 +1,14 @@
 """arq worker entry point for Tier 2 run execution.
 
+Updated: 2026-09-01 (feat/scale-concurrency-knobs) — ``WorkerSettings.max_jobs`` is
+now set, from ``POCKETPAW_ARQ_MAX_JOBS`` (default 10, arq's own). It was previously
+unset, so arq's default applied silently and the whole cluster ran ten concurrent
+jobs across ALL SIX registered lanes. That is the ceiling a multi-user deploy hits
+first — and it is invisible, because job 11 is not rejected or retried, it just sits
+in Redis behind a ``job_timeout`` of up to 30 minutes. Raise it together with the
+worker container's memory limit: the default ``claude_agent_sdk`` backend spawns a
+Node subprocess per run, so RAM binds before CPU does.
+
 Updated: 2026-07-22 (SHIP-3, feat/ship-3-cloud-entity) — registered the /ship
 deploy job ``deploy_app_job`` into ``WorkerSettings.functions``, wrapped the same
 way as ``provision_box_job``: its own long timeout (a deploy pulls an image and
@@ -254,6 +263,48 @@ def _job_timeout_seconds() -> int:
     return val
 
 
+# arq's own default is max_jobs=10 (arq/worker.py). That ceiling is shared by
+# EVERY function registered below — chat runs, workspace jobs, both /ship jobs
+# and both site builds — so ten concurrent site publishes leave no slot for a
+# chat run. It is the cluster-wide concurrency limit, not a per-lane one:
+# replicas multiply it, this value does not.
+_DEFAULT_MAX_JOBS = 10
+
+
+def _max_jobs() -> int:
+    """Resolve the worker's concurrent-job ceiling from ``POCKETPAW_ARQ_MAX_JOBS``.
+
+    Same fail-soft contract as ``_job_timeout_seconds``: an unparseable or
+    non-positive value falls back to the default rather than being handed to
+    arq, where ``0`` would wedge the worker into accepting nothing and a
+    negative would crash ``BoundedSemaphore``.
+
+    Raise this WITH the container's memory limit, not instead of it. The
+    default ``claude_agent_sdk`` backend spawns a Node subprocess per run, so
+    concurrency here is bounded by RAM long before it is bounded by CPU.
+    """
+    raw = os.environ.get("POCKETPAW_ARQ_MAX_JOBS", "").strip()
+    if not raw:
+        return _DEFAULT_MAX_JOBS
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.warning(
+            "POCKETPAW_ARQ_MAX_JOBS=%r is not an int; using default %d",
+            raw,
+            _DEFAULT_MAX_JOBS,
+        )
+        return _DEFAULT_MAX_JOBS
+    if val <= 0:
+        logger.warning(
+            "POCKETPAW_ARQ_MAX_JOBS=%d is not positive; using default %d",
+            val,
+            _DEFAULT_MAX_JOBS,
+        )
+        return _DEFAULT_MAX_JOBS
+    return val
+
+
 # Workspace jobs (pp#1459) run on this same worker but get their OWN
 # per-function timeout via ``arq.worker.func`` so a long-running job can't be
 # clipped by the chat-run timeout and vice-versa. The dotted name the web
@@ -348,5 +399,11 @@ class WorkerSettings:
     # it and make it env-tunable (POCKETPAW_CLOUD_RUN_JOB_TIMEOUT, default 30 min).
     # Plain int in __dict__ for the same arq-reads-__dict__ reason as redis_settings.
     job_timeout = _job_timeout_seconds()
+    # Concurrent-job ceiling, shared across every lane in ``functions``. arq's
+    # default of 10 is the first limit a multi-user deploy hits: job 11 waits in
+    # Redis behind a 30-minute ``job_timeout`` with ``max_tries=1``, so it is not
+    # retried, just queued. Plain int in __dict__ for the arq-reads-__dict__
+    # reason documented on `_redis_settings`.
+    max_jobs = _max_jobs()
     # Eager: arq reads __dict__, which bypasses descriptors. See `_redis_settings`.
     redis_settings = _redis_settings()

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -3,6 +3,13 @@
 Each cloud Agent gets its own AgentBackend + SoulManager + memory namespace.
 Instances are cached and evicted when idle (default 5 minutes).
 
+Updated: 2026-09-01 (feat/scale-concurrency-knobs) — ``get_agent_pool`` now builds the
+  singleton with ``max_instances`` from settings (``POCKETPAW_AGENT_POOL_MAX_INSTANCES``,
+  default 20 — the value that was already in force). The constructor default is
+  unchanged, so direct ``AgentPool(...)`` construction in tests is unaffected; only
+  the app's one shared instance reads config. The cap is PER-PROCESS: the web process
+  and each arq worker each hold their own pool.
+
 Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — ``_accepts_prompt_digest``
   and ``_accepts_prompt_digest_kwarg`` no longer live here; they moved to
   ``pocketpaw.agents.backend`` and are re-imported. The channel path grew a
@@ -1094,8 +1101,17 @@ _pool: AgentPool | None = None
 
 
 def get_agent_pool() -> AgentPool:
-    """Get or create the global agent pool."""
+    """Get or create the global agent pool.
+
+    ``max_instances`` is resolved from settings HERE rather than as a constructor
+    default so an explicit ``AgentPool(max_instances=...)`` — which every test uses
+    — keeps winning, and so the env knob reaches the one instance the app actually
+    runs on. The import is function-local for the same import-cycle reason as the
+    other ``Settings.load()`` calls in this module.
+    """
     global _pool
     if _pool is None:
-        _pool = AgentPool()
+        from pocketpaw.config import Settings
+
+        _pool = AgentPool(max_instances=Settings.load().agent_pool_max_instances)
     return _pool

--- a/src/pocketpaw/agents/session_supervisor.py
+++ b/src/pocketpaw/agents/session_supervisor.py
@@ -1,5 +1,13 @@
 """Session Supervisor — agent-session lifecycle across COLD/WARM tiers (SS-4).
 
+Updated 2026-09-01 (feat/scale-concurrency-knobs): ``get_session_supervisor`` now
+builds the singleton with ``max_warm_per_tenant`` / ``max_warm_global`` from settings
+(``POCKETPAW_SESSION_WARM_MAX_PER_TENANT`` / ``..._GLOBAL``, defaults 8 / 64 — the
+values already in force). Constructor defaults are untouched, so this module stays
+fully unit-testable with fakes and no ambient config; only the app's shared instance
+reads settings, via a function-local import that keeps this module config-free at
+import time. Both quotas are PER-PROCESS.
+
 Created 2026-06-30 (feat/session-supervisor SS-4): the policy / lifecycle engine
 that owns one ``SessionRuntime`` per ``(workspace_id, session_id)`` and decides,
 for each turn, whether to reuse a live warm slot (WARM) or take a fresh launch
@@ -504,8 +512,21 @@ _supervisor: SessionSupervisor | None = None
 
 
 def get_session_supervisor() -> SessionSupervisor:
-    """Get or create the global session supervisor."""
+    """Get or create the global session supervisor.
+
+    The two warm-slot quotas are resolved from settings here, not as constructor
+    defaults: the tests construct ``SessionSupervisor(...)`` directly with fakes and
+    must stay independent of ambient config, while the ONE instance the app runs on
+    needs to be tunable per deploy. Import is function-local, mirroring
+    ``pool.get_agent_pool`` — this module is otherwise config-free by design.
+    """
     global _supervisor
     if _supervisor is None:
-        _supervisor = SessionSupervisor()
+        from pocketpaw.config import Settings
+
+        settings = Settings.load()
+        _supervisor = SessionSupervisor(
+            max_warm_per_tenant=settings.session_warm_max_per_tenant,
+            max_warm_global=settings.session_warm_max_global,
+        )
     return _supervisor

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,18 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-09-01 (feat/scale-concurrency-knobs): Added ``agent_pool_max_instances``
+    (default 20), ``session_warm_max_per_tenant`` (default 8) and
+    ``session_warm_max_global`` (default 64) — the three agent-tier ceilings that
+    were previously HARDCODED constructor defaults reachable only by editing
+    ``pool.py`` / ``session_supervisor.py``, because both singletons are built with
+    no arguments (``AgentPool()``, ``SessionSupervisor()``). Every default is the
+    literal that was already in force, so no existing deploy changes behaviour;
+    they exist so a multi-user deploy can raise them from env. Note these are
+    PER-PROCESS ceilings — they bound one web or worker process, and replicas
+    multiply them. Distinct from ``max_concurrent_conversations`` below, which
+    gates only the OSS channel-adapter loop, and from ``POCKETPAW_ARQ_MAX_JOBS``,
+    which is the cluster-wide arq ceiling.
   - 2026-08-03 (PA-9): Re-measured ``prompt_pocket_summary_only``'s payoff against
     the live layer and corrected its description. The flag saves ~1,631 chars/turn
     (3,240 -> 1,609 on a 300-widget pocket), not the ~39.6k the old note implied —
@@ -2804,8 +2816,56 @@ class Settings(BaseSettings):
     )
 
     # Concurrency
+    #
+    # Three different ceilings live near each other and are easy to confuse, so:
+    #   * ``max_concurrent_conversations`` — the OSS AgentLoop semaphore. Gates the
+    #     CHANNEL adapters (Telegram / Discord / Slack / WhatsApp) only. The cloud
+    #     chat path (``ee.cloud.chat.runs.run_core``) does NOT import AgentLoop, so
+    #     raising this does nothing for a cloud deploy.
+    #   * ``agent_pool_max_instances`` / ``session_warm_*`` — PER-PROCESS agent-tier
+    #     ceilings, in force on both the web process and each arq worker.
+    #   * ``POCKETPAW_ARQ_MAX_JOBS`` (in the arq WorkerSettings, not here) — the
+    #     CLUSTER-WIDE concurrent-job ceiling. That is the one that bounds how many
+    #     agent runs execute at once in a cloud deploy.
     max_concurrent_conversations: int = Field(
-        default=5, gt=0, description="Max parallel conversations processed simultaneously"
+        default=5,
+        gt=0,
+        description=(
+            "Max parallel conversations processed simultaneously by the OSS "
+            "AgentLoop — the channel adapters (Telegram/Discord/Slack/WhatsApp). "
+            "Does NOT gate cloud chat runs, which bypass AgentLoop entirely; use "
+            "POCKETPAW_ARQ_MAX_JOBS for those."
+        ),
+    )
+    agent_pool_max_instances: int = Field(
+        default=20,
+        gt=0,
+        description=(
+            "Max live agent instances held by one process's AgentPool before it "
+            "refuses to build another. PER-PROCESS, not cluster-wide. Set via "
+            "POCKETPAW_AGENT_POOL_MAX_INSTANCES."
+        ),
+    )
+    session_warm_max_per_tenant: int = Field(
+        default=8,
+        gt=0,
+        description=(
+            "Max WARM session slots one workspace may hold in a single process. "
+            "Over the limit the SessionSupervisor LRU-evicts the oldest IDLE slot "
+            "(never a busy one). This is the per-tenant fairness knob: it stops one "
+            "workspace holding every warm slot. Set via "
+            "POCKETPAW_SESSION_WARM_MAX_PER_TENANT."
+        ),
+    )
+    session_warm_max_global: int = Field(
+        default=64,
+        gt=0,
+        description=(
+            "Max WARM session slots across ALL workspaces in a single process. Each "
+            "warm slot pins a live agent client (a subprocess under the default "
+            "claude_agent_sdk backend), so raise this with the container's memory "
+            "limit. Set via POCKETPAW_SESSION_WARM_MAX_GLOBAL."
+        ),
     )
 
     # Composio — MCP-direct tool provider for the parent cloud chat agent.

--- a/tests/cloud/runs/test_worker_config_and_pool.py
+++ b/tests/cloud/runs/test_worker_config_and_pool.py
@@ -22,6 +22,7 @@ descriptor magic.
 
 from __future__ import annotations
 
+import inspect
 from unittest.mock import AsyncMock
 
 import pytest
@@ -156,5 +157,56 @@ async def test_job_timeout_helper_invalid_or_nonpositive_falls_back(monkeypatch)
     for bad in ("not-a-number", "-5", "0", ""):
         monkeypatch.setenv("POCKETPAW_CLOUD_RUN_JOB_TIMEOUT", bad)
         assert worker_mod._job_timeout_seconds() == worker_mod._DEFAULT_RUN_JOB_TIMEOUT_SECONDS, (
+            f"{bad!r} should fall back to the default"
+        )
+
+
+# --- POCKETPAW_ARQ_MAX_JOBS: the cluster-wide concurrency ceiling ----------
+#
+# Added 2026-09-01 (feat/scale-concurrency-knobs). ``max_jobs`` was previously
+# UNSET on WorkerSettings, so arq's own default of 10 applied invisibly and
+# bounded every registered lane at once. These pin both halves of the fix: the
+# attribute reaches arq at all (same ``__dict__`` contract as redis_settings),
+# and the helper is fail-soft in the same way ``_job_timeout_seconds`` is.
+
+
+async def test_worker_settings_max_jobs_is_a_plain_int_in_dict():
+    """arq reads ``settings_cls.__dict__`` directly, so ``max_jobs`` must be a
+    concrete int there — not a property, not a descriptor. Same reason as
+    ``redis_settings`` above; a descriptor would be handed straight to
+    ``Worker.__init__`` and crash ``BoundedSemaphore(max_jobs + 1)``."""
+    raw = worker_mod.WorkerSettings.__dict__.get("max_jobs")
+    assert isinstance(raw, int), (
+        f"WorkerSettings.max_jobs in __dict__ is {type(raw).__name__}, expected int. "
+        "arq bypasses the descriptor protocol via __dict__ access."
+    )
+    assert raw > 0
+
+
+async def test_max_jobs_helper_default(monkeypatch):
+    monkeypatch.delenv("POCKETPAW_ARQ_MAX_JOBS", raising=False)
+    assert worker_mod._max_jobs() == worker_mod._DEFAULT_MAX_JOBS
+
+
+async def test_max_jobs_default_matches_arq_own_default():
+    """The default must stay arq's own (10), so merely shipping this knob does
+    not change the concurrency of any existing deploy."""
+    from arq.worker import Worker
+
+    arq_default = inspect.signature(Worker.__init__).parameters["max_jobs"].default
+    assert worker_mod._DEFAULT_MAX_JOBS == arq_default
+
+
+async def test_max_jobs_helper_env_override(monkeypatch):
+    monkeypatch.setenv("POCKETPAW_ARQ_MAX_JOBS", "40")
+    assert worker_mod._max_jobs() == 40
+
+
+async def test_max_jobs_helper_invalid_or_nonpositive_falls_back(monkeypatch):
+    """0 would wedge the worker into accepting no jobs and a negative would
+    crash arq's BoundedSemaphore, so neither may reach it."""
+    for bad in ("not-a-number", "-5", "0", "", "  "):
+        monkeypatch.setenv("POCKETPAW_ARQ_MAX_JOBS", bad)
+        assert worker_mod._max_jobs() == worker_mod._DEFAULT_MAX_JOBS, (
             f"{bad!r} should fall back to the default"
         )

--- a/tests/mutations/scale_concurrency_knobs.json
+++ b/tests/mutations/scale_concurrency_knobs.json
@@ -1,0 +1,92 @@
+[
+  {
+    "label": "max_jobs is dropped from WorkerSettings, so arq silently falls back to its own default of 10 and the whole knob is dead — the exact bug this change fixes, reintroduced",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "    max_jobs = _max_jobs()\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/runs/test_worker_config_and_pool.py"
+    ]
+  },
+  {
+    "label": "max_jobs becomes a property, so arq's __dict__ read hands a descriptor to BoundedSemaphore(max_jobs + 1) and the worker crashes on boot — the _LazyRedisSettings deploy crash, repeated",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "    max_jobs = _max_jobs()",
+    "replace": "    max_jobs = property(lambda self: _max_jobs())",
+    "tests": [
+      "tests/cloud/runs/test_worker_config_and_pool.py"
+    ]
+  },
+  {
+    "label": "the default stops tracking arq's own, so merely shipping this knob quietly changes the concurrency of every existing deploy",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "_DEFAULT_MAX_JOBS = 10",
+    "replace": "_DEFAULT_MAX_JOBS = 40",
+    "tests": [
+      "tests/cloud/runs/test_worker_config_and_pool.py"
+    ]
+  },
+  {
+    "label": "the non-positive guard is dropped, so POCKETPAW_ARQ_MAX_JOBS=0 wedges the worker into accepting no jobs and a negative crashes arq's BoundedSemaphore",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "    if val <= 0:\n        logger.warning(\n            \"POCKETPAW_ARQ_MAX_JOBS=%d is not positive; using default %d\",",
+    "replace": "    if False:\n        logger.warning(\n            \"POCKETPAW_ARQ_MAX_JOBS=%d is not positive; using default %d\",",
+    "tests": [
+      "tests/cloud/runs/test_worker_config_and_pool.py"
+    ]
+  },
+  {
+    "label": "a typoed POCKETPAW_ARQ_MAX_JOBS raises instead of falling back, so one bad env var takes the whole worker down at import",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "    raw = os.environ.get(\"POCKETPAW_ARQ_MAX_JOBS\", \"\").strip()\n    if not raw:\n        return _DEFAULT_MAX_JOBS\n    try:\n        val = int(raw)\n    except ValueError:",
+    "replace": "    raw = os.environ.get(\"POCKETPAW_ARQ_MAX_JOBS\", \"\").strip()\n    if not raw:\n        return _DEFAULT_MAX_JOBS\n    val = int(raw)\n    if False:",
+    "tests": [
+      "tests/cloud/runs/test_worker_config_and_pool.py"
+    ]
+  },
+  {
+    "label": "get_agent_pool stops reading settings, so POCKETPAW_AGENT_POOL_MAX_INSTANCES is accepted, documented, and silently ignored",
+    "file": "src/pocketpaw/agents/pool.py",
+    "find": "        _pool = AgentPool(max_instances=Settings.load().agent_pool_max_instances)",
+    "replace": "        _pool = AgentPool()",
+    "tests": [
+      "tests/test_agent_pool_max_instances.py"
+    ]
+  },
+  {
+    "label": "the AgentPool constructor default drifts from the config default, so a direct construction and the app singleton disagree about the ceiling",
+    "file": "src/pocketpaw/agents/pool.py",
+    "find": "    def __init__(self, max_idle: int = 300, max_instances: int = 20) -> None:",
+    "replace": "    def __init__(self, max_idle: int = 300, max_instances: int = 5) -> None:",
+    "tests": [
+      "tests/test_agent_pool_max_instances.py"
+    ]
+  },
+  {
+    "label": "get_session_supervisor stops reading settings, so both warm-slot knobs are accepted, documented, and silently ignored",
+    "file": "src/pocketpaw/agents/session_supervisor.py",
+    "find": "        _supervisor = SessionSupervisor(\n            max_warm_per_tenant=settings.session_warm_max_per_tenant,\n            max_warm_global=settings.session_warm_max_global,\n        )",
+    "replace": "        _supervisor = SessionSupervisor()",
+    "tests": [
+      "tests/test_session_supervisor.py"
+    ]
+  },
+  {
+    "label": "the two warm quotas are wired to each other's settings, so the per-tenant fairness cap silently becomes the global one and one workspace can hold every slot",
+    "file": "src/pocketpaw/agents/session_supervisor.py",
+    "find": "            max_warm_per_tenant=settings.session_warm_max_per_tenant,\n            max_warm_global=settings.session_warm_max_global,",
+    "replace": "            max_warm_per_tenant=settings.session_warm_max_global,\n            max_warm_global=settings.session_warm_max_per_tenant,",
+    "tests": [
+      "tests/test_session_supervisor.py"
+    ]
+  },
+  {
+    "label": "the config default for the global warm cap drifts from the constructor's, so shipping the knob moves a deploy nobody set it on",
+    "file": "src/pocketpaw/config.py",
+    "find": "    session_warm_max_global: int = Field(\n        default=64,",
+    "replace": "    session_warm_max_global: int = Field(\n        default=32,",
+    "tests": [
+      "tests/test_session_supervisor.py"
+    ]
+  }
+]

--- a/tests/test_agent_pool_max_instances.py
+++ b/tests/test_agent_pool_max_instances.py
@@ -1,0 +1,59 @@
+# tests/test_agent_pool_max_instances.py
+# Created: 2026-09-01 (feat/scale-concurrency-knobs) — pins that the AgentPool
+# instance ceiling is reachable from config.
+#
+# Why this file exists: ``max_instances`` was a hardcoded constructor default
+# (20) and ``get_agent_pool()`` built the singleton with NO arguments, so the
+# only way to raise it on a deploy serving many users was to edit pool.py. The
+# risk in fixing that is the opposite mistake — resolving config inside
+# ``AgentPool.__init__`` would drag ambient settings into the ~8 places that
+# construct ``AgentPool()`` directly in tests. So the contract is split, and
+# both halves are pinned here:
+#   * ``get_agent_pool()`` — the ONE instance the app runs on — reads settings.
+#   * ``AgentPool(...)`` direct construction does NOT; explicit args still win.
+
+from __future__ import annotations
+
+from pocketpaw.agents import pool as pool_mod
+from pocketpaw.agents.pool import AgentPool
+
+
+def test_get_agent_pool_reads_max_instances_from_settings(monkeypatch):
+    monkeypatch.setenv("POCKETPAW_AGENT_POOL_MAX_INSTANCES", "50")
+    monkeypatch.setattr(pool_mod, "_pool", None)
+
+    pool = pool_mod.get_agent_pool()
+    try:
+        assert pool._max_instances == 50
+    finally:
+        pool_mod._pool = None
+
+
+def test_get_agent_pool_default_matches_the_constructor(monkeypatch):
+    """Shipping the knob must not move any existing deploy: with no env set the
+    singleton lands on the same 20 the constructor has always used."""
+    monkeypatch.delenv("POCKETPAW_AGENT_POOL_MAX_INSTANCES", raising=False)
+    monkeypatch.setattr(pool_mod, "_pool", None)
+
+    pool = pool_mod.get_agent_pool()
+    try:
+        assert pool._max_instances == AgentPool()._max_instances == 20
+    finally:
+        pool_mod._pool = None
+
+
+def test_direct_construction_ignores_settings(monkeypatch):
+    """Explicit args beat the environment — this is what keeps the direct
+    ``AgentPool()`` construction used across the pool test suite independent of
+    ambient config."""
+    monkeypatch.setenv("POCKETPAW_AGENT_POOL_MAX_INSTANCES", "99")
+    assert AgentPool(max_instances=4)._max_instances == 4
+
+
+def test_singleton_is_still_cached(monkeypatch):
+    """The settings read must happen once, on first build — not per call."""
+    monkeypatch.setattr(pool_mod, "_pool", None)
+    try:
+        assert pool_mod.get_agent_pool() is pool_mod.get_agent_pool()
+    finally:
+        pool_mod._pool = None

--- a/tests/test_session_supervisor.py
+++ b/tests/test_session_supervisor.py
@@ -651,3 +651,54 @@ async def test_reaped_lease_then_cold_pruned_without_second_disconnect() -> None
     assert spy.disconnect_count == 1  # NOT torn down a second time
     assert ("ws-a", "sess-1") not in sup._runtimes
     assert ("ws-a", "sess-busy") in sup._runtimes  # busy survives
+
+
+# --- Singleton reads its quotas from settings -----------------------------
+#
+# Added 2026-09-01 (feat/scale-concurrency-knobs). The two warm quotas were
+# hardcoded constructor defaults and ``get_session_supervisor()`` passed no
+# arguments, so the only way to change them on a busy deploy was to edit this
+# module. These pin that the env knob actually reaches the ONE instance the app
+# runs on — asserting the config field exists proves nothing about that.
+
+
+def test_get_session_supervisor_reads_warm_quotas_from_settings(monkeypatch):
+    from pocketpaw.agents import session_supervisor as mod
+
+    monkeypatch.setenv("POCKETPAW_SESSION_WARM_MAX_PER_TENANT", "3")
+    monkeypatch.setenv("POCKETPAW_SESSION_WARM_MAX_GLOBAL", "17")
+    monkeypatch.setattr(mod, "_supervisor", None)
+
+    sup = mod.get_session_supervisor()
+    try:
+        assert sup._max_warm_per_tenant == 3
+        assert sup._max_warm_global == 17
+    finally:
+        mod._supervisor = None
+
+
+def test_get_session_supervisor_defaults_match_the_constructor(monkeypatch):
+    """Shipping the knob must not move any existing deploy: with no env set, the
+    singleton has to land on the same 8 / 64 the constructor has always used."""
+    from pocketpaw.agents import session_supervisor as mod
+
+    monkeypatch.delenv("POCKETPAW_SESSION_WARM_MAX_PER_TENANT", raising=False)
+    monkeypatch.delenv("POCKETPAW_SESSION_WARM_MAX_GLOBAL", raising=False)
+    monkeypatch.setattr(mod, "_supervisor", None)
+
+    sup = mod.get_session_supervisor()
+    try:
+        bare = SessionSupervisor()
+        assert sup._max_warm_per_tenant == bare._max_warm_per_tenant == 8
+        assert sup._max_warm_global == bare._max_warm_global == 64
+    finally:
+        mod._supervisor = None
+
+
+def test_direct_construction_ignores_settings(monkeypatch):
+    """The engine stays config-free: an explicit constructor argument must win
+    over the environment, which is what keeps every fake-driven test above
+    independent of ambient config."""
+    monkeypatch.setenv("POCKETPAW_SESSION_WARM_MAX_PER_TENANT", "99")
+    sup = SessionSupervisor(max_warm_per_tenant=2)
+    assert sup._max_warm_per_tenant == 2


### PR DESCRIPTION
The arq worker never set `max_jobs`, so arq's own default of 10 applied silently. That ceiling is shared by all six functions the worker registers — chat runs, workspace jobs, both `/ship` jobs, both site builds — rather than divided among them, so ten concurrent site publishes leave no slot for a chat message.

The failure mode is what makes it worth fixing. Job 11 is not rejected, and with `max_tries = 1` it is not retried either. It waits in Redis behind a `job_timeout` of up to 30 minutes, so the user sees a reply that never starts and nothing logs it.

Two smaller ceilings had the same shape. `AgentPool(max_instances=20)` and `SessionSupervisor(max_warm_per_tenant=8, max_warm_global=64)` were constructor defaults, and `get_agent_pool()` / `get_session_supervisor()` both built their singleton with no arguments — so the only way to move them on a busy deploy was to edit the module.

## What changed

Four knobs, every default the value that was already in force:

| Var | Default | Scope |
|---|---|---|
| `POCKETPAW_ARQ_MAX_JOBS` | 10 (arq's own) | cluster-wide, per worker |
| `POCKETPAW_AGENT_POOL_MAX_INSTANCES` | 20 | per process |
| `POCKETPAW_SESSION_WARM_MAX_PER_TENANT` | 8 | per process |
| `POCKETPAW_SESSION_WARM_MAX_GLOBAL` | 64 | per process |

No existing deploy moves as a result of merging this. There's a test pinning `_DEFAULT_MAX_JOBS` against arq's own signature default so that stays true if arq changes it.

Two decisions worth flagging for review:

**Settings are read at the singleton construction sites, not in the constructors.** Direct `AgentPool(...)` / `SessionSupervisor(...)` still ignore the environment. `session_supervisor.py` is deliberately config-free and fully unit-testable with fakes; resolving settings in `__init__` would have dragged ambient config into the ~8 places that construct these directly in tests.

**`max_jobs` is a plain int in the class body** for the reason already documented on `redis_settings` — arq reads `settings_cls.__dict__` directly, so a descriptor would be handed to `Worker.__init__` and crash `BoundedSemaphore(max_jobs + 1)`. That's the `_LazyRedisSettings` deploy crash, and there's a mutation for it.

## Docs

The knobs are only useful if you know which one to reach for, so the docs also record what they don't do:

- `max_concurrent_conversations` (default 5) gates the OSS `AgentLoop` — the channel adapters only. `run_core` never imports `AgentLoop`, so raising it does nothing for a cloud deploy. This is the knob you'd reach for first and it's the wrong one.
- `POCKETPAW_CLOUD_WORKER_BOOT_SWEEP` must stay false once a second worker replica exists.
- Memory binds before CPU: the default `claude_agent_sdk` backend spawns a Node subprocess per run, so `max_jobs` has to rise with the container limit.

`docs/internal/2026-05-resumable-runs-deploy.md` gains a "Sizing the worker" section covering which lever to pull — raise `max_jobs` for IO-bound runs, add replicas for CPU/memory-bound ones.

## Testing

12 new tests. `tests/mutations/scale_concurrency_knobs.json` has 10 mutations and all 10 are caught, including both directions of the settings wiring and a swap of the two warm quotas (which would silently turn the per-tenant fairness cap into the global one).

Repo-wide `mutate.py --validate` still passes: 843 anchors across 67 plans.

Six failures in the wider suite are pre-existing on `dev` — verified by stashing and re-running. Two are `test_run_core.py` surface tool-allowlist assertions; four are `Settings` round-trip tests picking up a local `.env`.