### PR TITLE
fix(deep_agents): bill the runs this backend was giving away

### DIFF
--- a/src/pocketpaw/agents/deep_agents.py
+++ b/src/pocketpaw/agents/deep_agents.py
@@ -8,6 +8,32 @@ Uses the Deep Agents SDK (pip install deepagents) which provides:
 
 Requires: pip install deepagents
 
+Updated 2026-09-02 (fix/deep-agents-usage-parity): THE RUNS ON THIS BACKEND
+BILLED ZERO, all of them. The ``token_usage`` event added by MCG-11 below was
+built for the prompt-cache A/B and carried only what that needed, so it reached
+``metering.resolve_cost`` with no ``model``, no ``output_tokens`` and no
+``total_cost_usd`` — exactly the three that function needs — and it was GATED on
+cache activity, so a cold turn emitted nothing and the run persisted
+``usage: {}``. ``pydantic_ai`` carried the identical defect until 2026-08-21;
+the fix was never swept across the siblings. Four changes:
+
+  * ``_accumulate_cache_usage`` now keeps ``output_tokens`` and the INCLUSIVE
+    input total alongside the uncached remainder. The remainder is what
+    ``report_savings`` and the meter read; the inclusive total is what
+    ``price_run`` reads, because it subtracts the cached portion itself and
+    handing it the remainder subtracts that portion twice.
+  * Cache WRITES are summed across ``cache_creation`` and the two ephemeral
+    TTL keys. ``langchain_anthropic`` zeroes the generic key whenever a TTL
+    key carries the value, and this backend marks every prefix 5m or 1h, so
+    reading only the generic key saw 0 writes forever. This one is telemetry,
+    not money: writes were already inside the inclusive total, so the bill was
+    unaffected — the hit rate was not.
+  * ``_build_usage_event`` prices the run and names the model that answered,
+    read off ``response_metadata`` rather than off configuration.
+  * The emit is unconditional, and survives a mid-stream error or a hard
+    cancel via the except handlers rather than ``finally`` — a yield from
+    ``finally`` raises out of the consumer's ``aclose()``.
+
 Updated 2026-08-03 (PA-9, feat/prompt-budget-measurement): ``_ANTHROPIC_CACHE_MIN_CHARS``
 is now measured. The value is unchanged at 4000, but the reasoning attached to it
 was wrong on all three counts — the chars/token ratio, the per-model floors, and
@@ -440,34 +466,194 @@ def _unwrap(value: Any) -> Any:
     return value
 
 
