### PR TITLE
Group spend_by_model in Mongo instead of pulling a year of ledger rows

### DIFF
--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -153,6 +153,29 @@
 # ``QuotaExceeded`` (402 ``credits.quota_exceeded``) when month-to-date spend is
 # ``>=`` that effective ceiling. Reads only; charges nothing. Chunk 3 wires the
 # gate at run-start — this chunk owns only the reusable read + assertion.
+# Changed 2026-09-02 (fix/credits-spend-by-model-aggregation): ``spend_by_model``
+# now folds SERVER-SIDE. It used to run ``CreditLedgerEntry.find(query).to_list()``
+# and group the result in a Python loop, under a comment claiming the load was
+# "bounded — matches ``sum_debits_by_cause``". Neither is bounded: the window is
+# the caller's, and ``billing/usage.py`` lets it reach 366 days, so a busy
+# workspace's whole year of debits was materialised as Beanie documents to produce
+# a few dozen rows. The new ``_spend_by_model_pipeline`` does the work in Mongo —
+# ``$match`` (tenant + causes + applied + window + ``amount_delta < 0``) then
+# ``$group`` on (``$dateToString`` day, ``ref.model``) with ``$sum`` / ``$sum: 1``
+# for credits, requests and tokens — using the same cross-driver cursor idiom as
+# ``_sum_amount_delta`` (``inspect.isawaitable``: the pymongo-async client returns
+# a coroutine, mongomock-motor a directly-iterable cursor). Only the process
+# memory changed: every documented semantic is preserved, including the skip (not
+# clamp) of a non-negative delta, the ``"unknown"`` bucket for unattributed spend
+# so the chart still reconciles with the wallet, and the UTC day boundary. Rows
+# now come back sorted by (day, model) — ``$group`` order is unspecified, and the
+# old dict order was incidental. The one difference is a ``ref.total_tokens``
+# stored as something ``int()`` would coerce but BSON does not call a number — a
+# numeric string, a bool — which the pipeline reads as 0; the field's only writer
+# (``metering.service._total_tokens``) returns a non-negative ``int``, so no such
+# document exists, and 0 is the safer reading of junk. Still a pure read — no
+# writes, no change to anything charged. The ``(workspace, createdAt)`` compound
+# index on ``CreditLedgerEntry`` already serves the ``$match``.
 
 from __future__ import annotations
 
@@ -670,6 +693,72 @@ async def month_to_date_spend(workspace: str) -> int:
     return max(-net, 0)
 
 
