### PR TITLE
Instinct is a gate, not a tier

### DIFF
--- a/ee/pocketpaw_ee/guards/abac.py
+++ b/ee/pocketpaw_ee/guards/abac.py
@@ -25,6 +25,31 @@
 #   Other display-only flags (studio, code, deep_work, chain_flow, fleet, belt,
 #   foresight) are surfaced to the UI but not yet enforced. ``automations`` stays
 #   on pro+; ``audit``/``sso``/``instinct``/``custom_roles`` stay enterprise-only.
+# Updated 2026-09-01 (fix/instinct-is-a-gate-not-a-tier) — ``instinct`` moved OUT
+#   of the enterprise-only set and onto EVERY tier, free included. It is not a
+#   capability you buy; it is the APPROVAL GATE agents propose through, and the
+#   gate it was priced above was HALF-OPEN. Roughly twenty modules WRITE Instinct
+#   actions (belt, external actions, growth, fabric conflicts/proposals, admin
+#   proposals, the site-publish merge gate, the chat agent service) and almost
+#   none of them check this flag. Exactly ONE place reads and approves them —
+#   ``instinct/router.py``'s ``require_plan_feature("instinct")`` — so on
+#   free/go/pro/pro_max those proposals were created and could never be read,
+#   approved, or rejected. Not "unavailable": a queue with no door. The reported
+#   symptom was a workspace OWNER unable to publish a site, because the builder's
+#   Publish button self-approves through ``instinct/actions/pending`` +
+#   ``/approve`` and both 403'd with ``plan.feature_denied``.
+#   The floor gets it for the same reason the rest do: ``free`` carries
+#   ``sessions``, so agents ACT there, and oversight of agent actions cannot be
+#   the thing a cheaper tier does without. It costs no paid upstream either —
+#   the store is a local per-workspace SQLite file — which is the stated bar for
+#   the free floor.
+#   THIS LOOSENS NO PERMISSION. ``instinct.approve`` is still ADMIN in
+#   ``guards/actions.py``, the artifact-change workspace tenancy asserts still
+#   run, and ``require_license`` still gates the router. What is removed is a
+#   BILLING gate that sat redundantly on top of a working PERMISSION gate.
+#   What stays enterprise is the intelligence built ON Instinct — ``audit``
+#   (the ledger + its export) and ``custom_roles`` — which are keyed separately
+#   and untouched here.
 
 from __future__ import annotations
 