-def _accumulate_cache_usage(msg_chunk: Any, acc: dict[str, int]) -> None:
-    """Fold a LangChain ``AIMessageChunk``'s cache token counts into ``acc``
-    (MCG-11 telemetry).
+# Every key LangChain can file a cache WRITE under. ``langchain_anthropic``
+# copies Anthropic's per-TTL breakdown across as ``ephemeral_5m_input_tokens`` /
+# ``ephemeral_1h_input_tokens`` and then ZEROES the generic ``cache_creation`` so
+# its own total does not double-count (``_create_usage_metadata``). Reading only
+# the generic key therefore sees 0 for every write this backend actually makes —
+# it marks its prefixes 5m or 1h, never untagged. Summing all three is safe
+# precisely because that zeroing guarantees at most one of them is ever set.
+_CACHE_WRITE_KEYS = (
+    "cache_creation",
+    "ephemeral_5m_input_tokens",
+    "ephemeral_1h_input_tokens",
+)
 
-    LangChain normalises provider usage onto ``usage_metadata``:
-    ``input_tokens`` is the TOTAL input (cached + uncached) and the cache split
-    lives under ``input_token_details.{cache_read, cache_creation}``. A tool
-    loop yields several AI turns, each with its own ``usage_metadata``, so we
-    SUM across chunks. ``acc`` carries Anthropic-NATIVE keys (read / write /
-    total) so it can be handed straight to ``report_savings`` — which expects
-    ``input_tokens`` to be the UNCACHED remainder, hence we store
-    ``uncached = total - read - write``.
+
+def _accumulate_cache_usage(msg_chunk: Any, acc: dict[str, int]) -> None:
+    """Fold a LangChain ``AIMessageChunk``'s token counts into ``acc``.
+
+    LangChain normalises provider usage onto ``usage_metadata``, where
+    ``input_tokens`` is the INCLUSIVE input — ``UsageMetadata`` documents it as
+    the "sum of all input token types", and ``langchain_anthropic`` adds the
+    cache lines back onto Anthropic's disjoint count to get there. The split
+    lives under ``input_token_details``. A tool loop yields several AI turns,
+    each with its own ``usage_metadata``, so we SUM across chunks.
+
+    Three of the accumulated keys are load-bearing for the invoice and were not
+    here before, which is most of why every run on this backend billed $0:
+
+    * ``input_tokens`` is the UNCACHED REMAINDER, because that is the shape
+      ``report_savings`` reads and the shape ``metering._prompt_tokens`` expects
+      from an Anthropic-shaped payload.
+    * ``inclusive_input_tokens`` keeps the total that remainder came out of, and
+      it is NOT redundant with it. ``price_run`` subtracts the cached portion
+      itself, so pricing off the remainder removes those tokens a second time.
+      The remainder is what the meter wants; the inclusive total is what the
+      price wants; both have to survive the fold.
+    * ``output_tokens`` is simply the half of a conversation that costs the most
+      — Anthropic bills output at roughly 5x input — and this function used to
+      drop it on the floor.
     """
     um = getattr(msg_chunk, "usage_metadata", None)
     if not isinstance(um, dict):
         return
-    total_input = um.get("input_tokens") or 0
     details = um.get("input_token_details") or {}
-    read = details.get("cache_read") or 0
-    write = details.get("cache_creation") or 0
+    if not isinstance(details, dict):
+        details = {}
     try:
-        total_input, read, write = int(total_input), int(read), int(write)
+        total_input = int(um.get("input_tokens") or 0)
+        output = int(um.get("output_tokens") or 0)
+        read = int(details.get("cache_read") or 0)
+        # A write is filed under whichever key the marker's TTL selected.
+        write = sum(int(details.get(key) or 0) for key in _CACHE_WRITE_KEYS)
     except (TypeError, ValueError):
         return
-    uncached = max(0, total_input - read - write)
-    acc["cache_read_input_tokens"] += max(0, read)
-    acc["cache_creation_input_tokens"] += max(0, write)
-    acc["input_tokens"] += uncached
+    total_input, output = max(0, total_input), max(0, output)
+    read, write = max(0, read), max(0, write)
+    acc["cache_read_input_tokens"] += read
+    acc["cache_creation_input_tokens"] += write
+    acc["input_tokens"] += max(0, total_input - read - write)
+    acc["inclusive_input_tokens"] += total_input
+    acc["output_tokens"] += output
+
+
+def _model_name_from_chunk(msg_chunk: Any) -> str | None:
+    """The model that actually answered this turn, off ``response_metadata``.
+
+    ``langchain_anthropic`` stamps ``model_name`` from the provider's own
+    ``message_start`` event onto the first chunk of EVERY AI turn, and that is
+    the only truthful source. The configured setting can be an alias, can carry
+    a ``provider:`` prefix the price library does not know, and can be
+    overridden per run; the tokens being priced belong to whatever the provider
+    actually served. ``claude_sdk`` takes the model off the CLI's own report for
+    the same reason. Other integrations spell it ``model``, so both are read.
+
+    Returns None for most chunks, which is expected rather than a miss: the
+    model rides ``message_start`` and the usage rides ``message_delta``, so the
+    caller keeps the last non-None it saw instead of reading both off one chunk.
+    """
+    meta = getattr(msg_chunk, "response_metadata", None)
+    if not isinstance(meta, dict):
+        return None
+    for key in ("model_name", "model"):
+        value = meta.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _build_usage_event(acc: dict[str, int], model: str | None) -> AgentEvent:
+    """Build the ``token_usage`` event from an accumulated stream.
+
+    THIS EVENT IS THE INVOICE. It was written for the MCG-11 prompt-cache A/B
+    and carried only what that measurement needed, so every deep_agents run
+    reached ``metering.resolve_cost`` with no ``model``, no ``output_tokens``
+    and no ``total_cost_usd`` — precisely the set that function needs — and
+    billed zero. ``pydantic_ai`` carried the identical defect until 2026-08-21,
+    where it cost 37 unbillable runs before anyone noticed; the fix was never
+    swept across the siblings, and this is that sweep.
+
+    It is built UNCONDITIONALLY. The old emit was gated on cache activity, so a
+    cold turn — a first message, a short chat, any prompt under the 4000-char
+    marker threshold — emitted nothing at all and the run persisted
+    ``usage: {}``. A turn with no cache activity is a real, priceable turn, and
+    gating the invoice on a telemetry signal is how it stayed invisible.
+
+    The two input numbers point opposite ways ON PURPOSE:
+
+    * The payload's ``input_tokens`` is the UNCACHED REMAINDER. Any payload
+      carrying ``cache_read_tokens`` / ``cache_write_tokens`` is read as
+      Anthropic-shaped by ``metering._prompt_tokens``, which reconstitutes the
+      inclusive prompt by adding the cache lines back. Sending the inclusive
+      total here would count the cache twice and overbill.
+    * ``price_run`` is handed the INCLUSIVE total, because both pricing rungs
+      subtract the cached portion themselves. Handing it the remainder would
+      subtract that portion a second time.
+
+    Pricing happens here rather than being left to the meter's estimator for the
+    reason ``pydantic_ai`` gives: this runs the instant the run finished, so
+    ``now()`` genuinely IS the run's moment. The meter cannot say that — it
+    bills off a sweeper draining a backlog, which is why ``resolve_cost`` takes
+    the run's own timestamp instead.
+    """
+    from pocketpaw.llm.caching import report_savings
+
+    savings = report_savings(acc)
+    read = acc.get("cache_read_input_tokens", 0)
+    write = acc.get("cache_creation_input_tokens", 0)
+    inclusive = acc.get("inclusive_input_tokens", 0)
+    output = acc.get("output_tokens", 0)
+
+    if read or write:
+        logger.info(
+            "[deep_agents] prompt-cache: read=%d write=%d "
+            "hit_rate=%.1f%% est_saved=%.0f input-tok-equiv",
+            savings.cache_read_tokens,
+            savings.cache_write_tokens,
+            savings.hit_rate * 100,
+            savings.est_tokens_saved,
+        )
+
+    cost = 0.0
+    if model and (inclusive or output):
+        from datetime import UTC, datetime
+
+        from pocketpaw.usage_tracker import price_run
+
+        priced = price_run(
+            model,
+            input_tokens=inclusive,
+            output_tokens=output,
+            cache_read_tokens=read,
+            cache_write_tokens=write,
+            at=datetime.now(tz=UTC),
+        )
+        if priced is not None:
+            cost = float(priced)
+        else:
+            logger.warning(
+                "[deep_agents] no price for model %r — this turn bills $0 "
+                "(in=%d out=%d cache_read=%d cache_write=%d). Add a row to "
+                "usage_tracker._PRICING if genai-prices lacks the id.",
+                model,
+                inclusive,
+                output,
+                read,
+                write,
+            )
+
+    return AgentEvent(
+        type="token_usage",
+        content="",
+        metadata={
+            "input_tokens": acc.get("input_tokens", 0),
+            "output_tokens": output,
+            # Read PLUS write, matching ``claude_sdk``. ``_prompt_tokens``
+            # ignores this key on the Anthropic branch, but ``_total_tokens``
+            # sums input + output + cached_input, and with ``input_tokens``
+            # carrying the remainder only read+write closes that back to the
+            # real total.
+            "cached_input_tokens": read + write,
+            "cache_read_tokens": savings.cache_read_tokens,
+            "cache_write_tokens": savings.cache_write_tokens,
+            "cache_hit_rate": savings.hit_rate,
+            "cache_est_tokens_saved": savings.est_tokens_saved,
+            "total_cost_usd": cost,
+            "model": model,
+            "backend": "deep_agents",
+        },
+    )
 
 
 def _extract_content_text(content: Any) -> str:
@@ -1037,6 +1223,25 @@ class DeepAgentsBackend:
         # except branch, generator-close from caller).
         _stream: Any = None
 
+        # Usage accumulates in the RUN-level scope rather than inside the try,
+        # because the handlers below emit the invoice on the failure paths too
+        # and a crash before the stream opens would otherwise leave these
+        # unbound — trading a billing bug for a NameError.
+        cache_usage: dict[str, int] = {
+            "input_tokens": 0,
+            "inclusive_input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+        }
+        # Seeded from configuration and overwritten by the first AI turn that
+        # names a model, last-seen-wins (see ``_model_name_from_chunk``). The
+        # seed is the weaker source — it can be an alias, and for a
+        # ``provider:model`` setting only the model half is priceable — but a
+        # weak id still prices, and None prices at nothing.
+        _, _answering_model = self._parse_provider_model()
+        _usage_emitted = False
+
         try:
             model = self._build_model()
             instructions = system_prompt or _DEFAULT_IDENTITY
@@ -1074,17 +1279,6 @@ class DeepAgentsBackend:
             # path emits the final args. Same tool_call_id → emit once.
             announced_tool_ids: set[str] = set()
 
-            # MCG-11 — accumulate prompt-cache token usage across the stream's
-            # AI turns (Anthropic-native keys, so report_savings consumes it
-            # directly). Emitted as a token_usage event before "done" so the
-            # margin from the 1h-cached specialist prefix is MEASURABLE on this
-            # backend (the pocket specialist's default).
-            cache_usage: dict[str, int] = {
-                "input_tokens": 0,
-                "cache_read_input_tokens": 0,
-                "cache_creation_input_tokens": 0,
-            }
-
             # Stream using LangGraph's async streaming. Hold the stream in
             # a variable so the ``finally`` block below can call
             # ``aclose()`` on it. LangGraph's astream is backed by
@@ -1113,9 +1307,14 @@ class DeepAgentsBackend:
                         continue
                     # v2 format: data is (AIMessageChunk, metadata_dict) tuple
                     msg_chunk = data[0] if isinstance(data, tuple | list) else data
-                    # Fold this turn's cache token counts into the accumulator
-                    # (no-op when the chunk carries no usage_metadata).
+                    # Fold this turn's token counts into the accumulator
+                    # (no-op when the chunk carries no usage_metadata) and
+                    # remember which model answered. The two ride DIFFERENT
+                    # chunks — usage on ``message_delta``, the model on
+                    # ``message_start`` — so both are read off every chunk and
+                    # the model keeps its last non-None value.
                     _accumulate_cache_usage(msg_chunk, cache_usage)
+                    _answering_model = _model_name_from_chunk(msg_chunk) or _answering_model
                     text, thinking = _split_content_text_and_thinking(
                         getattr(msg_chunk, "content", "")
                     )
@@ -1197,40 +1396,44 @@ class DeepAgentsBackend:
                                     metadata={"name": tool_name},
                                 )
 
-            # MCG-11 — emit prompt-cache telemetry before "done" so the margin
-            # from the 1h-cached specialist prefix is observable on this backend
-            # (the pocket specialist's default). Mirrors the claude_sdk hook.
-            if cache_usage["cache_read_input_tokens"] or cache_usage["cache_creation_input_tokens"]:
-                from pocketpaw.llm.caching import report_savings
-
-                savings = report_savings(cache_usage)
-                logger.info(
-                    "[deep_agents] prompt-cache: read=%d write=%d "
-                    "hit_rate=%.1f%% est_saved=%.0f input-tok-equiv",
-                    savings.cache_read_tokens,
-                    savings.cache_write_tokens,
-                    savings.hit_rate * 100,
-                    savings.est_tokens_saved,
-                )
-                yield AgentEvent(
-                    type="token_usage",
-                    content="",
-                    metadata={
-                        "input_tokens": cache_usage["input_tokens"],
-                        "cache_read_tokens": savings.cache_read_tokens,
-                        "cache_write_tokens": savings.cache_write_tokens,
-                        "cache_hit_rate": savings.hit_rate,
-                        "cache_est_tokens_saved": savings.est_tokens_saved,
-                        "backend": "deep_agents",
-                    },
-                )
+            # The invoice, emitted before "done". UNCONDITIONAL as of
+            # 2026-09-02: it used to be gated on cache activity, so a cold turn
+            # billed nothing at all. See ``_build_usage_event``.
+            _usage_emitted = True
+            yield _build_usage_event(cache_usage, _answering_model)
 
             yield AgentEvent(type="done", content="")
 
+        except GeneratorExit:
+            # The consumer closed the stream — an early ``break``, or GC. A
+            # yield from here raises "async generator ignored GeneratorExit"
+            # OUT OF the caller's ``aclose()``, turning a billing gap into a
+            # crash, so the usage for a half-consumed run is genuinely
+            # unrecoverable on this path. Re-raise untouched.
+            raise
         except Exception as e:
+            # Usage FIRST. The turns that completed before the failure consumed
+            # real tokens and the provider has already billed us for them;
+            # yielding the error without them is how a failed run bills $0.
+            if not _usage_emitted:
+                _usage_emitted = True
+                yield _build_usage_event(cache_usage, _answering_model)
             logger.error("Deep Agents streaming error: %s", e, exc_info=True)
             yield AgentEvent(type="error", content=f"Deep Agents error: {e}")
             yield AgentEvent(type="done", content="")
+        except BaseException:
+            # A hard cancel lands here — ``CancelledError`` is a BaseException
+            # and the handler above never sees it. ``usage_metadata`` rides the
+            # ``message_delta`` chunk at the END of each AI turn, so every turn
+            # that finished before the cancel is already accumulated and is
+            # billable. A yield from an except handler DOES reach the consumer
+            # before the exception resumes propagating; a yield from ``finally``
+            # does not, and breaks ``aclose()`` besides, which is why the
+            # recovery lives here and not down there.
+            if not _usage_emitted:
+                _usage_emitted = True
+                yield _build_usage_event(cache_usage, _answering_model)
+            raise
         finally:
             # Close the astream generator so LangGraph's background
             # Queue readers are cancelled cleanly. Without this, those

--- a/tests/mutations/deep_agents_usage.json
+++ b/tests/mutations/deep_agents_usage.json
@@ -1,0 +1,119 @@
+[
+  {
+    "label": "the invoice goes back behind the cache gate — a cold turn bills nothing at all",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "            _usage_emitted = True\n            yield _build_usage_event(cache_usage, _answering_model)\n\n            yield AgentEvent(type=\"done\", content=\"\")",
+    "replace": "            if cache_usage[\"cache_read_input_tokens\"] or cache_usage[\"cache_creation_input_tokens\"]:\n                _usage_emitted = True\n                yield _build_usage_event(cache_usage, _answering_model)\n\n            yield AgentEvent(type=\"done\", content=\"\")",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestTheStreamAlwaysBills::test_a_cold_turn_still_emits_the_usage_event",
+      "tests/test_deep_agents_anthropic_cache.py::TestTheStreamAlwaysBills::test_configuration_is_the_fallback_when_no_chunk_names_a_model",
+      "tests/test_deep_agents_anthropic_cache.py::TestTheStreamAlwaysBills::test_a_soft_stop_keeps_the_turns_that_finished"
+    ]
+  },
+  {
+    "label": "the model is dropped from the payload — the meter cannot price a run it cannot name",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "            \"total_cost_usd\": cost,\n            \"model\": model,\n",
+    "replace": "            \"total_cost_usd\": cost,\n            \"model\": None,\n",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestTheUsageEventIsTheInvoice::test_the_payload_carries_what_the_meter_actually_reads",
+      "tests/test_deep_agents_anthropic_cache.py::TestTheMeterPricesADeepAgentsRun::test_the_meter_bills_a_real_amount"
+    ]
+  },
+  {
+    "label": "the model is read off configuration instead of the response that answered",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "                    _accumulate_cache_usage(msg_chunk, cache_usage)\n                    _answering_model = _model_name_from_chunk(msg_chunk) or _answering_model",
+    "replace": "                    _accumulate_cache_usage(msg_chunk, cache_usage)",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestTheStreamAlwaysBills::test_the_model_comes_off_the_response_not_configuration",
+      "tests/test_deep_agents_anthropic_cache.py::TestTheMeterPricesADeepAgentsRun::test_the_meter_bills_a_real_amount"
+    ]
+  },
+  {
+    "label": "output tokens are dropped from the fold — the half of a turn that costs the most",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "    acc[\"inclusive_input_tokens\"] += total_input\n    acc[\"output_tokens\"] += output",
+    "replace": "    acc[\"inclusive_input_tokens\"] += total_input",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestAccumulateCacheUsage::test_output_tokens_survive_the_fold",
+      "tests/test_deep_agents_anthropic_cache.py::TestAccumulateCacheUsage::test_folds_cache_read_and_creation",
+      "tests/test_deep_agents_anthropic_cache.py::TestTheUsageEventIsTheInvoice::test_the_payload_carries_what_the_meter_actually_reads"
+    ]
+  },
+  {
+    "label": "the inclusive input total is not kept — pricing has only the remainder to work from",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "    acc[\"input_tokens\"] += max(0, total_input - read - write)\n    acc[\"inclusive_input_tokens\"] += total_input",
+    "replace": "    acc[\"input_tokens\"] += max(0, total_input - read - write)\n    acc[\"inclusive_input_tokens\"] += max(0, total_input - read - write)",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestAccumulateCacheUsage::test_the_inclusive_total_is_kept_beside_the_remainder",
+      "tests/test_deep_agents_anthropic_cache.py::TestTheUsageEventIsTheInvoice::test_the_price_is_taken_on_the_inclusive_total_not_the_remainder"
+    ]
+  },
+  {
+    "label": "the run is priced off the uncached remainder — the cache is subtracted a second time",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "            input_tokens=inclusive,\n            output_tokens=output,",
+    "replace": "            input_tokens=acc.get(\"input_tokens\", 0),\n            output_tokens=output,",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestTheUsageEventIsTheInvoice::test_the_price_is_taken_on_the_inclusive_total_not_the_remainder"
+    ]
+  },
+  {
+    "label": "the payload reports the inclusive total as input_tokens — the meter counts the cache twice",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "            \"input_tokens\": acc.get(\"input_tokens\", 0),\n            \"output_tokens\": output,",
+    "replace": "            \"input_tokens\": acc.get(\"inclusive_input_tokens\", 0),\n            \"output_tokens\": output,",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestTheUsageEventIsTheInvoice::test_the_payload_carries_what_the_meter_actually_reads",
+      "tests/test_deep_agents_anthropic_cache.py::TestTheMeterPricesADeepAgentsRun::test_the_meter_reconstitutes_the_inclusive_prompt"
+    ]
+  },
+  {
+    "label": "a cache write filed under its TTL key is invisible again — the hit rate lies",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "_CACHE_WRITE_KEYS = (\n    \"cache_creation\",\n    \"ephemeral_5m_input_tokens\",\n    \"ephemeral_1h_input_tokens\",\n)",
+    "replace": "_CACHE_WRITE_KEYS = (\"cache_creation\",)",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestAccumulateCacheUsage::test_a_write_filed_under_a_ttl_key_is_not_lost",
+      "tests/test_deep_agents_anthropic_cache.py::TestTheUsageEventIsTheInvoice::test_the_payload_carries_what_the_meter_actually_reads"
+    ]
+  },
+  {
+    "label": "cached_input_tokens drops the write — the run's total token count comes up short",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "            \"cached_input_tokens\": read + write,",
+    "replace": "            \"cached_input_tokens\": read,",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestTheUsageEventIsTheInvoice::test_the_payload_carries_what_the_meter_actually_reads"
+    ]
+  },
+  {
+    "label": "a mid-stream failure discards the turns that already completed and were billed to us",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "            if not _usage_emitted:\n                _usage_emitted = True\n                yield _build_usage_event(cache_usage, _answering_model)\n            logger.error(\"Deep Agents streaming error: %s\", e, exc_info=True)",
+    "replace": "            logger.error(\"Deep Agents streaming error: %s\", e, exc_info=True)",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestTheStreamAlwaysBills::test_usage_survives_a_mid_stream_failure"
+    ]
+  },
+  {
+    "label": "a hard cancel discards the usage — CancelledError is not an Exception and slips past",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "            if not _usage_emitted:\n                _usage_emitted = True\n                yield _build_usage_event(cache_usage, _answering_model)\n            raise",
+    "replace": "            raise",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestTheStreamAlwaysBills::test_usage_survives_a_hard_cancel"
+    ]
+  },
+  {
+    "label": "the invoice moves into finally — every consumer that closes the stream early now crashes",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "        except GeneratorExit:",
+    "replace": "        except GeneratorExit:\n            if not _usage_emitted:\n                _usage_emitted = True\n                yield _build_usage_event(cache_usage, _answering_model)",
+    "tests": [
+      "tests/test_deep_agents_anthropic_cache.py::TestTheStreamAlwaysBills::test_closing_the_stream_early_does_not_break_aclose"
+    ]
+  }
+]

--- a/tests/test_deep_agents_anthropic_cache.py
+++ b/tests/test_deep_agents_anthropic_cache.py
@@ -14,6 +14,16 @@
 # ``_cache_ttl_for_system`` (1h for the ``<pocket-scope>`` prefix, 5m otherwise)
 # and ``_accumulate_cache_usage`` (the LangChain→native usage fold the
 # token_usage telemetry consumes).
+#
+# Updated 2026-09-02 (fix/deep-agents-usage-parity): the token_usage event is
+# the INVOICE, not just cache telemetry, and it billed $0 on every run. Four new
+# suites cover the fix: ``TestAccumulateCacheUsage`` gains the output/inclusive
+# keys and the TTL-filed cache write; ``TestTheModelComesOffTheResponse`` covers
+# ``_model_name_from_chunk``; ``TestTheUsageEventIsTheInvoice`` pins the payload
+# ``metering.resolve_cost`` actually reads; ``TestTheStreamAlwaysBills`` drives
+# ``run()`` end to end over a fake graph to prove a COLD turn emits, and that a
+# mid-stream error, a hard cancel and a soft stop all keep the usage; and
+# ``TestTheMeterPricesADeepAgentsRun`` feeds the real payload to the real meter.
 """Tests for the Anthropic prompt-cache monkey-patch in deep_agents.
 
 The patch wraps ``langchain_anthropic.chat_models._format_messages`` to
