### PR TITLE
feat(sites): give a gallery card the site's own icon

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -503,6 +503,17 @@ class Site(TimestampedDocument):
     # public url, capture failed, Cloudflare unconfigured); the card falls back to
     # the text layout on empty, so this is never a gate on publishing.
     preview_image_url: str = ""
+    # 2026-09-02: the site's own ICON, as a data: URI, for the gallery card's mark
+    # chip — which until now was a hard-coded globe for every site alike. Written by
+    # the best-effort lookup ``sites.favicon`` schedules alongside the screenshot,
+    # via a targeted ``set`` for the same reason. Held INLINE rather than as an
+    # uploads link (and capped at a few KB by ``favicon._MAX_ICON_BYTES``): an icon
+    # is small enough that a blob row plus a per-card auth grant would cost more
+    # than the bytes themselves. "" when the site declares no icon we can use, when
+    # the page could not be read, or when the icon was over the cap — the card falls
+    # back to the globe on empty, so this is never a gate on publishing. Defaults ""
+    # so every existing row reads "no icon" — no migration.
+    favicon_url: str = ""
     # The site owner's record of WHO this site is for, and what they have billed
     # them. Two billing relationships meet on this document and they are not the
     # same one: ``plan_tier`` / ``subscription_status`` above are what the owner

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -171,6 +171,15 @@
 # rather than a reused ``SiteResponse``: the call answers one question ("what is
 # the new picture"), and unlike every deploy-triggered capture it REPORTS failure
 # — a person asked for it and is waiting on the answer.
+# Updated 2026-09-02 (the card's MARK): both DTOs gain ``favicon_url`` — the site's
+# own icon, for the chip that had been a hard-coded globe on every card alike. It sits
+# beside ``preview_image_url`` and answers a different question ("whose site is this"
+# rather than "what does it look like"), and it differs from it in one way worth
+# knowing before reading either field: this one carries a data: URI INLINE rather than
+# an uploads link. An icon is a few KB, so paying for a blob row and a per-card auth
+# grant to serve it would cost more than the bytes; ``sites.favicon`` holds the cap
+# that keeps a list response bounded and drops anything over it. None whenever the
+# site declares no icon we can use, so the card falls back to the globe.
 
 from __future__ import annotations
 
@@ -356,6 +365,23 @@ class SiteResponse(BaseModel):
     # uuid-keyed row), so a client may treat a changed value as new art and a
     # cached one as unchanged — nothing ever overwrites bytes behind a stable URL.
     preview_image_url: str | None = None
+    # 2026-09-02: the site's own icon, as a data: URI, for the gallery card's mark
+    # chip. Until now that chip was a hard-coded globe tinted by a hash of the site
+    # id, so every card in a gallery wore the same glyph.
+    #
+    # A data: URI and not an uploads link, which is the one way this field differs
+    # from ``preview_image_url`` directly above. A screenshot is a 1280x800 PNG and
+    # needs blob storage behind the auth-gated ``/api/v1/uploads/{id}``, which is
+    # why the card resolves that one through a per-card grant. An icon is a few KB,
+    # so it rides on the wire and the card can paint it with no second request —
+    # see ``sites.favicon`` for the cap that keeps a list response bounded.
+    #
+    # WHEN IT CHANGES: looked up on every successful deploy (a republish included,
+    # for the reason the screenshot policy above gives) and from the tail of a draft
+    # capture. None whenever the site declares no icon we can use, the page could
+    # not be read, or the icon was over the cap; the card falls back to the globe,
+    # which is exactly the pre-existing card, so this is never a gate on anything.
+    favicon_url: str | None = None
 
 
 class SitePreviewRefreshResponse(BaseModel):
@@ -439,6 +465,12 @@ class SiteStatusResponse(BaseModel):
     # republish updates it), plus POST /sites/{site_id}/preview-refresh on demand,
     # and the value is a different uploads link every capture.
     preview_image_url: str | None = None
+    # 2026-09-02: the site's own icon as a data: URI — the same field the list
+    # response carries (see ``SiteResponse.favicon_url`` above for the full
+    # write-up), duplicated onto the by-pocket read for the same reason
+    # ``preview_image_url`` already is: a builder polling by pocket has nowhere else
+    # to look. None until a lookup lands, and whenever the site declares no icon.
+    favicon_url: str | None = None
     # ── SL-3: the build lane's state on the BY-POCKET read too ──────────────────
     # The same three fields ``SiteResponse`` carries (see there for the full write-up
     # of each). They are duplicated onto this DTO for the same reason ``deployed_at`` /