@@ -56,7 +81,9 @@ PLAN_FEATURES: dict[str, set[str]] = {
     # The base/free floor — a workspace with no paid plan (or an unknown plan)
     # resolves here. Deliberately minimal: the core canvas (pockets) and the
     # ability to run sessions, nothing that costs the platform a paid upstream.
-    "free": {"pockets", "sessions"},
+    # ``instinct`` is here because the floor RUNS AGENTS (``sessions``), and the
+    # approval gate has to exist wherever agents act — see the note above.
+    "free": {"pockets", "sessions", "instinct"},
     # Paw Go — everyday: chat, pockets, agents, memory + Studio + Sites. ``sites``
     # is ENFORCED here (go gets a site); ``fabric`` (the ontology) is NOT.
     "go": {
@@ -66,6 +93,7 @@ PLAN_FEATURES: dict[str, set[str]] = {
         "memory",
         "studio",
         "sites",
+        "instinct",
     },
     # Paw Pro — daily drivers. Adds automations + knowledge_base + display flags
     # for the power surfaces (code, deep_work, chain_flow, fleet, belt,
@@ -86,6 +114,7 @@ PLAN_FEATURES: dict[str, set[str]] = {
         "fleet",
         "belt",
         "foresight",
+        "instinct",
     },
     # Paw Pro Max — uncapped power users. Everything in pro (incl. belt +
     # foresight) + nothing extra at the feature-set level — the differentiator
@@ -105,6 +134,7 @@ PLAN_FEATURES: dict[str, set[str]] = {
         "fleet",
         "belt",
         "foresight",
+        "instinct",
     },
     # Enterprise — the full set: every consumer flag PLUS the enterprise-only
     # gates (the ``fabric`` ONTOLOGY, instinct, audit, sso, custom_roles).

--- a/tests/cloud/entitlements/test_entitlements.py
+++ b/tests/cloud/entitlements/test_entitlements.py
@@ -188,9 +188,16 @@ async def test_missing_workspace_falls_back_to_free(patch_plan):
     assert ent.monthly_credit_allotment == 0
     # FAIL-CLOSED: a missing workspace caps at the Free ceiling, never uncapped.
     assert ent.monthly_ceiling == 1_000
-    # Crucially, free must NOT carry any paid-tier feature.
+    # Crucially, free must NOT carry any paid-tier feature. ``instinct`` used to
+    # be one of these sentinels and no longer is — it is the agent APPROVAL GATE,
+    # which every tier that runs agents needs (fix/instinct-is-a-gate-not-a-tier),
+    # so it would now pass here for the right reason and stop testing anything.
+    # The enterprise-only flags it was standing in for are asserted instead, so
+    # this keeps the same fail-closed strength.
     assert "fabric" not in ent.features
-    assert "instinct" not in ent.features
+    assert "audit" not in ent.features
+    assert "sso" not in ent.features
+    assert "custom_roles" not in ent.features
 
 
 async def test_empty_workspace_id_is_rejected_at_entry():

--- a/tests/cloud/test_ee_guards.py
+++ b/tests/cloud/test_ee_guards.py
@@ -402,8 +402,15 @@ class TestPolicyResult:
 class TestPlanFeatureTable:
     """Validate the PLAN_FEATURES table contract (consumer ladder)."""
 
-    def test_free_is_chat_and_pockets_only(self):
-        assert PLAN_FEATURES["free"] == {"pockets", "sessions"}
+    def test_free_is_chat_and_pockets_plus_the_approval_gate(self):
+        """The floor is the canvas, sessions, and the gate those sessions need.
+
+        ``instinct`` joined the floor in fix/instinct-is-a-gate-not-a-tier. It is
+        not a paid capability that leaked down — it is the approval gate agents
+        propose through, and ``sessions`` on this tier means agents ACT here. A
+        floor that can create proposals but not approve them strands them.
+        """
+        assert PLAN_FEATURES["free"] == {"pockets", "sessions", "instinct"}
 
     def test_go_has_core_four(self):
         assert {"pockets", "sessions", "agents", "memory"} <= PLAN_FEATURES["go"]

--- a/tests/cloud/test_ee_instinct.py
+++ b/tests/cloud/test_ee_instinct.py
@@ -126,11 +126,14 @@ def test_app(tmp_path: Path, monkeypatch):
     """
     fake_user = _FakeUser()
 
-    # instinct is an enterprise-tier feature in PLAN_FEATURES; team and
-    # non-enterprise plans don't include it, so the require_plan_feature guard
-    # only passes at enterprise. Mirror the AsyncMock pattern from
-    # tests/cloud/test_plan_feature_gate.py so the patch reaches the same
-    # module attribute the guard reads from.
+    # ``instinct`` is on EVERY tier in PLAN_FEATURES since
+    # fix/instinct-is-a-gate-not-a-tier — it is the agent approval gate, not a
+    # capability a workspace buys — so this stub no longer has to say
+    # "enterprise" for the require_plan_feature guard to pass. It still does,
+    # because these tests are about the ROUTER's own RBAC and tenancy asserts and
+    # pinning one plan keeps the plan ladder out of their failure modes. Mirror
+    # the AsyncMock pattern from tests/cloud/test_plan_feature_gate.py so the
+    # patch reaches the same module attribute the guard reads from.
     import pocketpaw_ee.cloud.workspace.service as ws_svc
 
     monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))

--- a/tests/cloud/test_plan_feature_gate.py
+++ b/tests/cloud/test_plan_feature_gate.py
@@ -1,7 +1,7 @@
 # Tests for ee/cloud require_plan_feature FastAPI dependency.
 # Created: 2026-05-07
 # Covers plan-tier gating for sites (go+), the Fabric ontology fabric flag
-# (enterprise-only), and instinct (enterprise-only).
+# (enterprise-only), and instinct (EVERY tier — see the 2026-09-01 note below).
 # Patches workspace_service.get_workspace_plan so no DB is needed.
 # Updated 2026-06-25 (feat/consumer-plan-ladder): rekeyed the plan strings from
 #   {team, business, enterprise} to the consumer ladder {free, go, pro, pro_max,
@@ -10,6 +10,13 @@
 #   was split. Sites/Leads now gate on a NEW ``sites`` flag (go+) — go is ALLOWED,
 #   free is DENIED. The ``fabric`` flag is now the Fabric ONTOLOGY gate and is
 #   ENTERPRISE-ONLY — pro/pro_max are DENIED, enterprise is ALLOWED.
+# Updated 2026-09-01 (fix/instinct-is-a-gate-not-a-tier): the two instinct DENIAL
+#   tests became ALLOW tests across every tier. They were pinning a gate that was
+#   half-open — ~20 modules write Instinct proposals without checking the flag,
+#   and only the router that approves them carried it, so free/go/pro/pro_max
+#   accumulated proposals nobody could act on. A workspace OWNER could not publish
+#   a site for this reason: the builder self-approves through the Instinct API and
+#   got ``plan.feature_denied`` no matter the role. Approving remains ADMIN.
 
 from __future__ import annotations
 
@@ -160,32 +167,48 @@ class TestFabricOntologyFeatureGate:
 
 
 class TestInstinctFeatureGate:
-    """require_plan_feature("instinct") allows enterprise, blocks every paid consumer tier."""
+    """require_plan_feature("instinct") allows EVERY tier — it is a gate, not a tier.
 
-    def test_member_on_enterprise_plan_can_access_instinct(self, patch_plan):
-        """Enterprise plan includes instinct."""
-        patch_plan("enterprise")
+    Instinct is the approval layer agents propose through, not a capability a
+    workspace buys. Pricing it above the tiers that run agents left those tiers
+    creating proposals nobody could read, approve, or reject: ~20 modules WRITE
+    Instinct actions and almost none check this flag, while the single router
+    that reads and approves them carried the gate. The reported symptom was a
+    workspace OWNER unable to publish a site — the builder's Publish button
+    self-approves through ``instinct/actions/pending`` + ``/approve``, and both
+    403'd with ``plan.feature_denied`` regardless of role.
+
+    Approving is still ADMIN (``guards/actions.py``); only the BILLING gate moved.
+    """
+
+    @pytest.mark.parametrize("plan", ["free", "go", "pro", "pro_max", "enterprise"])
+    def test_every_tier_can_reach_instinct(self, patch_plan, plan):
+        """The approval gate exists on every tier, including the free floor.
+
+        MUTATION: drop ``"instinct"`` from any tier in ``PLAN_FEATURES`` and that
+        tier's parametrization fails with 403 ``plan.feature_denied``.
+        """
+        patch_plan(plan)
         client = TestClient(_build_app("instinct"), raise_server_exceptions=False)
         resp = client.get("/guarded")
-        assert resp.status_code == 200
+        assert resp.status_code == 200, f"{plan} must reach the approval gate"
 
-    def test_admin_on_pro_max_plan_is_denied_instinct(self, patch_plan):
-        """Pro Max plan does not include instinct; must return 403."""
-        patch_plan("pro_max")
-        client = TestClient(_build_app("instinct"), raise_server_exceptions=False)
-        resp = client.get("/guarded")
-        assert resp.status_code == 403
-        body = resp.json()
-        assert body["error"]["code"] == "plan.feature_denied"
+    def test_the_free_floor_that_runs_agents_also_gets_the_gate(self, patch_plan):
+        """The floor carries ``sessions``, so agents ACT there.
 
-    def test_go_plan_is_denied_instinct(self, patch_plan):
-        """Go plan does not include instinct; must return 403."""
-        patch_plan("go")
-        client = TestClient(_build_app("instinct"), raise_server_exceptions=False)
-        resp = client.get("/guarded")
-        assert resp.status_code == 403
-        body = resp.json()
-        assert body["error"]["code"] == "plan.feature_denied"
+        This is the coherence rule the tier list has to keep: any tier that can
+        run an agent can produce a proposal, and a proposal nobody can approve is
+        worse than no gate at all. Pinned separately from the parametrized case
+        because it is the reasoning, not just the value.
+        """
+        from pocketpaw_ee.guards.abac import PLAN_FEATURES
+
+        for plan, features in PLAN_FEATURES.items():
+            if "sessions" in features:
+                assert "instinct" in features, (
+                    f"{plan!r} runs agent sessions but cannot reach the approval "
+                    "gate — its proposals would strand unapprovable"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mutations/instinct_plan_gate.json
+++ b/tests/mutations/instinct_plan_gate.json
@@ -1,0 +1,16 @@
+[
+  {
+    "label": "the free floor loses the approval gate while still running agent sessions",
+    "file": "ee/pocketpaw_ee/guards/abac.py",
+    "find": "    \"free\": {\"pockets\", \"sessions\", \"instinct\"},",
+    "replace": "    \"free\": {\"pockets\", \"sessions\"},",
+    "tests": ["tests/cloud/test_plan_feature_gate.py"]
+  },
+  {
+    "label": "go loses the approval gate, stranding every proposal it can still create",
+    "file": "ee/pocketpaw_ee/guards/abac.py",
+    "find": "        \"studio\",\n        \"sites\",\n        \"instinct\",\n    },",
+    "replace": "        \"studio\",\n        \"sites\",\n    },",
+    "tests": ["tests/cloud/test_plan_feature_gate.py"]
+  }
+]


### PR DESCRIPTION
## The report

A workspace **owner** clicked Publish on a free-plan site and got "Sent for review — a reviewer will sign off in their queue." No reviewer ever saw it, because nothing was ever queued.

## What actually happens

The builder's Publish button files an `_artifact_change` proposal and then approves it in the same click — the owner self-approve path. Both halves go through the Instinct API, and that whole router carries a plan gate:

```python
# instinct/router.py:1498
router = APIRouter(
    dependencies=[Depends(require_license), Depends(require_plan_feature("instinct"))],
)
```

`instinct` was enterprise-only. So the first call, `listPendingActions`, returned

```json
{"error": {"code": "plan.feature_denied", "message": "feature 'instinct' requires enterprise"}}
```

`requestPublish` never ran. `approveAction` never ran. And `runPublish` maps *any* 403 to `sent_for_review`, so the UI reported a hand-off that had not happened. Role was never involved — owner, admin and member all fail identically.

## The gate was half-open

This is the part that makes it a bug rather than a pricing decision. About twenty modules **write** Instinct actions — belt, external actions, growth, fabric conflicts and proposals, admin proposals, the site-publish merge gate, the chat agent service — and almost none of them check the flag. Exactly one place **reads and approves** them, and that one carried it.

On free, go, pro and pro_max, proposals were therefore created and could never be read, approved, or rejected. Not "the feature is unavailable" — a queue with no door. Sites publish is just the instance someone hit. Belt strands the same way: `belt` is a display-only flag that is never enforced, so `belt_propose_change` is reachable on every tier.

There is no tier where the old configuration behaved correctly except enterprise.

## The change

`instinct` moves onto every tier, the free floor included.

The floor gets it for the same reason the rest do: `free` carries `sessions`, so agents act there, and oversight of what agents do cannot be the thing a cheaper plan does without. It also costs no paid upstream — the store is a local per-workspace SQLite file — which is the stated bar for the floor.

**This loosens no permission.** `instinct.approve` is still `WorkspaceRole.ADMIN` in `guards/actions.py`, the artifact-change workspace tenancy asserts still run on both approve and reject, and `require_license` still gates the router. What goes is a billing gate that sat redundantly on top of a working permission gate.

The intelligence built on Instinct stays paid: `audit` (the ledger and its export) and `custom_roles` are keyed separately and are untouched here.

## Tests

The two instinct denial tests became allow tests across all five tiers. Added alongside them: any tier carrying `sessions` must carry `instinct`, so a future tier cannot quietly reintroduce the stranded queue.

`tests/mutations/instinct_plan_gate.json` proves both directions catch — dropping `instinct` from the floor, and dropping it from go:

```
caught   the free floor loses the approval gate while still running agent sessions
caught   go loses the approval gate, stranding every proposal it can still create
all 2 mutations caught
```

`test_entitlements` used `instinct` as a sentinel for "free carries no paid feature". It would now pass for the wrong reason and stop testing anything, so it asserts the genuinely enterprise-only flags instead — same fail-closed strength.

## Verification

- `test_plan_feature_gate`, `entitlements`, `test_ee_instinct`, `test_ee_guards`, `billing`, `cloud/sites`, `ee/sites`, `growth` — 430 passed in the focused re-run
- `scripts/mutate.py --validate` — 835 anchors across 67 plans each resolve exactly once
- `ruff check` and `ruff format --check` clean

Four failures in that scope are pre-existing and run code this branch does not touch: `test_admin_level_is_2` and `test_owner_level_is_3` assert levels 2 and 3 against a `_ROLE_LEVELS` map that has said 3 and 4 since `EDITOR` was inserted, and two `billing/test_plans.py` cases assert `dodo_product_id is None` "until BC7" when BC7 has shipped real product ids. `rbac.py` and `billing/plans.py` are not in this diff. Worth their own cleanup.

## Not in this PR

`runPublish` reporting `sent_for_review` for a 403 that did not come from `approveAction` is a separate defect in paw-enterprise. It is what hid this one — a failure to even create the proposal read as a successful hand-off. Filing separately.