@@ -27,12 +37,14 @@ function reference so tests don't interfere with each other.
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 
 import pytest
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from pocketpaw.agents import deep_agents
+from pocketpaw.config import Settings
 
 
 @pytest.fixture
@@ -259,28 +271,47 @@ class TestSpecialistLivePathTTL:
         assert text_a != text_b
 
 
+def _fresh_acc():
+    """The accumulator ``run()`` seeds, in the shape the fold expects."""
+
+    return {
+        "input_tokens": 0,
+        "inclusive_input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+    }
+
+
+class _Chunk:
+    """Stand-in for a LangChain ``AIMessageChunk``.
+
+    Only the four attributes the stream loop reads are modelled; ``content`` and
+    ``tool_call_chunks`` are here so the same object can be fed to ``run()``.
+    """
+
+    def __init__(self, usage_metadata=None, response_metadata=None, content=""):
+        self.usage_metadata = usage_metadata
+        self.response_metadata = response_metadata
+        self.content = content
+        self.tool_call_chunks = []
+
+
 class TestAccumulateCacheUsage:
     """``_accumulate_cache_usage`` — the LangChain usage_metadata → Anthropic-
-    native fold the deep_agents token_usage telemetry consumes."""
-
-    class _Chunk:
-        def __init__(self, usage_metadata):
-            self.usage_metadata = usage_metadata
+    native fold the deep_agents token_usage event consumes."""
 
     def _fresh_acc(self):
-        return {
-            "input_tokens": 0,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
-        }
+        return _fresh_acc()
 
     def test_folds_cache_read_and_creation(self):
         """LangChain's input_tokens is the TOTAL (cached+uncached); the fold
         derives the uncached remainder and stores native keys."""
         acc = self._fresh_acc()
-        chunk = self._Chunk(
+        chunk = _Chunk(
             {
                 "input_tokens": 5000,  # total incl. cache
+                "output_tokens": 700,
                 "input_token_details": {"cache_read": 4000, "cache_creation": 500},
             }
         )
@@ -288,6 +319,8 @@ class TestAccumulateCacheUsage:
         assert acc["cache_read_input_tokens"] == 4000
         assert acc["cache_creation_input_tokens"] == 500
         assert acc["input_tokens"] == 500  # 5000 - 4000 - 500 uncached remainder
+        assert acc["inclusive_input_tokens"] == 5000
+        assert acc["output_tokens"] == 700
 
         # And report_savings reads the accumulated native dict correctly:
         from pocketpaw.llm.caching import report_savings
@@ -301,13 +334,503 @@ class TestAccumulateCacheUsage:
         """A tool loop yields several AI turns; usage SUMS."""
         acc = self._fresh_acc()
         for _ in range(3):
-            chunk = self._Chunk({"input_tokens": 1000, "input_token_details": {"cache_read": 900}})
+            chunk = _Chunk(
+                {
+                    "input_tokens": 1000,
+                    "output_tokens": 40,
+                    "input_token_details": {"cache_read": 900},
+                }
+            )
             deep_agents._accumulate_cache_usage(chunk, acc)
         assert acc["cache_read_input_tokens"] == 2700
         assert acc["input_tokens"] == 300  # 3 * (1000 - 900)
+        assert acc["inclusive_input_tokens"] == 3000
+        assert acc["output_tokens"] == 120
 
     def test_no_usage_metadata_is_noop(self):
         acc = self._fresh_acc()
-        deep_agents._accumulate_cache_usage(self._Chunk(None), acc)
+        deep_agents._accumulate_cache_usage(_Chunk(None), acc)
         deep_agents._accumulate_cache_usage(object(), acc)  # no attr at all
         assert acc == self._fresh_acc()
+
+    def test_output_tokens_survive_the_fold(self):
+        """Output is the half of a turn that costs the most — Anthropic bills it
+        at ~5x input — and the fold used to drop it entirely."""
+        acc = self._fresh_acc()
+        deep_agents._accumulate_cache_usage(
+            _Chunk({"input_tokens": 900, "output_tokens": 1500}), acc
+        )
+        assert acc["output_tokens"] == 1500
+
+    def test_the_inclusive_total_is_kept_beside_the_remainder(self):
+        """Both numbers are needed and they are NOT the same number: the meter
+        and report_savings read the remainder, price_run reads the inclusive
+        total because it subtracts the cached portion itself."""
+        acc = self._fresh_acc()
+        deep_agents._accumulate_cache_usage(
+            _Chunk(
+                {
+                    "input_tokens": 10_000,
+                    "input_token_details": {"cache_read": 8000, "cache_creation": 1500},
+                }
+            ),
+            acc,
+        )
+        assert acc["input_tokens"] == 500
+        assert acc["inclusive_input_tokens"] == 10_000
+
+    @pytest.mark.parametrize("ttl_key", ["ephemeral_5m_input_tokens", "ephemeral_1h_input_tokens"])
+    def test_a_write_filed_under_a_ttl_key_is_not_lost(self, ttl_key):
+        """``langchain_anthropic`` zeroes the generic ``cache_creation`` whenever
+        a TTL-specific key carries the write, and this backend marks every prefix
+        5m or 1h — so reading only the generic key saw zero writes forever."""
+        acc = self._fresh_acc()
+        deep_agents._accumulate_cache_usage(
+            _Chunk(
+                {
+                    "input_tokens": 6000,
+                    "input_token_details": {
+                        "cache_read": 3000,
+                        "cache_creation": 0,  # zeroed by langchain, on purpose
+                        ttl_key: 2000,
+                    },
+                }
+            ),
+            acc,
+        )
+        assert acc["cache_creation_input_tokens"] == 2000
+        assert acc["cache_read_input_tokens"] == 3000
+        assert acc["input_tokens"] == 1000  # 6000 - 3000 - 2000
+
+    def test_the_three_write_keys_are_never_double_counted(self):
+        """The sum is only safe because at most one key is ever set. Pin that:
+        an untagged write still lands exactly once."""
+        acc = self._fresh_acc()
+        deep_agents._accumulate_cache_usage(
+            _Chunk(
+                {
+                    "input_tokens": 4000,
+                    "input_token_details": {
+                        "cache_creation": 1200,
+                        "ephemeral_5m_input_tokens": 0,
+                        "ephemeral_1h_input_tokens": 0,
+                    },
+                }
+            ),
+            acc,
+        )
+        assert acc["cache_creation_input_tokens"] == 1200
+
+
+class TestTheModelComesOffTheResponse:
+    """``_model_name_from_chunk`` — the only truthful source of the model that
+    priced these tokens. Configuration can be an alias, prefixed, or overridden
+    per run."""
+
+    def test_reads_langchain_anthropics_model_name(self):
+        chunk = _Chunk(response_metadata={"model_name": "claude-sonnet-4-5-20250929"})
+        assert deep_agents._model_name_from_chunk(chunk) == "claude-sonnet-4-5-20250929"
+
+    def test_falls_back_to_the_plain_model_key(self):
+        """Not every integration spells it ``model_name``."""
+        chunk = _Chunk(response_metadata={"model": "gpt-4.1-mini"})
+        assert deep_agents._model_name_from_chunk(chunk) == "gpt-4.1-mini"
+
+    def test_a_chunk_with_no_model_is_none_not_a_guess(self):
+        """Most chunks have none — the model rides ``message_start`` and the
+        usage rides ``message_delta`` — so the caller keeps its last non-None."""
+        assert deep_agents._model_name_from_chunk(_Chunk()) is None
+        assert deep_agents._model_name_from_chunk(_Chunk(response_metadata={})) is None
+        assert deep_agents._model_name_from_chunk(_Chunk(response_metadata={"model": ""})) is None
+        assert deep_agents._model_name_from_chunk(object()) is None
+
+
+class TestTheUsageEventIsTheInvoice:
+    """``_build_usage_event`` — the payload ``metering.resolve_cost`` reads.
+
+    Every run on this backend billed $0 because this payload carried no model,
+    no output tokens and no cost, and was skipped outright on a cold turn.
+    """
+
+    MODEL = "claude-sonnet-4-5-20250929"
+
+    def _warm_acc(self):
+        """One warm turn: 12000 inclusive prompt, 9000 read, 2000 written."""
+        acc = _fresh_acc()
+        deep_agents._accumulate_cache_usage(
+            _Chunk(
+                {
+                    "input_tokens": 12_000,
+                    "output_tokens": 800,
+                    "input_token_details": {
+                        "cache_read": 9000,
+                        "ephemeral_5m_input_tokens": 2000,
+                    },
+                }
+            ),
+            acc,
+        )
+        return acc
+
+    def test_the_payload_carries_what_the_meter_actually_reads(self):
+        event = deep_agents._build_usage_event(self._warm_acc(), self.MODEL)
+        meta = event.metadata
+
+        assert event.type == "token_usage"
+        # The remainder, NOT the inclusive total: metering._prompt_tokens adds
+        # the cache lines back for any Anthropic-shaped payload.
+        assert meta["input_tokens"] == 1000
+        assert meta["output_tokens"] == 800
+        assert meta["cached_input_tokens"] == 11_000  # read + write
+        assert meta["cache_read_tokens"] == 9000
+        assert meta["cache_write_tokens"] == 2000
+        assert meta["cache_hit_rate"] == 0.75  # 9000 / 12000
+        assert meta["cache_est_tokens_saved"] == 8100.0  # 9000 * 0.90
+        assert meta["model"] == self.MODEL
+        assert meta["backend"] == "deep_agents"
+        assert meta["total_cost_usd"] > 0
+
+    def test_the_price_is_taken_on_the_inclusive_total_not_the_remainder(self):
+        """price_run subtracts the cached portion itself. Pricing off the
+        already-reduced remainder removes those tokens a SECOND time, which is
+        a materially smaller bill that still looks like a real number."""
+        from datetime import UTC, datetime
+
+        from pocketpaw.usage_tracker import price_run
+
+        acc = self._warm_acc()
+        event = deep_agents._build_usage_event(acc, self.MODEL)
+
+        at = datetime.now(tz=UTC)
+        correct = price_run(
+            self.MODEL,
+            input_tokens=12_000,
+            output_tokens=800,
+            cache_read_tokens=9000,
+            cache_write_tokens=2000,
+            at=at,
+        )
+        double_subtracted = price_run(
+            self.MODEL,
+            input_tokens=1000,  # the remainder — the bug
+            output_tokens=800,
+            cache_read_tokens=9000,
+            cache_write_tokens=2000,
+            at=at,
+        )
+        assert correct is not None
+        assert event.metadata["total_cost_usd"] == pytest.approx(float(correct))
+        assert float(double_subtracted) < float(correct)
+
+    def test_a_cold_turn_with_no_cache_activity_is_still_billed(self):
+        """The old emit was gated on cache activity, so a first message or any
+        prompt under the 4000-char marker threshold billed nothing at all."""
+        acc = _fresh_acc()
+        deep_agents._accumulate_cache_usage(
+            _Chunk({"input_tokens": 500, "output_tokens": 120}), acc
+        )
+        meta = deep_agents._build_usage_event(acc, self.MODEL).metadata
+
+        assert meta["input_tokens"] == 500
+        assert meta["output_tokens"] == 120
+        assert meta["cached_input_tokens"] == 0
+        assert meta["cache_read_tokens"] == 0
+        assert meta["cache_write_tokens"] == 0
+        assert meta["cache_hit_rate"] == 0.0
+        assert meta["model"] == self.MODEL
+        assert meta["total_cost_usd"] > 0
+
+    def test_an_unpriceable_model_degrades_to_zero_instead_of_raising(self):
+        """One bad id must not take the turn down with it."""
+        meta = deep_agents._build_usage_event(self._warm_acc(), "not-a-real-model-xyz").metadata
+        assert meta["total_cost_usd"] == 0.0
+        assert meta["model"] == "not-a-real-model-xyz"
+        assert meta["input_tokens"] == 1000  # counts still reported
+
+    def test_a_run_with_nothing_to_bill_still_builds_a_payload(self):
+        meta = deep_agents._build_usage_event(_fresh_acc(), self.MODEL).metadata
+        assert meta["total_cost_usd"] == 0.0
+        assert meta["input_tokens"] == 0
+        assert meta["output_tokens"] == 0
+
+
+class _FakeAgent:
+    """A stand-in for the compiled Deep Agents graph.
+
+    Yields the given chunks in the ``messages`` shape ``run()`` parses, then
+    optionally raises — which is how the error and hard-cancel paths are driven.
+    """
+
+    def __init__(self, chunks, raises=None):
+        self._chunks = chunks
+        self._raises = raises
+
+    def astream(self, *args, **kwargs):
+        async def _gen():
+            for chunk in self._chunks:
+                yield {"type": "messages", "data": (chunk, {})}
+            if self._raises is not None:
+                raise self._raises
+
+        return _gen()
+
+
+def _backend_over(chunks, *, raises=None, model="anthropic:claude-sonnet-4-5-20250929"):
+    """A DeepAgentsBackend whose graph is ``_FakeAgent``.
+
+    Everything between ``run()`` and the stream is stubbed on the INSTANCE, so
+    the test needs neither the deepagents SDK nor a provider key, and the real
+    accumulate → capture → emit path still runs.
+    """
+    from pocketpaw.agents.deep_agents import DeepAgentsBackend
+
+    backend = DeepAgentsBackend(Settings(deep_agents_model=model))
+    backend._sdk_available = True
+    backend._build_model = lambda: object()
+
+    async def _no_mcp():
+        return []
+
+    backend._build_mcp_tools = _no_mcp
+    backend._get_or_create_agent = lambda *a, **k: _FakeAgent(chunks, raises=raises)
+    return backend
+
+
+def _usage_events(events):
+    return [e for e in events if e.type == "token_usage"]
+
+
+class TestTheStreamAlwaysBills:
+    """``run()`` end to end over a fake graph. The defect was invisible at this
+    level: nothing errored, the bill was simply zero."""
+
+    WARM = {
+        "input_tokens": 12_000,
+        "output_tokens": 800,
+        "input_token_details": {"cache_read": 9000, "ephemeral_5m_input_tokens": 2000},
+    }
+    COLD = {"input_tokens": 500, "output_tokens": 120}
+
+    @pytest.mark.asyncio
+    async def test_a_cold_turn_still_emits_the_usage_event(self):
+        """THE regression. The emit was gated on cache activity, so a turn that
+        never touched the cache persisted ``usage: {}``."""
+        backend = _backend_over(
+            [
+                _Chunk(response_metadata={"model_name": "claude-sonnet-4-5-20250929"}),
+                _Chunk(self.COLD),
+            ]
+        )
+        events = [e async for e in backend.run("hi")]
+
+        usage = _usage_events(events)
+        assert len(usage) == 1
+        assert usage[0].metadata["input_tokens"] == 500
+        assert usage[0].metadata["output_tokens"] == 120
+        assert usage[0].metadata["total_cost_usd"] > 0
+        assert events[-1].type == "done"
+
+    @pytest.mark.asyncio
+    async def test_the_model_comes_off_the_response_not_configuration(self):
+        """The configured id and the served id differ here on purpose — only the
+        response says which model actually priced these tokens."""
+        backend = _backend_over(
+            [
+                _Chunk(response_metadata={"model_name": "claude-haiku-4-5-20251001"}),
+                _Chunk(self.WARM),
+            ],
+            model="anthropic:claude-sonnet-4-5-20250929",
+        )
+        events = [e async for e in backend.run("hi")]
+
+        assert _usage_events(events)[0].metadata["model"] == "claude-haiku-4-5-20251001"
+
+    @pytest.mark.asyncio
+    async def test_configuration_is_the_fallback_when_no_chunk_names_a_model(self):
+        """A provider that never stamps ``response_metadata`` still bills: a weak
+        id prices, and None prices at nothing."""
+        backend = _backend_over([_Chunk(self.COLD)], model="anthropic:claude-sonnet-4-5-20250929")
+        events = [e async for e in backend.run("hi")]
+
+        meta = _usage_events(events)[0].metadata
+        # The provider half is stripped — the price library wants the bare id.
+        assert meta["model"] == "claude-sonnet-4-5-20250929"
+        assert meta["total_cost_usd"] > 0
+
+    @pytest.mark.asyncio
+    async def test_a_warm_turn_reports_the_remainder_and_the_cache_lines(self):
+        backend = _backend_over([_Chunk(self.WARM)])
+        meta = _usage_events([e async for e in backend.run("hi")])[0].metadata
+
+        assert meta["input_tokens"] == 1000
+        assert meta["cache_read_tokens"] == 9000
+        assert meta["cache_write_tokens"] == 2000
+        assert meta["cached_input_tokens"] == 11_000
+
+    @pytest.mark.asyncio
+    async def test_usage_from_several_turns_sums_into_one_event(self):
+        backend = _backend_over([_Chunk(self.COLD), _Chunk(self.COLD), _Chunk(self.COLD)])
+        usage = _usage_events([e async for e in backend.run("hi")])
+
+        assert len(usage) == 1
+        assert usage[0].metadata["input_tokens"] == 1500
+        assert usage[0].metadata["output_tokens"] == 360
+
+    @pytest.mark.asyncio
+    async def test_a_soft_stop_keeps_the_turns_that_finished(self):
+        """``stop()`` breaks the loop ABOVE the emit, so the completed turns are
+        still billable — but only now that the cache gate is gone.
+
+        Both chunks carry text so the first one reaches the consumer while the
+        stream is still running; with silent chunks the first event a consumer
+        sees is already the invoice and nothing is being stopped mid-stream.
+        """
+        backend = _backend_over(
+            [_Chunk(self.COLD, content="one"), _Chunk(self.COLD, content="two")]
+        )
+        events = []
+        async for event in backend.run("hi"):
+            events.append(event)
+            if event.type == "message":
+                await backend.stop()
+
+        assert [e.content for e in events if e.type == "message"] == ["one"]
+        usage = _usage_events(events)
+        assert len(usage) == 1
+        assert usage[0].metadata["input_tokens"] == 500  # the one turn that landed
+        assert usage[0].metadata["total_cost_usd"] > 0
+
+    @pytest.mark.asyncio
+    async def test_usage_survives_a_mid_stream_failure(self):
+        """The turns before the failure consumed real tokens and the provider
+        has already billed us for them."""
+        backend = _backend_over([_Chunk(self.WARM)], raises=RuntimeError("provider blew up"))
+        events = [e async for e in backend.run("hi")]
+
+        types = [e.type for e in events]
+        usage = _usage_events(events)
+        assert len(usage) == 1
+        assert usage[0].metadata["input_tokens"] == 1000
+        # Usage lands BEFORE the error, and the error path still completes.
+        assert types.index("token_usage") < types.index("error")
+        assert types[-1] == "done"
+
+    @pytest.mark.asyncio
+    async def test_usage_survives_a_hard_cancel(self):
+        """CancelledError is a BaseException, so ``except Exception`` never sees
+        it. usage_metadata rides the message_delta at the END of each turn, so
+        every turn that finished before the cancel is billable."""
+        backend = _backend_over([_Chunk(self.WARM)], raises=asyncio.CancelledError())
+
+        events = []
+        with pytest.raises(asyncio.CancelledError):
+            async for event in backend.run("hi"):
+                events.append(event)
+
+        usage = _usage_events(events)
+        assert len(usage) == 1
+        assert usage[0].metadata["input_tokens"] == 1000
+        assert usage[0].metadata["total_cost_usd"] > 0
+
+    @pytest.mark.asyncio
+    async def test_closing_the_stream_early_does_not_break_aclose(self):
+        """A yield from the GeneratorExit path raises "async generator ignored
+        GeneratorExit" out of the consumer's aclose(). The usage for a
+        half-consumed run is unrecoverable; crashing the consumer is worse.
+
+        The break has to land MID-stream, which is why the chunk carries text:
+        on a silent stream the first event a consumer sees is already the
+        invoice, and closing after that never reaches the un-emitted branch.
+        """
+        backend = _backend_over(
+            [_Chunk(self.WARM, content="one"), _Chunk(self.COLD, content="two")]
+        )
+        stream = backend.run("hi")
+
+        seen = []
+        async for event in stream:
+            seen.append(event)
+            if event.type == "message":
+                break
+
+        # Closed with usage accumulated and NOT yet emitted — the branch that
+        # a yield would turn into a RuntimeError.
+        assert [e.type for e in seen] == ["message"]
+        await stream.aclose()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_exactly_one_usage_event_per_run(self):
+        """The emitted-flag exists so the error path cannot double-bill a run
+        that already reported."""
+        backend = _backend_over([_Chunk(self.WARM)])
+        assert len(_usage_events([e async for e in backend.run("hi")])) == 1
+
+
+class TestTheMeterPricesADeepAgentsRun:
+    """The round trip that was actually broken: this backend's payload through
+    the real ``metering.resolve_cost``."""
+
+    WARM = TestTheStreamAlwaysBills.WARM
+
+    @pytest.fixture
+    def resolve_cost(self):
+        service = pytest.importorskip(
+            "pocketpaw_ee.cloud.metering.service",
+            reason="pocketpaw-ee is not installed in this environment",
+        )
+        return service.resolve_cost
+
+    async def _payload(self):
+        backend = _backend_over(
+            [
+                _Chunk(response_metadata={"model_name": "claude-sonnet-4-5-20250929"}),
+                _Chunk(self.WARM),
+            ]
+        )
+        return _usage_events([e async for e in backend.run("hi")])[0].metadata
+
+    @pytest.mark.asyncio
+    async def test_the_meter_bills_a_real_amount(self, resolve_cost):
+        from datetime import UTC, datetime
+
+        cost = resolve_cost(await self._payload(), at=datetime.now(tz=UTC))
+
+        assert cost.cost_usd > 0
+        assert cost.source == "reported"
+        assert cost.model == "claude-sonnet-4-5-20250929"
+
+    @pytest.mark.asyncio
+    async def test_the_meter_reconstitutes_the_inclusive_prompt(self, resolve_cost):
+        """With the reported cost removed the meter prices it itself, which is
+        the path that proves ``input_tokens`` is the remainder: _prompt_tokens
+        adds the cache lines back to reach 12000."""
+        from datetime import UTC, datetime
+
+        payload = await self._payload()
+        payload.pop("total_cost_usd")
+
+        service = pytest.importorskip("pocketpaw_ee.cloud.metering.service")
+        assert service._prompt_tokens(payload) == (12_000, 9000, 2000)
+
+        cost = resolve_cost(payload, at=datetime.now(tz=UTC))
+        assert cost.cost_usd > 0
+        assert cost.source == "estimated"
+
+    @pytest.mark.asyncio
+    async def test_the_old_payload_billed_nothing(self, resolve_cost):
+        """The shape this backend emitted before the fix — no model, no output,
+        no cost. Kept as the regression's own headstone."""
+        from datetime import UTC, datetime
+
+        payload = await self._payload()
+        old = {
+            "input_tokens": payload["input_tokens"],
+            "cache_read_tokens": payload["cache_read_tokens"],
+            "cache_write_tokens": payload["cache_write_tokens"],
+            "cache_hit_rate": payload["cache_hit_rate"],
+            "cache_est_tokens_saved": payload["cache_est_tokens_saved"],
+            "backend": "deep_agents",
+        }
+        cost = resolve_cost(old, at=datetime.now(tz=UTC))
+        assert cost.cost_usd == 0.0
+        assert cost.model is None


### PR DESCRIPTION
> **Stacked on #2037** (`fix/metering-dated-pricing`). **Merge #2037 first**,
> then this. It targets `dev`, so until #2037 lands GitHub shows both commits
> here and the file list looks much bigger than this change is.
>
> This branch's own commit is `767c8842` and it touches **three files**:
> `src/pocketpaw/agents/deep_agents.py`, `tests/test_deep_agents_anthropic_cache.py`,
> and the new `tests/mutations/deep_agents_usage.json`. Everything under
> `metering/`, `usage_tracker.py` and `pydantic_ai.py` in the diff belongs to
> #2037 — `price_run`, the dated `resolve_cost` and `run_moment` all come from
> there and are built on, not re-derived.

Every run on the `deep_agents` backend billed $0.

Its `token_usage` event was written for the MCG-11 prompt-cache A/B and carried
only what that measurement needed. It reached `metering.resolve_cost` with no
`model`, no `output_tokens` and no `total_cost_usd` — which is exactly the set
that function needs to price anything — so it fell through to a zero. It was
also gated on cache activity, so a cold turn (a first message, a short chat, any
prompt under the 4000-char marker threshold) emitted nothing at all and the run
persisted `usage: {}`.

`pydantic_ai` carried the identical defect until 2026-08-21, where it cost 37
unbillable runs before anyone looked; its own docstring narrates the fix. The
sweep across the siblings never happened. This is the one for `deep_agents`.

The meter was already expecting this backend to report. `metering._prompt_tokens`
names `deep_agents` in its list of Anthropic-shaped producers and reconstitutes
the inclusive prompt from the cache lines. The shape was right; three of the
fields were simply never sent.

## What moves the bill and what does not

| | Effect |
|---|---|
| No `model` / `output_tokens` / `total_cost_usd` in the payload | **Money.** This is the whole $0. |
| Emit gated on cache activity | **Money.** A cold turn persisted `usage: {}` and billed nothing. |
| Pricing off the uncached remainder | **Money**, and only because this PR starts pricing in the backend. `price_run` subtracts the cached portion itself, so the remainder subtracts it twice. |
| Cache writes read only from `cache_creation` | **Telemetry only.** The write tokens were already inside the inclusive total and were billed as ordinary input, so today's invoice is unchanged. What was wrong is the reported hit rate — and a rate card that prices a write at a premium would have been wrong too. |

## Two things in this diff look wrong on a skim. Read these before reviewing them.

Both were the obvious-looking thing at first, and both are wrong in a way that
does real damage. They are called out here because a reviewer will otherwise
read each as an oversight and "fix" it.

### 1. `input_tokens` in the payload is the uncached REMAINDER, not the total

It looks like an off-by-a-cache-line bug. It is the contract.

`metering._prompt_tokens` has no flag telling it which convention a run used, so
**it detects the convention from the payload's own shape**. A payload carrying
`cache_read_tokens` / `cache_write_tokens` is read as Anthropic-shaped — its
docstring names `pydantic_ai`, `claude_sdk` and `deep_agents` as the three
producers of that shape — and on that branch `input_tokens` is *defined* as the
uncached remainder, with the inclusive prompt reconstituted as
`input + read + write`.

So sending the inclusive total here would make the meter add the cache lines a
**second** time. On this PR's own test payload that turns a 12,000-token prompt
into 23,000 and **overbills the customer** — the exact inverse of the defect
this PR exists to fix.

The tempting "consistency" fix is the dangerous one: making all three token
numbers inclusive looks tidier and silently overbills every cached turn on this
backend. `price_run` is the one that wants the inclusive total, because both
pricing rungs subtract the cached portion internally — hand *it* the remainder
and the bill halves. The two numbers genuinely point opposite ways.

Pinned three ways: `test_the_payload_carries_what_the_meter_actually_reads`
asserts the remainder, `test_the_meter_reconstitutes_the_inclusive_prompt`
asserts `_prompt_tokens(payload) == (12000, 9000, 2000)` through the real meter,
and mutations 6 and 7 swap the two numbers in each direction.

### 2. The usage emit is in `except`, not `finally`

`finally` is where you would put it, and it cannot go there.

A `yield` inside `finally` raises `RuntimeError: async generator ignored
GeneratorExit` **out of the caller's `aclose()`** the moment any consumer breaks
out of the stream early. That trades a billing gap for a crash on every
early-closing consumer, which is a much worse deal than the gap.

Measured, not assumed, before the code was written: yielding from an
`except BaseException` handler *does* deliver to the consumer before the
exception resumes propagating, for both `RuntimeError` and `CancelledError`.
Yielding from `finally` does not, and takes `aclose()` down with it.

So `except GeneratorExit` re-raises untouched and accepts that a half-consumed
run's usage is lost, `except Exception` emits before the error event, and
`except BaseException` catches the hard cancel that `except Exception` never
sees. `test_closing_the_stream_early_does_not_break_aclose` closes the stream
mid-turn and asserts `aclose()` stays quiet; mutation 12 puts the yield back on
the `GeneratorExit` path to prove that test catches it.

## Cache writes were in the wrong bucket

`langchain_anthropic._create_usage_metadata` copies Anthropic's per-TTL
breakdown into `ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens` and then
sets the generic `cache_creation` to 0 so its own total does not double-count.
We read only the generic key, and this backend marks every prefix 5m or 1h — so
it saw zero writes, always. Summing all three keys is safe precisely because that
zeroing guarantees at most one is ever set.

## The emit is unconditional, and survives a failure or a cancel

The cache gate is gone: a turn with no cache activity is a real, priceable turn,
and gating the invoice on a telemetry signal is how it stayed invisible. The
emit also fires from the error and cancel handlers, because the turns that
completed before a failure consumed tokens the provider has already charged us
for. See correction 2 above for why those are `except` handlers.

## It is not only the cloud meter

`agents/loop.py` forwards this event to `usage_tracker.record(...)` and then to
the budget snapshot. It was passing `model=""` and `total_cost_usd=None` for
every deep_agents run, so the OSS runtime's own spend tracking and budget caps
were blind to this backend too. They start seeing it with this change — worth
knowing if you run with a budget ceiling set.

## Evidence

**Mutations — all 12 caught.** A new plan,
`tests/mutations/deep_agents_usage.json`, with 12 mutations; the sweep catches
every one. They include putting the invoice back behind the cache gate, dropping
`model` from the payload, reading the model off configuration instead of the
response, swapping the remainder and the inclusive total in both directions, and
moving the emit into `finally`.

Anchor count: **849 on the base commit, plus the 12 in this plan = 861**, across
the base's 68 plans plus this one = 69. (`dev` itself is 845/68; the base PR
added four.) Nothing leaked — `mutate.py --validate` resolves every anchor in
every plan exactly once, repo-wide, and no pre-existing plan anchors on
`deep_agents.py` (checked by exact path, since a basename match gives false
hits).