--- a/ee/pocketpaw_ee/sites/favicon.py
+++ b/ee/pocketpaw_ee/sites/favicon.py
@@ -1,0 +1,616 @@
+# ee/pocketpaw_ee/sites/favicon.py — a site's gallery card wears the site's own
+# mark, not a globe.
+#
+# Created 2026-09-02. The /sites card had a hard-coded Lucide globe tinted by a
+# hash of the site id (SiteCard.svelte's ``.site-logo``), so a gallery of ten
+# published sites showed ten globes in ten colours. Nothing anywhere in the stack
+# had ever read a site's icon: there was no field on the Site document, none on
+# either DTO, and no extraction step. This module is that missing step.
+#
+# IT IS NOT THE SCREENSHOT LANE, deliberately. ``sites.screenshot`` answers "what
+# does this page look like" and pays a paid, quota'd Cloudflare Browser Rendering
+# call to do it. An icon is a string in the markup: finding it costs one GET of a
+# page we have already probed, or nothing at all when the icon is a data: URI. So
+# this is its own module and its own scheduled task, and a deployment with Browser
+# Rendering unconfigured — which gets no screenshots at all — still gets favicons.
+#
+# THE SAME THREE RULES the screenshot lane runs under, for the same reasons: it
+# can never block a publish, never raise into one, and never gate anything. A site
+# whose icon cannot be found keeps the globe, which is exactly the pre-existing
+# card. Hence the ``safe_`` wrapper that swallows everything, the module-attribute
+# scheduler tests patch to run inline, and the strong-ref task set (asyncio holds
+# only a WEAK ref to a bare create_task, so a fire-and-forget task can be collected
+# mid-run).
+#
+# THE VALUE IS A data: URI, NOT AN UPLOADS LINK — the one real design decision
+# here, and the opposite of what ``preview_image_url`` does. A screenshot is a
+# 1280x800 PNG and has to live in blob storage behind ``/api/v1/uploads/{id}``,
+# which is auth-gated, which is why the card resolves it through a per-card grant
+# (``grantThumbUrl``). An icon is typically under 3 KB. Inlining it on the wire
+# costs a few KB of list response and buys: no blob row, no grant round-trip per
+# card, no auth dance, no second request before the card can paint, and no
+# third-party host learning the IP of everyone who opens the gallery. The cost is
+# that the list response grows with the number of sites, which is what
+# ``_MAX_ICON_BYTES`` bounds — an icon over the cap is DROPPED (the card keeps its
+# globe) rather than stored somewhere else, because two storage paths for one field
+# is how a field starts lying about what it holds. If real sites turn out to carry
+# icons over the cap, raise the cap or move the whole field to blob storage; do not
+# add a second branch.
+#
+# SSRF — the reason ``_same_origin`` exists and is not optional. Unlike the
+# screenshot lane, which only ever addresses a hostname WE composed
+# (``<site_id>.<PAW_CF_SITES_DOMAIN>``), this module reads hrefs out of MARKUP, and
+# for an imported site that markup is written by whoever we imported. A
+# ``<link rel=icon href="http://169.254.169.254/latest/meta-data/">`` would
+# otherwise make this server fetch cloud-instance metadata and base64 it onto a
+# card. So a candidate is fetched ONLY when its host equals the site's own host —
+# the host we already probe and already photograph. A data: URI carries its own
+# bytes and reaches no network at all, so it needs no such check. Everything else
+# (a third-party CDN icon, an absolute link to another domain) is skipped, which
+# also disposes of the IP-leak problem: we never hot-link, we store what we
+# fetched.
+#
+# SVG SAFETY — an icon can be an SVG, an SVG can carry <script>, and for an
+# imported site the SVG is attacker-supplied. The primary control is on the render
+# side: the card draws this through <img src>, and scripts inside an SVG do not
+# execute in an <img> context (they do when the same markup is inlined into the
+# DOM). ``_svg_is_inert`` is a SECOND, independent control here at the source, so
+# the field never carries active content in the first place — the two are checked
+# by different tests and neither is load-bearing for the other.
+#
+# WHAT IT LOOKS AT, best first (``extract_icon_candidates``). "The favicon" is not
+# one tag; a real page declares its mark two or three different ways and a
+# generated one may use any of them:
+#   * a scalable SVG icon — sharp at any DPR, so it wins outright;
+#   * apple-touch-icon / -precomposed, conventionally 180px and reliably square;
+#   * rel=icon / rel="shortcut icon", largest declared ``sizes`` first;
+#   * <meta name=msapplication-TileImage>, the Windows tile;
+#   * rel=mask-icon, Safari's pinned-tab silhouette — monochrome and meant to be
+#     tinted, so it is a poor chip and ranks last among declared icons;
+#   * rel=manifest -> the web-app manifest's ``icons`` array, which is where a PWA
+#     puts its good 192/512px art. Costs one extra same-origin GET, so it is tried
+#     only after everything already in the document;
+#   * /favicon.ico at the site root — the pre-HTML default, tried last because it
+#     is a guess rather than a declaration.
+# og:image is deliberately NOT in that list. It is a ~1200x630 social banner; a
+# wide banner cropped into a 24px round chip is worse than the globe it would
+# replace, and unlike everything above it was never a claim about the site's mark.
+#
+# ABSENCE IS AUTHORITATIVE, but only when we actually read the page. If the markup
+# was fetched and declares no icon, the field is CLEARED — a site that removed its
+# icon should lose it from the card. If the fetch failed, nothing is written and
+# the card keeps what it had. The draft lane passes ``clear_when_absent=False``
+# because its markup is lossy in exactly this respect: ``draft_markup``'s
+# ``inline_document`` DROPS every local <link> that is not a stylesheet, icons
+# included, so "no icon in the assembled draft" is not evidence of "no icon".
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import unquote_to_bytes, urljoin, urlsplit
+
+logger = logging.getLogger(__name__)
+
+# The decoded icon's byte ceiling. 8 KB comfortably holds an SVG mark (a few
+# hundred bytes to ~2 KB) and a 64-128px PNG, and bounds what N cards add to one
+# list response: 30 sites x 8 KB raw is ~330 KB of base64 worst case, and real
+# icons land far under it. An icon over the cap is dropped — see the header.
+_MAX_ICON_BYTES = 8 * 1024
+
+# How much of a page we are willing to read to find a <link> in its head. The head
+# is at the top by definition; a document that has not declared its icon in the
+# first 512 KB is not going to.
+_MAX_MARKUP_BYTES = 512 * 1024
+
+# A manifest is a small JSON document. This is a sanity bound, not a real limit.
+_MAX_MANIFEST_BYTES = 128 * 1024
+
+_FETCH_TIMEOUT = 5.0
+
+# Named in an operator's access log next to the screenshot lane's probe UA.
+_FETCH_UA = "PocketPaw-SiteFavicon/1.0 (+card-icon)"
+
+# What we are willing to put on a card. Anything the BYTES are not is dropped —
+# ``_sniff_image_mime`` reads magic numbers and never falls back to the
+# Content-Type the other end claimed, because for an imported site that header is
+# as attacker-controlled as the bytes.
+_ALLOWED_MIMES = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "image/avif",
+        "image/x-icon",
+        "image/svg+xml",
+    }
+)
+
+_TAG_RE = re.compile(r"<(link|meta)\b[^>]*>", re.IGNORECASE)
+
+
+def _attr(tag: str, name: str) -> str:
+    """One attribute off a raw tag, quoted or bare. "" when absent."""
+    m = re.search(
+        r"\b" + name + r"""\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))""",
+        tag,
+        re.IGNORECASE,
+    )
+    if not m:
+        return ""
+    return (m.group(1) or m.group(2) or m.group(3) or "").strip()
+
+
+def _rel_tokens(tag: str) -> set[str]:
+    """``rel`` is a space-separated TOKEN LIST, so rel="shortcut icon" is both
+    "shortcut" and "icon" and a substring match on it would also fire on
+    rel="apple-touch-icon". Tokenise, never substring."""
+    return {t for t in _attr(tag, "rel").lower().split() if t}
+
+
+def _largest_size(sizes: str) -> int:
+    """The biggest width in a ``sizes`` list ("32x32 16x16" -> 32). ``any`` means a
+    scalable icon, which outranks every raster size."""
+    s = sizes.strip().lower()
+    if not s:
+        return 0
+    if "any" in s.split():
+        return 1 << 20
+    best = 0
+    for token in s.split():
+        m = re.match(r"^(\d+)x(\d+)$", token)
+        if m:
+            best = max(best, int(m.group(1)))
+    return best
+
+
+@dataclass(frozen=True)
+class IconCandidate:
+    """One declared icon, with everything needed to rank it before fetching it."""
+
+    href: str
+    source: str
+    tier: int
+    size: int = 0
+
+
+# Tiers. Within a tier the largest declared size wins, so a <link rel=icon
+# sizes="192x192"> beats an unsized one without needing its own tier.
+_TIER_SVG = 0
+_TIER_RASTER = 1
+_TIER_TILE = 2
+_TIER_MASK = 3
+_TIER_MANIFEST = 4
+
+# apple-touch-icon is conventionally 180x180 and is reliably square with no
+# transparency, so an unsized one is assumed large rather than assumed small. An
+# unsized rel=icon gets 0 and sorts behind it — in the wild it is usually the 32px
+# one or the .ico.
+_APPLE_ASSUMED_SIZE = 180
+
+
+def _looks_svg(href: str, declared_type: str) -> bool:
+    if declared_type.lower().startswith("image/svg"):
+        return True
+    if href[:14].lower().startswith("data:image/svg"):
+        return True
+    return urlsplit(href).path.lower().endswith(".svg")
+
+
+def extract_icon_candidates(markup: str) -> list[IconCandidate]:
+    """Every icon this document declares, best first. Pure — no network, no I/O.
+
+    Ranked by :data:`_TIER_SVG` … :data:`_TIER_MANIFEST` and then by declared size
+    descending; see the module header for what each tier is and why og:image is not
+    among them. The ``/favicon.ico`` guess is NOT added here — it is not a
+    declaration, and this function reports what the page said.
+    """
+    out: list[IconCandidate] = []
+    for m in _TAG_RE.finditer(markup or ""):
+        tag = m.group(0)
+        kind = m.group(1).lower()
+
+        if kind == "meta":
+            name = _attr(tag, "name").lower() or _attr(tag, "property").lower()
+            if name == "msapplication-tileimage":
+                href = _attr(tag, "content")
+                if href:
+                    out.append(IconCandidate(href, "msapplication-tile", _TIER_TILE))
+            continue
+
+        rels = _rel_tokens(tag)
+        href = _attr(tag, "href")
+        if not href:
+            continue
+        declared_type = _attr(tag, "type")
+        sizes = _largest_size(_attr(tag, "sizes"))
+
+        if "manifest" in rels:
+            out.append(IconCandidate(href, "manifest", _TIER_MANIFEST))
+            continue
+        if "mask-icon" in rels:
+            out.append(IconCandidate(href, "mask-icon", _TIER_MASK))
+            continue
+
+        is_apple = bool(rels & {"apple-touch-icon", "apple-touch-icon-precomposed"})
+        is_icon = "icon" in rels
+        if not (is_apple or is_icon):
+            continue
+
+        if _looks_svg(href, declared_type):
+            out.append(IconCandidate(href, "svg-icon", _TIER_SVG, 1 << 20))
+            continue
+        size = sizes or (_APPLE_ASSUMED_SIZE if is_apple else 0)
+        source = "apple-touch-icon" if is_apple else "icon"
+        out.append(IconCandidate(href, source, _TIER_RASTER, size))
+
+    out.sort(key=lambda c: (c.tier, -c.size))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Turning a candidate into bytes we are willing to put on a card
+# --------------------------------------------------------------------------- #
+
+_SVG_ACTIVE_RE = re.compile(rb"<script\b|javascript:|\son\w+\s*=", re.IGNORECASE)
+
+
+def _svg_is_inert(data: bytes) -> bool:
+    """True when this SVG carries no script, no javascript: url and no on* handler.
+
+    The SECOND of two independent controls — the card renders through <img src>,
+    where SVG script does not execute at all. This one keeps active content out of
+    the stored field regardless of who renders it later. See the module header.
+    """
+    return not _SVG_ACTIVE_RE.search(data)
+
+
+def _sniff_image_mime(data: bytes) -> str:
+    """The mime these BYTES are. "" when they are not an image we accept.
+
+    Magic numbers only. The Content-Type header is never consulted, not even as a
+    fallback: on the fetch path it is set by whatever host the imported markup
+    pointed at, so trusting it is trusting the thing we are validating. SVG is the
+    one format with no magic number, so it is recognised structurally instead.
+    """
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    if data[4:12] == b"ftypavif":
+        return "image/avif"
+    if data[:4] == b"\x00\x00\x01\x00":
+        return "image/x-icon"
+    head = data[:512].lstrip()
+    if head.startswith(b"<") and b"<svg" in data[:2048].lower():
+        return "image/svg+xml"
+    return ""
+
+
+def _accept(data: bytes) -> str:
+    """The mime to publish these bytes under, or "" to drop them. One place, so the
+    cap, the format allowlist and the SVG check cannot be applied on one path and
+    forgotten on the other."""
+    if not data or len(data) > _MAX_ICON_BYTES:
+        return ""
+    mime = _sniff_image_mime(data)
+    if mime not in _ALLOWED_MIMES:
+        return ""
+    if mime == "image/svg+xml" and not _svg_is_inert(data):
+        logger.debug("sites.favicon: dropped an SVG icon carrying active content")
+        return ""
+    return mime
+
+
+def decode_data_uri(href: str) -> tuple[bytes, str]:
+    """(bytes, declared-mime) for a data: URI, or (b"", "") when it is not one or
+    will not decode. Handles both the base64 and the percent-encoded forms — a
+    hand-written SVG favicon is usually the latter."""
+    if href[:5].lower() != "data:":
+        return b"", ""
+    head, sep, payload = href[5:].partition(",")
+    if not sep:
+        return b"", ""
+    params = head.split(";")
+    mime = (params[0] or "").strip().lower()
+    is_b64 = any(p.strip().lower() == "base64" for p in params[1:])
+    try:
+        raw = base64.b64decode(payload, validate=False) if is_b64 else unquote_to_bytes(payload)
+    except Exception:  # noqa: BLE001 — a malformed icon is a skip, not a failure
+        return b"", ""
+    return raw, mime
+
+
+def _same_origin(href: str, base_url: str) -> bool:
+    """True when ``href`` resolves onto the SAME host as the site itself.
+
+    The SSRF gate — see the module header. The scheme must be http(s) (so a
+    ``file:`` / ``gopher:`` / ``javascript:`` href is refused outright) and the
+    netloc must match the site's, case-insensitively. The port is part of that
+    comparison, because a different port on the same host is a different service.
+    """
+    if not base_url:
+        return False
+    try:
+        target = urlsplit(urljoin(base_url, href))
+        base = urlsplit(base_url)
+    except Exception:  # noqa: BLE001
+        return False
+    if target.scheme not in ("http", "https"):
+        return False
+    return target.netloc.lower() == base.netloc.lower()
+
+
+async def _get(url: str, *, limit: int, transport: Any = None) -> bytes:
+    """One capped GET. b"" on anything that is not a 2xx, and never raises — every
+    failure here is "this site has no icon we can use", not an error to report."""
+    import httpx
+
+    kwargs: dict[str, Any] = {"timeout": _FETCH_TIMEOUT, "follow_redirects": True}
+    if transport is not None:
+        kwargs["transport"] = transport
+    try:
+        async with httpx.AsyncClient(**kwargs) as client:
+            async with client.stream("GET", url, headers={"user-agent": _FETCH_UA}) as resp:
+                if resp.status_code // 100 != 2:
+                    return b""
+                buf = bytearray()
+                async for chunk in resp.aiter_bytes():
+                    buf.extend(chunk)
+                    if len(buf) > limit:
+                        # Over budget: stop pulling and drop it. Truncated bytes are
+                        # not a smaller icon, they are a corrupt one.
+                        return b""
+                return bytes(buf)
+    except Exception:  # noqa: BLE001 — unreachable is a NO, not a failure
+        return b""
+
+
+def _as_data_uri(data: bytes, mime: str) -> str:
+    return "data:" + mime + ";base64," + base64.b64encode(data).decode("ascii")
+
+
+async def _resolve_one(cand: IconCandidate, *, base_url: str, transport: Any) -> str:
+    """One candidate -> a data: URI to store, or "" to move on to the next."""
+    href = cand.href.strip()
+    if not href:
+        return ""
+
+    if href[:5].lower() == "data:":
+        raw, _declared = decode_data_uri(href)
+        if not _accept(raw):
+            return ""
+        # Pass the ORIGINAL through rather than re-encoding: a percent-encoded SVG
+        # is smaller than its base64 form, and re-encoding would change a value
+        # clients may be caching on equality.
+        return href
+
+    if not _same_origin(href, base_url):
+        logger.debug("sites.favicon: skipped off-origin icon %r", href[:120])
+        return ""
+
+    absolute = urljoin(base_url, href)
+    data = await _get(absolute, limit=_MAX_ICON_BYTES, transport=transport)
+    mime = _accept(data)
+    if not mime:
+        return ""
+    return _as_data_uri(data, mime)
+
+
+async def _resolve_manifest(cand: IconCandidate, *, base_url: str, transport: Any) -> str:
+    """A web-app manifest's best icon. One extra same-origin GET for the JSON and one
+    for the image it names, and every gate the declared path uses applies to both."""
+    if not _same_origin(cand.href, base_url):
+        return ""
+    manifest_url = urljoin(base_url, cand.href)
+    body = await _get(manifest_url, limit=_MAX_MANIFEST_BYTES, transport=transport)
+    if not body:
+        return ""
+    try:
+        doc = json.loads(body.decode("utf-8", "replace"))
+    except Exception:  # noqa: BLE001 — a broken manifest is a skip
+        return ""
+    icons = doc.get("icons") if isinstance(doc, dict) else None
+    if not isinstance(icons, list):
+        return ""
+
+    ranked: list[tuple[int, str]] = []
+    for entry in icons:
+        if not isinstance(entry, dict):
+            continue
+        src = entry.get("src")
+        if not isinstance(src, str) or not src.strip():
+            continue
+        ranked.append((_largest_size(str(entry.get("sizes") or "")), src.strip()))
+    ranked.sort(key=lambda p: -p[0])
+
+    for _size, src in ranked:
+        # An icon src is relative to the MANIFEST, not to the document.
+        inner = IconCandidate(urljoin(manifest_url, src), "manifest-icon", _TIER_MANIFEST)
+        got = await _resolve_one(inner, base_url=base_url, transport=transport)
+        if got:
+            return got
+    return ""
+
+
+async def resolve_favicon(markup: str, *, base_url: str = "", transport: Any = None) -> str:
+    """This document's best usable icon as a data: URI, or "" when it has none.
+
+    Walks :func:`extract_icon_candidates` in order and returns the first candidate
+    that survives every gate, then falls back to the ``/favicon.ico`` guess. With no
+    ``base_url`` only data: URIs can resolve — nothing else has an origin to be
+    same-origin with — which is exactly the draft case.
+    """
+    for cand in extract_icon_candidates(markup):
+        if cand.source == "manifest":
+            got = await _resolve_manifest(cand, base_url=base_url, transport=transport)
+        else:
+            got = await _resolve_one(cand, base_url=base_url, transport=transport)
+        if got:
+            logger.debug("sites.favicon: resolved icon from %s", cand.source)
+            return got
+
+    if base_url:
+        data = await _get(
+            urljoin(base_url, "/favicon.ico"), limit=_MAX_ICON_BYTES, transport=transport
+        )
+        mime = _accept(data)
+        if mime:
+            logger.debug("sites.favicon: resolved icon from /favicon.ico")
+            return _as_data_uri(data, mime)
+    return ""
+
+
+async def fetch_markup(url: str, *, transport: Any = None) -> str | None:
+    """The page's HTML, or None when it could not be read.
+
+    None and "" are DIFFERENT answers and the caller depends on it: None is "we
+    never saw the page" (leave the stored icon alone) and "" is a page that served
+    us nothing (treat it as declaring no icon). See the header's absence rule.
+    """
+    data = await _get(url, limit=_MAX_MARKUP_BYTES, transport=transport)
+    if not data:
+        return None
+    return data.decode("utf-8", "replace")
+
+
+# --------------------------------------------------------------------------- #
+# Recording it on the Site
+# --------------------------------------------------------------------------- #
+
+
+async def take_site_favicon(
+    site: Any,
+    *,
+    markup: str | None = None,
+    transport: Any = None,
+    clear_when_absent: bool = True,
+) -> str:
+    """Find this site's icon and record it on the Site. Returns the stored data URI,
+    or "" when there is none.
+
+    ``markup`` lets a caller that ALREADY has the document hand it over — the draft
+    lane has just assembled one and must not pay for it twice. Without it the site's
+    own live url is fetched, which is also what supplies the ``base_url`` every
+    non-data: candidate is resolved and origin-checked against.
+
+    ``clear_when_absent`` is the draft lane's escape hatch, and the header explains
+    why it exists: assembled draft markup has had its local icon links stripped, so
+    absence there is not evidence.
+
+    Written with a targeted ``set()``, never ``save()`` — same reason as the
+    screenshot lane: this lands after the publish that scheduled it, holding a doc
+    snapshotted before it, so a whole-document write would roll back anything
+    committed in between.
+    """
+    url = (getattr(site, "url", "") or "").strip()
+    if markup is None:
+        if not url:
+            return ""
+        fetched = await fetch_markup(url, transport=transport)
+        if fetched is None:
+            # We never saw the page. Not evidence of anything — keep what is stored.
+            logger.debug(
+                "sites.favicon: could not read %s — leaving site %s's icon alone",
+                url,
+                getattr(site, "id", "?"),
+            )
+            return ""
+        markup = fetched
+
+    icon = await resolve_favicon(markup, base_url=url, transport=transport)
+    if not icon:
+        if clear_when_absent and (getattr(site, "favicon_url", "") or ""):
+            await site.set({"favicon_url": ""})
+            logger.info(
+                "sites.favicon: site %s no longer declares an icon — cleared",
+                getattr(site, "id", "?"),
+            )
+        return ""
+
+    if (getattr(site, "favicon_url", "") or "") == icon:
+        # Unchanged. Skipping the write keeps a republish from touching the document
+        # for nothing; the value is content-addressed by construction.
+        return icon
+
+    await site.set({"favicon_url": icon})
+    logger.info("sites.favicon: recorded icon for site %s", getattr(site, "id", "?"))
+    return icon
+
+
+async def safe_take_site_favicon(
+    site: Any,
+    *,
+    markup: str | None = None,
+    transport: Any = None,
+    clear_when_absent: bool = True,
+) -> str:
+    """:func:`take_site_favicon` that never raises — the form every caller on a
+    publish, create or import path uses. A card with a globe is the pre-existing
+    card; it is not worth failing anything over."""
+    try:
+        return await take_site_favicon(
+            site,
+            markup=markup,
+            transport=transport,
+            clear_when_absent=clear_when_absent,
+        )
+    except Exception:  # noqa: BLE001 — an icon is never a gate on a publish
+        logger.warning(
+            "sites.favicon: lookup failed for site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
+        return ""
+
+
+# Background-task keepalive — see the module header. Its own set rather than the
+# screenshot lane's, so a test that drains one lane cannot silently drain the other.
+_FAVICON_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _default_favicon_scheduler(coro: Any) -> None:
+    """Detach onto the running loop and return. With no running loop the coroutine
+    is closed and skipped. Tests patch this module attribute to run it inline."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        coro.close()
+        return
+    task = loop.create_task(coro)
+    _FAVICON_TASKS.add(task)
+    task.add_done_callback(_FAVICON_TASKS.discard)
+
+
+def schedule_site_favicon(site: Any, *, markup: str | None = None) -> None:
+    """Fire a background icon lookup for a site. Never blocks, never raises."""
+    _default_favicon_scheduler(safe_take_site_favicon(site, markup=markup))
+
+
+def schedule_draft_favicon(site: Any, *, markup: str) -> None:
+    """Record a DRAFT's icon from markup the caller already has. Never blocks, never
+    raises, and never clears — see ``clear_when_absent``."""
+    _default_favicon_scheduler(safe_take_site_favicon(site, markup=markup, clear_when_absent=False))
+
+
+__all__ = [
+    "IconCandidate",
+    "decode_data_uri",
+    "extract_icon_candidates",
+    "fetch_markup",
+    "resolve_favicon",
+    "safe_take_site_favicon",
+    "schedule_draft_favicon",
+    "schedule_site_favicon",
+    "take_site_favicon",
+]

--- a/ee/pocketpaw_ee/sites/screenshot.py
+++ b/ee/pocketpaw_ee/sites/screenshot.py
@@ -144,6 +144,17 @@
 # The DRAFT path is deliberately ungated: it renders markup at ``about:blank``, so
 # there is no address that could be unready, and a gate there would poll nothing and
 # reject every draft.
+#
+# Updated 2026-09-02 (the card's mark, not just its picture): ``take_draft_screenshot``
+# now hands the document it just assembled to ``sites.favicon`` before it resolves the
+# Cloudflare client. That is the ONLY favicon work this module does — the live lane is
+# its own scheduled task in ``sites.service``, because an icon costs one GET and must
+# not be gated on Browser Rendering being configured, while everything here is.
+# The hook sits inside this function purely because ``build_draft_markup`` can cost a
+# real Node build and a second lane would race this one into rebuilding the same
+# pocket; the ordering (before ``_cf_client``) is what keeps a draft's icon landing in
+# a deployment where the capture on the next line raises. See ``sites.favicon`` for
+# why that call cannot clear a stored icon.
 
 from __future__ import annotations
 
@@ -512,6 +523,29 @@ async def take_draft_screenshot(site: Any, *, cloudflare: Any | None = None) -> 
     markup = await build_draft_markup(site)
     if not markup:
         return ""
+
+    # 2026-09-02: the draft's ICON, off the document we have just assembled. Hung
+    # here rather than given its own scheduled task purely to avoid paying twice:
+    # ``build_draft_markup`` can cost a real Node build, and a second lane would
+    # race this one into building the same pocket again. Fired BEFORE the Cloudflare
+    # client is resolved, so a deployment with Browser Rendering unconfigured — where
+    # the next line raises — still gets its cards' marks.
+    #
+    # It cannot CLEAR a stored icon, and that is not incidental: ``inline_document``
+    # drops every local <link> that is not a stylesheet, icons included, so a missing
+    # icon in assembled draft markup is an artefact of the assembly, not a fact about
+    # the site. Only the live lane, which reads the served page, is allowed to
+    # conclude that an icon is gone.
+    try:
+        from pocketpaw_ee.sites.favicon import schedule_draft_favicon
+
+        schedule_draft_favicon(site, markup=markup)
+    except Exception:  # noqa: BLE001 — an icon is never a gate on a capture
+        logger.warning(
+            "sites.favicon: could not schedule draft icon lookup for site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
 
     from pocketpaw_ee.sites.service import _cf_client
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -193,6 +193,19 @@
 # so nothing about it may fail, delay, or block the publish. On any failure the
 # field stays empty and the card falls back to its text layout.
 #
+# Updated 2026-09-02 (the card's MARK, not just its picture): both live-deploy tails
+# now also schedule ``_schedule_site_favicon``, and ``_to_response`` / ``pocket_status``
+# surface the resulting ``favicon_url`` on both DTOs — so the gallery card's chip can
+# be the site's own icon instead of the hard-coded globe every card wore. A SEPARATE
+# scheduler from the screenshot deliberately: a screenshot needs Cloudflare Browser
+# Rendering (paid, quota'd, unconfigured in plenty of deployments) while an icon needs
+# one GET of a page the readiness probe already proved is serving, so folding the two
+# together would cost every Browser-Rendering-less deployment its cards' marks for no
+# reason. Wrapped exactly like the screenshot and the KB sync, and for the same
+# reason: this runs at the tail of a publish that has already succeeded. The DRAFT
+# half is not scheduled here — it hangs off ``screenshot.take_draft_screenshot``,
+# which already holds the assembled markup and must not pay to build it twice.
+#
 # Updated 2026-08-07 (SC-2 — drafts get art too): ``create_draft_site`` now schedules
 # a capture of its own (``_schedule_draft_screenshot``). A draft has no url, so that
 # capture shoots the pocket's MARKUP rather than a page (``sites.draft_markup`` +
@@ -2050,6 +2063,11 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         # None until a capture lands (empty string on the doc, and every pre-SC-1
         # row via the getattr default, read as None on the wire).
         preview_image_url=getattr(doc, "preview_image_url", "") or None,
+        # 2026-09-02: the site's own icon for the card's mark chip, as a data: URI.
+        # None until a lookup lands (empty string on the doc, and every row that
+        # predates the field via the getattr default, read as None on the wire) and
+        # whenever the site declares no icon — the card falls back to the globe.
+        favicon_url=getattr(doc, "favicon_url", "") or None,
         # SL-3: the build lane's state, straight off the persisted row. These three
         # were declared on the DTO by SG-9i and never populated here, so every
         # response carried the DEFAULTS — ``build_status`` frozen at "none" no matter
@@ -2939,6 +2957,12 @@ async def _deploy_site_doc(
     # already live, so a screenshot may never fail or delay the publish. A
     # preview publish never reaches here, so a draft is never photographed.
     _schedule_site_screenshot(doc)
+    # 2026-09-02: and its ICON, on the same trigger and under the same rule. A
+    # separate lane from the screenshot rather than a step inside it: this one costs
+    # a single GET of a page we already probe, so it must not be gated on Cloudflare
+    # Browser Rendering being configured — a deployment that gets no screenshots at
+    # all still gets its cards' marks.
+    _schedule_site_favicon(doc)
     return doc
 
 
@@ -3250,6 +3274,34 @@ def _schedule_site_screenshot(site: _SiteDoc) -> None:
     except Exception:  # noqa: BLE001 — never fail a live publish over a screenshot
         logger.warning(
             "sites.screenshot: could not schedule capture for site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
+
+
+def _schedule_site_favicon(site: _SiteDoc) -> None:
+    """Fire the background lookup of a LIVE site's own icon, for the gallery card's
+    mark chip. Non-async, never blocks, never raises. Looked up through the module so
+    tests can patch it, mirroring ``_schedule_site_screenshot`` directly above.
+
+    Its own scheduler rather than a step inside the screenshot's, because the two
+    have different dependencies and different failure modes. A screenshot needs
+    Cloudflare Browser Rendering — paid, quota'd, and unconfigured in plenty of
+    deployments; an icon needs one GET of a page the readiness probe has already
+    proved is serving. Folding this into the screenshot would mean every deployment
+    without Browser Rendering also lost its cards' marks, for no reason.
+
+    The try/except is the same requirement as the screenshot's and no weaker: this
+    runs from the tail of a LIVE deploy, so anything escaping fails a publish of a
+    site that is already deployed and serving — in exchange for an icon.
+    """
+    try:
+        from pocketpaw_ee.sites.favicon import schedule_site_favicon
+
+        schedule_site_favicon(site)
+    except Exception:  # noqa: BLE001 — never fail a live publish over an icon
+        logger.warning(
+            "sites.favicon: could not schedule icon lookup for site %s",
             getattr(site, "id", "?"),
             exc_info=True,
         )
@@ -4192,6 +4244,9 @@ async def finalize_provisioned_site(site: _SiteDoc, *, url: str, deploy_target: 
     # dynamic site becomes reachable, so it is the moment there is a page to
     # photograph. The url was stamped a few lines above.
     _schedule_site_screenshot(site)
+    # 2026-09-02: and its icon, for the same reason — a reachable page is a page
+    # whose <head> can finally be read.
+    _schedule_site_favicon(site)
 
 
 async def mark_provision_failed(site: _SiteDoc) -> None:
@@ -7775,6 +7830,10 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
         preview_image_url=(getattr(doc, "preview_image_url", "") or None)
         if doc is not None
         else None,
+        # 2026-09-02: the same icon the list row carries, so a by-pocket status read
+        # can show the site's own mark too. None when there is no Site doc, no
+        # lookup has landed, or the site declares no icon we can use.
+        favicon_url=(getattr(doc, "favicon_url", "") or None) if doc is not None else None,
         # SL-3: the build lane's state on the read a builder polls BY POCKET. This is
         # the only GET keyed on a pocket id, so a client watching a build it just
         # triggered has nowhere else to look — without these it would have to fetch the

--- a/tests/ee/sites/test_favicon.py
+++ b/tests/ee/sites/test_favicon.py
@@ -1,0 +1,525 @@
+# tests/ee/sites/test_favicon.py — a site's gallery card wears the site's OWN mark,
+# and finding that mark can never cost anyone a publish or reach a host we did not
+# mean to touch.
+#
+# Created 2026-09-02. The card's chip was a hard-coded Lucide globe for every site
+# alike; ``sites.favicon`` is the lookup that replaces it. Four things are pinned
+# here, in the order they can hurt:
+#
+#   * THE SSRF GATE. This is the one thing in the module that is a security control
+#     rather than a nicety, and it is the reason the module exists in the shape it
+#     does. Unlike the screenshot lane — which only ever addresses a hostname WE
+#     composed — this reads hrefs out of MARKUP, and for an imported site that
+#     markup belongs to whoever we imported. The tests below prove that an
+#     off-origin href causes NO REQUEST AT ALL (asserting on the transport's call
+#     log, not on the return value: "" is also what a failed fetch returns, so a
+#     test that only checked the result would pass with the gate deleted).
+#   * THE BYTES DECIDE, not the Content-Type. A server that answers `image/png`
+#     with an HTML error page must not get that page base64'd onto a card.
+#   * THE RANKING. "The favicon" is three or four different tags and a page can
+#     declare all of them; the card gets the best one, and rel is a TOKEN LIST so
+#     rel="shortcut icon" must match on the token and not on a substring.
+#   * THE RULE, shared with the screenshot lane: a lookup that fails, at any layer,
+#     cannot propagate into a publish. A card with a globe is the pre-existing card.
+#
+# The mutations that break these tests (run via scripts/mutate.py — a gate nobody
+# has watched fail is not a gate):
+#   * make ``_same_origin`` return True unconditionally → the off-origin tests fail
+#     with a request that should never have been made;
+#   * make ``_sniff_image_mime`` fall back to the declared Content-Type → the
+#     lying-server test fails;
+#   * delete the ``len(data) > _MAX_ICON_BYTES`` check in ``_accept`` → the oversize
+#     test fails;
+#   * drop ``_svg_is_inert`` from ``_accept`` → the active-SVG test fails;
+#   * tokenise ``rel`` with ``in`` instead of ``split()`` → the shortcut-icon and
+#     apple-touch ranking tests fail;
+#   * delete the try/except in ``service._schedule_site_favicon`` → the broken
+#     scheduler test fails with "scheduler down" instead of a deployed site;
+#   * delete the try/except in ``favicon.safe_take_site_favicon`` → the raising
+#     lookup test fails;
+#   * make ``take_site_favicon`` clear on a FAILED fetch → the "we never saw the
+#     page" test fails, which is the case where clearing would wipe a good icon off
+#     every card the moment a site had a bad minute.
+from __future__ import annotations
+
+import base64
+
+import httpx
+import pytest
+from pocketpaw_ee.sites import favicon as favicon_mod
+from pocketpaw_ee.sites import service as sites_service
+
+# The real inline SVG a Paw site ships: a percent-encoded paw print, single-quoted
+# attributes inside a double-quoted href. Held verbatim because the two things most
+# likely to break extraction are the quoting and the percent-encoding, and a
+# tidied-up fixture would test neither.
+_PAW_SVG_URI = (
+    "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'"
+    "%3E%3Crect width='64' height='64' rx='14' fill='%230B0F14'/%3E"
+    "%3Ccircle cx='24' cy='22' r='6' fill='%2314E19C'/%3E"
+    "%3Ccircle cx='32' cy='46' r='9' fill='%2314E19C'/%3E%3C/svg%3E"
+)
+
+# A real 1x1 PNG. It has to be real: ``_accept`` sniffs magic bytes, so b"not-a-png"
+# would make a happy-path test pass for the wrong reason.
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+_SITE_URL = "https://paw-site-abc.pawsites.test/"
+
+
+def _doc(markup: str, *, head: str = "") -> str:
+    return "<!doctype html><html><head>" + head + markup + "</head><body>hi</body></html>"
+
+
+class _FakeSite:
+    """The two things ``take_site_favicon`` touches on a Site: ``url`` and a
+    targeted ``set``. Deliberately NOT a real Site doc — the point of these tests is
+    the lookup, and a save() that silently worked would hide the module's rule that
+    it may only ever ``set`` the one field it owns."""
+
+    def __init__(self, url: str = _SITE_URL, favicon_url: str = "") -> None:
+        self.id = "site-1"
+        self.url = url
+        self.favicon_url = favicon_url
+        self.writes: list[dict] = []
+
+    async def set(self, patch: dict) -> None:
+        self.writes.append(patch)
+        for k, v in patch.items():
+            setattr(self, k, v)
+
+
+def _transport(routes: dict[str, tuple[int, bytes, str]], log: list[str] | None = None):
+    """A MockTransport over {path: (status, body, content_type)} that RECORDS every
+    url it is asked for. The log is what the SSRF tests assert on: a gate that is
+    deleted shows up as a request, and only as a request."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if log is not None:
+            log.append(str(request.url))
+        key = request.url.path
+        if key not in routes:
+            return httpx.Response(404)
+        status, body, ctype = routes[key]
+        return httpx.Response(status, content=body, headers={"content-type": ctype})
+
+    return httpx.MockTransport(handler)
+
+
+# --------------------------------------------------------------------------- #
+# What the page declares, and which one wins
+# --------------------------------------------------------------------------- #
+
+
+def test_the_inline_svg_a_paw_site_actually_ships_is_found():
+    """The reported case, end to end at the parse layer: the icon is a data: URI
+    with single-quoted SVG attributes inside a double-quoted href, and there is no
+    /favicon.ico anywhere."""
+    cands = favicon_mod.extract_icon_candidates(
+        _doc('<link rel="icon" href="' + _PAW_SVG_URI + '">')
+    )
+    assert [c.source for c in cands] == ["svg-icon"]
+    assert cands[0].href == _PAW_SVG_URI
+
+
+def test_rel_is_a_token_list_not_a_substring():
+    """rel="shortcut icon" is the token "icon". Matching on substrings would also
+    make rel="apple-touch-icon" an "icon" and collapse the ranking below."""
+    cands = favicon_mod.extract_icon_candidates(_doc("<link rel='shortcut icon' href='/f.png'>"))
+    assert [c.source for c in cands] == ["icon"]
+
+
+def test_a_scalable_svg_outranks_every_raster_icon():
+    cands = favicon_mod.extract_icon_candidates(
+        _doc(
+            '<link rel="apple-touch-icon" href="/apple.png">'
+            '<link rel="icon" sizes="512x512" href="/big.png">'
+            '<link rel="icon" type="image/svg+xml" href="/mark.svg">'
+        )
+    )
+    assert cands[0].source == "svg-icon"
+
+
+def test_apple_touch_beats_an_unsized_icon_but_loses_to_a_bigger_declared_one():
+    """An unsized rel=icon is usually the 32px or the .ico, so apple-touch's
+    conventional 180 is assumed larger. A rel=icon that DECLARES 512 is not."""
+    cands = favicon_mod.extract_icon_candidates(
+        _doc('<link rel="icon" href="/small.png"><link rel="apple-touch-icon" href="/a.png">')
+    )
+    assert [c.source for c in cands] == ["apple-touch-icon", "icon"]
+
+    cands = favicon_mod.extract_icon_candidates(
+        _doc(
+            '<link rel="icon" sizes="512x512" href="/big.png">'
+            '<link rel="apple-touch-icon" href="/a.png">'
+        )
+    )
+    assert [c.source for c in cands] == ["icon", "apple-touch-icon"]
+
+
+def test_the_windows_tile_and_the_safari_mask_are_found_but_rank_below_real_icons():
+    cands = favicon_mod.extract_icon_candidates(
+        _doc(
+            '<link rel="mask-icon" href="/pinned.svg" color="#000">'
+            '<meta name="msapplication-TileImage" content="/tile.png">'
+            '<link rel="icon" href="/f.png">'
+        )
+    )
+    assert [c.source for c in cands] == ["icon", "msapplication-tile", "mask-icon"]
+
+
+def test_og_image_is_not_treated_as_an_icon():
+    """A 1200x630 social banner cropped into a 24px chip is worse than the globe it
+    would replace, and it was never a claim about the site's mark."""
+    cands = favicon_mod.extract_icon_candidates(
+        _doc('<meta property="og:image" content="/banner.png">')
+    )
+    assert cands == []
+
+
+def test_a_page_that_declares_nothing_has_no_candidates():
+    assert favicon_mod.extract_icon_candidates(_doc("<title>x</title>")) == []
+
+
+# --------------------------------------------------------------------------- #
+# THE SSRF GATE — the tests that assert on requests, not on return values
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_an_off_origin_icon_is_never_fetched():
+    """Markup we did not write must not be able to point this server at an address
+    of its choosing. ``169.254.169.254`` is the cloud instance-metadata endpoint —
+    the payload this gate exists for.
+
+    Asserting on the REQUEST LOG, not on the result: "" is also what a failed fetch
+    returns, so a result-only assertion passes with ``_same_origin`` deleted."""
+    log: list[str] = []
+    transport = _transport({"/latest/meta-data/": (200, _PNG, "image/png")}, log)
+    got = await favicon_mod.resolve_favicon(
+        _doc('<link rel="icon" href="http://169.254.169.254/latest/meta-data/">'),
+        base_url=_SITE_URL,
+        transport=transport,
+    )
+    assert got == ""
+    assert not any("169.254.169.254" in u for u in log), (
+        "the metadata endpoint must never be contacted"
+    )
+    # Everything the lookup DID reach was the site's own host — the /favicon.ico
+    # last resort still runs, and it is same-origin by construction.
+    assert all(u.startswith(_SITE_URL) for u in log), log
+
+
+@pytest.mark.asyncio
+async def test_a_third_party_cdn_icon_is_skipped_rather_than_hot_linked():
+    """Also the IP-leak case: hot-linking would hand that host the address of
+    everyone who opens the gallery."""
+    log: list[str] = []
+    got = await favicon_mod.resolve_favicon(
+        _doc('<link rel="icon" href="https://cdn.example.com/f.png">'),
+        base_url=_SITE_URL,
+        transport=_transport({}, log),
+    )
+    assert got == ""
+    assert not any("cdn.example.com" in u for u in log), "the CDN must never be contacted"
+    assert all(u.startswith(_SITE_URL) for u in log), log
+
+
+@pytest.mark.asyncio
+async def test_a_javascript_href_is_refused():
+    got = await favicon_mod.resolve_favicon(
+        _doc('<link rel="icon" href="javascript:alert(1)">'),
+        base_url=_SITE_URL,
+        transport=_transport({}),
+    )
+    assert got == ""
+
+
+@pytest.mark.asyncio
+async def test_a_relative_icon_on_the_site_s_own_origin_is_fetched():
+    """The other side of the gate: same-origin is the case that must still work, or
+    the guard has quietly disabled the feature."""
+    log: list[str] = []
+    got = await favicon_mod.resolve_favicon(
+        _doc('<link rel="icon" href="/assets/f.png">'),
+        base_url=_SITE_URL,
+        transport=_transport({"/assets/f.png": (200, _PNG, "image/png")}, log),
+    )
+    assert got.startswith("data:image/png;base64,")
+    assert log == ["https://paw-site-abc.pawsites.test/assets/f.png"]
+
+
+# --------------------------------------------------------------------------- #
+# What we are willing to put on a card
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_data_uri_icon_is_passed_through_verbatim():
+    """Not re-encoded: a percent-encoded SVG is smaller than its base64 form, and
+    re-encoding would change a value clients may be caching on equality."""
+    got = await favicon_mod.resolve_favicon(_doc('<link rel="icon" href="' + _PAW_SVG_URI + '">'))
+    assert got == _PAW_SVG_URI
+
+
+@pytest.mark.asyncio
+async def test_a_data_uri_icon_resolves_with_no_base_url_and_no_network():
+    """The draft case. Assembled draft markup has no origin, so a data: URI is the
+    only kind of icon that can resolve there — and it must, with no transport."""
+    got = await favicon_mod.resolve_favicon(
+        _doc('<link rel="icon" href="' + _PAW_SVG_URI + '">'), base_url=""
+    )
+    assert got == _PAW_SVG_URI
+
+
+def test_an_svg_carrying_script_is_refused():
+    """The second of two independent controls — the card renders through <img>,
+    where SVG script does not execute. This one keeps active content out of the
+    stored field regardless of who renders it later."""
+    hostile = b"<svg xmlns='http://www.w3.org/2000/svg'><script>fetch('/x')</script></svg>"
+    assert favicon_mod._sniff_image_mime(hostile) == "image/svg+xml"
+    assert favicon_mod._accept(hostile) == ""
+
+
+def test_an_svg_carrying_an_event_handler_is_refused():
+    hostile = b"<svg xmlns='http://www.w3.org/2000/svg'><rect onload='x()'/></svg>"
+    assert favicon_mod._accept(hostile) == ""
+
+
+def test_a_plain_svg_is_accepted():
+    """The guard above must not be so broad it refuses ordinary marks."""
+    assert favicon_mod._accept(b"<svg xmlns='http://www.w3.org/2000/svg'><rect/></svg>") == (
+        "image/svg+xml"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_server_that_lies_about_the_content_type_is_not_believed():
+    """An HTML error page served as image/png. Trusting the header is trusting the
+    thing being validated — and on a fetch path the header is set by whatever host
+    the imported markup pointed at."""
+    got = await favicon_mod.resolve_favicon(
+        _doc('<link rel="icon" href="/f.png">'),
+        base_url=_SITE_URL,
+        transport=_transport({"/f.png": (200, b"<!doctype html><h1>404</h1>", "image/png")}),
+    )
+    assert got == ""
+
+
+@pytest.mark.asyncio
+async def test_an_icon_over_the_cap_is_dropped_not_stored():
+    """The cap is what bounds a list response carrying N inline icons. An oversized
+    icon means a globe, not a truncated picture."""
+    huge = _PNG + b"\x00" * (favicon_mod._MAX_ICON_BYTES + 1)
+    got = await favicon_mod.resolve_favicon(
+        _doc('<link rel="icon" href="/f.png">'),
+        base_url=_SITE_URL,
+        transport=_transport({"/f.png": (200, huge, "image/png")}),
+    )
+    assert got == ""
+
+
+@pytest.mark.asyncio
+async def test_a_404_on_the_declared_icon_falls_through_to_the_next_candidate():
+    """A page can declare an icon it no longer serves. The ladder exists so that
+    does not cost the card its mark."""
+    got = await favicon_mod.resolve_favicon(
+        _doc('<link rel="icon" sizes="512x512" href="/gone.png"><link rel="icon" href="/f.png">'),
+        base_url=_SITE_URL,
+        transport=_transport({"/f.png": (200, _PNG, "image/png")}),
+    )
+    assert got.startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_favicon_ico_is_the_last_resort_when_the_page_declares_nothing():
+    got = await favicon_mod.resolve_favicon(
+        _doc("<title>x</title>"),
+        base_url=_SITE_URL,
+        transport=_transport({"/favicon.ico": (200, _PNG, "image/x-icon")}),
+    )
+    assert got.startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_a_web_app_manifest_s_largest_icon_is_used():
+    """Where a PWA keeps its good art. Costs an extra same-origin GET, so it is
+    tried only after everything already in the document."""
+    manifest = (
+        b'{"icons":[{"src":"/i/small.png","sizes":"48x48"},{"src":"/i/big.png","sizes":"512x512"}]}'
+    )
+    log: list[str] = []
+    got = await favicon_mod.resolve_favicon(
+        _doc('<link rel="manifest" href="/site.webmanifest">'),
+        base_url=_SITE_URL,
+        transport=_transport(
+            {
+                "/site.webmanifest": (200, manifest, "application/manifest+json"),
+                "/i/big.png": (200, _PNG, "image/png"),
+            },
+            log,
+        ),
+    )
+    assert got.startswith("data:image/png;base64,")
+    assert any(u.endswith("/i/big.png") for u in log)
+    assert not any(u.endswith("/i/small.png") for u in log)
+
+
+# --------------------------------------------------------------------------- #
+# Recording it on the Site — and the absence rule
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_found_icon_is_recorded_with_a_targeted_set():
+    site = _FakeSite()
+    got = await favicon_mod.take_site_favicon(
+        site,
+        transport=_transport(
+            {
+                "/": (
+                    200,
+                    _doc('<link rel="icon" href="' + _PAW_SVG_URI + '">').encode(),
+                    "text/html",
+                )
+            }
+        ),
+    )
+    assert got == _PAW_SVG_URI
+    assert site.writes == [{"favicon_url": _PAW_SVG_URI}]
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_icon_is_not_rewritten():
+    """A republish must not touch the document to store the value already there."""
+    site = _FakeSite(favicon_url=_PAW_SVG_URI)
+    await favicon_mod.take_site_favicon(
+        site,
+        transport=_transport(
+            {
+                "/": (
+                    200,
+                    _doc('<link rel="icon" href="' + _PAW_SVG_URI + '">').encode(),
+                    "text/html",
+                )
+            }
+        ),
+    )
+    assert site.writes == []
+
+
+@pytest.mark.asyncio
+async def test_a_page_that_no_longer_declares_an_icon_clears_the_stored_one():
+    """We READ the page and it declares nothing. That is evidence, so the card
+    should stop showing a mark the site has removed."""
+    site = _FakeSite(favicon_url=_PAW_SVG_URI)
+    got = await favicon_mod.take_site_favicon(
+        site, transport=_transport({"/": (200, _doc("<title>x</title>").encode(), "text/html")})
+    )
+    assert got == ""
+    assert site.writes == [{"favicon_url": ""}]
+
+
+@pytest.mark.asyncio
+async def test_a_page_we_could_not_read_leaves_the_stored_icon_alone():
+    """The distinction the whole absence rule turns on. A site having a bad minute
+    must not wipe the mark off its card — and this is the mutation most likely to
+    look harmless: clearing unconditionally passes every other test in this file."""
+    site = _FakeSite(favicon_url=_PAW_SVG_URI)
+    got = await favicon_mod.take_site_favicon(site, transport=_transport({"/": (503, b"", "")}))
+    assert got == ""
+    assert site.writes == []
+    assert site.favicon_url == _PAW_SVG_URI
+
+
+@pytest.mark.asyncio
+async def test_the_draft_lane_never_clears_an_icon():
+    """Assembled draft markup has had its local <link> icons stripped by
+    ``draft_markup.inline_document``, so absence there is an artefact of the
+    assembly and not a fact about the site."""
+    site = _FakeSite(url="", favicon_url=_PAW_SVG_URI)
+    got = await favicon_mod.take_site_favicon(
+        site, markup=_doc("<title>x</title>"), clear_when_absent=False
+    )
+    assert got == ""
+    assert site.writes == []
+
+
+@pytest.mark.asyncio
+async def test_a_site_with_no_url_and_no_markup_is_skipped_not_guessed_at():
+    site = _FakeSite(url="")
+    assert await favicon_mod.take_site_favicon(site) == ""
+    assert site.writes == []
+
+
+@pytest.mark.asyncio
+async def test_a_raising_lookup_is_swallowed_by_the_safe_form():
+    """THE RULE. Mutation: delete the try/except in ``safe_take_site_favicon`` and
+    this raises instead of returning ""."""
+
+    class _Boom(_FakeSite):
+        async def set(self, patch):  # noqa: ANN001
+            raise RuntimeError("mongo down")
+
+    site = _Boom()
+    got = await favicon_mod.safe_take_site_favicon(
+        site,
+        transport=_transport(
+            {
+                "/": (
+                    200,
+                    _doc('<link rel="icon" href="' + _PAW_SVG_URI + '">').encode(),
+                    "text/html",
+                )
+            }
+        ),
+    )
+    assert got == ""
+
+
+# --------------------------------------------------------------------------- #
+# Wiring — a live publish looks for the icon, and cannot be hurt by looking
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def scheduled_favicons(monkeypatch):
+    """Record the sites a publish schedules a lookup for, without doing one."""
+    seen: list = []
+    monkeypatch.setattr(sites_service, "_schedule_site_favicon", seen.append)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_a_live_publish_schedules_an_icon_lookup(
+    beanie_test_db, scheduled_favicons, monkeypatch
+):
+    """The page just changed, so the mark it declares may have too."""
+    monkeypatch.setattr(sites_service, "_schedule_site_screenshot", lambda *_a, **_k: None)
+    from tests.ee.sites.test_screenshot_capture import _publish
+
+    await _publish()
+    assert len(scheduled_favicons) == 1
+    assert scheduled_favicons[0].pocket_id == "pocket-1"
+
+
+@pytest.mark.asyncio
+async def test_publish_survives_a_broken_favicon_scheduler(beanie_test_db, monkeypatch):
+    """THE RULE at the scheduling layer. This fires from the tail of a LIVE deploy,
+    so anything escaping it fails a publish of a site that is already serving.
+
+    Mutation: delete the try/except in ``service._schedule_site_favicon`` and this
+    fails with "scheduler down" instead of returning a deployed site."""
+    monkeypatch.setattr(sites_service, "_schedule_site_screenshot", lambda *_a, **_k: None)
+
+    def _boom(coro):
+        coro.close()
+        raise RuntimeError("scheduler down")
+
+    monkeypatch.setattr(favicon_mod, "_default_favicon_scheduler", _boom)
+    from tests.ee.sites.test_screenshot_capture import _publish
+
+    site = await _publish()
+    assert site is not None


### PR DESCRIPTION
The chip on a /sites gallery card was a hard-coded Lucide globe tinted by a hash of the site id. Ten published sites showed ten globes in ten colours. Nothing in the stack had ever read a site's icon: no field on the Site document, none on either DTO, no extraction step anywhere.

The site that prompted this declares its icon as an inline `data:image/svg+xml` paw print and serves no `/favicon.ico` at all, which rules out the obvious shortcut of pointing an `<img>` at `<site-url>/favicon.ico`.

## What this adds

`ee/pocketpaw_ee/sites/favicon.py` reads the served page's head and walks a ranked ladder of everything a page can use to declare a mark:

- a scalable SVG icon, which wins outright because it stays sharp at any DPR
- `apple-touch-icon` and its precomposed variant, conventionally 180px and reliably square
- `rel=icon` / `rel="shortcut icon"`, largest declared `sizes` first
- `<meta name=msapplication-TileImage>`, the Windows tile
- `rel=mask-icon`, Safari's pinned-tab silhouette, which ranks last among declared icons because it is a monochrome shape meant to be tinted
- `rel=manifest`, resolving the web-app manifest's `icons` array
- `/favicon.ico`, tried last because it is a guess rather than a declaration

`og:image` is deliberately not on that list. It is a ~1200x630 social banner, and cropping one into a 24px chip looks worse than the globe it would replace.

## Why it is a separate lane from the screenshot

A screenshot needs Cloudflare Browser Rendering, which is paid, quota'd, and unconfigured in plenty of deployments. An icon needs one GET of a page the readiness probe has already proved is serving. Folding them together would cost every deployment without Browser Rendering its cards' marks for no reason.

Drafts are the exception. That hook hangs off `take_draft_screenshot`, which already holds the assembled markup, because `build_draft_markup` can cost a real Node build and a second lane would race it into building the same pocket twice.

## Two security controls

This reads hrefs out of markup, and for an imported site that markup belongs to whoever we imported.

A candidate is fetched only when its host matches the site's own. Without that, `<link rel=icon href="http://169.254.169.254/latest/meta-data/">` makes this server fetch cloud instance metadata and base64 it onto a card. The same rule settles the hot-linking question: we never point a card at a third party, we store what we fetched, so no outside host learns the IP of everyone who opens the gallery.

The bytes decide the format, never the Content-Type. A host answering `image/png` with an HTML error page does not get that page onto a card.

An SVG icon is also checked for `<script>`, `javascript:` and `on*=` before it is stored. That is the second of two independent controls. The first is on the render side, where the card draws through `<img src>` and SVG script cannot execute.

## The value is inline

`favicon_url` carries a `data:` URI rather than an uploads link, which is the one way it differs from `preview_image_url`. A screenshot is a 1280x800 PNG and needs blob storage behind the auth-gated `/api/v1/uploads/{id}`, which is why the card resolves that one through a per-card grant. An icon is a few KB, so it rides on the wire and the card paints it with no second request. `_MAX_ICON_BYTES` (8 KB) bounds what N cards add to one list response, and an icon over the cap is dropped rather than stored somewhere else.

## Absence

A page we fetched that declares no icon clears the field, because a site that removed its mark should lose it from the card. A fetch that failed writes nothing. The draft lane can never clear, because `inline_document` strips local icon links, so absence there is an artefact of the assembly rather than a fact about the site.

## Tests

30 new cases in `tests/ee/sites/test_favicon.py`. The SSRF ones assert on the transport's request log rather than the return value, since `""` is also what a failed fetch returns and a result-only assertion would pass with the guard deleted.

I ran the mutations rather than only naming them. Neutering `_same_origin` gets the metadata endpoint contacted, which is what the test catches.

Full suite: `1507 passed, 4 skipped` in `tests/ee/sites/`. Ruff clean.

## Paired with

qbtrix/paw-enterprise#854 renders it. Until that merges the field is written and served but nothing displays it, which is harmless.

## Not merging

Opened for review per the PR gate.
