### PR TITLE
fix(billing): put the billing routes behind the roles that already governed them

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
@@ -53,11 +53,15 @@
 #       permission filtering inside the service; workspace.view is the MEMBER read
 #       gate that mirrors that membership requirement fail-closed. Service passes
 #       user_id so the service applies the same permission filter the route does.
-#     * billing_usage_read(start?, end?) — READ usage/spend. Gate ``workspace.view``
-#       (MEMBER) — the REST GET /billing/usage route is membership-only (any role
-#       may read its own workspace's usage; it does NOT gate on billing.manage), so
-#       we match it and do NOT over-gate to OWNER. Service:
-#       billing.usage.get_workspace_usage (start/end → start_date/end_date).
+#     * billing_usage_read(start?, end?) — READ usage/spend. Gate ``billing.view``
+#       (ADMIN) — EXACTLY what the REST GET /billing/usage route gates on. This
+#       said ``workspace.view`` (MEMBER) until 2026-09-02, and the reason given was
+#       that the REST route was membership-only. That was true, and it was the bug:
+#       the billing router carried no action gate at all, so "mirroring" it meant
+#       inheriting a hole. Now that the route gates at ``billing.view``, so does
+#       this — the mirror is the point, and it has to move in the same direction.
+#       Still NOT ``billing.manage`` (OWNER): reading the bill is not managing it.
+#       Service: billing.usage.get_workspace_usage (start/end → start_date/end_date).
 #     * audit_read(limit?) — READ recent audit rows. Gate ``audit.read`` (ADMIN —
 #       EXACTLY what the REST GET /{id}/audit route gates on). Service:
 #       audit.service.list_events_response (limit → AuditQueryRequest.limit).
@@ -122,6 +126,16 @@
 #       ``seats`` field). With no safe, honest execution path, wiring it would mean
 #       either a silent seat DB write (bypassing billing) or a fabricated flow —
 #       both refused. Skipped; escalated as NEEDS_CONTEXT.
+#
+# Updated: 2026-09-02 (fix/billing-router-authorization) — billing_usage_read now
+#   gates at ``billing.view`` (ADMIN), not ``workspace.view`` (MEMBER). The gate
+#   did not change independently: the REST GET /billing/usage route moved to
+#   ``billing.view`` in the same change (it had been running on ``require_license``
+#   alone, as had every other route on that router), and this tool's contract has
+#   always been to MIRROR that route. Leaving it at MEMBER would have left a member
+#   who is refused the usage read over HTTP able to ask the agent for the same
+#   numbers — a documented bypass of a gate added in the same commit. The other
+#   four READ tools are unchanged and stay on ``_READ_ACTION`` / ``workspace.view``.
 """Agent-side MCP surface for workspace administration.
 
 Tools registered:
@@ -215,13 +229,17 @@ ADMIN_TOOL_IDS = (
 
 # The RBAC action keys these tools gate on (canonical entries in
 # ``guards.actions.ACTIONS``). ``workspace.view`` = MEMBER (read the roster /
-# settings / connectors / usage), ``workspace.member.role_change`` = ADMIN
+# settings / connectors), ``workspace.member.role_change`` = ADMIN
 # (change a member's role), ``invite.create`` = ADMIN (read/manage invites —
-# the REST invites route's action), ``audit.read`` = ADMIN (read the audit log).
+# the REST invites route's action), ``audit.read`` = ADMIN (read the audit log),
+# ``billing.view`` = ADMIN (read the workspace's spend — its own key rather than
+# the shared read action, because the REST GET /billing/usage route gates on
+# exactly this one and the two must not drift apart again).
 _READ_ACTION = "workspace.view"
 _ROLE_CHANGE_ACTION = "workspace.member.role_change"
 _INVITE_ACTION = "invite.create"
 _AUDIT_ACTION = "audit.read"
+_BILLING_READ_ACTION = "billing.view"
 # WA-5 ADMIN WRITE actions (all ADMIN in guards.actions.ACTIONS). The tool RBAC-
 # gates on these; the executor whitelists + re-checks the SAME keys.
 _MEMBER_REMOVE_ACTION = "workspace.member.remove"
@@ -776,10 +794,11 @@ async def _connectors_list_handler(args: dict) -> dict:  # noqa: ARG001 — no a
 
 async def _billing_usage_read_handler(args: dict) -> dict:
     """READ the workspace's daily usage/spend over an optional date window. Gated
-    at ``workspace.view`` (MEMBER — the REST GET /billing/usage route is
-    membership-only; it does NOT gate on billing.manage, so we match it and do NOT
-    over-gate to OWNER). EXECUTES directly on a gate pass. ``start`` / ``end`` are
-    optional ``YYYY-MM-DD`` strings (default: the trailing 30 days)."""
+    at ``billing.view`` (ADMIN — EXACTLY what the REST GET /billing/usage route
+    gates on; the two are deliberately the same key so they cannot drift). NOT
+    ``billing.manage`` (OWNER): reading the bill is not managing it. EXECUTES
+    directly on a gate pass. ``start`` / ``end`` are optional ``YYYY-MM-DD``
+    strings (default: the trailing 30 days)."""
     start = args.get("start")
     end = args.get("end")
     if start is not None and not isinstance(start, str):
@@ -789,7 +808,7 @@ async def _billing_usage_read_handler(args: dict) -> dict:
 
     gate = await _gate_read(
         "billing_usage_read",
-        _READ_ACTION,
+        _BILLING_READ_ACTION,
         "You don't have permission to view this workspace's usage",
     )
     if isinstance(gate, dict):

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -46,6 +46,61 @@
 #   Thin adapter over ``billing_service.cancel``; the plan revert lands reactively on
 #   the ``subscription.cancelled`` webhook, and a workspace with no active
 #   subscription gets 402 ``billing.no_active_subscription``.