**Tests.** The suite drives `run()` end to end over a fake graph and feeds the
real payload to the real `resolve_cost`, so the round trip that was broken is
the round trip that is tested. Token counts are pinned to exact numbers. The
price is asserted against `price_run` rather than a hardcoded dollar figure,
because the rate card legitimately moves — which is the whole subject of the
base PR — and a magic constant there would be a test that ages into a lie.

**What was run, and why not more.** Every test file that can reach
`deep_agents.py` or the `token_usage` payload, in full, by explicit path — found
by grepping `tests/` for `deep_agents` / `DeepAgentsBackend` /
`_accumulate_cache_usage` / `token_usage` / `usage_tracker` / `price_run` /
`resolve_cost`:

- **Non-cloud, 25 files** — the four `test_deep_agents_*` suites,
  `test_stream_aclose_cleanup`, `test_agent_loop`, `test_backend_protocol`,
  `test_agent_backend_protocol`, `test_pool_route_model`,
  `test_prompt_backend_digest`, `test_router_isolated_backend`,
  `test_tool_bridge_deep_agents`, `test_tool_bridge_narration_registry`,
  `test_langchain_react_backend`, `test_health`, `test_pydantic_ai_backend`,
  `test_codex_cli_backend`, `test_status_tracker`, `test_trace_collector`,
  `test_trace_integration`, `test_analytics_gap_fixes`, `test_usage_tracker`,
  `llm/test_caching`, and the rest.