+def _spend_by_model_pipeline(query: dict[str, Any]) -> list[dict[str, Any]]:
+    """The ``$match`` + ``$group`` that folds a spend window by (UTC day, model).
+
+    ``query`` is the caller's tenant + cause + applied + ``createdAt`` filter; the
+    pipeline adds ``amount_delta < 0`` to it. That predicate is load-bearing:
+    spend is debit-only, and a stray non-negative delta under a spend cause must
+    be SKIPPED ENTIRELY rather than clamped — out of the credits sum, out of the
+    request count, out of the token sum, and unable to conjure a (day, model)
+    group of its own. A ``$match`` is the one construct that does all four at
+    once. It also drops an entry with no ``createdAt``: a missing or null field
+    never satisfies a date range.
+
+    ``day`` uses ``$dateToString`` with NO ``timezone`` key, so it takes Mongo's
+    UTC default — the same boundary ``createdAt.date()`` gave on the UTC datetimes
+    the driver returns. ``model`` falls back to ``"unknown"`` for a null, missing
+    or empty ``ref.model``, because unattributed spend still has to chart for the
+    total to reconcile with the wallet. The ``$ifNull`` subexpression is repeated
+    instead of bound to a variable: ``$let`` is unimplemented in the
+    mongomock-motor harness this read is tested against.
+
+    ``tokens`` sums ``ref.total_tokens`` per group, counting a value only when it
+    is a real number above zero — missing, null, negative and non-numeric refs all
+    read 0. ``$isNumber`` has to gate ``$toLong``: Mongo's cross-type ordering
+    sorts a string ABOVE any number, so a bare ``$gt`` would wave junk through and
+    ``$toLong`` would then fail the whole aggregation.
+    """
+    # ``$cond`` returns "unknown" for null / missing / empty, matching what the
+    # Python ``ref.get("model") or "unknown"`` did. A falsy NON-string (0, False)
+    # would differ, but the field's only writer stores ``str | None``.
+    model_or_unknown = {
+        "$cond": [
+            {"$eq": [{"$ifNull": ["$ref.model", ""]}, ""]},
+            "unknown",
+            "$ref.model",
+        ]
+    }
+    tokens_or_zero = {
+        "$cond": [
+            {"$isNumber": "$ref.total_tokens"},
+            {
+                "$cond": [
+                    {"$gt": ["$ref.total_tokens", 0]},
+                    {"$toLong": "$ref.total_tokens"},
+                    0,
+                ]
+            },
+            0,
+        ]
+    }
+    return [
+        {"$match": {**query, "amount_delta": {"$lt": 0}}},
+        {
+            "$group": {
+                "_id": {
+                    "day": {"$dateToString": {"format": "%Y-%m-%d", "date": "$createdAt"}},
+                    "model": model_or_unknown,
+                },
+                # A debit's delta is negative; flip it to positive credits spent.
+                "credits": {"$sum": {"$subtract": [0, "$amount_delta"]}},
+                "requests": {"$sum": 1},
+                "tokens": {"$sum": tokens_or_zero},
+            }
+        },
+    ]
+
+
 async def spend_by_model(
     workspace: str,
     *,
@@ -704,6 +793,13 @@ async def spend_by_model(
     metering path now records it — a legacy entry without it contributes 0, so the
     figure reflects real volume going forward without breaking historical reads).
 
+    The fold runs SERVER-SIDE (``_spend_by_model_pipeline``): a Mongo ``$match``
+    on the tenant, causes, applied flag and window feeds a ``$group`` on (day,
+    model), so a busy tenant's window is never materialised in the process. The
+    window is the CALLER's and ``billing/usage.py`` allows up to 366 days of it,
+    which is exactly why this must not be a pull-all-then-fold. The
+    ``(workspace, createdAt)`` compound index serves the ``$match``.
+
     EE entity-isolation: billing must not read ``CreditLedgerEntry`` directly, so
     this owns the read (sibling to ``sum_debits_by_cause``). It performs NO writes.
     """
@@ -716,40 +812,29 @@ async def spend_by_model(
         "applied": True,
         "createdAt": {"$gte": since, "$lt": until},
     }
-    entries = await CreditLedgerEntry.find(query).to_list()
+    # ``aggregate()`` returns a coroutine under the pymongo-async client the app
+    # uses in prod and a directly-iterable latent cursor under mongomock-motor;
+    # discriminate the same way ``_sum_amount_delta`` does.
+    cursor = CreditLedgerEntry.get_pymongo_collection().aggregate(_spend_by_model_pipeline(query))
+    if inspect.isawaitable(cursor):
+        cursor = await cursor
 
-    # In-Python aggregation over the fetched window (bounded — matches
-    # ``sum_debits_by_cause``). Group by (UTC day, model); sum positive-debited
-    # credits and count entries. A stray positive ``amount_delta`` under a spend
-    # cause (there should be none — spend is debit-only) is skipped so a bad row
-    # can't make a group read as a refund.
-    # (day, model) -> [credits, requests, tokens]
-    grouped: dict[tuple[str, str], list[int]] = {}
-    for e in entries:
-        delta = int(e.amount_delta)
-        if delta >= 0:
-            continue
-        created = getattr(e, "createdAt", None)
-        if created is None:
-            continue
-        day = created.date().isoformat()
-        ref = e.ref or {}
-        model = ref.get("model") or "unknown"
-        # ``total_tokens`` is the real per-run volume the metering path stamps on
-        # the ref; a legacy entry without it (or a non-int) reads 0.
-        try:
-            tokens = int(ref.get("total_tokens") or 0)
-        except (TypeError, ValueError):
-            tokens = 0
-        bucket = grouped.setdefault((day, model), [0, 0, 0])
-        bucket[0] += -delta  # positive credits debited
-        bucket[1] += 1  # one more request in this group
-        bucket[2] += tokens if tokens > 0 else 0  # real token volume
-
-    return [
-        ModelSpendRow(day=day, model=model, credits=credits, requests=requests, tokens=tokens)
-        for (day, model), (credits, requests, tokens) in grouped.items()
-    ]
+    rows: list[ModelSpendRow] = []
+    async for doc in cursor:
+        key = doc.get("_id") or {}
+        rows.append(
+            ModelSpendRow(
+                day=str(key.get("day") or ""),
+                model=str(key.get("model") or "unknown"),
+                credits=int(doc.get("credits") or 0),
+                requests=int(doc.get("requests") or 0),
+                tokens=int(doc.get("tokens") or 0),
+            )
+        )
+    # ``$group`` makes no ordering promise (nor did the dict this used to build).
+    # The caller sorts for display; sort here too so the read itself is stable.
+    rows.sort(key=lambda r: (r.day, r.model))
+    return rows
 
 
 async def history(

--- a/tests/cloud/credits/test_spend_by_model.py
+++ b/tests/cloud/credits/test_spend_by_model.py
@@ -25,11 +25,30 @@
 # param (stamps ``ref.total_tokens``) and two cases cover the new token sum —
 # real per-group volume across token-bearing debits + a legacy debit adding 0,
 # and an all-legacy group reporting tokens=0.
+# Updated 2026-09-02 (fix/credits-spend-by-model-aggregation): the fold moved off
+# a pull-the-window-into-Python loop onto a server-side ``$match`` + ``$group``.
+# Five cases were added to hold that migration honest, three of them covering
+# behaviour the suite never asserted before:
+#   * a non-negative ``amount_delta`` under a spend cause is SKIPPED, not clamped
+#     — it must not reach credits, the request count, the token sum, or invent a
+#     (day, model) group. The old suite never seeded one, so a pipeline that
+#     clamped instead of skipping would have passed.
+#   * the UTC day boundary — 23:59:59Z and the next 00:00:00Z land in different
+#     day buckets. This is the case ``$dateToString`` could silently get wrong if
+#     it were ever given a non-UTC timezone.
+#   * one kitchen-sink window asserting the EXACT row set across multiple days,
+#     multiple models, a missing model, a missing token count and an excluded
+#     positive delta — the aggregate equivalent of the old fold's output.
+#   * ``spend_by_model`` no longer loads documents: with ``CreditLedgerEntry.find``
+#     sabotaged to raise, the read still returns correct rows.
+#   * the pipeline document itself is asserted, so the ``$group`` can't quietly
+#     regress into a client-side fold that still passes the behavioural cases.
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
 from pocketpaw_ee.cloud.credits import service as credits
 from pocketpaw_ee.cloud.credits.domain import ModelSpendRow
 from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
@@ -37,6 +56,10 @@ from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
 WS = "ws_spend_by_model"
 SONNET = "anthropic/claude-3-5-sonnet"
 GPT = "openai/gpt-4o"
+
+# Distinguishes "no ``total_tokens`` key at all" (a legacy debit) from a key
+# explicitly set to null — two different branches of the token fold.
+_NO_TOKENS = object()
 
 
 async def _seed(
@@ -48,16 +71,17 @@ async def _seed(
     applied: bool = True,
     idem: str,
     ws: str = WS,
-    tokens: int | None = None,
+    tokens: object = _NO_TOKENS,
 ) -> None:
     """Insert one ledger entry stamped at ``when`` (back-dated via the raw
     collection so the window boundaries can be asserted).
 
     When ``tokens`` is given it is stamped on the ref as ``total_tokens`` (the real
-    volume the metering path records); omitting it models a legacy debit whose ref
-    predates token attribution (contributes 0 to the group's token sum)."""
+    volume the metering path records) — including an explicit ``None``. Omitting
+    it entirely models a legacy debit whose ref predates token attribution
+    (contributes 0 to the group's token sum)."""
     ref = {"model": model} if model is not None else {}
-    if tokens is not None:
+    if tokens is not _NO_TOKENS:
         ref["total_tokens"] = tokens
     entry = CreditLedgerEntry(
         workspace=ws,
@@ -280,6 +304,212 @@ async def test_tokens_default_zero_when_no_ref_tokens(mongo_db):
     assert len(rows) == 1
     assert rows[0].tokens == 0
     assert rows[0].credits == 7
+
+
+async def test_non_negative_delta_is_skipped_not_clamped(mongo_db):
+    # Spend is debit-only. A stray zero-or-positive ``amount_delta`` under a spend
+    # cause is a bad row: it must not reach the credits sum, must not inflate the
+    # request count, must not contribute its tokens, and must not conjure a group
+    # of its own on a day that had no real spend.
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
+        amount_delta=-10,
+        model=SONNET,
+        idem="real",
+        tokens=100,
+    )
+    await _seed(  # same (day, model) group as the real debit
+        when=datetime(2026, 6, 1, 10, 0, tzinfo=UTC),
+        amount_delta=50,
+        model=SONNET,
+        idem="stray_positive",
+        tokens=9999,
+    )
+    await _seed(  # a group that would exist ONLY because of the bad row
+        when=datetime(2026, 6, 2, 10, 0, tzinfo=UTC),
+        amount_delta=0,
+        model=GPT,
+        idem="stray_zero",
+        tokens=9999,
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 3, tzinfo=UTC),
+    )
+
+    assert len(rows) == 1  # the zero-delta row invented no second group
+    assert rows[0] == ModelSpendRow(
+        day="2026-06-01", model=SONNET, credits=10, requests=1, tokens=100
+    )
+
+
+async def test_day_bucket_splits_on_the_utc_midnight_boundary(mongo_db):
+    # One second before midnight UTC and midnight itself are different days. A
+    # fold that resolved the day in any other timezone would merge them.
+    await _seed(
+        when=datetime(2026, 6, 1, 23, 59, 59, tzinfo=UTC),
+        amount_delta=-11,
+        model=SONNET,
+        idem="late",
+        tokens=2,
+    )
+    await _seed(
+        when=datetime(2026, 6, 2, 0, 0, 0, tzinfo=UTC),
+        amount_delta=-13,
+        model=SONNET,
+        idem="early",
+        tokens=4,
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 3, tzinfo=UTC),
+    )
+    by = _by_key(rows)
+
+    assert len(rows) == 2
+    assert by[("2026-06-01", SONNET)].credits == 11
+    assert by[("2026-06-01", SONNET)].tokens == 2
+    assert by[("2026-06-02", SONNET)].credits == 13
+    assert by[("2026-06-02", SONNET)].tokens == 4
+
+
+async def test_folds_a_mixed_window_into_the_exact_row_set(mongo_db):
+    # Every branch of the fold in one window: two days, two models, a debit with
+    # no ``ref.model``, a debit with no ``ref.total_tokens``, and a positive delta
+    # that must not appear anywhere. Asserting the EXACT list (not spot values)
+    # is what makes this a byte-for-byte contract rather than a smoke test.
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
+        amount_delta=-4,
+        model=SONNET,
+        idem="d1a",
+        tokens=1000,
+    )
+    await _seed(
+        when=datetime(2026, 6, 1, 18, 0, tzinfo=UTC),
+        amount_delta=-6,
+        model=SONNET,
+        idem="d1b",  # legacy: no total_tokens
+    )
+    await _seed(
+        when=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+        amount_delta=-5,
+        model=GPT,
+        cause="litellm_spend",
+        idem="d1c",
+        tokens=250,
+    )
+    await _seed(
+        when=datetime(2026, 6, 1, 13, 0, tzinfo=UTC),
+        amount_delta=7,  # refund-shaped row under a spend cause: excluded
+        model=GPT,
+        idem="d1d",
+        tokens=9999,
+    )
+    await _seed(
+        when=datetime(2026, 6, 2, 8, 0, tzinfo=UTC),
+        amount_delta=-25,
+        model=None,  # unattributed spend still charts, under "unknown"
+        idem="d2a",
+        tokens=42,
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 3, tzinfo=UTC),
+    )
+
+    assert rows == [
+        ModelSpendRow(day="2026-06-01", model=SONNET, credits=10, requests=2, tokens=1000),
+        ModelSpendRow(day="2026-06-01", model=GPT, credits=5, requests=1, tokens=250),
+        ModelSpendRow(day="2026-06-02", model="unknown", credits=25, requests=1, tokens=42),
+    ]
+    # The wallet's own total for the window: 4 + 6 + 5 + 25. The chart reconciles.
+    assert sum(r.credits for r in rows) == 40
+
+
+async def test_reads_without_loading_ledger_documents(mongo_db, monkeypatch):
+    # The point of the change: the grouping happens in Mongo. Sabotage the
+    # document-loading entry point and the read must still work — if anything
+    # reintroduces a ``find(...).to_list()`` fold this fails loudly.
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
+        amount_delta=-8,
+        model=SONNET,
+        idem="s1",
+        tokens=64,
+    )
+
+    def _no_document_loads(*_args, **_kwargs):
+        raise AssertionError("spend_by_model must not fetch ledger documents")
+
+    monkeypatch.setattr(CreditLedgerEntry, "find", _no_document_loads)
+    monkeypatch.setattr(CreditLedgerEntry, "find_all", _no_document_loads)
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+
+    assert rows == [ModelSpendRow(day="2026-06-01", model=SONNET, credits=8, requests=1, tokens=64)]
+
+
+def test_pipeline_groups_server_side():
+    # Guard the pipeline document itself. The behavioural cases above would still
+    # pass if the grouping quietly moved back into Python, so assert the stages.
+    query = {"workspace": WS, "applied": True}
+    match_stage, group_stage = credits._spend_by_model_pipeline(query)
+
+    # The caller's filter survives, and non-negative deltas are excluded by the
+    # query rather than by a post-hoc clamp.
+    assert match_stage["$match"]["workspace"] == WS
+    assert match_stage["$match"]["applied"] is True
+    assert match_stage["$match"]["amount_delta"] == {"$lt": 0}
+    assert query == {"workspace": WS, "applied": True}  # caller's dict untouched
+
+    group = group_stage["$group"]
+    # The day is resolved by Mongo, in UTC (no ``timezone`` key means UTC).
+    assert group["_id"]["day"] == {"$dateToString": {"format": "%Y-%m-%d", "date": "$createdAt"}}
+    assert "timezone" not in group["_id"]["day"]["$dateToString"]
+    # All three measures accumulate in the ``$group``, not in a Python loop.
+    assert group["credits"] == {"$sum": {"$subtract": [0, "$amount_delta"]}}
+    assert group["requests"] == {"$sum": 1}
+    assert set(group["tokens"]) == {"$sum"}
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        (None, 0),  # explicit null on the ref
+        (0, 0),
+        (-50, 0),  # negative volume is nonsense; reads 0
+        (7, 7),
+    ],
+)
+async def test_token_values_that_do_not_count(mongo_db, stored, expected):
+    await _seed(
+        when=datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
+        amount_delta=-3,
+        model=SONNET,
+        idem=f"tok_{stored}",
+        tokens=stored,
+    )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+
+    assert len(rows) == 1
+    assert rows[0].tokens == expected
+    assert rows[0].credits == 3  # the credits figure is never affected
 
 
 async def test_is_tenant_scoped(mongo_db):