+# Updated 2026-09-02 (fix/billing-router-authorization): the routes that SPEND,
+#   and the route that reads what has been spent, are now gated on the workspace
+#   ACTION table. Until now the router's ONLY dependency was ``require_license``.
+#   Every route then resolved ``current_workspace_id`` / ``current_user_id`` —
+#   which answer WHICH workspace the caller is acting in, and say nothing about
+#   WHETHER they may act on it. So the most junior member of a workspace could
+#   cancel the organisation's subscription, switch its plan, or open a checkout
+#   for up to 1,000,000 credits ($10,000) against the company card.
+#
+#   THE GATE ALREADY EXISTED; it was never attached here. ``guards/actions.py``
+#   has carried billing-specific rules the whole time — ``billing.view`` (ADMIN,
+#   deny code ``billing.admin_only``) and ``billing.manage`` (OWNER, deny code
+#   ``billing.owner_only``) — ``audit/listeners.py`` has carried their denial copy
+#   ("only admins can view billing info" / "only the workspace owner can manage
+#   billing"), and every OTHER surface enforces them: the MCP workspace-admin
+#   server, the admin-proposals executor (which RE-CHECKS ``billing.manage``
+#   against the proposer's CURRENT role at approve time), and ``sites.buy_plan``,
+#   whose rationale states as settled fact that a member is "too junior to so much
+#   as VIEW the billing page". The upshot was that the AGENT path was STRICTER
+#   than the human one: an agent proposing a plan change was re-checked at OWNER,
+#   while the same person could simply POST /billing/subscribe and skip the gate.
+#
+#   The mapping, and why each route sits where it does:
+#     * POST /topup, POST /subscribe, POST /cancel -> ``billing.manage`` (OWNER).
+#       These three move money or the recurring commitment, and OWNER is the tier
+#       actions.py reserves for "the tier that governs money".
+#       On /topup specifically, against the ``sites.buy_plan`` precedent (which
+#       deliberately chose ADMIN over OWNER): that trade was argued from a $7-19
+#       monthly add-on line bought as part of the ordinary publish workflow, at
+#       per-site frequency, where "requiring the owner personally for every site a
+#       company publishes makes the feature unusable at any real size". A raw
+#       wallet top-up is a different shape — up to $10,000 in a SINGLE call, and
+#       nothing bounds how many calls — so it is the thing OWNER exists for, not
+#       an exception to it. There is also no ADMIN-tier billing SPEND action to
+#       put it on: ``billing.view`` is a read verb, and gating a $10,000 purchase
+#       on it would fire the "only admins can VIEW billing info" denial copy on a
+#       refused purchase. Minting a new action is a policy change, not this fix.
+#       If OWNER proves too blunt in practice, the escalation pattern already
+#       exists — ``cloud/site_plan_requests/`` turns a refusal into a proposal an
+#       owner approves. Widening this gate is not the answer.
+#     * GET /usage -> ``billing.view`` (ADMIN). Per-model spend for the whole
+#       workspace IS the "billing info" the audit denial copy names.
+#     * GET /plans, GET /site-plans -> DELIBERATELY UNGATED. Both are
+#       tenant-independent catalogues holding no workspace data (they sit on the
+#       ALLOWED_WITHOUT_ROUTE_GUARD list in tests/cloud/auth/test_route_auth_audit
+#       .py as "public price list"). Gating them would break the pricing UI for
+#       ordinary members, who are exactly the people meant to read a price list
+#       before asking an owner to buy.
+#
+#   The action guard is ADDITIVE — it goes in ``dependencies=[...]`` and the
+#   existing ``current_workspace_id`` / ``current_user_id`` handler params are
+#   untouched, because the guard answers "may they" and those still answer
+#   "where". The PUBLIC Dodo webhook router (``billing.webhooks``) is NOT touched:
+#   it is mounted separately with no auth ON PURPOSE — Dodo is the caller and the
+#   Standard-Webhooks signature is its trust boundary.
 
 from __future__ import annotations
 
@@ -70,9 +125,27 @@ from pocketpaw_ee.cloud.entitlements.dto import (
     site_plan_tier_to_dto,
 )
 from pocketpaw_ee.cloud.license import require_license
-from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
+from pocketpaw_ee.cloud.shared.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
 
 router = APIRouter(prefix="/billing", tags=["Billing"], dependencies=[Depends(require_license)])
+
+# WHO MAY SPEND, AND WHO MAY LOOK.
+#
+# ``require_license`` on the router answers "is this deployment entitled to
+# billing at all". It does not answer "may THIS caller charge the company card",
+# and neither do the handlers' ``current_workspace_id`` / ``current_user_id``:
+# those establish WHICH workspace, never whether the caller may act on it. These
+# two dependencies are the part that decides.
+#
+# ``require_action_any_workspace`` rather than plain ``require_action`` because no
+# route here has a ``{workspace_id}`` path param — the workspace resolves from the
+# caller's ``active_workspace``.
+_require_billing_owner = Depends(require_action_any_workspace("billing.manage"))
+_require_billing_admin = Depends(require_action_any_workspace("billing.view"))
 
 
 @router.get("/plans", response_model=PlanCatalogResponse)
@@ -104,7 +177,11 @@ async def list_billing_site_plans() -> SitePlanCatalogResponse:
 _DATE_PATTERN = r"^\d{4}-\d{2}-\d{2}$"
 
 