- **Cloud / ee, 7 paths** — all of `tests/cloud/metering/`,
  `cloud/runs/test_run_core_token_usage`, `cloud/runs/test_run_core_narration`,
  `cloud/composio/test_providers`, `cloud/shared/test_agent_bridge_plan`,
  `cloud/test_agent_chat_schemas`, and all of
  `tests/ee/agent/test_pocket_specialist/`.

| | this branch | base (`64a64876`) |
|---|---|---|
| non-cloud coverage set | 617 passed, 1 failed, 1 skipped | 591 passed, 1 failed, 1 skipped |
| cloud / ee coverage set | **237 passed, 0 failed** | 237 passed, 0 failed |

The failure **lists** are identical, not just the counts. The one failure is
`test_pydantic_ai_backend.py::test_local_machine_tools_are_never_offered`, which
asserts `remember` is in the bridged tool surface; it fails the same way with
this branch's three paths reverted to the base commit, in the same environment,
minutes apart. Nothing here touches the tool bridge. The +26 passing tests are
this PR's own.

The rest of the cloud tree was deliberately not run. It cannot reach
`deep_agents.py` — no file outside the list above references the module, the
backend class, or the `token_usage` payload — so running it would enumerate
other people's breakage rather than verify this change, at a measured cost of
hours. `dev`'s cloud tree is not green today and this branch does not make it
any worse.

## Scope

`deep_agents.py` only, plus its test suite and a new mutation plan. `run_core.py`
and `pydantic_ai.py` are untouched.

One thing for whoever owns `pydantic_ai.py`: it sends `cached_input_tokens: read`
where `claude_sdk` and this now send `read + write`. The meter ignores that key on
the Anthropic branch, so no bill is affected, but `_total_tokens` sums
`input + output + cached_input`, and with `input_tokens` being the remainder only
`read + write` closes it back to the real total. Not changed here.