### PR DESCRIPTION
## The comment that was wrong

`spend_by_model` is the read behind the billing "Usage by model" chart. It pulled every matching ledger entry into the process and folded them in a Python loop:

```python
entries = await CreditLedgerEntry.find(query).to_list()

# In-Python aggregation over the fetched window (bounded — matches
# ``sum_debits_by_cause``). Group by (UTC day, model); ...
```

That comment is the bug. The window is not bounded by anything this function controls. It comes from the caller, and `billing/usage.py` sets `_MAX_WINDOW_DAYS = 366`. A workspace with a busy year therefore hydrates a year of `CreditLedgerEntry` documents, as Beanie models, to produce a handful of rows. `sum_debits_by_cause`, which the comment points at for reassurance, does the same thing and is no more bounded than this one.

Thirty lines up in the same file, `_sum_amount_delta` already runs its `$sum` as a `$match` + `$group` in Mongo. That was the pattern to follow.

## The change

`_spend_by_model_pipeline` builds the aggregation; `spend_by_model` iterates the cursor and maps rows.

```python
{"$match": {**query, "amount_delta": {"$lt": 0}}},
{"$group": {
    "_id": {
        "day": {"$dateToString": {"format": "%Y-%m-%d", "date": "$createdAt"}},
        "model": {"$cond": [{"$eq": [{"$ifNull": ["$ref.model", ""]}, ""]}, "unknown", "$ref.model"]},
    },
    "credits": {"$sum": {"$subtract": [0, "$amount_delta"]}},
    "requests": {"$sum": 1},
    "tokens": {"$sum": <numeric-and-positive guard on $ref.total_tokens>},
}}
```