-@router.get("/usage", response_model=WorkspaceUsageResponse)
+@router.get(
+    "/usage",
+    response_model=WorkspaceUsageResponse,
+    dependencies=[_require_billing_admin],
+)
 async def get_usage(
     workspace_id: str = Depends(current_workspace_id),
     start_date: str | None = Query(
@@ -138,7 +215,11 @@ async def get_usage(
     )
 
 
-@router.post("/topup", response_model=CreateTopupResponse)
+@router.post(
+    "/topup",
+    response_model=CreateTopupResponse,
+    dependencies=[_require_billing_owner],
+)
 async def create_topup(
     body: CreateTopupRequest,
     workspace_id: str = Depends(current_workspace_id),
@@ -179,7 +260,11 @@ def _request_origin(request: Request) -> str:
     return ""
 
 
-@router.post("/subscribe", response_model=CreateSubscriptionResponse)
+@router.post(
+    "/subscribe",
+    response_model=CreateSubscriptionResponse,
+    dependencies=[_require_billing_owner],
+)
 async def create_subscription(
     body: CreateSubscriptionRequest,
     request: Request,
@@ -206,7 +291,11 @@ async def create_subscription(
     return CreateSubscriptionResponse(checkout_url=result["checkout_url"])
 
 
-@router.post("/cancel", response_model=CancelSubscriptionResponse)
+@router.post(
+    "/cancel",
+    response_model=CancelSubscriptionResponse,
+    dependencies=[_require_billing_owner],
+)
 async def cancel_subscription(
     workspace_id: str = Depends(current_workspace_id),
 ) -> CancelSubscriptionResponse:

--- a/tests/cloud/billing/test_subscriptions.py
+++ b/tests/cloud/billing/test_subscriptions.py
@@ -50,6 +50,13 @@
 #   (opens exactly one new checkout AND cancels the old sub id), does NOT cancel when
 #   there's no active sub (or only a cancelled row), and stays event_id-idempotent on
 #   the new subscription's active-webhook replay.
+# Updated 2026-09-02 (fix/billing-router-authorization): the ``billing_app_client``
+#   fixture now carries an OWNER identity for w1. POST /billing/cancel became gated
+#   on ``billing.manage`` (OWNER), so the route resolves ``current_active_user`` in
+#   addition to the two ids this fixture already overrode — and overriding only the
+#   ids left the real fastapi-users dependency to run and 401 both cancel-route
+#   tests. OWNER because that is who can cancel a subscription in production; the
+#   role gate itself is tested in tests/cloud/test_ee_guards.py, not here.
 
 from __future__ import annotations
 
@@ -735,20 +742,49 @@ async def test_cancel_with_only_cancelled_row_raises_402(mongo_db, monkeypatch):
 
 
 @pytest_asyncio.fixture
-async def billing_app_client() -> AsyncClient:
+async def billing_app_client(monkeypatch) -> AsyncClient:
     """A FastAPI app with ONLY the billing router mounted + auth/license overridden,
     scoped to workspace ``w1`` — so the POST /billing/cancel wiring is exercised
-    without a real JWT / license (mirrors the shared cloud_app_client fixture)."""
+    without a real JWT / license (mirrors the shared cloud_app_client fixture).
+
+    The caller is an OWNER of w1. Updated 2026-09-02
+    (fix/billing-router-authorization): /billing/cancel is now gated on
+    ``billing.manage`` (OWNER), so the route resolves ``current_active_user`` as
+    well as the two ids this fixture already overrode. Overriding only the ids left
+    the real fastapi-users dependency to run, and it 401s with no session. The
+    identity is OWNER because that is who can cancel a subscription in production —
+    a fixture whose caller would be refused is not exercising the cancel path, it is
+    exercising the gate, and the gate has its own tests in
+    tests/cloud/test_ee_guards.py.
+    """
+    from types import SimpleNamespace
+
     from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
     from pocketpaw_ee.cloud.billing.router import router as billing_router
     from pocketpaw_ee.cloud.license import require_license
     from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
+    from pocketpaw_ee.guards import deps as guards_deps
+
+    # Per-member action overrides are a separate mechanism and would otherwise drive
+    # a Mongo read on the deny path. Not what this file measures.
+    monkeypatch.setattr(guards_deps, "_has_action_override", lambda *a, **k: False)
+
+    owner = SimpleNamespace(
+        id="u1",
+        active_workspace="w1",
+        workspaces=[SimpleNamespace(workspace="w1", role="owner")],
+    )
+
+    async def _fake_current_active_user():
+        return owner
 
     app = FastAPI()
     add_error_handler(app)
     app.include_router(billing_router)
     app.dependency_overrides[current_user_id] = lambda: "u1"
     app.dependency_overrides[current_workspace_id] = lambda: "w1"
+    app.dependency_overrides[current_active_user] = _fake_current_active_user
     app.dependency_overrides[require_license] = lambda: None
 
     transport = ASGITransport(app=app)

--- a/tests/cloud/test_ee_guards.py
+++ b/tests/cloud/test_ee_guards.py
@@ -44,11 +44,30 @@ class TestWorkspaceRole:
     def test_member_level_is_1(self):
         assert WorkspaceRole.MEMBER.level == 1
 
-    def test_admin_level_is_2(self):
-        assert WorkspaceRole.ADMIN.level == 2
+    def test_editor_level_is_2(self):
+        # The tier whose insertion stranded the two assertions below. Pinned so
+        # the next person to widen the ladder sees the whole shape fail at once
+        # rather than the top two silently.
+        assert WorkspaceRole.EDITOR.level == 2
 
-    def test_owner_level_is_3(self):
-        assert WorkspaceRole.OWNER.level == 3
+    def test_admin_level_is_3(self):
+        assert WorkspaceRole.ADMIN.level == 3
+
+    def test_owner_level_is_4(self):
+        assert WorkspaceRole.OWNER.level == 4
+
+    def test_the_ladder_is_strictly_ascending(self):
+        # The property the three literals above are only a sample of. Had this
+        # existed, inserting EDITOR would still have passed here and failed
+        # loudly there — which is the right split: the literals pin the contract,
+        # this pins that the contract stays ordered.
+        levels = [
+            WorkspaceRole.MEMBER.level,
+            WorkspaceRole.EDITOR.level,
+            WorkspaceRole.ADMIN.level,
+            WorkspaceRole.OWNER.level,
+        ]
+        assert levels == sorted(set(levels))
 
     @pytest.mark.parametrize(
         "value,expected",

--- a/tests/cloud/test_ee_guards.py
+++ b/tests/cloud/test_ee_guards.py
@@ -5,8 +5,15 @@
 #   pro_max, enterprise}. PolicyContext.plan now defaults to "free" (the base
 #   floor) instead of "team"; the PLAN_FEATURES table sanity checks assert the new
 #   superset ladder (free < go < pro < pro_max < enterprise).
+# Updated 2026-09-02 (fix/billing-router-authorization): added
+#   TestBillingRouteAuthorization — the /billing router's routes driven through the
+#   REAL router with the REAL role resolution, because the gap that change closes
+#   was never in the ACTION table (billing.view / billing.manage were correct all
+#   along) but in nothing depending on it.
 
 from __future__ import annotations
+
+from types import SimpleNamespace
 
 import pytest
 from fastapi import Depends, FastAPI, Request
@@ -450,6 +457,23 @@ class TestActionRolesTable:
     def test_billing_manage_requires_owner(self):
         assert ACTION_ROLES["billing.manage"] == WorkspaceRole.OWNER
 
+    def test_billing_actions_carry_their_tiers_and_deny_codes(self):
+        """The read/manage pair IS the billing policy.
+
+        Pinned together with their deny CODES because until 2026-09-02 nothing in
+        the HTTP surface consulted either of them, and the codes are what proves,
+        in TestBillingRouteAuthorization below, that this gate refused rather than
+        some other 403. Reads guards.actions.ACTIONS rather than abac.ACTION_ROLES
+        because ACTIONS is the table check_workspace_action actually consults (and
+        ACTION_ROLES has no billing.view entry at all).
+        """
+        from pocketpaw_ee.guards.actions import ACTIONS
+
+        assert ACTIONS["billing.view"].minimum == WorkspaceRole.ADMIN
+        assert ACTIONS["billing.view"].deny_code == "billing.admin_only"
+        assert ACTIONS["billing.manage"].minimum == WorkspaceRole.OWNER
+        assert ACTIONS["billing.manage"].deny_code == "billing.owner_only"
+
     def test_workspace_delete_requires_owner(self):
         assert ACTION_ROLES["workspace.delete"] == WorkspaceRole.OWNER
 
@@ -743,3 +767,174 @@ class TestRequirePolicyDep:
             params={"agent_id": "agent-99"},
         )
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /billing route authorization — the gate is ATTACHED, not merely declared
+#
+# Created 2026-09-02 (fix/billing-router-authorization). The billing router's only
+# dependency was ``require_license``. Every route then resolved
+# ``current_workspace_id`` / ``current_user_id``, which answer WHICH workspace the
+# caller is acting in and say nothing about WHETHER they may act — so any member
+# could cancel the organisation's subscription, switch its plan, or open a
+# checkout for $10,000 against it.
+#
+# ``billing.view`` (ADMIN) and ``billing.manage`` (OWNER) already existed in
+# ACTIONS, already had denial copy in audit/listeners.py, and were already enforced
+# on the MCP and admin-proposal surfaces. Nothing attached them here. A table entry
+# nobody depends on is not a gate — which is why these tests drive the REAL router
+# instead of asserting the table again (that assertion lives in
+# TestActionRolesTable above, and would have passed throughout the whole
+# vulnerable period).
+#
+# WHY EVERY TEST HERE IS A REFUSAL. A happy path passes just as well with no gate
+# at all: the OWNER cases below would have been green on the day the hole was open.
+# The load-bearing assertions are the denials, and each carries two parts:
+#   * the exact deny CODE (``billing.owner_only`` / ``billing.admin_only``) — a
+#     bare 403 is not evidence, since a non-member, a missing workspace and a
+#     licence failure all produce one too; and
+#   * the spied service asserted NOT called, so nothing reaches Dodo on the way to
+#     the refusal (the same shape as
+#     tests/cloud/sites/test_site_plan_purchase_authz.py).
+#
+# ADMIN is refused on the money routes on purpose. It is the case that separates
+# "OWNER-gated" from "gated at all" — a plain-member-only test would still pass if
+# the routes had been put on billing.view.
+# ---------------------------------------------------------------------------
+
+_BILLING_WS = "ws-billing"
+
+
+def _billing_client(monkeypatch, *, role: str):
+    """The REAL /billing router with only identity, licence and the money services
+    stubbed. Returns ``(client, spy)``.
+
+    Deliberately does NOT stub ``check_workspace_action`` — the real role
+    resolution is the thing under test, which is the one difference from
+    tests/cloud/meetings/test_router.py's fixture. ``require_license`` is bypassed
+    because entitlement is a different question from authorization, and the
+    services are recorders so an OWNER pass never reaches a payment gateway.
+    """
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.billing import service as billing_service
+    from pocketpaw_ee.cloud.billing import usage as usage_service
+    from pocketpaw_ee.cloud.billing.dto import WorkspaceUsageResponse
+    from pocketpaw_ee.cloud.billing.router import router as billing_router
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.guards import deps as guards_deps
+
+    spy: dict = {}
+
+    # Per-member action overrides are a separate mechanism from the role ladder and
+    # are not what these tests measure. Pinned False so a denial is decided by the
+    # role alone. (In practice the live lookup already resolves to [] — it drives an
+    # async Mongo read through run_until_complete from a thread with no running loop
+    # — but pinning it makes that explicit rather than incidental.)
+    monkeypatch.setattr(guards_deps, "_has_action_override", lambda *a, **k: False)
+
+    async def _create_topup(**kwargs):
+        spy["topup"] = kwargs
+        return {"checkout_url": "https://checkout.test/topup"}
+
+    async def _subscribe(**kwargs):
+        spy["subscribe"] = kwargs
+        return {"checkout_url": "https://checkout.test/subscribe"}
+
+    async def _cancel(**kwargs):
+        spy["cancel"] = kwargs
+        return {"ok": True}
+
+    async def _get_workspace_usage(workspace_id, *, start_date=None, end_date=None):  # noqa: ANN001
+        spy["usage"] = {"workspace_id": workspace_id}
+        return WorkspaceUsageResponse(start_date="2026-08-01", end_date="2026-08-31")
+
+    monkeypatch.setattr(billing_service, "create_topup", _create_topup)
+    monkeypatch.setattr(billing_service, "subscribe", _subscribe)
+    monkeypatch.setattr(billing_service, "cancel", _cancel)
+    monkeypatch.setattr(usage_service, "get_workspace_usage", _get_workspace_usage)
+
+    user = SimpleNamespace(
+        id=f"u-{role}",
+        active_workspace=_BILLING_WS,
+        workspaces=[SimpleNamespace(workspace=_BILLING_WS, role=role)],
+    )
+
+    async def _fake_current_active_user():
+        return user
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = _fake_current_active_user
+    app.include_router(billing_router)
+    return TestClient(app, raise_server_exceptions=False), spy
+
+
+#: The money routes: (spy key, verb, path, body). All three move money or the
+#: recurring commitment, so all three are OWNER (``billing.manage``).
+_MONEY_ROUTES = [
+    ("topup", "post", "/billing/topup", {"amount_credits": 1000}),
+    ("subscribe", "post", "/billing/subscribe", {"plan_key": "pro"}),
+    ("cancel", "post", "/billing/cancel", None),
+]
+
+
+class TestBillingRouteAuthorization:
+    """The /billing router's money routes are OWNER-gated, its usage read is
+    ADMIN-gated, and its catalogue reads stay open to everyone."""
+
+    # -- the money routes: OWNER only ------------------------------------
+
+    @pytest.mark.parametrize("spy_key,verb,path,body", _MONEY_ROUTES)
+    def test_owner_may_spend(self, monkeypatch, spy_key, verb, path, body):
+        client, spy = _billing_client(monkeypatch, role="owner")
+        resp = getattr(client, verb)(path, json=body) if body else getattr(client, verb)(path)
+        assert resp.status_code == 200, resp.text
+        assert spy_key in spy, "the owner's request never reached the service"
+
+    @pytest.mark.parametrize("role", ["admin", "member"])
+    @pytest.mark.parametrize("spy_key,verb,path,body", _MONEY_ROUTES)
+    def test_non_owner_cannot_spend(self, monkeypatch, role, spy_key, verb, path, body):
+        """THE HOLE. Before this gate every one of these returned 200 for a plain
+        member. ADMIN is included deliberately: it is the case that separates
+        OWNER-gated from merely gated."""
+        client, spy = _billing_client(monkeypatch, role=role)
+        resp = getattr(client, verb)(path, json=body) if body else getattr(client, verb)(path)
+        assert resp.status_code == 403, resp.text
+        # The CODE, not just the status — a non-member and a missing workspace also
+        # produce a 403, and neither would prove this gate ran.
+        assert resp.json()["error"]["code"] == "billing.owner_only"
+        # And nothing charged the card on the way to the refusal.
+        assert spy_key not in spy
+
+    # -- the usage read: ADMIN -------------------------------------------
+
+    @pytest.mark.parametrize("role", ["owner", "admin"])
+    def test_admin_and_owner_may_read_usage(self, monkeypatch, role):
+        client, spy = _billing_client(monkeypatch, role=role)
+        resp = client.get("/billing/usage")
+        assert resp.status_code == 200, resp.text
+        assert spy["usage"]["workspace_id"] == _BILLING_WS
+
+    def test_member_cannot_read_usage(self, monkeypatch):
+        """Per-model spend for the whole workspace is the "billing info" that the
+        audit denial copy in cloud/audit/listeners.py names, and that copy could
+        never fire before this route was attached to billing.view."""
+        client, spy = _billing_client(monkeypatch, role="member")
+        resp = client.get("/billing/usage")
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "billing.admin_only"
+        assert "usage" not in spy
+
+    # -- the catalogues stay open ----------------------------------------
+
+    @pytest.mark.parametrize("path", ["/billing/plans", "/billing/site-plans"])
+    def test_member_may_still_read_the_catalogues(self, monkeypatch, path):
+        """Both are tenant-independent price lists holding no workspace data.
+        Gating them would break the pricing UI for exactly the people meant to read
+        a price before asking an owner to buy — so this pins that the fix did NOT
+        over-reach while it was closing the hole next door."""
+        client, _ = _billing_client(monkeypatch, role="member")
+        resp = client.get(path)
+        assert resp.status_code == 200, resp.text

--- a/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
+++ b/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
@@ -26,6 +26,14 @@
 #   ok=False/denied=True/code, and the service is SPIED and asserted NOT called).
 #   READ tools EXECUTE directly on a gate pass (no Instinct proposal — that's
 #   writes only). The contract test now asserts all seven tool ids.
+# Updated: 2026-09-02 (fix/billing-router-authorization) — billing_usage_read's
+#   gate moved from ``workspace.view`` (MEMBER) to ``billing.view`` (ADMIN), in
+#   lockstep with the REST GET /billing/usage route it exists to mirror. The
+#   member-allowed test below is INVERTED rather than deleted (its envelope
+#   assertions are kept, now under an ADMIN identity), and a new test pins the
+#   ACTION KEY the handler passes — because every other test in this file stubs
+#   ``check_workspace_action`` to a blanket allow/deny, which means none of them
+#   would notice the key changing, or drifting back.
 #
 # What this pins — the WA-1/WA-2 tools, driven through the REAL handlers:
 #   * tool-id / server-name contract (SERVER_NAME, *_TOOL_ID, ADMIN_TOOL_IDS)
@@ -605,15 +613,26 @@ async def test_connectors_list_denied_no_service_call(monkeypatch, _patch_user):
 
 
 # ---------------------------------------------------------------------------
-# billing_usage_read — READ (workspace.view / MEMBER)
+# billing_usage_read — READ (billing.view / ADMIN)
+#
+# This was ``workspace.view`` / MEMBER until 2026-09-02. The tool's contract is to
+# mirror the REST GET /billing/usage route, and that route had no action gate at
+# all — so mirroring it meant inheriting a hole. Both moved to ``billing.view``
+# together; had only HTTP moved, a member refused the usage read over HTTP could
+# have asked the agent for the same numbers instead.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_billing_usage_read_member_allowed(monkeypatch, _patch_user):
-    """A MEMBER may read usage — gate passes; start/end are threaded to the
-    service as start_date/end_date and the summary comes back."""
-    monkeypatch.setattr("pocketpaw_ee.guards.deps.check_workspace_action", _allow())
+async def test_billing_usage_read_admin_allowed(monkeypatch, _patch_user):
+    """An ADMIN may read usage — gate passes; start/end are threaded to the
+    service as start_date/end_date and the summary comes back.
+
+    Body is the old ``test_billing_usage_read_member_allowed`` verbatim; only the
+    role it is granted under changed (see the section note above)."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.guards.deps.check_workspace_action", _allow(WorkspaceRole.ADMIN)
+    )
 
     called = {}
 
@@ -651,11 +670,17 @@ async def test_billing_usage_read_member_allowed(monkeypatch, _patch_user):
 
 
 @pytest.mark.asyncio
-async def test_billing_usage_read_denied_no_service_call(monkeypatch, _patch_user):
-    """A gate failure → deny envelope; the usage service is NOT reached."""
+async def test_billing_usage_read_member_denied_no_service_call(monkeypatch, _patch_user):
+    """A MEMBER is refused → deny envelope; the usage service is NOT reached.
+
+    THE INVERSION. This file used to assert a member was ALLOWED here, and it was
+    right about the behaviour of its day: the REST route it mirrors was ungated, so
+    the tool matched an open door. Now that the route gates at ``billing.view``
+    (ADMIN), a member gets a deny envelope carrying the billing deny code.
+    """
     monkeypatch.setattr(
         "pocketpaw_ee.guards.deps.check_workspace_action",
-        _deny_forbidden("workspace.not_member"),
+        _deny_forbidden("billing.admin_only"),
     )
     hit = {"called": False}
 
@@ -666,13 +691,55 @@ async def test_billing_usage_read_denied_no_service_call(monkeypatch, _patch_use
 
     monkeypatch.setattr(usage_service, "get_workspace_usage", _get_workspace_usage)
 
-    with _identity(workspace="w1", user="outsider"):
+    with _identity(workspace="w1", user="member1"):
         res = await wa_mcp._billing_usage_read_handler({})
 
     body = _body(res)
     assert body["ok"] is False
     assert body["denied"] is True
+    assert body["code"] == "billing.admin_only"
     assert hit["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_billing_usage_read_gates_on_the_billing_action(monkeypatch, _patch_user):
+    """THE LOCKSTEP PIN — assert WHICH action key the handler asks about.
+
+    Every other test in this file stubs the gate to a blanket allow or deny, so
+    none of them can see the key. The two tests above would both still pass if this
+    tool silently went back to ``workspace.view`` (MEMBER) while the REST route
+    stayed at ADMIN — which is exactly the bypass this change closed. So assert the
+    key itself, and assert its tier from the canonical table rather than trusting a
+    copied string.
+    """
+    seen: dict = {}
+
+    def _record(user, workspace_id, action):  # noqa: ANN001
+        seen["action"] = action
+        return WorkspaceRole.ADMIN
+
+    monkeypatch.setattr("pocketpaw_ee.guards.deps.check_workspace_action", _record)
+
+    async def _get_workspace_usage(workspace_id, *, start_date=None, end_date=None):  # noqa: ANN001
+        return SimpleNamespace(
+            start_date="2026-06-01",
+            end_date="2026-06-30",
+            models=[],
+            total_credits=0,
+            buckets=[],
+        )
+
+    import pocketpaw_ee.cloud.billing.usage as usage_service
+
+    monkeypatch.setattr(usage_service, "get_workspace_usage", _get_workspace_usage)
+
+    with _identity(workspace="w1", user="u1"):
+        await wa_mcp._billing_usage_read_handler({})
+
+    from pocketpaw_ee.guards.actions import ACTIONS
+
+    assert seen["action"] == "billing.view"
+    assert ACTIONS[seen["action"]].minimum == WorkspaceRole.ADMIN
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The billing router's only dependency was `require_license`. Nothing else. Each route then resolved `current_workspace_id` / `current_user_id`, and those answer which workspace the caller is in, not whether they are allowed to act on it. So the most junior member of a workspace could:

* `POST /billing/cancel` and cancel the organisation's subscription
* `POST /billing/topup` and open a checkout for 1,000,000 credits ($10,000)
* `POST /billing/subscribe` and switch the plan

The part worth stressing is that **the gate already existed**. `guards/actions.py` has carried `billing.view` (ADMIN) and `billing.manage` (OWNER) since the table was written. `cloud/audit/listeners.py` has carried their denial copy, including "only admins can view billing info", which could never fire. Every other surface enforces them already: the MCP workspace-admin server, the admin-proposals executor (which re-checks `billing.manage` against the proposer's current role at approve time), and `sites.buy_plan`, whose rationale in `actions.py` states as settled fact that a member is "too junior to so much as VIEW the billing page".

The result was that the agent path was stricter than the human path. An agent proposing a plan change got re-checked at OWNER and had to wait for a human. The same person could just call `POST /billing/subscribe` and skip all of it. This attaches the rules that were already written for this router.

## What each route gates on now

| Route | Action | Role |
|---|---|---|
| `POST /topup` | `billing.manage` | OWNER |
| `POST /subscribe` | `billing.manage` | OWNER |
| `POST /cancel` | `billing.manage` | OWNER |
| `GET /usage` | `billing.view` | ADMIN |
| `GET /plans` | none, deliberately | anyone |
| `GET /site-plans` | none, deliberately | anyone |

The guard goes in `dependencies=[...]`, so it is additive. The existing `current_workspace_id` / `current_user_id` handler params are untouched: the guard answers "may they", those still answer "where". It uses `require_action_any_workspace` rather than plain `require_action` because no route here has a `{workspace_id}` path param.

The public Dodo webhook router (`billing/webhooks.py`) is not touched. It is mounted separately with no auth on purpose. Dodo is the caller and the Standard-Webhooks signature is its trust boundary.

## Why `/topup` is OWNER and not ADMIN

Worth addressing head on, because anyone who knows `sites.buy_plan` will ask. That one deliberately chose ADMIN over OWNER, and the reasoning in `actions.py` is good: a $7-19 monthly add-on line, bought as part of the ordinary publish workflow, at per-site frequency, where "requiring the owner personally for every site a company publishes makes the feature unusable at any real size".

A wallet top-up is a different shape. It is up to $10,000 in a single call and nothing bounds how many calls. That is the thing OWNER exists for rather than an exception to it, and the same comment says so: it reserves OWNER for "the tier that governs money" and derives ADMIN for site plans from `billing.view` being the tier that can already see the bill it is adding to.

There is also nothing to put `/topup` on at ADMIN. `billing.view` is a read verb, and gating a $10,000 purchase on it would fire "only admins can view billing info" as the denial message on a refused purchase. Minting a `billing.topup` action is a policy change, not a fix for an unattached gate.

If OWNER turns out to be too blunt, the escalation pattern already exists: `cloud/site_plan_requests/` turns a refusal into a proposal an owner approves. That is the follow-up. Widening the gate is not.

## `GET /usage`: ADMIN, and the comments it contradicts

This is the one that needed a call rather than a lookup, so here is the argument in full.

`workspace_admin.py` says in two places that the usage read is membership-only and that the MCP tool matches the HTTP route on purpose:

> the REST GET /billing/usage route is membership-only (any role may read its own workspace's usage; it does NOT gate on billing.manage), so we match it and do NOT over-gate to OWNER

That was accurate about the running system and I am changing it anyway. Two reasons.

First, the comment is describing an absence, not a decision. The billing router had no action gate on any route, so "the REST route is membership-only" was a description of the hole rather than a policy anyone chose. Mirroring it meant inheriting it. The comment's actual argument is against over-gating to OWNER (`billing.manage`), and I agree with that. ADMIN is the third option it never considered, and it is the one the table already provides.

Second, the codebase already says the opposite everywhere else. Two comments from this week, in `guards/actions.py` and `sites/service.py`, both justify gating a purchase by asserting a member is too junior to view the billing page. Both cite `billing.view` being ADMIN as established fact. Those statements are currently false about the HTTP surface. One of the two positions has to give, and the one backed by the action table, the audit denial copy, and the reasoning behind `sites.buy_plan` is the one I kept.

Per-model spend for the whole workspace is the "billing info" that denial copy names.

## The MCP tool moves with it

Flagging this because the file list is wider than a router fix implies.

`billing_usage_read` in `ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py` moves from `workspace.view` (MEMBER) to `billing.view` (ADMIN). Not an independent decision: that tool exists to mirror the REST route, and if HTTP moves to ADMIN while the tool stays at MEMBER, a member refused the usage read over HTTP asks the agent for the same numbers instead. The gate would be decorative.

Both comment blocks are rewritten rather than left standing, since a stale rationale is how the next person reopens this.

`test_billing_usage_read_member_allowed` is inverted rather than deleted, keeping its envelope assertions in the new ADMIN-passes case. It was correct about the behaviour of its day. There is also a new test pinning the action key the handler passes, because every other test in that file stubs the gate to a blanket allow/deny and none of them can see which key is being asked about. Without it the tool could drift back to MEMBER with the suite still green.

The other four READ tools are unchanged.

## Tests

New `TestBillingRouteAuthorization` in `tests/cloud/test_ee_guards.py` drives the real router with real role resolution, deliberately not stubbing `check_workspace_action` the way the meetings fixture does.

Every case that matters is a refusal. A happy-path assertion passes just as well with no gate at all, so each denial asserts two things: the exact deny code (`billing.owner_only` / `billing.admin_only`), because a bare 403 is also what a non-member or a missing workspace produces; and the spied service asserted not called, so nothing reaches Dodo on the way to the refusal. Same shape as `test_site_plan_purchase_authz.py`.

ADMIN is tested as refused on the money routes on purpose. It is the case that separates "OWNER-gated" from "gated at all": a member-only test would still pass if these had been put on `billing.view`.

I checked the tests are not vacuous by removing the four `dependencies=[...]` from the router and re-running, which restores the pre-fix surface exactly. Result: 7 failed, 7 passed. The seven failures are precisely the refusals (all six non-owner spend cases plus the member usage read); the seven that still passed are the OWNER happy paths and the catalogue reads. That is the claim above measured rather than asserted, and it also confirms the happy paths alone would have been green throughout the vulnerable period.

There is also a test pinning that a member can still read `/plans` and `/site-plans`, so the fix is on record as not having over-reached into the price list while it was closing the hole next door.

## Blast radius

Two findings. One is fixed here, one must not be.

**An existing test fixture had to change, and it is in this diff.** `billing_app_client` in `tests/cloud/billing/test_subscriptions.py` mounts the real router and posts to `/billing/cancel`. It overrides `current_user_id` and `current_workspace_id` directly but never `current_active_user`, because nothing on the router asked for one until now. The new guard does, so the real fastapi-users dependency ran and returned 401, failing both cancel-route tests.

The fixture now carries an OWNER identity for `w1`. That is the repair rather than dropping the gate: a cancel-route fixture whose caller would be refused in production was not exercising the cancel path. The gate has its own tests elsewhere.

Two neighbouring fixtures needed nothing. `plans_client` in `test_plans.py` and `site_plans_client` in `test_cloudflare_tiers.py` mount the same router with only `require_license` overridden, and both hit routes that stay ungated. A concrete payoff of leaving the catalogues open.

**The frontend gap is a required follow-up, tracked as audit finding M8. Please do not merge this believing the surface is fully closed.** `paw-enterprise/src/routes/settings/+layout.svelte:58` omits `/settings/billing` from `ADMIN_ONLY_ROUTES`, and the nav link carries no `adminOnly` flag, so every member sees Billing in settings. The page's default tab is Usage.

This change converts that from a silent over-share into a visible 403 on the first tab that loads. That is the correct direction — the data stops leaking — but it is a worse experience than either end state, and it lands in a different repo that this PR cannot touch. The follow-up is to add `/settings/billing` to `ADMIN_ONLY_ROUTES` and `adminOnly: true` to the nav link, matching how Meetings, Compute, Policy, SSO and Audit log already work. I did not weaken the gate to avoid it.

Checked and clear otherwise. `GET /billing/usage` is only called from `creditsStore.loadUsage`, which only the billing page and `UsageBarChart` drive; it is explicitly excluded from the socket-drop reconciler and from app-wide store hydration, so no member hits it on ordinary page loads. `/plans` and `/site-plans` stay ungated, so their `ALLOWED_WITHOUT_ROUTE_GUARD` entries in `test_route_auth_audit.py` stay accurate. `test_ga_two_tenant_pentest.py` only touches the public webhook route. And `admin_proposals/executor.py` calls `billing_service.subscribe` directly rather than through the router, so its existing OWNER re-check is unaffected.

## A pre-existing bug this found, fixed in its own commit

`TestWorkspaceRole::test_admin_level_is_2` and `test_owner_level_is_3` were **already red on `dev`**, unrelated to authorization. An `EDITOR` tier sits at level 2 in `guards/rbac.py` `_ROLE_LEVELS`, which shifted ADMIN to 3 and OWNER to 4, and the two assertions were never updated. I confirmed it on `dev` directly rather than inferring it: I checked out `dev`'s copy of that file over mine and ran the class, and both still failed with none of this change present.

It is in this branch, as commit `3f596710`, for one reason. They live in the file that gains `TestBillingRouteAuthorization`, so leaving them red would mean the new gate's own test file could not show a green run and a reviewer could not tell the gate from the breakage. It is a separate commit with its own message so it can be reverted independently of the authorization change.

The method names carried the values, so both are renamed rather than edited in place. I also added an assertion for `EDITOR` itself, since the tier nobody pinned is the one that stranded the others, and an ordering test for the ladder: the three literals only sample the property they exist to protect, and inserting `EDITOR` would have kept an ordering test green while the literals failed loudly, which is the correct split.

## Why the test evidence below looks different from other PRs here

The repo's documented full-suite command does not run the tree this change lives in, and I would rather say so than present a green run that proves less than it appears to.

`pyproject.toml:615` sets `addopts = "--ignore=tests/cloud --ignore=tests/e2e"`. The command in `CLAUDE.md`, `pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py`, passes `tests/` as a directory, so that ignore applies:

* as documented: **10,745 collected, zero under `tests/cloud`**
* the same command with `-o addopts=""`: **20,277 collected**

Roughly half the suite, and it is the half holding billing, credits, metering, entitlements, sites and paw_bar. Every file this PR touches sits in it. An explicitly named path overrides `--ignore`, so targeted runs are unaffected and collect normally. Per-file runs are honest; the one command people treat as the final gate is the one that skips the tree.

CI has the same hole and already knows it. Its main test step uses the identical `pytest tests/` form, so it inherits the ignore. Six cloud files are pulled back in by explicit `-o addopts=""` steps, out of **672** cloud test files (1,293 repo-wide):

```
tests/cloud/test_herdr_cockpit.py
tests/cloud/test_agent_activity.py
tests/cloud/runs/test_run_core_narration.py
tests/cloud/runs/test_run_core_plan_surface.py
tests/cloud/shared/test_agent_bridge_plan.py
tests/cloud/shared/test_agent_bridge_narration.py
```

Those steps name the problem in their own comments: "The wider 'no lane runs tests/cloud' gap is pre-existing and tracked separately", and "Living in the tests/cloud blind spot is how HTN-2 merged green while breaking an assertion in HTN-5's own sibling file: no lane ran either one, so 'CI is green' said nothing about this surface." Each escape was added by whoever last needed one surface covered. Billing was never one of them.

There is a second, weaker observation, and I am flagging the uncertainty rather than the headline. I could not run `pytest tests/cloud tests/ee` to completion at all. Three attempts stopped partway: two at 47%, both at `tests/cloud/test_herdr_cockpit.py::test_endpoints_require_admin` with byte-identical output, and a third at 51%. I initially read that repetition as a deterministic crash in that test. I no longer think that is established: all three runs lasted roughly 60 minutes, the only run I ever got to complete anywhere was a 23-minute one, and a background-execution time limit explains every stop I saw just as well. The test passes in isolation (14 passed) and after its immediate predecessors, so there is no direct evidence of a fault in it.

What is solid is the consequence: the cloud tree takes long enough that it is not routinely runnable, which is the practical reason a blind spot this size persisted. Whether it also crashes is unresolved and I am not asserting it.

So instead of the documented command alone I ran `pytest tests/cloud tests/ee` for the tree this changes, and the documented command separately for the rest. Both are reported below.

This is worth fixing in `CLAUDE.md`, and it is plausibly why the stale `WorkspaceRole` assertions above sat red long enough to reach this branch: nothing in the documented workflow would ever have collected them. I have not edited `CLAUDE.md` here, because changing workspace config on the strength of one PR's finding is the captain's call and is being raised separately.

One more of the same shape, from checking my own work. To find out whether any failing cloud file could reach this change I first ran `grep -c "billing|workspace_admin" "$f" || echo 0` in a loop. For a non-matching file that emits `0
0`, which my numeric test read as a hit, producing six false positives — including `test_api_contracts.py`, the one file I had flagged as genuinely risky, since a contract test over routers is exactly what added `dependencies=[...]` could break. `grep -l` gave the real answer: three files match, every hit is `billing_enforced` config posture or a file-header comment, and `test_api_contracts.py` contains no billing reference at all. The check ran, returned a plausible answer, and was wrong in the direction that looks safe. That is the same shape as the addopts gap and the same shape as the defect this PR fixes, so it belongs in the record rather than being quietly replaced by the corrected list.

## Verification

* `scripts/mutate.py --validate` -> `OK: 845 anchors across 68 plans each resolve exactly once.` That is `dev`'s current baseline, which moved from 835/67 while this was in flight as #2033 and #2034 landed their own plans. This change adds no plan, and no plan references any of the five files it touches, checked by exact path across all 68.
* `tests/cloud/test_ee_guards.py` in full -> **92 passed, 0 failed**. That file is the one this PR both adds to and repairs, so it is worth stating on its own.
* `tests/cloud/billing/`, `tests/ee/agent/test_workspace_admin_mcp/`, `tests/cloud/sites/test_site_plan_purchase_authz.py`, `tests/cloud/auth/test_route_auth_audit.py`, `tests/cloud/test_plan_feature_gate.py` alongside it -> 344 passed, the only 2 failures being the stale role assertions described above, now fixed.
* The documented command, `pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py` -> **48 failed, 10651 passed, 47 skipped** in 23:07. All 48 are pre-existing and none is reachable from this change. Measured rather than argued: the failures fall in six files, none of which references `billing` or `workspace_admin`, and re-running exactly those six against `dev`'s copies of the two source files this PR edits gives the identical **48 failed, 63 passed**. They are environmental (20 are `herdr binary not found`, two are a Windows cp1252 encoding error, one asserts a Unix 0600 file mode).
* The cloud tree, which the documented command skips. I took the 30 files that fail in `pytest tests/cloud tests/ee` and ran 29 of them (holding `test_e2e_api.py` aside, see below) twice: once on this branch, once with the five changed files swapped to `origin/dev`'s copies so the tree was byte-identical to `dev`, verified with `git diff --quiet origin/dev`. Both runs: **87 failed, 267 passed, 1 skipped, 11 errors**, and the sorted list of 98 `FAILED`/`ERROR` ids is **identical between the two**. Not a matching total, the same tests.
* `test_e2e_api.py` is held aside because it contributes ~66 errors on its own from a single environmental fixture, which is enough to swing any aggregate and make it useless as a comparison key.
* `ruff check` and `ruff format --check` clean on all five files.

None of those cloud failures is reachable from this change: no failing file imports the billing router or the workspace-admin MCP tool. That is reasoning the run confirms rather than replaces. Note also that per-file totals differ between running a file in isolation and running it inside the whole tree, so the durable comparison is the id list, not the count.


