### PR TITLE
Bill the tokens a run burned before it stopped

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,22 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-09-02 (fix/metering-partial-usage-capture) — the terminal states that
+  could never carry usage now do, and latest-wins grew a floor.
+
+  ``mark_terminal`` was called WITHOUT ``usage=`` on the ``failed`` path, and
+  ``_handle_interrupted_cleanup`` did not take the parameter at all. So a run
+  that crashed, or that the host killed mid-flight, persisted no token counts —
+  and ``metering/sweeper.py`` bills all four terminal states on purpose ("a
+  partial run consumed tokens too"), so it faithfully billed them zero. Only
+  ``cancelled`` ever passed usage; all three are pinned together now.
+
+  The captured usage is also FLOORED rather than blindly overwritten. Every
+  backend reports a RUN-CUMULATIVE payload, so keeping the LATEST is right and
+  summing would bill the conversation once per turn; the floor
+  (``_usage_total``, deliberately the same definition the meter bills on) means
+  a payload that shrank — a backend regressed to per-turn reporting — cannot
+  silently halve a bill.
 - 2026-08-15 (HTN-11) — the ``tool_start`` frame carries an additive
   ``narration``: the tool's plain-language phrase, from the SAME
   ``shared/tool_narration.py`` the group/DM bridge calls.
@@ -412,6 +428,44 @@ def _looks_like_legacy_ripple_spec(candidate: Any) -> bool:
 
 def _stream_ttl() -> int:
     return int(os.environ.get("POCKETPAW_CLOUD_RUN_STREAM_TTL", "3600"))
+
+
+def _usage_int(value: Any) -> int:
+    """Coerce one usage count to a non-negative int, tolerating None / strings."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+def _usage_total(usage: dict[str, Any] | None) -> int:
+    """Total tokens a ``token_usage`` payload represents.
+
+    Deliberately the SAME definition as ``metering.service._total_tokens``:
+    prefer an explicit ``total_tokens`` the backend supplied, otherwise sum
+    input + output + cached_input. This function decides which payload gets
+    KEPT and that one gets BILLED, so it has to rank payloads the way the biller
+    measures them — two definitions that drifted would let a payload the meter
+    considers larger lose to one it considers smaller.
+
+    Spelled out here rather than imported so this hot streaming path stays
+    decoupled from the metering package; ``test_run_core_token_usage.py`` pins
+    the two against each other so the copy cannot drift.
+
+    A payload carrying none of those keys totals 0 — which is the honest answer
+    for a payload that reports no volume, and it makes the floor a no-op for
+    metadata-only payloads rather than a trap.
+    """
+    usage = usage or {}
+    explicit = _usage_int(usage.get("total_tokens"))
+    if explicit > 0:
+        return explicit
+    return (
+        _usage_int(usage.get("input_tokens"))
+        + _usage_int(usage.get("output_tokens"))
+        + _usage_int(usage.get("cached_input_tokens"))
+    )
 
 
 # Default-OFF flag (feat/session-supervisor SS-5). When truthy, the live executor
@@ -1888,6 +1942,7 @@ async def _handle_interrupted_cleanup(
     ctx: ScopeContext,
     full_text: str,
     transport: Any,
+    usage: dict[str, Any] | None = None,
 ) -> None:
     """Best-effort finalisation when ``execute_run`` is cancelled by the host.
 
@@ -1895,6 +1950,11 @@ async def _handle_interrupted_cleanup(
     block the others — every action is independently best-effort. The
     caller wraps THIS in ``asyncio.shield`` so a second cancel arriving
     during the cleanup can't abort it mid-flight.
+
+    ``usage`` carries whatever the backend had reported by the time the host
+    cancelled. It used not to be a parameter at all, so a worker shutdown wrote
+    a terminal doc with no counts and the sweeper billed the run zero — the
+    third of the three terminal states that could never carry usage.
     """
     try:
         await _broadcast_agent_typing(ctx, active=False)
@@ -1905,6 +1965,7 @@ async def _handle_interrupted_cleanup(
             spec.run_id,
             status="interrupted",
             partial_text=full_text,
+            usage=usage or None,
         )
     except Exception:
         logger.exception("mark_terminal(interrupted) failed for %s", spec.run_id)
@@ -2143,7 +2204,25 @@ async def execute_run(spec: RunSpec) -> None:
                         full_text += content
                 elif event_name == "token_usage":
                     if isinstance(event_data, dict) and event_data:
-                        usage = event_data
+                        # LATEST-WINS, FLOORED. Every backend reports a
+                        # RUN-CUMULATIVE payload — ``pydantic_ai`` accumulates
+                        # into one ``RunUsage``, ``deep_agents`` and
+                        # ``claude_sdk`` each report a run total, and
+                        # ``codex_cli`` accumulates its per-turn events — so
+                        # taking the latest is right and SUMMING would bill the
+                        # conversation once per turn.
+                        #
+                        # The floor is what makes latest-wins safe: a payload
+                        # smaller than the one already held can only be a
+                        # regression (a backend that went back to per-turn
+                        # reporting), and a regression must not be able to
+                        # silently halve a bill. ``>=`` and not ``>`` so an
+                        # equal-volume payload still replaces — that keeps a
+                        # later payload's better metadata (a resolved model
+                        # name) and means two zero-token payloads behave as
+                        # plain latest-wins rather than pinning the first.
+                        if _usage_total(event_data) >= _usage_total(usage):
+                            usage = event_data
                 await transport.append_event(spec.run_id, event_name, event_data)
                 if event_name == "error":
                     # ``_drive_agent_loop`` already broke out after yielding this.
@@ -2162,7 +2241,9 @@ async def execute_run(spec: RunSpec) -> None:
             # and strand the doc in ``running`` with no terminal stream frame.
             logger.info("execute_run %s cancelled by host", spec.run_id)
             try:
-                await asyncio.shield(_handle_interrupted_cleanup(spec, ctx, full_text, transport))
+                await asyncio.shield(
+                    _handle_interrupted_cleanup(spec, ctx, full_text, transport, usage)
+                )
             except asyncio.CancelledError:
                 # The outer await is cancelled but the shielded inner task
                 # continues running to completion in the background. That's
@@ -2203,11 +2284,18 @@ async def execute_run(spec: RunSpec) -> None:
     if error is not None or backend_error_message is not None:
         err_msg = str(error) if error is not None else (backend_error_message or "")
         try:
+            # ``usage=`` was omitted here, so a run that crashed after the model
+            # had already answered persisted no counts and swept through
+            # ``bill_run`` at $0 however much context it had paid for.
+            # ``metering/sweeper.py`` bills all four terminal states on purpose
+            # ("a partial run consumed tokens too") — three of them simply had
+            # nothing to bill.
             await run_service.mark_terminal(
                 spec.run_id,
                 status="failed",
                 partial_text=full_text,
                 error=err_msg,
+                usage=usage or None,
             )
         except Exception:
             logger.exception("mark_terminal(failed) failed for %s", spec.run_id)

--- a/src/pocketpaw/agents/codex_cli.py
+++ b/src/pocketpaw/agents/codex_cli.py
@@ -39,6 +39,15 @@ project-level context. We avoided the ``-c experimental_instructions_file``
 config flag because it's not a documented kwarg on ``ThreadOptions`` and
 the path-quoting on Windows TOML is fiddly. ``AGENTS.md`` is the
 documented, stable extension point.
+
+Updated 2026-09-02 (fix/metering-partial-usage-capture) — the ``token_usage``
+event reports the RUN total instead of the last turn's. Codex emits usage per
+``TurnCompletedEvent`` and a run completes several, which made this the only
+backend whose payloads were not run-cumulative; every consumer reads a payload
+as the run's running total (the cloud run loop keeps the LATEST one), so a
+multi-turn run was billed for its final turn alone. The counters are locals in
+``run`` — ``AgentPool`` caches ONE instance per agent, so per-run state on
+``self`` would bill one run for another's tokens.
 """
 
 from __future__ import annotations
@@ -481,6 +490,18 @@ class CodexCLIBackend(BaseAgentBackend):
                 TurnOptions(signal=self._abort_controller.signal),
             )
 
+            # Run-cumulative token counters (N1). Codex reports usage PER TURN
+            # and a run can complete several, so these turn the per-turn numbers
+            # into the run total every other backend already reports. LOCALS,
+            # not instance state: ``AgentPool`` caches one backend instance per
+            # agent and drives concurrent runs through it, so a counter on
+            # ``self`` would bill one run for another run's tokens — the same
+            # shape as the shared-stop-flag bug this backend's siblings were
+            # reshaped around.
+            run_input = 0
+            run_output = 0
+            run_cached = 0
+
             async for event in streamed.events:
                 if self._stop_flag:
                     break
@@ -626,13 +647,24 @@ class CodexCLIBackend(BaseAgentBackend):
 
                 elif isinstance(event, TurnCompletedEvent):
                     usage = event.usage
+                    # Accumulate, then report the RUN total. This used to emit
+                    # the raw per-turn counts, which made Codex the only backend
+                    # whose ``token_usage`` payloads were not run-cumulative —
+                    # and the cloud run loop keeps the LATEST payload rather than
+                    # summing, so a multi-turn Codex run was billed for its final
+                    # turn alone. Summing in the run loop instead would have
+                    # over-billed the other three backends by the length of the
+                    # conversation, so the accumulator belongs here.
+                    run_input += int(getattr(usage, "input_tokens", 0) or 0)
+                    run_output += int(getattr(usage, "output_tokens", 0) or 0)
+                    run_cached += int(getattr(usage, "cached_input_tokens", 0) or 0)
                     yield AgentEvent(
                         type="token_usage",
                         content="",
                         metadata={
-                            "input_tokens": getattr(usage, "input_tokens", 0),
-                            "output_tokens": getattr(usage, "output_tokens", 0),
-                            "cached_input_tokens": getattr(usage, "cached_input_tokens", 0),
+                            "input_tokens": run_input,
+                            "output_tokens": run_output,
+                            "cached_input_tokens": run_cached,
                             "model": model or "(codex-config)",
                             "backend": "codex_cli",
                         },

--- a/src/pocketpaw/agents/copilot_sdk.py
+++ b/src/pocketpaw/agents/copilot_sdk.py
@@ -7,6 +7,14 @@ tool use, and session management.
 Built-in tools: shell, file operations, git, web search.
 
 Requires: `copilot` CLI on PATH + `pip install github-copilot-sdk`.
+
+Updated 2026-09-02 (fix/metering-partial-usage-capture) — the ``token_usage``
+event reports the RUN total instead of one API call's. ``assistant.usage`` is
+emitted PER LLM API CALL — the SDK's own payload carries ``apiCallId``,
+``duration`` and ``ttft_ms``, which only mean anything per call — and one agent
+turn makes several. Every consumer reads a payload as the run's running total,
+so the per-call numbers are accumulated here. The counters are locals in
+``run``: one backend instance serves every run on its agent.
 """
 
 import asyncio
@@ -255,9 +263,19 @@ class CopilotSDKBackend(BaseAgentBackend):
             queue: asyncio.Queue[AgentEvent | None] = asyncio.Queue()
             _streamed_via_deltas = False  # Track if we got streaming deltas
 
+            # Run-cumulative token counters. ``assistant.usage`` is emitted PER
+            # LLM API CALL — the SDK's own payload carries ``apiCallId``,
+            # ``duration`` and ``ttft_ms``, which only make sense per call — and
+            # an agent turn makes several. Every consumer of ``token_usage``
+            # treats a payload as the run's running total (the cloud run loop
+            # keeps the LATEST one), so the per-call numbers have to be summed
+            # here or a multi-call run bills for one call.
+            _run_input = 0
+            _run_output = 0
+
             def on_event(event: Any) -> None:
                 """Map Copilot SDK events to AgentEvents and enqueue."""
-                nonlocal _streamed_via_deltas
+                nonlocal _streamed_via_deltas, _run_input, _run_output
                 # event.type is an enum; use .value for string comparison
                 event_type = _get_event_type(event)
                 data = getattr(event, "data", event)
@@ -310,13 +328,17 @@ class CopilotSDKBackend(BaseAgentBackend):
                     input_t = getattr(data, "input_tokens", 0) or 0
                     output_t = getattr(data, "output_tokens", 0) or 0
                     if input_t or output_t:
+                        # Accumulate, then report the RUN total — see
+                        # ``_run_input`` above. The SDK types these as floats.
+                        _run_input += int(input_t)
+                        _run_output += int(output_t)
                         queue.put_nowait(
                             AgentEvent(
                                 type="token_usage",
                                 content="",
                                 metadata={
-                                    "input_tokens": input_t,
-                                    "output_tokens": output_t,
+                                    "input_tokens": _run_input,
+                                    "output_tokens": _run_output,
                                     "model": model,
                                     "backend": "copilot_sdk",
                                 },

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -45,6 +45,15 @@ SystemEvent apiece ({file_id,name,mime,size}) ahead of ``stream_end``, and
 persists a matching ``{type:"artifact", meta}`` attachment on the assistant
 message (persisting even on an artifact-only, empty-text turn). Mirrors the cloud
 run_core collector-drain contract so the client's card+viewer works in local mode.
+
+Updated: 2026-09-02 (fix/metering-partial-usage-capture) — ``token_usage``
+payloads are RUN-CUMULATIVE and ``usage_tracker.record`` is ADDITIVE, so the
+handler records the DELTA between payloads rather than each payload whole.
+Recording them whole counted turn 1 again in every later payload. This was
+latent while every backend reported exactly once per run; it stopped being
+latent when ``pydantic_ai`` began reporting as the run progresses — which it
+must, because the cloud run loop abandons a cancelled run's stream and never
+sees a payload produced at the end.
 """
 
 import asyncio
@@ -1383,6 +1392,15 @@ class AgentLoop:
             # boundaries are still caught.
             stream_buffer = ""
             safe_sent = ""
+            # What this run has already handed to the usage tracker. Backends
+            # report token_usage as a RUN-CUMULATIVE total, and
+            # ``usage_tracker.record`` is ADDITIVE, so a run that reports twice
+            # would count its first turn again in every later payload. Recording
+            # the delta keeps one row per model call and the right run total.
+            recorded_input = 0
+            recorded_output = 0
+            recorded_cached = 0
+            recorded_cost = 0.0
 
             await _policy_ctx.__aenter__()
             run_iter = router.run(
@@ -1489,15 +1507,34 @@ class AgentLoop:
                             if usage_tracker is None:
                                 usage_tracker = usage_tracker_module.get_usage_tracker()
 
-                            usage_tracker.record(
-                                backend=meta.get("backend", "unknown"),
-                                model=meta.get("model", ""),
-                                input_tokens=input_tokens,
-                                output_tokens=output_tokens,
-                                cached_input_tokens=cached_input_tokens,
-                                session_id=session_key or "",
-                                total_cost_usd=meta.get("total_cost_usd"),
-                            )
+                            # DELTA, not the payload. See ``recorded_*`` above:
+                            # the payload is the run's running total and this
+                            # call adds to a ledger, so passing it whole
+                            # re-counts every earlier turn. max(0, ...) because
+                            # a shrinking payload can only be a backend
+                            # regression and must never subtract from a bill.
+                            d_input = max(0, input_tokens - recorded_input)
+                            d_output = max(0, output_tokens - recorded_output)
+                            d_cached = max(0, cached_input_tokens - recorded_cached)
+                            reported_cost = meta.get("total_cost_usd")
+                            d_cost = None
+                            if isinstance(reported_cost, (int, float)):
+                                d_cost = max(0.0, float(reported_cost) - recorded_cost)
+                            if d_input or d_output or d_cached or d_cost:
+                                usage_tracker.record(
+                                    backend=meta.get("backend", "unknown"),
+                                    model=meta.get("model", ""),
+                                    input_tokens=d_input,
+                                    output_tokens=d_output,
+                                    cached_input_tokens=d_cached,
+                                    session_id=session_key or "",
+                                    total_cost_usd=d_cost,
+                                )
+                                recorded_input += d_input
+                                recorded_output += d_output
+                                recorded_cached += d_cached
+                                if d_cost is not None:
+                                    recorded_cost += d_cost
                         except Exception:
                             logger.debug(
                                 "Failed to persist token usage metrics",

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -290,6 +290,36 @@ follow, and the middle one contradicts what this file used to say:
   instant the run finishes, so now IS the run's moment. The meter cannot say the
   same, because it bills off a sweeper draining a backlog, which is why
   ``resolve_cost`` takes the run's own timestamp instead of assuming one.
+
+Updated 2026-09-02 (fix/metering-partial-usage-capture) — a run that does not
+finish now reports the tokens it burned. ``_usage_event`` was reachable only
+from ``AgentRunResultEvent``, which is the last event of a COMPLETED run, so
+every cancel, ``stop()`` and crash emitted no ``token_usage`` at all and the
+meter faithfully billed them zero. Three things carry the fix:
+
+* **The run owns a ``RunUsage`` ledger**, built here and passed to
+  ``run_stream_events``. pydantic-ai does not copy it — ``Agent.iter`` hands the
+  same instance to ``GraphAgentState`` — and accumulates into it in place after
+  every completed model response AND for a response whose stream was cut
+  mid-flight. So the counts stay readable from this frame however the run ends.
+* **Usage is emitted AS the run consumes it**, not on the way out. This is not a
+  style choice: the cloud run loop does not ask this backend to stop on a
+  cancel, it stops READING (``_drive_agent_loop`` breaks on the cancel flag and
+  its ``finally`` cancels the pending ``__anext__``), so a payload produced at
+  the end of an abandoned run is never delivered. A ``finally:`` yield does not
+  rescue it either — the OSS loop closes this generator
+  (``agents/loop.py`` ``run_iter.aclose()``) and yielding under GeneratorExit
+  raises ``RuntimeError: async generator ignored GeneratorExit``.
+* **Payloads are RUN-CUMULATIVE and monotonic**, which is the contract every
+  consumer now reads them under: the cloud run loop keeps the largest, and
+  ``agents/loop.py``, ``status.py`` and ``trace_collector.py`` fold in the
+  difference. The crash path emits BEFORE its ``error`` frame because the run
+  loop treats ``error`` as terminal and stops reading there.
+
+``_usage_event`` split into ``_usage_event_from`` for this: the counts are the
+same object either way, but only a completed run has a response to read the
+model name off, so the caller supplies it. The abnormal path falls back to the
+resolved model — no mid-stream event carries one.
 """
 
 from __future__ import annotations
@@ -2032,6 +2062,55 @@ class PydanticAIBackend:
         # ``_announce_tool`` for why the id alone was the wrong key.
         announced: set[str] = set()
 
+        # THE RUN'S USAGE LEDGER (C2). pydantic-ai does NOT copy this object —
+        # ``Agent.iter`` does ``usage = usage or RunUsage()`` and hands that same
+        # instance to ``GraphAgentState``, which accumulates into it in place
+        # after every completed model response AND for a response whose stream
+        # was cut mid-flight. So this reference stays readable from here no
+        # matter how the run ends.
+        #
+        # That matters because ``AgentRunResultEvent`` — until now the only
+        # producer of ``token_usage`` on this backend — is the last event of a
+        # COMPLETED run. A cancel, a ``stop()`` or a raise never produces one,
+        # so those runs reported no usage at all and the meter faithfully billed
+        # them zero. Hoisted ABOVE the try so every exit path can read it,
+        # including a failure inside ``_build_model``.
+        from pydantic_ai.usage import RunUsage
+
+        run_usage = RunUsage()
+        model: Any = None
+        emitted_total = 0
+
+        def _usage_snapshot() -> AgentEvent | None:
+            """A cumulative ``token_usage`` for what the run has consumed SO FAR.
+
+            Emitted DURING the run and not merely at the end, because the end is
+            exactly what an abandoned run never reaches. The cloud run loop does
+            not ask this backend to stop on a cancel — it stops READING
+            (``_drive_agent_loop`` breaks on the cancel flag and its ``finally``
+            cancels the pending ``__anext__``), so anything produced after that
+            moment is discarded no matter where it is produced. A payload built
+            only on the way out therefore cannot bill a cancelled run.
+
+            Yielding from a ``finally`` is not the answer either: the OSS loop
+            closes this generator (``agents/loop.py`` ``run_iter.aclose()``), and
+            a generator that yields while GeneratorExit is propagating raises
+            ``RuntimeError: async generator ignored GeneratorExit``.
+
+            Returns None when nothing new has been consumed, so a run that burns
+            no tokens stays silent instead of emitting an empty payload.
+            """
+            nonlocal emitted_total
+            total = int(getattr(run_usage, "total_tokens", 0) or 0)
+            if total <= emitted_total:
+                return None
+            emitted_total = total
+            # The model name off the RESOLVED model, not off a response: no
+            # mid-stream event carries one (the event union is parts, tools and
+            # enqueued messages only). The completed path still takes it from
+            # the response, which is the truthful source there.
+            return self._usage_event_from(run_usage, model_name=getattr(model, "model_name", None))
+
         try:
             model = self._build_model()
 
@@ -2087,6 +2166,11 @@ class PydanticAIBackend:
 
                 kwargs["model_settings"] = ModelSettings(max_tokens=max_output)
 
+            # Hand the SDK the ledger built above. Per-RUN like ``usage_limits``
+            # and ``model_settings``: the cached agent is shared across runs, so
+            # a run's accounting cannot live on it.
+            kwargs["usage"] = run_usage
+
             async with agent.run_stream_events(message, **kwargs) as stream:
                 async for event in stream:
                     if handle.stopped:
@@ -2096,20 +2180,42 @@ class PydanticAIBackend:
                     # ``_map_event`` returns nothing for a usage-less result.
                     self._retain_run_transcript(session_key, event)
                     for agent_event in self._map_event(event, announced):
+                        if agent_event.type == "token_usage":
+                            # The terminal result event just reported the run
+                            # total (``result.usage`` IS ``run_usage``), so the
+                            # snapshot below has nothing left to add.
+                            emitted_total = int(getattr(run_usage, "total_tokens", 0) or 0)
                         yield agent_event
+                    snapshot = _usage_snapshot()
+                    if snapshot is not None:
+                        yield snapshot
 
         except asyncio.CancelledError:
             # Caller cancelled this run specifically — the correct per-run
             # cancellation path. Propagate; do not degrade it into "done".
+            # Nothing is emitted here on purpose: the consumer has already
+            # stopped reading, and the usage this run burned was delivered by
+            # the in-run snapshots above.
             raise
         except Exception as exc:
             logger.error("Pydantic AI streaming error: %s", exc, exc_info=True)
+            # Usage BEFORE the error frame, and the order is load-bearing: the
+            # cloud run loop treats ``error`` as terminal and stops reading the
+            # stream at it, so a payload emitted after it is thrown away.
+            snapshot = _usage_snapshot()
+            if snapshot is not None:
+                yield snapshot
             yield AgentEvent(type="error", content=self._explain_error(exc))
             yield AgentEvent(type="done", content="")
             return
         finally:
             self._active.discard(handle)
 
+        # Reached on a clean finish AND on the ``stop()`` break, which is the
+        # other path that never sees ``AgentRunResultEvent``.
+        snapshot = _usage_snapshot()
+        if snapshot is not None:
+            yield snapshot
         yield AgentEvent(type="done", content="")
 
     def _explain_error(self, exc: Exception) -> str:
@@ -2342,6 +2448,24 @@ class PydanticAIBackend:
         usage = getattr(getattr(event, "result", None), "usage", None)
         if usage is None:
             return None
+        response = getattr(getattr(event, "result", None), "response", None)
+        model_name = getattr(response, "model_name", None)
+        model_name = model_name if isinstance(model_name, str) and model_name else None
+        return self._usage_event_from(usage, model_name=model_name)
+
+    def _usage_event_from(self, usage: Any, *, model_name: str | None) -> AgentEvent:
+        """Build the ``token_usage`` payload from a ``RunUsage``, whatever produced it.
+
+        Split out of ``_usage_event`` on 2026-09-02 so the ABNORMAL paths can
+        reach it. The counts are the same object either way — pydantic-ai
+        accumulates into the ledger the run was handed, and a completed run's
+        ``result.usage`` IS that ledger — but the model name is not: only a
+        completed run has a response to read it off, so the caller supplies it.
+
+        ``model_name=None`` is a real state and not an error. It bills zero and
+        says so in the log rather than raising, because one unpriceable turn must
+        not stall a sweep over everyone else's.
+        """
         total = int(getattr(usage, "input_tokens", 0) or 0)
         read = int(getattr(usage, "cache_read_tokens", 0) or 0)
         write = int(getattr(usage, "cache_write_tokens", 0) or 0)
@@ -2365,10 +2489,6 @@ class PydanticAIBackend:
                 savings.hit_rate * 100,
                 savings.est_tokens_saved,
             )
-
-        response = getattr(getattr(event, "result", None), "response", None)
-        model_name = getattr(response, "model_name", None)
-        model_name = model_name if isinstance(model_name, str) and model_name else None
 
         cost = 0.0
         if model_name is not None:

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -2191,11 +2191,33 @@ class PydanticAIBackend:
                         yield snapshot
 
         except asyncio.CancelledError:
-            # Caller cancelled this run specifically — the correct per-run
-            # cancellation path. Propagate; do not degrade it into "done".
-            # Nothing is emitted here on purpose: the consumer has already
-            # stopped reading, and the usage this run burned was delivered by
-            # the in-run snapshots above.
+            # HARD-CANCEL RECOVERY. Yielding while an exception is propagating
+            # sounds impossible, but for a cancel it is not: a consumer that
+            # cancelled a pending ``__anext__`` receives this value from that
+            # await, and the CancelledError resumes propagating afterwards, so
+            # the cancel is delivered rather than swallowed. Measured, both
+            # halves, before this was written.
+            #
+            # It catches ``CancelledError`` SPECIFICALLY and never
+            # ``BaseException``. GeneratorExit is a sibling of CancelledError,
+            # not a subclass, so it stays uncaught here — which is the whole
+            # point: yielding while GeneratorExit propagates raises
+            # ``RuntimeError: async generator ignored GeneratorExit`` out of the
+            # consumer's ``aclose()``, and ``agents/loop.py`` calls exactly that
+            # on every early break. Widening this to BaseException would trade a
+            # billing gap for a crash on a path that today merely under-bills.
+            #
+            # This covers the one case the in-run snapshots cannot: usage that
+            # advanced with no further event behind it to carry a snapshot out —
+            # the response cut off mid-flight. Best-effort, because a cancel must
+            # never be blocked by the bookkeeping that describes it.
+            try:
+                snapshot = _usage_snapshot()
+            except Exception:
+                logger.debug("usage snapshot failed on cancel", exc_info=True)
+                snapshot = None
+            if snapshot is not None:
+                yield snapshot
             raise
         except Exception as exc:
             logger.error("Pydantic AI streaming error: %s", exc, exc_info=True)

--- a/src/pocketpaw/status.py
+++ b/src/pocketpaw/status.py
@@ -1,3 +1,12 @@
+"""Per-session agent status tracked off the message bus.
+
+Updated 2026-09-02 (fix/metering-partial-usage-capture) — ``token_usage``
+payloads are RUN-CUMULATIVE, so the per-session token counters fold in the
+DIFFERENCE between payloads rather than adding each one whole. Adding them whole
+was right only while every backend reported exactly once per run, and it does
+not survive a backend that reports as the run progresses.
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -25,6 +34,13 @@ class _SessionState:
     state_changed_at: float = field(default_factory=time.monotonic)
     token_input: int = 0
     token_output: int = 0
+    # The last RUN-CUMULATIVE token_usage payload folded in. Backends report a
+    # running total rather than one turn's delta, so the counters above add the
+    # difference instead of the payload — otherwise a run that reports twice
+    # counts its first turn again in every later payload. Reset with the rest of
+    # the state on ``agent_start``, which builds a fresh instance per run.
+    _last_cum_input: int = 0
+    _last_cum_output: int = 0
 
 
 class StatusTracker:
@@ -125,8 +141,15 @@ class StatusTracker:
         elif etype == "token_usage":
             s = self._sessions.get(session_key)
             if s:
-                s.token_input += data.get("input", 0)
-                s.token_output += data.get("output", 0)
+                # Fold in the DELTA of a cumulative payload — see
+                # ``_last_cum_input``. max(0, ...) because a payload that went
+                # backwards is a backend regression, never a refund.
+                cum_input = data.get("input", 0) or 0
+                cum_output = data.get("output", 0) or 0
+                s.token_input += max(0, cum_input - s._last_cum_input)
+                s.token_output += max(0, cum_output - s._last_cum_output)
+                s._last_cum_input = max(s._last_cum_input, cum_input)
+                s._last_cum_output = max(s._last_cum_output, cum_output)
 
         elif etype == "error":
             s = self._sessions.get(session_key)

--- a/src/pocketpaw/trace_collector.py
+++ b/src/pocketpaw/trace_collector.py
@@ -1,4 +1,11 @@
-"""TraceCollector subscribes to system events and persists request traces."""
+"""TraceCollector subscribes to system events and persists request traces.
+
+Updated 2026-09-02 (fix/metering-partial-usage-capture) — a ``token_usage``
+payload is the RUN's running total, so each ``llm_calls`` row stores the
+DIFFERENCE from what the trace already holds. Storing them whole would put a
+running total in every row and, worse, ``total.total_cost_usd`` is a plain sum
+over those rows, so it would charge the whole run once per payload.
+"""
 
 from __future__ import annotations
 
@@ -170,6 +177,30 @@ class TraceCollector:
                     data.get("cached_input_tokens", data.get("cached_tokens", 0)),
                     0,
                 )
+                # A ``token_usage`` payload is the RUN's running total, not one
+                # call's, so store the DIFFERENCE from what this trace already
+                # holds. Each stored entry is itself a delta, so their sum is
+                # the cumulative already recorded — which keeps one entry per
+                # model call and, more importantly, keeps the ``total_cost``
+                # roll-up below (a plain sum over these entries) from counting
+                # the whole run once per payload.
+                prev_input = sum(_to_int(c.get("input_tokens"), 0) for c in active.llm_calls)
+                prev_output = sum(_to_int(c.get("output_tokens"), 0) for c in active.llm_calls)
+                prev_cached = sum(
+                    _to_int(c.get("cached_input_tokens"), 0) for c in active.llm_calls
+                )
+                prev_cost = sum(_to_float(c.get("cost_usd")) for c in active.llm_calls)
+
+                # max(0, ...) — a payload that went backwards is a backend
+                # regression, never a refund.
+                input_tokens = max(0, input_tokens - prev_input)
+                output_tokens = max(0, output_tokens - prev_output)
+                cached_input_tokens = max(0, cached_input_tokens - prev_cached)
+                cost_delta = max(
+                    0.0,
+                    _to_float(data.get("total_cost_usd", data.get("cost_usd", 0.0))) - prev_cost,
+                )
+
                 active.llm_calls.append(
                     {
                         "timestamp": str(data.get("timestamp") or _now_iso()),
@@ -179,10 +210,7 @@ class TraceCollector:
                         "output_tokens": output_tokens,
                         "cached_input_tokens": cached_input_tokens,
                         "total_tokens": input_tokens + output_tokens + cached_input_tokens,
-                        "cost_usd": round(
-                            _to_float(data.get("total_cost_usd", data.get("cost_usd", 0.0))),
-                            6,
-                        ),
+                        "cost_usd": round(cost_delta, 6),
                         "latency_ms": _to_int(data.get("latency_ms"), 0),
                     }
                 )

--- a/tests/cloud/runs/test_run_core_token_usage.py
+++ b/tests/cloud/runs/test_run_core_token_usage.py
@@ -7,8 +7,22 @@
 #     mark_completed / mark_terminal) AND the ``stream_end`` SSE frame, replacing
 #     the old hardcoded ``{}``. Covers the success, empty-text, and cancelled
 #     paths.
+#
+# Updated 2026-09-02 (fix/metering-partial-usage-capture) — the three terminal
+# states that could never carry usage now do, and latest-wins grew a floor.
+#   * failed / interrupted: ``mark_terminal`` was called without ``usage=`` on
+#     both (``_handle_interrupted_cleanup`` did not even take the parameter), so
+#     a run that crashed or was killed by the host persisted no counts and the
+#     sweeper billed it zero however much context it had already paid for.
+#     ``cancelled`` always passed usage; it is pinned here too so the three
+#     cannot drift apart again.
+#   * the floor: every backend reports a RUN-CUMULATIVE payload, so keeping the
+#     LATEST is right and summing would bill the conversation once per turn. The
+#     floor is what makes that safe — a payload smaller than the one already
+#     held can only be a regression, and a regression must not halve a bill.
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 
@@ -265,3 +279,209 @@ async def test_execute_run_empty_text_path_carries_usage(monkeypatch):
     # The empty-text completion path forwarded the usage to mark_completed.
     assert len(mark_calls) == 1
     assert mark_calls[0]["usage"]["input_tokens"] == 1200
+
+
+# ---------------------------------------------------------------------------
+# A partial run consumed tokens too (C1)
+#
+# ``metering/sweeper.py`` bills all four terminal states on purpose. Three of
+# them could never carry usage, so it faithfully billed them zero.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_failed_run_carries_the_tokens_it_burned(monkeypatch):
+    """A run that crashes after the model answered is not a free run.
+
+    ``mark_terminal(status="failed")`` omitted ``usage=`` entirely, so every
+    crashed run persisted whatever ``usage`` the doc already had — nothing —
+    and swept through ``bill_run`` at $0 no matter how much context it had
+    already paid for.
+    """
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    marked: list[dict[str, Any]] = []
+
+    async def _track_terminal(
+        run_id, *, status, partial_text="", error=None, assistant_message_id=None, usage=None
+    ):
+        marked.append({"status": status, "usage": usage})
+
+    async def fake_agent_events(spec, ctx):
+        yield ("chunk", {"content": "partial", "type": "text"})
+        yield ("token_usage", dict(_USAGE_META))
+        yield ("error", {"code": "agent.run_failed", "message": "provider exploded"})
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", fake_agent_events)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.run_core.run_service.mark_terminal", _track_terminal
+    )
+
+    await run_core.execute_run(_spec())
+
+    assert [m["status"] for m in marked] == ["failed"]
+    assert marked[0]["usage"] is not None, "a failed run persisted no usage at all"
+    assert marked[0]["usage"]["input_tokens"] == 1200
+    assert marked[0]["usage"]["output_tokens"] == 350
+
+
+async def test_an_interrupted_run_carries_the_tokens_it_burned(monkeypatch):
+    """Host cancel (worker shutdown / SIGTERM) is the third unbilled state.
+
+    ``_handle_interrupted_cleanup`` did not take a ``usage`` parameter at all,
+    so the shielded finalisation wrote a terminal doc with no counts.
+    """
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    marked: list[dict[str, Any]] = []
+
+    async def _track_terminal(
+        run_id, *, status, partial_text="", error=None, assistant_message_id=None, usage=None
+    ):
+        marked.append({"status": status, "usage": usage})
+
+    async def fake_agent_events(spec, ctx):
+        yield ("chunk", {"content": "partial", "type": "text"})
+        yield ("token_usage", dict(_USAGE_META))
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", fake_agent_events)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.run_core.run_service.mark_terminal", _track_terminal
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_core.execute_run(_spec())
+
+    assert [m["status"] for m in marked] == ["interrupted"]
+    assert marked[0]["usage"] is not None, "an interrupted run persisted no usage at all"
+    assert marked[0]["usage"]["input_tokens"] == 1200
+
+
+async def test_a_cancelled_run_carries_the_tokens_it_burned(monkeypatch):
+    """The one terminal state that already passed ``usage=`` — pinned so the
+    other two can never quietly drift back apart from it."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    marked: list[dict[str, Any]] = []
+
+    async def _track_terminal(
+        run_id, *, status, partial_text="", error=None, assistant_message_id=None, usage=None
+    ):
+        marked.append({"status": status, "usage": usage})
+
+    async def fake_agent_events(spec, ctx):
+        yield ("chunk", {"content": "partial", "type": "text"})
+        yield ("token_usage", dict(_USAGE_META))
+        # The user hits stop. The run loop notices at the NEXT event boundary,
+        # which is why the adapter has to have delivered usage BEFORE this.
+        await transport.request_cancel("r1")
+        yield ("chunk", {"content": "more", "type": "text"})
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", fake_agent_events)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.run_core.run_service.mark_terminal", _track_terminal
+    )
+
+    await run_core.execute_run(_spec())
+
+    assert [m["status"] for m in marked] == ["cancelled"]
+    assert marked[0]["usage"]["input_tokens"] == 1200
+
+
+# ---------------------------------------------------------------------------
+# latest-wins, floored (N1)
+# ---------------------------------------------------------------------------
+
+
+async def test_a_shrinking_payload_cannot_halve_the_bill(monkeypatch):
+    """Every backend emits RUN-CUMULATIVE usage, so keeping the LATEST payload
+    is right. The floor is what makes that safe: a payload smaller than the one
+    already held can only be a regression, and it must not be able to overwrite
+    a bill downward."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    async def _persist_stub(spec, ctx, full_text, attachments, usage=None):
+        return "assistant-msg-1"
+
+    async def fake_agent_events(spec, ctx):
+        yield ("chunk", {"content": "hi", "type": "text"})
+        yield ("token_usage", dict(_USAGE_META))
+        # A regressed adapter reports a single turn instead of the run total.
+        yield ("token_usage", {**_USAGE_META, "input_tokens": 10, "output_tokens": 1})
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", fake_agent_events)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _persist_stub)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+
+    await run_core.execute_run(_spec())
+
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    end = events[-1]
+    assert end.event == "stream_end"
+    assert end.data["usage"]["input_tokens"] == 1200
+
+
+async def test_a_growing_payload_replaces_the_one_before_it(monkeypatch):
+    """The floor must not freeze the bill at the first payload — cumulative
+    usage grows, and the LAST (largest) snapshot is the run's real total."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    async def _persist_stub(spec, ctx, full_text, attachments, usage=None):
+        return "assistant-msg-1"
+
+    async def fake_agent_events(spec, ctx):
+        yield ("chunk", {"content": "hi", "type": "text"})
+        yield ("token_usage", {**_USAGE_META, "input_tokens": 100, "output_tokens": 10})
+        yield ("token_usage", {**_USAGE_META, "input_tokens": 900, "output_tokens": 80})
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", fake_agent_events)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _persist_stub)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+
+    await run_core.execute_run(_spec())
+
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    assert events[-1].data["usage"]["input_tokens"] == 900
+
+
+def test_the_run_loops_total_agrees_with_the_meters():
+    """``_usage_total`` mirrors ``metering.service._total_tokens`` on purpose —
+    the floor decides which payload gets BILLED, so it has to rank payloads the
+    same way the biller measures them. Two definitions that drift would let a
+    payload the meter thinks is bigger lose to one it thinks is smaller."""
+    from pocketpaw_ee.cloud.metering.service import _total_tokens
+
+    payloads = [
+        {},
+        {"input_tokens": 10},
+        {"input_tokens": 10, "output_tokens": 5, "cached_input_tokens": 3},
+        {"total_tokens": 999, "input_tokens": 1},
+        {"model": "m", "backend": "b"},
+        {"input_tokens": 0, "output_tokens": 0, "cached_input_tokens": 0},
+        {"input_tokens": "12", "output_tokens": None},
+    ]
+    for p in payloads:
+        assert run_core._usage_total(p) == _total_tokens(p), p

--- a/tests/mutations/partial_usage_capture.json
+++ b/tests/mutations/partial_usage_capture.json
@@ -1,0 +1,113 @@
+[
+  {
+    "label": "the run's usage ledger is never handed to the SDK, so an abnormal run has nothing to report and a cancel is free again",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            kwargs[\"usage\"] = run_usage",
+    "replace": "            pass",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_usage_reaches_a_consumer_that_walks_away_mid_run",
+      "tests/test_pydantic_ai_backend.py::test_a_stopped_run_still_reports_the_tokens_it_burned"
+    ]
+  },
+  {
+    "label": "usage is reported only when the run reaches its terminal event — the pre-fix behaviour, where every cancel and stop() billed zero",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            if total <= emitted_total:\n                return None",
+    "replace": "            if True:\n                return None",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_usage_reaches_a_consumer_that_walks_away_mid_run",
+      "tests/test_pydantic_ai_backend.py::test_a_stopped_run_still_reports_the_tokens_it_burned",
+      "tests/test_pydantic_ai_backend.py::test_a_run_that_dies_mid_response_still_bills_that_response"
+    ]
+  },
+  {
+    "label": "the crashed run emits its usage AFTER the error frame — the run loop stops reading at the error, so the payload is discarded and the bill is zero",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            snapshot = _usage_snapshot()\n            if snapshot is not None:\n                yield snapshot\n            yield AgentEvent(type=\"error\", content=self._explain_error(exc))",
+    "replace": "            yield AgentEvent(type=\"error\", content=self._explain_error(exc))\n            snapshot = _usage_snapshot()\n            if snapshot is not None:\n                yield snapshot",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_a_run_that_dies_mid_response_still_bills_that_response"
+    ]
+  },
+  {
+    "label": "a failed run stops recording usage — the crashed-run half of the three terminal states that could never carry it",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "                status=\"failed\",\n                partial_text=full_text,\n                error=err_msg,\n                usage=usage or None,",
+    "replace": "                status=\"failed\",\n                partial_text=full_text,\n                error=err_msg,",
+    "tests": [
+      "tests/cloud/runs/test_run_core_token_usage.py::test_a_failed_run_carries_the_tokens_it_burned"
+    ]
+  },
+  {
+    "label": "an interrupted run stops recording usage — a host cancel (worker shutdown) writes a terminal doc with no counts and the sweeper bills it zero",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "            status=\"interrupted\",\n            partial_text=full_text,\n            usage=usage or None,",
+    "replace": "            status=\"interrupted\",\n            partial_text=full_text,",
+    "tests": [
+      "tests/cloud/runs/test_run_core_token_usage.py::test_an_interrupted_run_carries_the_tokens_it_burned"
+    ]
+  },
+  {
+    "label": "latest-wins loses its floor, so a payload that shrank (a backend regressed to per-turn reporting) silently overwrites a larger bill downward",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "                        if _usage_total(event_data) >= _usage_total(usage):",
+    "replace": "                        if True:",
+    "tests": [
+      "tests/cloud/runs/test_run_core_token_usage.py::test_a_shrinking_payload_cannot_halve_the_bill"
+    ]
+  },
+  {
+    "label": "the run-loop total stops counting cached tokens, so it ranks payloads differently from the meter that bills them",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "        + _usage_int(usage.get(\"output_tokens\"))\n        + _usage_int(usage.get(\"cached_input_tokens\"))",
+    "replace": "        + _usage_int(usage.get(\"output_tokens\"))",
+    "tests": [
+      "tests/cloud/runs/test_run_core_token_usage.py::test_the_run_loops_total_agrees_with_the_meters"
+    ]
+  },
+  {
+    "label": "codex reports its per-turn counts again instead of the run total — the run loop keeps the LATEST payload, so a multi-turn run bills for its final turn alone",
+    "file": "src/pocketpaw/agents/codex_cli.py",
+    "find": "                            \"input_tokens\": run_input,\n                            \"output_tokens\": run_output,\n                            \"cached_input_tokens\": run_cached,",
+    "replace": "                            \"input_tokens\": int(getattr(usage, \"input_tokens\", 0) or 0),\n                            \"output_tokens\": int(getattr(usage, \"output_tokens\", 0) or 0),\n                            \"cached_input_tokens\": int(getattr(usage, \"cached_input_tokens\", 0) or 0),",
+    "tests": [
+      "tests/test_codex_cli_backend.py::TestCodexCLIEventMapping::test_multi_turn_usage_is_run_cumulative"
+    ]
+  },
+  {
+    "label": "copilot reports one API call's tokens instead of the run total — assistant.usage is per call, so a multi-call turn bills for one call",
+    "file": "src/pocketpaw/agents/copilot_sdk.py",
+    "find": "                                    \"input_tokens\": _run_input,\n                                    \"output_tokens\": _run_output,",
+    "replace": "                                    \"input_tokens\": int(input_t),\n                                    \"output_tokens\": int(output_t),",
+    "tests": [
+      "tests/test_copilot_sdk_backend.py::TestCopilotUsageCardinality::test_usage_is_run_cumulative_across_api_calls"
+    ]
+  },
+  {
+    "label": "the OSS loop records each cumulative payload whole into an ADDITIVE tracker, so a run that reports twice counts its first turn again in the second",
+    "file": "src/pocketpaw/agents/loop.py",
+    "find": "                            d_input = max(0, input_tokens - recorded_input)\n                            d_output = max(0, output_tokens - recorded_output)",
+    "replace": "                            d_input = input_tokens\n                            d_output = output_tokens",
+    "tests": [
+      "tests/test_agent_loop.py::test_cumulative_token_usage_is_recorded_as_a_delta"
+    ]
+  },
+  {
+    "label": "the status tracker adds each cumulative payload whole again, so the per-session token counters double-count every turn after the first",
+    "file": "src/pocketpaw/status.py",
+    "find": "                s.token_input += max(0, cum_input - s._last_cum_input)\n                s.token_output += max(0, cum_output - s._last_cum_output)",
+    "replace": "                s.token_input += cum_input\n                s.token_output += cum_output",
+    "tests": [
+      "tests/test_status_tracker.py::TestStatusTracker::test_token_usage_folds_in_a_run_total_without_double_counting"
+    ]
+  },
+  {
+    "label": "the trace collector stores the running total in every llm_calls row, so the total_cost roll-up (a plain sum over those rows) charges the whole run once per payload",
+    "file": "src/pocketpaw/trace_collector.py",
+    "find": "                input_tokens = max(0, input_tokens - prev_input)\n                output_tokens = max(0, output_tokens - prev_output)",
+    "replace": "                input_tokens = input_tokens\n                output_tokens = output_tokens",
+    "tests": [
+      "tests/test_trace_collector.py::test_cumulative_token_usage_becomes_one_entry_per_call"
+    ]
+  }
+]

--- a/tests/mutations/partial_usage_capture.json
+++ b/tests/mutations/partial_usage_capture.json
@@ -109,5 +109,32 @@
     "tests": [
       "tests/test_trace_collector.py::test_cumulative_token_usage_becomes_one_entry_per_call"
     ]
+  },
+  {
+    "label": "hard-cancel recovery is removed — a run cancelled mid-response loses the tokens that response already burned, because no later event exists to carry a snapshot out",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            if snapshot is not None:\n                yield snapshot\n            raise",
+    "replace": "            raise",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_a_hard_cancel_still_delivers_the_usage_it_had"
+    ]
+  },
+  {
+    "label": "the cancel handler widens to BaseException, so it also catches GeneratorExit and yields under it — turning every early break into RuntimeError out of the consumer's aclose()",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        except asyncio.CancelledError:",
+    "replace": "        except BaseException:",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_an_early_break_does_not_crash_the_consumers_aclose"
+    ]
+  },
+  {
+    "label": "the structured cache lines are dropped, so the meter reads the payload as OpenAI-shaped and prices the UNCACHED REMAINDER as the whole prompt — every cached turn underbills",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "                \"cache_read_tokens\": savings.cache_read_tokens,\n                \"cache_write_tokens\": savings.cache_write_tokens,",
+    "replace": "",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_a_cancelled_run_is_priced_under_the_same_convention_as_a_completed_one"
+    ]
   }
 ]

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,6 +1,12 @@
 # Tests for Unified Agent Loop
 # Updated for AgentEvent-based architecture (no more dict chunks)
 #
+# Updated: 2026-09-02 (fix/metering-partial-usage-capture) —
+# ``test_cumulative_token_usage_is_recorded_as_a_delta`` pins that the loop
+# records the DIFFERENCE between token_usage payloads. The payloads are the
+# run's running total and ``usage_tracker.record`` is additive, so recording
+# them whole counted turn 1 again in every later payload.
+#
 # Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the loop now calls
 # ``AgentContextBuilder.assemble_system_prompt`` (which returns text AND the
 # prompt's ``stable_digest``) instead of ``build_system_prompt``, so every stub
@@ -1532,3 +1538,98 @@ async def test_router_stop_failure_logged_as_warning(
     assert any("router" in m.lower() or "stop" in m.lower() for m in warning_messages), (
         "router.stop() failure must be logged at WARNING level"
     )
+
+
+@patch("pocketpaw.agents.loop.get_message_bus")
+@patch("pocketpaw.agents.loop.get_memory_manager")
+@patch("pocketpaw.agents.loop.AgentContextBuilder")
+@patch("pocketpaw.agents.loop.AgentRouter")
+@pytest.mark.asyncio
+async def test_cumulative_token_usage_is_recorded_as_a_delta(
+    mock_router_cls,
+    mock_builder_cls,
+    mock_get_memory,
+    mock_get_bus,
+    mock_bus,
+    mock_memory,
+):
+    """``token_usage`` payloads are RUN-CUMULATIVE and ``usage_tracker.record``
+    is ADDITIVE, so handing it each payload whole counts turn 1 again in every
+    later payload.
+
+    This was latent while every backend reported once per run. It stopped being
+    latent when ``pydantic_ai`` began reporting as the run progresses — which it
+    has to, because the cloud run loop abandons a cancelled run's stream and
+    never sees a payload produced at the end.
+    """
+    mock_get_bus.return_value = mock_bus
+    mock_get_memory.return_value = mock_memory
+
+    token_router = MagicMock()
+
+    async def mock_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
+        for in_tok, out_tok, cost in ((100, 20, 0.001), (350, 60, 0.004)):
+            yield AgentEvent(
+                type="token_usage",
+                content="",
+                metadata={
+                    "backend": "pydantic_ai",
+                    "model": "claude-3-haiku",
+                    "input_tokens": in_tok,
+                    "output_tokens": out_tok,
+                    "cached_input_tokens": 0,
+                    "total_cost_usd": cost,
+                },
+            )
+        yield AgentEvent(type="done", content="")
+
+    token_router.run = mock_run
+    token_router.stop = AsyncMock()
+    mock_router_cls.return_value = token_router
+
+    mock_builder_instance = mock_builder_cls.return_value
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
+
+    recorded = []
+
+    class _Tracker:
+        def record(self, **kwargs):
+            recorded.append(kwargs)
+
+        def get_stats(self, *a, **k):
+            return MagicMock(total_cost_usd=0.0)
+
+    with (
+        patch("pocketpaw.agents.loop.get_settings") as mock_settings,
+        patch("pocketpaw.agents.loop.Settings") as mock_settings_cls,
+        patch("pocketpaw.usage_tracker.get_usage_tracker", return_value=_Tracker()),
+    ):
+        settings = MagicMock()
+        settings.agent_backend = "pydantic_ai"
+        settings.max_concurrent_conversations = 5
+        mock_settings.return_value = settings
+        mock_settings_cls.load.return_value = settings
+
+        loop = AgentLoop()
+        await loop._process_message(
+            InboundMessage(
+                channel=Channel.CLI,
+                sender_id="user1",
+                chat_id="chat1",
+                content="Tokens please",
+            )
+        )
+
+    assert len(recorded) == 2, f"expected one record per payload, got {recorded}"
+    # Turn 1 whole...
+    assert recorded[0]["input_tokens"] == 100
+    assert recorded[0]["output_tokens"] == 20
+    # ...then only what turn 2 ADDED, not the cumulative 350/60.
+    assert recorded[1]["input_tokens"] == 250
+    assert recorded[1]["output_tokens"] == 40
+    # The run total is the sum of the deltas, and it is the real total.
+    assert sum(r["input_tokens"] for r in recorded) == 350
+    assert sum(r["output_tokens"] for r in recorded) == 60
+    assert recorded[1]["total_cost_usd"] == pytest.approx(0.003)

--- a/tests/test_codex_cli_backend.py
+++ b/tests/test_codex_cli_backend.py
@@ -1,5 +1,11 @@
 """Tests for Codex CLI backend — SDK-driven, mocked.
 
+Updated 2026-09-02 (fix/metering-partial-usage-capture) —
+``test_multi_turn_usage_is_run_cumulative`` pins that ``token_usage`` reports the
+RUN total rather than the last turn's, and
+``test_the_usage_accumulator_does_not_leak_between_runs`` pins that the counters
+are per-run locals (one backend instance serves every run on its agent).
+
 We mock ``Codex.start_thread`` to return a fake Thread whose
 ``run_streamed`` yields typed SDK events
 (``ItemStartedEvent``/``ItemCompletedEvent``/``TurnCompletedEvent`` with
@@ -556,6 +562,71 @@ class TestCodexCLIRun:
         assert usage_evts[0].metadata["output_tokens"] == 25
         assert usage_evts[0].metadata["cached_input_tokens"] == 50
         assert usage_evts[0].metadata["backend"] == "codex_cli"
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_usage_is_run_cumulative(self):
+        """Codex reports usage PER TURN and a run can complete several.
+
+        Every other backend reports a RUN total, and the cloud run loop keeps
+        the LATEST payload rather than summing — right for the others, and it
+        billed a multi-turn Codex run for its final turn alone. Summing in the
+        run loop instead would have over-billed the other backends by the length
+        of the conversation, so the accumulator belongs here.
+        """
+        from openai_codex_sdk import TurnCompletedEvent
+        from openai_codex_sdk.types import Usage
+
+        from pocketpaw.agents.codex_cli import CodexCLIBackend
+
+        backend = CodexCLIBackend(Settings())
+        events = [
+            TurnCompletedEvent(
+                type="turn.completed",
+                usage=Usage(input_tokens=100, output_tokens=25, cached_input_tokens=50),
+            ),
+            TurnCompletedEvent(
+                type="turn.completed",
+                usage=Usage(input_tokens=300, output_tokens=40, cached_input_tokens=10),
+            ),
+        ]
+        ctx, _ = _patch_codex(events)
+        with ctx:
+            out = [e async for e in backend.run("test")]
+
+        usage_evts = [e for e in out if e.type == "token_usage"]
+        assert len(usage_evts) == 2
+        # Turn 1 alone...
+        assert usage_evts[0].metadata["input_tokens"] == 100
+        # ...then the RUN total, not turn 2's 300.
+        assert usage_evts[-1].metadata["input_tokens"] == 400
+        assert usage_evts[-1].metadata["output_tokens"] == 65
+        assert usage_evts[-1].metadata["cached_input_tokens"] == 60
+
+    @pytest.mark.asyncio
+    async def test_the_usage_accumulator_does_not_leak_between_runs(self):
+        """``AgentPool`` caches ONE backend instance per agent and drives every
+        run through it, so per-run state kept on ``self`` bills one run for
+        another's tokens. The counters are locals in ``run`` for the same reason
+        this backend's siblings hold per-run cancellation in a private handle."""
+        from openai_codex_sdk import TurnCompletedEvent
+        from openai_codex_sdk.types import Usage
+
+        from pocketpaw.agents.codex_cli import CodexCLIBackend
+
+        backend = CodexCLIBackend(Settings())
+        event = TurnCompletedEvent(
+            type="turn.completed",
+            usage=Usage(input_tokens=100, output_tokens=25, cached_input_tokens=50),
+        )
+
+        for _ in range(2):
+            ctx, _ = _patch_codex([event])
+            with ctx:
+                out = [e async for e in backend.run("test")]
+            usage_evts = [e for e in out if e.type == "token_usage"]
+            assert usage_evts[-1].metadata["input_tokens"] == 100, (
+                "the second run inherited the first run's tokens"
+            )
 
     @pytest.mark.asyncio
     async def test_handles_error_item(self):

--- a/tests/test_copilot_sdk_backend.py
+++ b/tests/test_copilot_sdk_backend.py
@@ -1,4 +1,10 @@
-"""Tests for Copilot SDK backend — mocked (no real CLI/SDK needed)."""
+"""Tests for Copilot SDK backend — mocked (no real CLI/SDK needed).
+
+Updated 2026-09-02 (fix/metering-partial-usage-capture) — ``TestCopilotUsageCardinality``
+pins that ``token_usage`` reports the RUN total. ``assistant.usage`` is emitted
+per LLM API call and one turn makes several, so without the accumulator a
+multi-call turn billed for one call.
+"""
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -602,3 +608,60 @@ class TestCopilotSDKRegistry:
 
         backends = list_backends()
         assert "copilot_sdk" in backends
+
+
+class TestCopilotUsageCardinality:
+    """``assistant.usage`` is emitted PER LLM API CALL — the SDK's own payload
+    carries ``apiCallId``, ``duration`` and ``ttft_ms``, which only mean anything
+    per call — and one agent turn makes several.
+
+    Every consumer of ``token_usage`` reads a payload as the RUN's running total
+    (the cloud run loop keeps the latest; the OSS loop, the status tracker and
+    the trace collector fold in the difference), so the per-call numbers have to
+    be accumulated here or a multi-call run bills for one call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_usage_is_run_cumulative_across_api_calls(self):
+        backend, mock_session, _ = _setup_backend_with_mock_client()
+        _wire_events(
+            mock_session,
+            [
+                _make_sdk_event("assistant.usage", input_tokens=100, output_tokens=20),
+                _make_sdk_event("assistant.usage", input_tokens=300, output_tokens=40),
+                _make_sdk_event("session.idle"),
+            ],
+        )
+
+        events = []
+        async for event in backend.run("Hi"):
+            events.append(event)
+
+        usage = [e for e in events if e.type == "token_usage"]
+        assert len(usage) == 2
+        assert usage[0].metadata["input_tokens"] == 100
+        # The RUN total, not the second call's 300.
+        assert usage[-1].metadata["input_tokens"] == 400
+        assert usage[-1].metadata["output_tokens"] == 60
+
+    @pytest.mark.asyncio
+    async def test_the_usage_accumulator_does_not_leak_between_runs(self):
+        """One backend instance serves every run on its agent, so a counter kept
+        on ``self`` would bill one run for another's tokens."""
+        backend, mock_session, _ = _setup_backend_with_mock_client()
+
+        for _ in range(2):
+            _wire_events(
+                mock_session,
+                [
+                    _make_sdk_event("assistant.usage", input_tokens=100, output_tokens=20),
+                    _make_sdk_event("session.idle"),
+                ],
+            )
+            events = []
+            async for event in backend.run("Hi"):
+                events.append(event)
+            usage = [e for e in events if e.type == "token_usage"]
+            assert usage[-1].metadata["input_tokens"] == 100, (
+                "the second run inherited the first run's tokens"
+            )

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -1591,6 +1591,116 @@ def test_a_missing_response_does_not_lose_the_token_counts():
 
 
 # --------------------------------------------------------------------------
+# usage on the runs that never reach AgentRunResultEvent
+#
+# ``AgentRunResultEvent`` is the last event of a COMPLETED run, so while it was
+# the only producer of ``token_usage`` here, every cancel / stop() / crash
+# reported no usage at all and the meter faithfully billed it zero.
+# --------------------------------------------------------------------------
+
+
+async def test_usage_reaches_a_consumer_that_walks_away_mid_run():
+    """The cloud run loop does not ask this backend to stop on a cancel — it
+    stops READING. ``_drive_agent_loop`` breaks on the cancel flag and its
+    ``finally`` cancels the pending ``__anext__``, so nothing produced after
+    that moment is delivered.
+
+    That is why usage is emitted AS the run consumes it rather than on the way
+    out: a payload built only at the end cannot bill a cancelled run no matter
+    where it is built. Yielding from a ``finally`` is not an escape either — the
+    OSS loop closes this generator (``agents/loop.py`` ``run_iter.aclose()``)
+    and yielding under GeneratorExit raises ``RuntimeError``.
+    """
+    seen = []
+    async for ev in _search_backend("c1").run("search for pocketpaw"):
+        seen.append(ev)
+        if ev.type == "tool_result":
+            break  # the consumer walks away, exactly like the cancel path
+
+    usage = [e for e in seen if e.type == "token_usage"]
+    assert usage, f"nothing was delivered before the consumer stopped: {[e.type for e in seen]}"
+    assert usage[-1].metadata["input_tokens"] > 0
+    assert usage[-1].metadata["backend"] == "pydantic_ai"
+
+
+async def test_a_stopped_run_still_reports_the_tokens_it_burned():
+    """``stop()`` was a free-usage path: the loop broke out and the run ended on
+    a bare ``done``."""
+    backend = _search_backend("c1")
+    seen = []
+    async for ev in backend.run("search for pocketpaw"):
+        seen.append(ev)
+        if ev.type == "tool_result":
+            await backend.stop()
+
+    kinds = [e.type for e in seen]
+    assert kinds[-1] == "done"
+    usage = [e for e in seen if e.type == "token_usage"]
+    assert usage, f"a stopped run reported no usage at all: {kinds}"
+    assert usage[-1].metadata["input_tokens"] > 0
+
+
+async def test_a_run_that_dies_mid_response_still_bills_that_response():
+    """A provider dying part-way through a response is the ordinary crash, and it
+    is not free: pydantic-ai folds a cut-short response's tokens into the run's
+    usage before the exception propagates.
+
+    No completed response means no mid-run snapshot fired, so the payload here
+    comes from the crash path itself — and it has to arrive BEFORE the ``error``
+    frame, because the cloud run loop treats ``error`` as terminal and stops
+    reading the stream at it. A payload emitted after it is thrown away.
+    """
+
+    async def stream_fn(messages: list[ModelMessage], info: AgentInfo):
+        yield "partial answer "
+        raise RuntimeError("proxy died mid-response")
+
+    events = await _collect(_backend_with_model(FunctionModel(stream_function=stream_fn)), "go")
+    kinds = [e.type for e in events]
+
+    assert "error" in kinds
+    usage_at = [i for i, k in enumerate(kinds) if k == "token_usage"]
+    assert usage_at, f"a run that died mid-response reported no usage at all: {kinds}"
+    assert usage_at[-1] < kinds.index("error"), f"usage must precede the error frame: {kinds}"
+
+    usage = events[usage_at[-1]]
+    assert usage.metadata["input_tokens"] > 0, "the prompt it already paid for must be billed"
+
+
+async def test_usage_payloads_are_run_cumulative_and_never_shrink():
+    """Consumers keep the LATEST payload (the cloud run loop) or fold in its
+    DIFFERENCE (``agents/loop.py``, ``status.py``, ``trace_collector.py``). Both
+    read a payload as the run's running total, so the sequence has to grow."""
+    events = await _collect(_search_backend("c1"), "search for pocketpaw")
+    totals = [
+        e.metadata["input_tokens"] + e.metadata["output_tokens"]
+        for e in events
+        if e.type == "token_usage"
+    ]
+    assert len(totals) >= 2, f"expected a mid-run snapshot and a final total, got {totals}"
+    assert totals == sorted(totals), f"payloads must never shrink: {totals}"
+
+
+def test_the_abnormal_path_names_the_model_the_run_resolved():
+    """No mid-stream event carries a model name — the event union is parts,
+    tools and enqueued messages only — so an abnormal-path payload falls back to
+    the RESOLVED model. The completed path still reads it off the response,
+    which stays the truthful source there."""
+    from pydantic_ai.usage import RunUsage
+
+    event = PydanticAIBackend(_settings())._usage_event_from(
+        RunUsage(input_tokens=500, output_tokens=120),
+        model_name="claude-haiku-4-5-20251001",
+    )
+
+    assert event.type == "token_usage"
+    assert event.metadata["model"] == "claude-haiku-4-5-20251001"
+    assert event.metadata["input_tokens"] == 500
+    assert event.metadata["output_tokens"] == 120
+    assert event.metadata["total_cost_usd"] > 0
+
+
+# --------------------------------------------------------------------------
 # tool bridge
 # --------------------------------------------------------------------------
 

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -1681,6 +1681,99 @@ async def test_usage_payloads_are_run_cumulative_and_never_shrink():
     assert totals == sorted(totals), f"payloads must never shrink: {totals}"
 
 
+async def test_a_hard_cancel_still_delivers_the_usage_it_had():
+    """A consumer that cancels a pending ``__anext__`` still receives the run's
+    usage, and the cancel still propagates afterwards.
+
+    This covers the one case the in-run snapshots cannot reach: usage that
+    advanced with no further event behind it to carry a snapshot out. Yielding
+    from the ``except CancelledError`` handler delivers the value to that
+    cancelled await before the exception resumes.
+    """
+    started = asyncio.Event()
+
+    async def stream_fn(messages: list[ModelMessage], info: AgentInfo):
+        yield "partial "
+        started.set()
+        await asyncio.sleep(30)  # cancelled here, mid-response
+        yield "never"
+
+    gen = _backend_with_model(FunctionModel(stream_function=stream_fn)).run("go")
+
+    received = []
+    received.append(await gen.__anext__())
+
+    # The pending pull is what drives the model into its mid-response wait, so
+    # it has to exist BEFORE we wait on the event — otherwise nothing advances.
+    pending = asyncio.create_task(gen.__anext__())
+    await asyncio.wait_for(started.wait(), timeout=5)
+    await asyncio.sleep(0.1)
+    pending.cancel()
+    try:
+        received.append(await pending)
+    except asyncio.CancelledError:
+        pass
+
+    usage = [e for e in received if getattr(e, "type", None) == "token_usage"]
+    assert usage, f"a hard cancel delivered no usage: {[getattr(e, 'type', e) for e in received]}"
+    assert usage[-1].metadata["input_tokens"] > 0
+
+
+async def test_an_early_break_does_not_crash_the_consumers_aclose():
+    """The reason usage is NOT emitted from a ``finally:``.
+
+    ``agents/loop.py`` closes this generator on every early break. A generator
+    that yields while GeneratorExit is propagating raises ``RuntimeError: async
+    generator ignored GeneratorExit`` out of that ``aclose()`` — trading a
+    billing gap for a crash on a path that today merely under-bills. The cancel
+    handler is deliberately narrow (``CancelledError``, not ``BaseException``)
+    so GeneratorExit passes through untouched.
+    """
+    gen = _search_backend("c1").run("search for pocketpaw")
+
+    async for _ev in gen:
+        break  # walk away mid-stream, exactly as the OSS loop can
+
+    await gen.aclose()  # must not raise
+
+
+async def test_a_cancelled_run_is_priced_under_the_same_convention_as_a_completed_one():
+    """The meter reads a payload's CONVENTION off its own shape: one carrying
+    ``cache_read_tokens`` / ``cache_write_tokens`` is Anthropic-shaped and its
+    ``input_tokens`` is the UNCACHED REMAINDER, anything else is OpenAI-shaped
+    and ``input_tokens`` already includes the cached subset.
+
+    So a partial run must emit the SAME shape as a completed one, or the same
+    tokens get priced under two different conventions depending only on how the
+    run ended. Every path here builds the payload through one function, and this
+    is what keeps that true.
+    """
+    from pocketpaw_ee.cloud.metering.service import _prompt_tokens
+
+    completed = [
+        e.metadata
+        for e in await _collect(_search_backend("c1"), "search for pocketpaw")
+        if e.type == "token_usage"
+    ][-1]
+
+    partial = None
+    async for ev in _search_backend("c1").run("search for pocketpaw"):
+        if ev.type == "token_usage":
+            partial = ev.metadata
+        if ev.type == "tool_result":
+            break
+
+    assert partial is not None
+    assert sorted(partial) == sorted(completed), "a partial run emitted a different payload shape"
+    # Both must land on the Anthropic branch — the one that reads input_tokens
+    # as the uncached remainder. Emitting the inclusive total instead would make
+    # the meter add the cache lines a second time and overbill.
+    for name, payload in (("completed", completed), ("partial", partial)):
+        assert "cache_read_tokens" in payload and "cache_write_tokens" in payload, name
+        inclusive, read, write = _prompt_tokens(payload)
+        assert inclusive == payload["input_tokens"] + read + write, name
+
+
 def test_the_abnormal_path_names_the_model_the_run_resolved():
     """No mid-stream event carries a model name — the event union is parts,
     tools and enqueued messages only — so an abnormal-path payload falls back to

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -1747,7 +1747,12 @@ async def test_a_cancelled_run_is_priced_under_the_same_convention_as_a_complete
     tokens get priced under two different conventions depending only on how the
     run ended. Every path here builds the payload through one function, and this
     is what keeps that true.
+
+    Skipped on an OSS-only install: the meter it asserts against lives in
+    ``pocketpaw_ee``, and the OSS lane does not install it.
     """
+    pytest.importorskip("pocketpaw_ee", reason="pocketpaw-ee not installed")
+
     from pocketpaw_ee.cloud.metering.service import _prompt_tokens
 
     completed = [

--- a/tests/test_status_tracker.py
+++ b/tests/test_status_tracker.py
@@ -1,4 +1,12 @@
-"""Tests for StatusTracker."""
+"""Tests for StatusTracker.
+
+Updated 2026-09-02 (fix/metering-partial-usage-capture) —
+``test_token_usage_accumulates`` became
+``test_token_usage_folds_in_a_run_total_without_double_counting``. It asserted
+that two payloads SUM, which encoded the old contract: payloads are
+RUN-CUMULATIVE, so the second already contains the first and summing them showed
+300 input tokens for a run that used 200.
+"""
 
 import pytest
 
@@ -85,7 +93,16 @@ class TestStatusTracker:
         snap = tracker.snapshot()
         assert snap["sessions"][0]["state"] == "waiting_for_user"
 
-    async def test_token_usage_accumulates(self, tracker):
+    async def test_token_usage_folds_in_a_run_total_without_double_counting(self, tracker):
+        """``token_usage`` payloads are RUN-CUMULATIVE, so the tracker folds in
+        the DIFFERENCE between them rather than each payload whole.
+
+        It used to add each payload whole, and that was right only while every
+        backend reported exactly once per run. It does not survive a backend
+        that reports as the run goes: the second payload below already contains
+        the first, so summing them showed 300 input tokens for a run that
+        actually used 200.
+        """
         await tracker._on_event(SystemEvent(event_type="agent_start", data={"session_key": "ws:1"}))
         await tracker._on_event(
             SystemEvent(
@@ -100,7 +117,26 @@ class TestStatusTracker:
             )
         )
         snap = tracker.snapshot()
-        assert snap["sessions"][0]["token_usage"] == {"input": 300, "output": 130}
+        assert snap["sessions"][0]["token_usage"] == {"input": 200, "output": 80}
+
+    async def test_a_shrinking_token_payload_is_not_a_refund(self, tracker):
+        """A payload smaller than the one before it can only be a backend
+        regression. It must not walk the counters backwards."""
+        await tracker._on_event(SystemEvent(event_type="agent_start", data={"session_key": "ws:1"}))
+        await tracker._on_event(
+            SystemEvent(
+                event_type="token_usage",
+                data={"session_key": "ws:1", "input": 900, "output": 80},
+            )
+        )
+        await tracker._on_event(
+            SystemEvent(
+                event_type="token_usage",
+                data={"session_key": "ws:1", "input": 10, "output": 1},
+            )
+        )
+        snap = tracker.snapshot()
+        assert snap["sessions"][0]["token_usage"] == {"input": 900, "output": 80}
 
     async def test_max_concurrent_in_snapshot(self, tracker):
         snap = tracker.snapshot()

--- a/tests/test_trace_collector.py
+++ b/tests/test_trace_collector.py
@@ -1,4 +1,10 @@
-"""Tests for TraceCollector event aggregation."""
+"""Tests for TraceCollector event aggregation.
+
+Updated 2026-09-02 (fix/metering-partial-usage-capture) — ``token_usage``
+payloads are RUN-CUMULATIVE, so each ``llm_calls`` row stores the difference
+from what the trace already holds. The ``total_cost_usd`` roll-up is a plain sum
+over those rows, so storing payloads whole charged the run once per payload.
+"""
 
 from __future__ import annotations
 
@@ -127,3 +133,83 @@ async def test_trace_collector_aggregates_and_persists_trace(tmp_path):
     assert trace["total"]["tool_count"] == 1
     assert trace["outbound"]["chunks_count"] == 2
     assert trace["llm_calls"][0]["input_tokens"] == 100
+
+
+@pytest.mark.asyncio
+async def test_cumulative_token_usage_becomes_one_entry_per_call(tmp_path):
+    """``token_usage`` payloads are the RUN's running total, so each entry stores
+    the DIFFERENCE from what the trace already holds.
+
+    Storing them whole would put a running total in every ``llm_calls`` row —
+    and, worse, the ``total_cost`` roll-up is a plain sum over those rows, so it
+    would charge the whole run once per payload.
+    """
+    store = TraceStore(root=tmp_path / "traces")
+    collector = TraceCollector(store=store)
+
+    trace_id = "trace_cumulative_1"
+    session_key = "cli:chat1"
+
+    await collector._on_event(
+        SystemEvent(
+            event_type="trace_start",
+            data={
+                "trace_id": trace_id,
+                "session_key": session_key,
+                "started_at": "2026-04-20T10:00:00+00:00",
+                "inbound": {
+                    "channel": "cli",
+                    "chat_id": "chat1",
+                    "sender_id": "user1",
+                    "timestamp": "2026-04-20T10:00:00+00:00",
+                },
+            },
+        )
+    )
+
+    for in_tok, out_tok, cached, cost in ((100, 20, 10, 0.001), (350, 60, 30, 0.004)):
+        await collector._on_event(
+            SystemEvent(
+                event_type="token_usage",
+                data={
+                    "trace_id": trace_id,
+                    "session_key": session_key,
+                    "backend": "pydantic_ai",
+                    "model": "claude-3-haiku",
+                    "input_tokens": in_tok,
+                    "output_tokens": out_tok,
+                    "cached_input_tokens": cached,
+                    "total_cost_usd": cost,
+                },
+            )
+        )
+
+    await collector._on_event(
+        SystemEvent(
+            event_type="trace_end",
+            data={
+                "trace_id": trace_id,
+                "session_key": session_key,
+                "status": "ok",
+                "reason": "completed",
+                "outbound": {
+                    "channel": "cli",
+                    "timestamp": "2026-04-20T10:00:05+00:00",
+                    "chunks_count": 1,
+                },
+            },
+        )
+    )
+
+    trace = await store.get_trace(trace_id)
+    calls = trace["llm_calls"]
+    assert len(calls) == 2
+    assert calls[0]["input_tokens"] == 100
+    # Only what the second payload ADDED, not its cumulative 350.
+    assert calls[1]["input_tokens"] == 250
+    assert calls[1]["output_tokens"] == 40
+    assert calls[1]["cached_input_tokens"] == 20
+    # The roll-up sums the rows, so it must equal the run's real total.
+    assert sum(c["input_tokens"] for c in calls) == 350
+    assert trace["total"]["total_cost_usd"] == pytest.approx(0.004)
+    assert trace["total"]["llm_call_count"] == 2


### PR DESCRIPTION
**Stacked on #2037 (`fix/metering-dated-pricing`). Merge that first.** This branch builds on its `price_run` / `resolve_cost(at=...)` / `run_moment` work and will show that commit until #2037 lands.

A run only paid its way if it finished. Cancel it, kill the worker, or have the provider die mid-response, and the tokens were still spent but the bill came out at zero. Three separate things had to line up for that, and all three are fixed here.

## What was wrong

**A failed or interrupted run never persisted usage.** `mark_terminal(status="failed", ...)` was called without `usage=`, and `_handle_interrupted_cleanup` did not take the parameter at all. `metering/sweeper.py` deliberately bills all four terminal states ("a partial run consumed tokens too") — three of them simply had nothing to bill. Only `cancelled` ever passed usage.

**`pydantic_ai` only reported usage on the terminal event.** The `token_usage` event was produced from `AgentRunResultEvent`, which is the last event of a *completed* run. Every cancel, `stop()` and crash emitted nothing, so with the above, cancelling was a free-usage path.

**`codex_cli` reported per-turn counts into a latest-wins reader.** The run loop keeps the newest payload rather than summing, which is correct for the backends that report a run total and wrong for the one that did not: a multi-turn Codex run was billed for its final turn alone.

## What changed

The run owns a `RunUsage` ledger handed to `run_stream_events`. pydantic-ai does not copy it — `Agent.iter` passes the same instance into `GraphAgentState` — and accumulates into it in place after each completed model response and again for a response whose stream was cut mid-flight. The adapter keeps the reference, so the counts stay readable however the run ends.

Usage is emitted **as the run consumes it**, not on the way out, and that is not a style preference. The cloud run loop does not ask the backend to stop on a cancel; it stops reading. `_drive_agent_loop` breaks on the cancel flag and its `finally` cancels the pending `__anext__`, so anything produced after that moment is discarded no matter where it is produced.

Every backend now emits run-cumulative payloads, `codex_cli` and `copilot_sdk` via new accumulators, and every consumer reads them under that contract: the cloud run loop keeps the largest, and `agents/loop.py`, `status.py` and `trace_collector.py` fold in the difference.

Latest-wins keeps a floor. `_usage_total` mirrors `metering.service._total_tokens` deliberately, because the function that decides which payload is kept has to rank payloads the way the biller measures them; a test pins the two against each other so the copy cannot drift. `>=` rather than `>` so an equal-volume payload still replaces, which keeps a later payload's better metadata and makes two zero-token payloads behave as plain latest-wins.

## Where the event is emitted from, and why it matters

This was the subtlest part, so it is spelled out. Three exit shapes, three different answers, each measured before it was written.

**Not from `finally:`.** `agents/loop.py:1712` calls `run_iter.aclose()` on every early break, and a generator that yields while `GeneratorExit` is propagating raises `RuntimeError: async generator ignored GeneratorExit` **out of that `aclose()`**. That trades a billing gap for a crash on a path which today merely under-bills. `test_an_early_break_does_not_crash_the_consumers_aclose` pins it.

**From `except CancelledError:`, and never `except BaseException:`.** A consumer that cancels a pending `__anext__` *does* receive a value yielded from the cancel handler, and the `CancelledError` resumes propagating afterwards — so the cancel is delivered, not swallowed. That recovers the one case the in-run snapshots cannot reach: a response cut off mid-flight, where usage advanced but no later event exists to carry a snapshot out. Measured at 50 input tokens that were previously lost.

The clause is narrow on purpose. `GeneratorExit` is a *sibling* of `CancelledError`, not a subclass, so it stays uncaught here — which is exactly what keeps the `aclose()` path safe. Widening it to `BaseException` reintroduces the crash above, and a mutation that makes that one-word change is caught by the early-break test.

**Before the `error` frame on the crash path**, because the run loop treats `error` as terminal and stops reading there.

## Payload shape: deliberately not normalised

`metering/service._prompt_tokens` reads a payload's convention off its own shape. A payload carrying `cache_read_tokens` / `cache_write_tokens` is **Anthropic-shaped** and its `input_tokens` is the **uncached remainder**; anything else is **OpenAI-shaped** and `input_tokens` already includes the cached subset.

So `pydantic_ai` keeps emitting the uncached remainder plus both cache lines, and `codex_cli` keeps `input_tokens` inclusive with no cache lines. Making the two uniform would be the tempting cleanup and it would be a billing bug in both directions: switching `pydantic_ai` to the inclusive total makes the meter add the cache lines a second time and **overbill**, and dropping its cache lines flips it to the OpenAI branch so the remainder is priced as the whole prompt and it **underbills**. Both directions now have a mutation.

The partial paths matter here too: a cancelled run must emit the *same shape* as a completed one, or identical tokens are priced under two conventions depending only on how the run ended. Every path builds the payload through one function (`_usage_event_from`), and `test_a_cancelled_run_is_priced_under_the_same_convention_as_a_completed_one` asserts the key sets match and both land on the Anthropic branch.

## Scope beyond the three defects

Making payloads cumulative turns two latent double-counts into live ones, so three more files changed. `status.py` was adding each payload whole to its per-session counters. `trace_collector.py` was storing each payload as an `llm_calls` row whose `total_cost_usd` roll-up is a plain sum over those rows — it would have charged the whole run once per payload. And `copilot_sdk` turned out to be a **second** per-turn backend: `assistant.usage` is emitted per LLM API call, its payload carrying `apiCallId`, `duration` and `ttft_ms`.

`agents/loop.py`'s `usage_tracker.record()` is additive and was handed each payload whole. That was harmless while every backend reported once per run and stops being harmless the moment one reports as it goes, so it now records the delta.

`test_token_usage_accumulates` in `test_status_tracker.py` asserted two payloads sum to 300. That encoded the old contract, so it is renamed and asserts 200 — the run's real total — with the reasoning in the docstring rather than a silent number change.

## Verification

**Mutations.** `mutate.py --validate` reports **864 anchors across 69 plans**, up from 849/68 — 15 new anchors, one new plan. **No existing anchor needed re-pointing**, including the 15 in `pydantic_ai_metering.json` that sit in the function this PR restructured; splitting `_usage_event` into `_usage_event_from` moved only the two model-name lines into the caller and left every anchored line byte-identical.

- `partial_usage_capture.json` — **all 15 caught**
- `pydantic_ai_metering.json` — **all 15 still caught**, so none stopped testing its stated property

One escaped on the first run: the mutation moving the crash-path payload after the `error` frame. The test used a two-turn model whose mid-run snapshot had already reported the total, making the ordering unobservable. It now uses a model that dies mid-response, where the crash path is the only emitter — which also demonstrates the point of the ledger, since pydantic-ai bills a response cut mid-flight and those tokens used to be lost.

**Tests that cover this change**, run explicitly and in full — `tests/cloud/runs/`, `tests/cloud/metering/`, `tests/cloud/credits/`, `cloud/test_agent_chat_schemas.py`, and every non-cloud file referencing `token_usage`, `mark_terminal`, `usage_tracker` or `price_run` (`test_pydantic_ai_backend`, `test_codex_cli_backend`, `test_copilot_sdk_backend`, `test_agent_loop`, `test_status_tracker`, `test_trace_collector`, `test_trace_integration`, `test_usage_tracker`, `test_analytics_gap_fixes`, `test_deep_agents_anthropic_cache`):

| | base `64a64876` | this branch |
|---|---|---|
| targeted suites | 3 failed, 612 passed | **3 failed, 633 passed** |

Same three failures on both sides — `test_run_core.py::test_execute_run_marks_cloud_chat_run_for_jail_fail_closed`, `::test_execute_run_threads_surface_meta_into_ctx` (a stale `capturing_prewarm` stub that predates `flow_context`), and `test_pydantic_ai_backend.py::test_local_machine_tools_are_never_offered`, which passes alone and in its own file and fails only in a cross-file batch, identically at both commits.

633 − 612 = **21**, and collection counts agree independently: non-cloud 10763 → 10778 (+15) and cloud 9519 → 9525 (+6). Those 21 are exactly the tests added here, enumerated by diffing the two collection lists; the only removal is the renamed `test_token_usage_accumulates`.

The rest of the cloud tree cannot reach this code — nothing outside runs, metering and credits touches `token_usage` or `mark_terminal`.

**Full-suite runs** were also done before the targeted method was agreed, and they are reported because they are stronger, not because they were required:

| suite | base | this branch |
|---|---|---|
| `tests/` (non-cloud) | 48 failed | **48 failed, 10680 passed, 47 skipped** |
| `tests/cloud` | 195 failed, 9202 passed | **193 failed, 9210 passed** |

The non-cloud failure lists are **byte-identical**, and the 48 sit in six files this PR does not touch: `test_herdr_runtime.py` (26, no `herdr` binary), `test_code_mode_runner.py` (10), `test_code_mode_bridge.py` (8), `foresight/test_substrate.py` (2), `test_multitenant_session_isolation.py` (1, a Unix file mode on Windows) and `test_context_budget.py` (1). On the cloud side **no test fails here that does not also fail on the base** — `comm -13` on the sorted lists is empty; the two that fail on base and pass here are `livekit/test_call_budget.py`, which is flaky for the reason below. Three cloud files are excluded from that number and each was checked at both commits: `test_api_contracts.py` and `test_e2e_api.py` error identically (pymongo, no live Mongo), and `test_herdr_cockpit.py` passes in isolation at both (14 passed in 1.4s) but hangs inside the full suite.

## One thing worth knowing for local runs

`tests/ee/test_livekit_service.py` passes while leaking a real `pocketpaw_ee.cloud.livekit.agent` subprocess, and that child starves the rest of the run — measured at one test per six minutes with it alive, versus **816 tests in 45 seconds** after killing it. It is pre-existing and unrelated to this PR, but it is what makes a full local run look hung.