The cursor is unwrapped through the same `inspect.isawaitable` check `_sum_amount_delta` uses, because `aggregate()` hands back a coroutine under the pymongo-async client and a directly-iterable cursor under mongomock-motor.

## Why the pieces are shaped the way they are

`amount_delta < 0` lives in the `$match` rather than in a projection. Spend is debit-only, and a non-negative delta under a spend cause is a bad row that the old loop `continue`d past. Skipping is not the same as clamping to zero: the row must also stay out of the request count, contribute none of its tokens, and not create a (day, model) group on a day with no real spend. Filtering at `$match` is the one construct that gets all four right at once. That same `$match` drops an entry with a null `createdAt`, which the old code handled with an explicit `if created is None: continue`, since a missing date never satisfies a range.

`$dateToString` carries no `timezone` key, so it takes Mongo's UTC default, which is the boundary `createdAt.date()` produced on the UTC datetimes the driver returns. There is a test for 23:59:59Z against the next 00:00:00Z.

The `"unknown"` bucket still charts. Unattributed spend is real money off the wallet, and dropping it would break reconciliation between the chart and the balance.

`$isNumber` has to gate `$toLong`. Mongo's cross-type ordering sorts strings above every number, so a bare `$gt: 0` would let a string through and `$toLong` would then fail the whole aggregation.

Rows come back sorted by (day, model). `$group` promises no order, but neither did the dict the old code built, and the caller in `billing/usage.py` sorts anyway. Sorting here makes the read deterministic instead of incidentally stable.

## Behaviour

Identical, with one difference worth naming. A `ref.total_tokens` stored as a numeric string (`"1000"`) used to be accepted by `int()` and now reads 0. The only writer of that field is `metering.service._total_tokens`, which returns a non-negative `int`, so no such document exists, and 0 is the safer reading of junk in a field that feeds a chart.

## Which suite actually ran

The full-suite command this repo documents is

```
pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py
```

`pyproject.toml:615` sets `addopts = "--ignore=tests/cloud --ignore=tests/e2e"`. That command passes `tests/` as a directory rather than naming paths, so the addopts ignore applies and the entire `tests/cloud` tree is dropped. Measured on this branch:

| command | collected | under `tests/cloud` |
|---|---|---|
| the documented full-suite command | 10,745 | 0 |
| `pytest tests/cloud tests/ee` | 12,813 | all of them |

Both files this PR touches live under `tests/cloud`, or are only reached from it. The documented command therefore says nothing about this change, which is why there is a second number below that other PRs here do not carry. The honest reading is not that this change needed extra scrutiny; it is that the usual number was weaker than it looked.

An explicitly named path overrides `--ignore` on its own, so `-o addopts=""` is unnecessary once you name the directories.

## Cloud verification

`tests/cloud` and `tests/ee` were run by explicit path, in batches, because six agents were running pytest on this machine at once and a single 12,813-test invocation kept starving.

- `tests/cloud/credits` + `tests/cloud/billing`: **261 passed, 0 failed**. These are the trees the change lives in.
- `tests/ee`: **3283 passed, 2 failed**, both in `foresight/test_substrate.py`.
- The rest of `tests/cloud`, by subdirectory: 80 failures total, spread across `_core`, `agents`, `connectors`, `meetings`, `notifications`, `pockets`, `runs`, `workspace`, and four top-level `test_ee_*` files.

Every one of those 82 failures was checked rather than assumed. For each batch, the same files were re-run with `ee/pocketpaw_ee/cloud/credits/service.py` and `tests/cloud/credits/test_spend_by_model.py` checked out from `origin/dev`, and each batch reproduced its failure count and its exact test ids with the change absent: 11/11, 2/2, 19/19, 42/42, 6/6, 2/2. All pre-existing on `dev`.

Two files hang rather than fail, on `dev` as much as here: `tests/cloud/test_e2e_api.py` (wants a live server, errors then blocks) and a contention-dependent stall in the large combined run. Both pass or error identically without this change, and the files around them pass individually.

## Tests

`tests/cloud/credits/test_spend_by_model.py` gained five cases. Three cover behaviour the suite never asserted at all, which is how a clamping pipeline could have passed the old file:

- a non-negative delta under a spend cause is skipped rather than clamped, and a zero-delta row does not invent a group of its own
- the UTC midnight day boundary
- an exact-row-set fold over a window with two days, two models, a missing model, a missing token count and an excluded positive delta

Two more pin the mechanism instead of the output. The read still returns correct rows with `CreditLedgerEntry.find` monkeypatched to raise, and the pipeline document itself is asserted, so the grouping cannot quietly move back into Python while the behavioural cases stay green. Both fail against the old implementation.

