### PR TITLE
Only a paying site gets a visitor counter

### DIFF
--- a/docs/api/configuration-reference.mdx
+++ b/docs/api/configuration-reference.mdx
@@ -9,6 +9,13 @@ tags: ["api", "configuration"]
 
 {/*
   docs/api/configuration-reference.mdx
+  Updated 2026-09-02 (feat/sites-analytics-gate, SA-2) — added the "Paw Sites —
+  visitor analytics" section with PAW_SITES_ANALYTICS_DISABLED (the operator kill
+  switch SA-2 introduces) and PAW_SITES_ANALYTICS_DATASET (which SA-1 shipped
+  undocumented). They are the first entries in this file with NO settings field:
+  the Paw Sites deploy path reads its configuration from the environment directly,
+  so the lead sentence above no longer claims every variable carries the
+  POCKETPAW_ prefix.
   Updated 2026-08-03 (feat/prompt-bulk-retrieval, PA-8a) — added the "Prompt
   Assembly" section with prompt_pocket_summary_only, the default-off switch that
   moves bulk pocket widget detail out of the system prompt and onto the
@@ -20,7 +27,7 @@ tags: ["api", "configuration"]
 
 # Configuration Reference
 
-Complete reference of all configuration settings. All environment variables use the `POCKETPAW_` prefix.
+Complete reference of all configuration settings. Environment variables backed by a settings field use the `POCKETPAW_` prefix. The Paw Sites deploy knobs at the end are the exception — they are read straight from the process environment and carry no settings field.
 
 ## Core Settings
 
@@ -242,3 +249,26 @@ The pocket specialist does NOT receive Composio — its tool surface stays narro
 | Setting | Env Variable | Type | Default | Description |
 |---------|-------------|------|---------|-------------|
 | `fabric_source_truth_mode` | `POCKETPAW_FABRIC_SOURCE_TRUTH_MODE` | enum | `off` | Rollout mode for Fabric source truth (`off`, `shadow`, `enforce`). `off` = pure last-writer-wins, no statements. `shadow` = provenance statements + divergence log lines recorded alongside the LWW cache. `enforce` = the trust-ladder resolver's winner owns the cache. Gate the flip to `enforce` with `python -m pocketpaw.fabric.divergence_report` — see [Fabric Source Truth](/concepts/architecture#fabric-source-truth). |
+
+## Paw Sites — visitor analytics
+
+A published Paw Site on a paid per-site tier carries a small generated Cloudflare
+Worker that records one Analytics Engine row per pageview. These two variables are
+the deploy-side knobs for it.
+
+Both are read **straight from the process environment** and have no `POCKETPAW_`
+settings field, so the Setting column below is empty. That is deliberate: the Paw
+Sites deploy path reads its Cloudflare configuration (`PAW_CF_*`) from the
+environment directly rather than through the settings object, and these ride the
+same seam. The rest of the `PAW_SITES_*` and `PAW_CF_*` deploy variables are not
+catalogued here yet.
+
+Both take effect **at the next publish**. Neither one rewrites a site that is
+already deployed: the config and the counter are written into the project at publish
+time, so a site keeps whatever it was last published with until it is published
+again.
+
+| Setting | Env Variable | Type | Default | Description |
+|---------|-------------|------|---------|-------------|
+| — | `PAW_SITES_ANALYTICS_DISABLED` | boolean | unset (off) | **Operator kill switch.** Truthy (`1`, `true`, `yes`, `on`; case-insensitive) makes the next publish of **every** site emit the pre-analytics config shape: no `main`, no Analytics Engine binding, no `run_worker_first` rules, and no generated counter file. Paid sites included — it overrides the plan entitlement, it does not consult it. It exists for one failure: if the Cloudflare account is on the **Workers Free plan**, a `main` in the request path starts consuming a 100,000 request/day ceiling that is **account-wide**, and breaching that stops Cloudflare serving the Workers behind it rather than degrading analytics. Every published site goes dark together, so the mitigation has to be faster than a code change and a release. Already-deployed sites keep counting until they are republished, so pulling this switch during an incident means republishing the affected sites. Any other value, including `0` and `false`, leaves analytics on. |
+| — | `PAW_SITES_ANALYTICS_DATASET` | string | `paw_site_pageviews` | The Cloudflare Analytics Engine dataset the counter writes into. One dataset for all sites, partitioned by site id in `indexes[0]` — Analytics Engine is queried by index, and a dataset per site would need provisioning per site for no gain. Override it so a dev or staging publish cannot pollute the production dataset. An empty or whitespace-only value falls back to the default rather than emitting an empty dataset name, which wrangler accepts and Cloudflare does not. Changing it does not migrate existing rows: sites published against the old dataset keep writing there until they are republished, and Analytics Engine retains data for three months. |

--- a/ee/pocketpaw_ee/cloud/billing/site_plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/site_plans.py
@@ -124,6 +124,13 @@
 # paid selections as the free floor — the exact failure the 2026-08-22 rekey note
 # above describes. Per-site subscriptions already sold stay live and keep
 # renewing through the product half; only NEW purchases take the add-on rail.
+#
+# Updated 2026-09-02 (feat/sites-analytics-gate, SA-2): added
+# ``ANALYTICS_FEATURE`` — the name of the ``cloudflare_features`` member that
+# gates the visitor pageview counter. No new rule and no new column: the tiers
+# that resell ``analytics`` are the ones this catalog has listed since the pricing
+# ladder landed. What is new is that a seam finally READS it, so the string needs
+# a home other than a literal retyped at each caller. See its own comment.
 
 from __future__ import annotations
 
@@ -166,6 +173,22 @@ _SITE_PLAN_SCOPE: dict[str, str] = {
     "studio": ORG_SCOPE,
     "agency": ORG_SCOPE,
 }
+
+# The ``cloudflare_features`` member that gates VISITOR ANALYTICS: the pageview
+# counter a published site carries (``sites.analytics_worker``, SA-1). Named here
+# rather than spelled as a literal at the seams, because more than one seam asks
+# the same question — the PUBLISH path decides whether to deploy a counter at all
+# (SA-2), and the read endpoint decides whether a site's numbers may be served
+# (SA-4). A literal retyped at each of them is one typo away from a free site that
+# counts, or a paid one that does not.
+#
+# It names a member of ``_SITE_PLAN_CF_FEATURES`` below, which is deliberately
+# still written as literals — that dict is the declarative catalog and reads best
+# flat. ``tests/ee/sites/test_sites_analytics_gate.py`` pins the pairing, so a
+# rename of one without the other fails there rather than silently entitling
+# nobody: every other test in that file goes through this constant and would keep
+# passing against a catalog that no longer mentions the feature at all.
+ANALYTICS_FEATURE = "analytics"
 
 # The Cloudflare features each tier resells (BC-10 provisions them on publish).
 # A higher tier is a superset of the one below it.
@@ -673,6 +696,7 @@ def site_scoped_tier(key: str | None) -> SitePlanTier | None:
 
 
 __all__ = [
+    "ANALYTICS_FEATURE",
     "BASE_SITE_PLAN_KEY",
     "ORG_SCOPE",
     "SITE_SCOPE",

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -65,6 +65,15 @@
 #   to the free floor exactly as an unknown key does. The same call also resolves
 #   the LEGACY basic/pro/business keys, which is what stops the rekey demoting every
 #   already-published site the day it deploys.
+# Updated 2026-09-02 (feat/sites-analytics-gate, SA-2): added
+#   ``site_analytics_entitled`` — "may this site's visitors be counted", the gate
+#   the publish path reads before it deploys a pageview counter and the read
+#   endpoint will read before it serves the numbers. A module-level PURE function
+#   beside ``site_domain_allowance`` rather than a field on ``SiteEntitlements``,
+#   for the reason that function's own docstring gives: more than one seam asks it,
+#   and one of them (the deploy) holds two strings rather than a resolved
+#   entitlements object. Keeping it a function is what makes both seams able to
+#   share the single predicate instead of each re-deriving it.
 
 from __future__ import annotations
 
@@ -185,6 +194,48 @@ def site_domain_allowance(*, plan_tier: str | None, subscription_status: str | N
     if tier is not None and _subscription_is_active(subscription_status):
         allowance = tier.max_domained_sites
     return allowance
+
+
+def site_analytics_entitled(*, plan_tier: str | None, subscription_status: str | None) -> bool:
+    """May THIS site have its visitors counted?
+
+    THE ONE PREDICATE for visitor analytics, and public for that reason. Two seams
+    ask it and they must never disagree: the PUBLISH path (SA-2) decides whether
+    the deployed config carries a pageview counter at all, and the read endpoint
+    (SA-4) decides whether a site's numbers may be served. A site whose publish
+    counted but whose read refuses is a customer paying for a blank chart; the
+    reverse serves numbers a site was never entitled to gather.
+
+    Pure and synchronous over the site's two billing fields, exactly like
+    ``site_domain_allowance`` beside it, so the caller that owns the ``Site``
+    document passes what it owns (EE cloud rule 2 — ``entitlements`` may not import
+    ``models.site``).
+
+    A PAID grant, not a floor one, and the difference is money rather than tidiness.
+    A Worker invocation is billed and a static asset is not, so counting a free
+    site's traffic spends real money against no revenue — the cost has to track the
+    plan. The consequence is that upgrading does not backfill: a site's history
+    begins at the publish that first carried a counter, because nothing was
+    recorded before it. That is a product decision, and it belongs on screen rather
+    than in a docstring.
+
+    Tier AND active subscription, the same conjunction every other paid capability
+    here uses. Reading the tier alone is the bug this module exists to prevent —
+    cancellation leaves ``plan_tier`` on the paid key, and an unconfigured Dodo
+    product records a paid tier that was never charged at all.
+
+    Fails closed on every unknown. ``site_scoped_tier`` returns None for a missing
+    key, an unrecognised one, and an ORG-scoped key that has no business on a single
+    site; all three land on False.
+    """
+    tier = site_plan_catalog.site_scoped_tier(plan_tier)
+    if tier is None or not _subscription_is_active(subscription_status):
+        return False
+    # Read off the RESOLVED catalog row rather than the raw feature map, so the
+    # legacy key aliases (``pro`` → ``site``) resolve here exactly as they do for
+    # the badge and the domain allowance. A site whose document still holds a
+    # pre-rekey key is entitled to what it has always paid for.
+    return site_plan_catalog.ANALYTICS_FEATURE in tier.cloudflare_features
 
 
 def resolve_site_entitlements(

--- a/ee/pocketpaw_ee/sites/analytics_worker.py
+++ b/ee/pocketpaw_ee/sites/analytics_worker.py
@@ -6,6 +6,17 @@
 # Created 2026-09-02 (feat/sites-analytics-counter, SA-1). Slice 1 of Paw Sites
 # visitor analytics: an ``html`` site counts a real pageview, queryable by site id.
 #
+# Updated 2026-09-02 (feat/sites-analytics-gate, SA-2) — NOT EVERY SITE COUNTS ANY
+# MORE, and this module gained the two functions that say so. SA-1 wired the counter
+# onto every assets-only publish regardless of who was paying; a Worker invocation is
+# billed and a static asset is not, so that spent money on free sites. The gate is
+# ``counting_enabled(entitled=...)``, and its two halves are deliberately separate:
+# the per-site entitlement is resolved by ``entitlements.site_analytics_entitled``
+# at the publish seam (the only layer that can see a ``Site`` document), while the
+# operator kill switch ``PAW_SITES_ANALYTICS_DISABLED`` lives here and is global.
+# When counting is off the emitted config is the PRE-ANALYTICS one, byte for byte,
+# and no entry is written — see ``workers_deploy._wrangler_jsonc``.
+#
 # SHAPE MIRRORS ``badge.py`` / ``paw_bar/embed.py`` — a per-site injection into the
 # artifact between build and deploy, so what lands is already correct and there is no
 # second deploy and no post-publish patch. What differs is WHAT is injected: those two
@@ -92,14 +103,24 @@
 # before and after a republish on the same day counts twice. That is the safe
 # direction (over-splitting, never over-linking) and a republish is rare.
 #
-# ONE RESIDUAL EXPOSURE, stated rather than left to be discovered. The Cloudflare
-# deploy is not the only thing that serves a project dir: ``sites.local_server``
-# copies the WHOLE dir and serves it, deploy scaffold included, for the local target
-# and for previews. It already serves ``wrangler.jsonc`` that way; after a workers
-# publish into the same working dir it would serve this entry too, salt and all. That
-# server is loopback, so the reach is a developer's own machine rather than the
-# internet — but the fix, if it is ever wanted, belongs there (an ``ignore`` on the
-# copytree that skips the scaffold) and not here.
+# THE RESIDUAL EXPOSURE SA-1 NAMED HERE IS CLOSED (SA-2). The Cloudflare deploy is
+# not the only thing that serves a project dir: ``sites.local_server`` copies the
+# WHOLE dir and serves it, deploy scaffold included, for the local target. It already
+# served ``wrangler.jsonc`` that way, and after a workers publish into the same
+# per-pocket working dir it would have served this entry too, salt and all. The reach
+# was loopback — a developer's own machine rather than the internet — but the salt is
+# exactly what makes the visitor hash irreversible, so it does not get to leak on a
+# technicality. ``local_server.persist_site`` now passes an ``ignore`` to that
+# copytree, which is where SA-1 said the fix belonged.
+#
+# THE STALE-ENTRY CASE, which the gate created and which is handled in
+# ``workers_deploy``. A site that publishes paid and then publishes free reuses the
+# same working dir, so an entry written by the earlier publish is still sitting
+# there. The free config names no ``main``, so wrangler would upload that leftover as
+# a plain asset — the salt, downloadable, from a config that mentions nothing.
+# ``_write_deploy_files`` therefore DELETES the entry whenever counting is off, and
+# the ``.assetsignore`` keeps listing it unconditionally as the second line of
+# defence.
 #
 # ── THE ANALYTICS ENGINE ROW ──────────────────────────────────────────────────
 #
@@ -150,6 +171,28 @@ DATASET_BINDING = "PAW_ANALYTICS"
 _DEFAULT_DATASET = "paw_site_pageviews"
 _DATASET_ENV = "PAW_SITES_ANALYTICS_DATASET"
 
+# THE KILL SWITCH. Set it and the very next publish emits the pre-analytics config
+# again — no ``main``, no dataset binding, no routing rules, and no generated entry
+# on disk — for every site, paid ones included.
+#
+# It exists for ONE failure mode, and the mitigation has to be faster than a deploy
+# because of what that failure does. If this Cloudflare account turns out to be on
+# the Workers FREE plan, a config carrying a ``main`` starts drawing on a 100,000
+# request/day ceiling that is ACCOUNT-WIDE, and breaching it does not degrade
+# analytics — Cloudflare stops serving the Workers behind it. Every published site
+# goes dark together. A code change plus a release is minutes at best; an
+# environment variable plus a republish is the length of one publish.
+#
+# The value is read at PUBLISH time, not at import, so setting it takes effect for
+# the next publish without restarting anything that is already running.
+_DISABLED_ENV = "PAW_SITES_ANALYTICS_DISABLED"
+
+# The truthy spellings, matching ``sites.service``'s own env flags. A kill switch
+# read with ``bool(os.environ.get(...))`` would fire on ``=0`` and ``=false``, which
+# is the wrong direction to be surprising in — an operator who explicitly writes
+# "false" must not silently disable the feature.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
 # Page suffixes the route enumeration walks — the same pair ``badge.py`` and
 # ``paw_bar/embed.py`` treat as pages, so a file that earns a badge is a file that
 # earns a pageview.
@@ -189,6 +232,34 @@ def dataset_name() -> str:
     not.
     """
     return os.environ.get(_DATASET_ENV, "").strip() or _DEFAULT_DATASET
+
+
+def counting_disabled() -> bool:
+    """Is the operator kill switch set? See ``_DISABLED_ENV`` for what it is for.
+
+    Separate from ``counting_enabled`` below so a test — and an operator reading a
+    log line — can tell "this site is not entitled" apart from "counting is off
+    everywhere". They call for completely different responses.
+    """
+    return os.environ.get(_DISABLED_ENV, "").strip().lower() in _TRUTHY
+
+
+def counting_enabled(*, entitled: bool) -> bool:
+    """Does THIS publish carry a pageview counter?
+
+    The whole decision in one place: the site's plan entitles it AND the operator
+    has not pulled the switch. Both halves have to be false-able independently —
+    the entitlement is per site and answers to billing, the switch is global and
+    answers to an incident — but the config builder needs one boolean, and deriving
+    it at each call site is how the two halves eventually stop agreeing.
+
+    ``entitled`` is resolved by ``entitlements.site_analytics_entitled`` at the
+    publish seam, which is the only layer that can see a ``Site`` document. This
+    module deliberately does not resolve it: it would have to reach across into the
+    cloud billing layer to do so, and a generator of Worker source is the wrong
+    place to decide who is paying.
+    """
+    return entitled and not counting_disabled()
 
 
 def _clean_url(rel_posix: str, suffix: str) -> str:
@@ -371,6 +442,8 @@ __all__ = [
     "DATASET_BINDING",
     "ENTRY_FILENAME",
     "build_entry_js",
+    "counting_disabled",
+    "counting_enabled",
     "dataset_name",
     "run_worker_first_rules",
 ]

--- a/ee/pocketpaw_ee/sites/local_server.py
+++ b/ee/pocketpaw_ee/sites/local_server.py
@@ -59,6 +59,15 @@
 # P0a fix ``bun run build`` always runs, so a missing build dir should no longer
 # happen on the normal path — this is a defensive backstop, not the happy path.
 #
+# Updated 2026-09-02 (feat/sites-analytics-gate, SA-2 — the copy skips the deploy
+# scaffold): ``persist_site`` copied the whole static-output tree, and for an html site
+# that tree IS the project root, so it took ``wrangler.jsonc``, ``.assetsignore`` and —
+# once SA-1 landed — the generated analytics entry along with the pages, then served
+# all three. The entry carries the per-publish salt the visitor hash is built on, which
+# is the thing making that hash irreversible; loopback reach lowers the stakes but does
+# not change the direction. The copytree now takes an ``ignore``. See
+# ``_DEPLOY_SCAFFOLD_NAMES``.
+#
 # Design:
 #   * One server per process, rooted at the sites home (~/.pocketpaw/sites by
 #     default, override with PAW_SITES_LOCAL_DIR). A request for /<site_id>/
@@ -87,10 +96,33 @@ from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import urlsplit
 
-from pocketpaw_ee.sites import artifact_preview
+from pocketpaw_ee.sites import analytics_worker, artifact_preview
 from pocketpaw_ee.sites.engines import resolve_static_output_rel
 
 logger = logging.getLogger(__name__)
+
+# The DEPLOY SCAFFOLD — files ``workers_deploy`` writes into a project so wrangler can
+# ship it. None of them is site content, and ``persist_site`` copies right past them
+# into a tree this server hands out as plain static files.
+#
+# The generated counter entry is the one that made this a control rather than a tidy-up
+# (SA-2). It carries the per-publish salt the visitor hash is built on, and a salt an
+# attacker can read turns that hash into a confirmation oracle: given a candidate IP
+# and user-agent, recompute and compare. The reach here is loopback — a developer's own
+# machine, not the internet — which lowers the stakes without changing the direction.
+# A workers publish and a local publish share the pocket's working dir, so an entry
+# written by one is sitting there for the other to copy.
+#
+# ``wrangler.jsonc`` and ``.assetsignore`` join it because they are the same kind of
+# thing: deploy plumbing that a visitor to the served site has no business fetching.
+# Cloudflare already excludes all three from what it uploads (the ``.assetsignore``
+# ``workers_deploy`` writes), so this makes the local target agree with the deployed
+# one rather than inventing a new rule.
+_DEPLOY_SCAFFOLD_NAMES = (
+    analytics_worker.ENTRY_FILENAME,
+    "wrangler.jsonc",
+    ".assetsignore",
+)
 
 # The deployable static-output dir, relative to the project dir, is resolved off the
 # ARTIFACT via ``resolve_static_output_rel`` (HE-4 engine-awareness, SL-1 artifact-
@@ -126,14 +158,24 @@ def persist_site(site_id: str, project_dir: str, engine: str = "ripple") -> Path
     and return that dir. Replaces any prior deploy of the same site so a re-publish
     serves fresh content. The source tree is ``resolve_static_output_rel(...)`` —
     ``.svelte-kit/cloudflare`` for ripple and dynamic svelte, ``build`` for a STATIC
-    svelte site (SL-1), the project root for html."""
+    svelte site (SL-1), the project root for html.
+
+    THE DEPLOY SCAFFOLD DOES NOT COME WITH IT (SA-2). For an html site the static
+    output dir IS the project root, so an unfiltered copy takes the wrangler config
+    and the generated analytics entry along with the pages and then serves them. See
+    ``_DEPLOY_SCAFFOLD_NAMES`` for why the entry in particular must not travel.
+
+    ``shutil.ignore_patterns`` matches by NAME at every level rather than only at the
+    copy root, which is what we want: those three names are ours, no site authors a
+    file called any of them, and a nested one would be exactly as wrong as a top-level
+    one."""
     src = Path(project_dir, resolve_static_output_rel(project_dir, engine))
     if not src.is_dir():
         raise FileNotFoundError(f"no built static site at {src}")
     dest = sites_home() / site_id
     if dest.exists():
         shutil.rmtree(dest)
-    shutil.copytree(src, dest)
+    shutil.copytree(src, dest, ignore=shutil.ignore_patterns(*_DEPLOY_SCAFFOLD_NAMES))
     return dest
 
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,24 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-09-02 (feat/sites-analytics-gate, SA-2): the workers deploy now carries
+# whether THIS site's plan buys the visitor pageview counter. SA-1 wired that counter
+# onto every assets-only publish; a Worker invocation is billed where a static asset is
+# not, so a free site was costing money for numbers nobody paid for.
+#
+# The resolution belongs HERE and nowhere lower, because this is the only layer that
+# can see the Site document the plan lives on — ``_site_counts_pageviews`` reads the
+# two billing fields and hands them to ``entitlements.site_analytics_entitled``, which
+# is the single predicate the read endpoint gates on too. The deploy writer defaults to
+# counting, so the gate is worth nothing unless this call is actually made; that is
+# asserted end to end in ``tests/ee/sites/test_sites_analytics_gate.py`` rather than
+# left to the deploy writer's own unit tests, which would pass either way.
+#
+# ``provision_deploy`` (the dynamic lane) passes False outright. It holds a site id and
+# a directory and cannot resolve a plan from either, and a dynamic site's ``main`` is
+# already SvelteKit's own worker — so the honest value is a stated False rather than an
+# inherited default.
+#
 # Updated 2026-09-01 (fix/sites-html-orphan-create): ``edit_html_file`` gains the
 # same ``unreferenced`` verdict, for the same defect on the track where it costs
 # more. An unimported react component is invisible; an unlinked html page is written
@@ -2843,7 +2861,16 @@ async def _deploy_site_doc(
         # HE-4 / RX-1: pass the engine so an html OR react site deploys as an
         # assets-only Worker (no server script — react builds, but to a prerendered
         # static dist/), while ripple/svelte keep the SvelteKit-worker config.
-        url = await deploy_w(site_id, build.project_dir, engine=engine)
+        #
+        # SA-2: and pass whether this site's plan buys the visitor counter. Resolved
+        # HERE rather than defaulted in the deployer, because this is the only layer
+        # that can see the Site document the plan lives on — a Worker invocation is
+        # billed where a static asset is not, so a free site must deploy the config
+        # that ships no Worker at all.
+        counts_pageviews = await _site_counts_pageviews(workspace_id=workspace_id, site_id=site_id)
+        url = await deploy_w(
+            site_id, build.project_dir, engine=engine, analytics_entitled=counts_pageviews
+        )
     else:  # "wfp"
         cf = cloudflare or _cf_client()
         bundle = bundle_reader(build.project_dir)
@@ -3202,6 +3229,44 @@ async def _stamp_free_badge(
         len(changed),
         site_id,
     )
+
+
+async def _site_counts_pageviews(*, workspace_id: str, site_id: str) -> bool:
+    """May this site's visitors be counted? Resolved from its OWN per-site plan.
+
+    The publish path's read of ``entitlements.site_analytics_entitled`` (SA-2), which
+    is where the RULE lives — this function only fetches the two billing fields that
+    predicate takes. The read endpoint (SA-4) calls the same predicate over the same
+    fields, which is the whole reason it is a named function rather than a condition
+    written twice: a site whose publish counted but whose read refuses is a customer
+    paying for a blank chart.
+
+    A SEPARATE DOCUMENT READ from ``_stamp_free_badge``'s, deliberately. Sharing one
+    would mean threading a resolved object through two seams with opposite failure
+    postures — the badge aborts a publish, this one only decides a config key — and
+    this file already reads the doc per question (the concierge embed and the D1 id do
+    the same). One extra ``find_one`` on a path that runs a full site build is not the
+    cost worth trading that clarity for.
+
+    Fails closed on a missing doc, exactly as the badge does and for a related reason.
+    A FIRST publish reaches here before the ``Site`` row is inserted, so "no doc" has
+    to mean "free": ``getattr(None, "plan_tier", None)`` is already that answer. The
+    consequence is a real one and belongs on screen rather than buried here — a site's
+    first publish never counts, and nothing backfills what was not recorded.
+    """
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    doc = await _SiteDoc.find_one({"_id": ObjectId(site_id), "workspace": workspace_id})
+    entitled = entitlements_service.site_analytics_entitled(
+        plan_tier=getattr(doc, "plan_tier", None),
+        subscription_status=getattr(doc, "subscription_status", None),
+    )
+    if not entitled:
+        logger.info(
+            "sites: site %s is not entitled to visitor analytics — deploying with no counter",
+            site_id,
+        )
+    return entitled
 
 
 def _with_deployed_host(allowed_origins: list[str], url: str) -> list[str]:
@@ -4174,8 +4239,15 @@ async def provision_deploy(
     if mode == "workers":
         from pocketpaw_ee.sites import workers_deploy as workers_deploy_mod
 
+        # SA-2 — explicitly NOT counting, rather than riding the deployer's default.
+        # This lane provisions DYNAMIC sites, whose ``main`` is already SvelteKit's own
+        # worker, so no counter can be bolted in front of it from a config key and the
+        # answer is False whatever the plan says. Stating it here means a build that
+        # somehow resolved assets-only on this lane still cannot deploy a counter for a
+        # site whose plan was never consulted — this function holds a site id and a
+        # directory, and cannot resolve one.
         url = await workers_deploy_mod.deploy_workers(
-            site_id, project_dir, d1_database_id=d1_database_id
+            site_id, project_dir, d1_database_id=d1_database_id, analytics_entitled=False
         )
         return url, "workers"
 

--- a/ee/pocketpaw_ee/sites/workers_deploy.py
+++ b/ee/pocketpaw_ee/sites/workers_deploy.py
@@ -45,6 +45,27 @@
 # no counter, because ``main`` there is already SvelteKit's own worker and a second
 # entry cannot be bolted in front of it from a config key. That is a later slice.
 #
+# Updated 2026-09-02 (SA-2 — the gate) — THE COUNTER IS NO LONGER UNCONDITIONAL. SA-1
+# wired it onto every assets-only publish; a Worker invocation is billed and a static
+# asset is not, so that spent money on sites paying nothing. ``_write_deploy_files``
+# now takes ``analytics_entitled`` — the site's plan, resolved at the publish seam by
+# ``entitlements.site_analytics_entitled`` — ANDs it with the operator kill switch
+# ``PAW_SITES_ANALYTICS_DISABLED``, and writes ONE of two shapes.
+#
+# THE OFF SHAPE IS THE PRE-ANALYTICS CONFIG, BYTE FOR BYTE: no ``main``, no dataset
+# binding, no ``run_worker_first``, and an ``assets`` block of nothing but
+# ``directory`` — not even the ``ASSETS`` binding SA-1 added, because there is no
+# entry to bind it for. That exactness is the point of the kill switch rather than a
+# nicety: an operator pulling it in an incident is asking for the config that was
+# proven before analytics existed, and "nearly that config" is not a rollback.
+#
+# The entry file is DELETED, not merely skipped, whenever counting is off. A publish
+# reuses the pocket's working dir, so a site that published paid and then publishes
+# free still has the earlier entry on disk — and with no ``main`` naming it, wrangler
+# uploads it as an ordinary asset and serves the per-publish salt to anyone who asks.
+# The ``.assetsignore`` still lists it on every assets-only publish for the same
+# reason, counting or not.
+#
 # Updated 2026-08-07 (RX-1 — the react engine) — the assets-only branch now keys on
 # ``emits_server_worker(engine)`` instead of ``not needs_node_build(engine)``. Those
 # two questions had the same answer for ripple/svelte/html, so the old condition read
@@ -151,6 +172,13 @@ _ASSETSIGNORE_LINES = ("_worker.js", "_routes.json", "_headers")
 # The entry carries the per-publish salt the visitor hash is built on; served as a
 # public asset it hands out the salt, and the hash stops being irreversible. Removing
 # this line does not break a deploy — it breaks the privacy claim, silently.
+#
+# SA-2 — that line is written on EVERY assets-only publish, including the ones that
+# deploy no counter at all. Naming a file that is not there is a no-op (the same
+# reason both engines share this one list), and the case it covers is real: a site
+# that publishes paid and then free reuses the working dir, so a leftover entry can
+# still be sitting in it. ``_write_deploy_files`` deletes that leftover; this line is
+# what stands if the delete ever stops happening.
 _ASSETS_ONLY_ASSETSIGNORE_LINES = (
     "wrangler.jsonc",
     ".assetsignore",
@@ -219,6 +247,7 @@ def _wrangler_jsonc(
     d1_database_id: str | None = None,
     *,
     project_dir: str | os.PathLike[str],
+    count_pageviews: bool = True,
 ) -> str:
     """The clean wrangler config for a workers.dev deploy (the proven recipe).
 
@@ -230,12 +259,12 @@ def _wrangler_jsonc(
     * html / react / STATIC svelte (no worker emitted) → an ASSETS-ONLY Worker. The
       build output is a static tree with no ``_worker.js``, so the config carries no
       ``nodejs_compat`` and serves ``assets.directory`` (``"."`` for html, ``"dist"``
-      for react, ``build`` for static svelte). SA-1 — it DOES carry a ``main`` now:
-      the generated pageview counter, plus the ``ASSETS`` binding it serves through,
-      the analytics dataset binding, and the ``run_worker_first`` allow-list that
-      keeps stylesheets, scripts, fonts and images off the Worker. The counter is not
-      the SvelteKit worker under another name; ``main`` still never points into the
-      build output.
+      for react, ``build`` for static svelte). SA-1 — it carries a ``main`` WHEN THE
+      SITE COUNTS: the generated pageview counter, plus the ``ASSETS`` binding it
+      serves through, the analytics dataset binding, and the ``run_worker_first``
+      allow-list that keeps stylesheets, scripts, fonts and images off the Worker.
+      The counter is not the SvelteKit worker under another name; ``main`` still
+      never points into the build output.
     * ripple / DYNAMIC svelte (worker emitted) → the SvelteKit Cloudflare worker,
       UNCHANGED. ``main`` points at the worker entry adapter-cloudflare emits INSIDE
       the asset dir (``.svelte-kit/cloudflare``), and
@@ -256,6 +285,20 @@ def _wrangler_jsonc(
     binding — the same binding WfP's ``put_worker`` passes — so a dynamic site's
     remote functions reach their per-tenant database on the FREE tier. Dynamic html is
     out of scope (it has no server runtime), so an html config never carries a binding.
+
+    ``count_pageviews`` (SA-2) picks between the two ASSETS-ONLY shapes: True is the
+    counting config above, False is the PRE-ANALYTICS config byte for byte. It is the
+    already-resolved answer — the site's plan ANDed with the operator kill switch, via
+    ``analytics_worker.counting_enabled`` in ``_write_deploy_files`` — and NOT a
+    question this function re-asks, so there is exactly one place that decides.
+
+    It DEFAULTS TO TRUE, which is worth naming rather than leaving to be discovered.
+    This is a private config builder whose only production caller passes an explicitly
+    resolved value; the default keeps the direct-call tests (and the SA-1 shape they
+    pin) reading as the subject rather than the exception. The gate that actually
+    protects revenue is at the publish seam, and it is asserted end-to-end there — a
+    default here can never be what decides whether a free site counts, because the one
+    caller always passes.
 
     Deliberately still NO Queue bindings. The generator's own wrangler.toml declares
     ``LEADS_QUEUE`` / ``WRITEBACK_QUEUE`` producers, but Cloudflare Queues is a paid
@@ -281,7 +324,29 @@ def _wrangler_jsonc(
     # asset router would send every request, subresources included, through the
     # Worker. ``analytics_worker`` owns the rules and the reasoning; the ``ASSETS``
     # binding is what the entry serves the page through once it has counted.
+    #
+    # SA-2 — ``count_pageviews`` selects between the two shapes, and the FALSE one is
+    # written to be the pre-analytics config EXACTLY: no ``main``, no dataset binding,
+    # no routing rules, and an ``assets`` block of nothing but ``directory``. Not even
+    # the ``ASSETS`` binding, which SA-1 added — a free site's config has no entry to
+    # bind it for, and a spare binding is a difference a byte-for-byte comparison
+    # would find. The two shapes are built as separate literals rather than one dict
+    # with keys popped off it, because "which keys does the un-analytics config have"
+    # is then something a reader can see rather than replay.
     if not resolve_emits_server_worker(project_dir, engine):
+        if not count_pageviews:
+            return (
+                json.dumps(
+                    {
+                        "name": name,
+                        "compatibility_date": "2024-09-23",
+                        "workers_dev": True,
+                        "assets": {"directory": output_rel},
+                    },
+                    indent=2,
+                )
+                + "\n"
+            )
         config: dict[str, object] = {
             "name": name,
             "main": analytics_worker.ENTRY_FILENAME,
@@ -350,6 +415,7 @@ def _write_deploy_files(
     d1_database_id: str | None = None,
     *,
     site_id: str = "",
+    analytics_entitled: bool = True,
 ) -> None:
     """Write the recipe files into the project: an ``.assetsignore`` inside the asset
     dir + the clean ``wrangler.jsonc`` at the project root, and — on the assets-only
@@ -381,7 +447,24 @@ def _write_deploy_files(
     branch, which writes no counter at all. The counter is written REGARDLESS of
     whether the id is empty: skipping it would leave the emitted ``main`` pointing at
     a file that is not there, and wrangler fails a deploy on a missing ``main``. An
-    empty id costs unqueryable rows; the only caller always has a real one."""
+    empty id costs unqueryable rows; the only caller always has a real one.
+
+    ``analytics_entitled`` (SA-2) is the SITE's half of the counting decision, as
+    resolved by ``entitlements.site_analytics_entitled`` at the publish seam. The
+    operator kill switch is the other half and is read here, not passed, because it is
+    global and per-publish: ``analytics_worker.counting_enabled`` ANDs the two, and its
+    answer decides BOTH whether the config names a ``main`` and whether an entry file
+    exists at all. Those two must move together — a config naming an absent ``main``
+    fails the deploy, and an entry with no config naming it is a salt served as a
+    static asset.
+
+    WHEN COUNTING IS OFF THE ENTRY IS DELETED rather than merely not written, and that
+    is not tidiness. A publish reuses the pocket's working dir, so a site that
+    published paid and then publishes free still has the earlier entry on disk. The
+    free config names no ``main``, so wrangler would upload that leftover as an
+    ordinary asset and hand out the per-publish salt from a config that mentions
+    nothing. The ``.assetsignore`` names the entry on EVERY assets-only publish,
+    counting or not, as the second line of defence behind the delete."""
     # SL-1 — RESOLVED against the artifact, not predicted from the engine name. A
     # static svelte site builds on adapter-static: its output is ``build`` and it emits
     # no ``_worker.js``, so it must deploy assets-only exactly as react does. Answering
@@ -400,17 +483,35 @@ def _write_deploy_files(
     emits_worker = resolve_emits_server_worker(project_dir, engine)
     ignore_lines = _ASSETSIGNORE_LINES if emits_worker else _ASSETS_ONLY_ASSETSIGNORE_LINES
     (out_dir / ".assetsignore").write_text("\n".join(ignore_lines) + "\n")
-    if not emits_worker:
+    # SA-2 — the whole counting decision, resolved once and read twice below so the
+    # config and the file on disk can never disagree. The server-worker branch never
+    # counts whatever the plan says: ``main`` there is already SvelteKit's own worker.
+    count_pageviews = not emits_worker and analytics_worker.counting_enabled(
+        entitled=analytics_entitled
+    )
+    entry_path = Path(project_dir, analytics_worker.ENTRY_FILENAME)
+    if count_pageviews:
         # The counter the assets-only config names as ``main``. Written BEFORE the
         # config so a crash between the two leaves a project with no config rather
         # than one naming an entry that isn't there. The salt is minted here, fresh
         # per publish — see the privacy note in ``analytics_worker``.
-        Path(project_dir, analytics_worker.ENTRY_FILENAME).write_text(
+        entry_path.write_text(
             analytics_worker.build_entry_js(site_id=site_id, secret=secrets.token_hex(16)),
             encoding="utf-8",
         )
+    else:
+        # A leftover from an earlier counting publish into this same working dir. The
+        # config about to be written names no ``main``, so an entry left here is a
+        # salt uploaded as an ordinary static asset.
+        entry_path.unlink(missing_ok=True)
     Path(project_dir, _CONFIG_FILENAME).write_text(
-        _wrangler_jsonc(name, engine, d1_database_id, project_dir=project_dir)
+        _wrangler_jsonc(
+            name,
+            engine,
+            d1_database_id,
+            project_dir=project_dir,
+            count_pageviews=count_pageviews,
+        )
     )
 
 
@@ -423,7 +524,12 @@ def _cf_env() -> dict[str, str]:
 
 
 async def deploy_workers(
-    site_id: str, project_dir: str, *, engine: str = "ripple", d1_database_id: str | None = None
+    site_id: str,
+    project_dir: str,
+    *,
+    engine: str = "ripple",
+    d1_database_id: str | None = None,
+    analytics_entitled: bool = True,
 ) -> str:
     """Deploy a Paw Site as a regular Worker on the free workers.dev tier.
 
@@ -447,6 +553,17 @@ async def deploy_workers(
     the emitted config is what keeps that counter off every request that is not a
     page. The server-worker shape is untouched and carries no counter.
 
+    SA-2 — ``analytics_entitled`` says whether THIS site's plan buys the counter, as
+    resolved at the publish seam by ``entitlements.site_analytics_entitled``. False
+    deploys the pre-analytics config: no ``main``, no dataset binding, no routing
+    rules, no entry on disk. The operator kill switch
+    (``PAW_SITES_ANALYTICS_DISABLED``) is ANDed in one layer down and produces the
+    same shape for every site, entitled or not.
+
+    It defaults to True for the same reason ``_wrangler_jsonc``'s does, and with the
+    same caveat: this is the mechanism, the gate is at the publish seam, and the
+    publish seam always passes an explicitly resolved value.
+
     ``d1_database_id`` (DYNAMIC ripple/svelte sites) binds the site's per-tenant D1 as
     ``DB``, so a dynamic site can serve its live data WITHOUT a Workers-for-Platforms
     dispatch namespace (a paid add-on). The D1 must already exist and be migrated — the
@@ -463,7 +580,14 @@ async def deploy_workers(
             "sites.workers_bad_name",
             f"Computed an invalid worker name from site id {site_id!r}.",
         )
-    _write_deploy_files(project_dir, name, engine, d1_database_id, site_id=site_id)
+    _write_deploy_files(
+        project_dir,
+        name,
+        engine,
+        d1_database_id,
+        site_id=site_id,
+        analytics_entitled=analytics_entitled,
+    )
 
     # ``--config`` is REQUIRED, not cosmetic: a dynamic project dir also holds the
     # generator's wrangler.toml (whose queue producers reference queues that do not

--- a/ee/pocketpaw_ee/sites/workers_deploy.py
+++ b/ee/pocketpaw_ee/sites/workers_deploy.py
@@ -464,7 +464,15 @@ def _write_deploy_files(
     free config names no ``main``, so wrangler would upload that leftover as an
     ordinary asset and hand out the per-publish salt from a config that mentions
     nothing. The ``.assetsignore`` names the entry on EVERY assets-only publish,
-    counting or not, as the second line of defence behind the delete."""
+    counting or not, as the second line of defence behind the delete.
+
+    THE DELETE CANNOT FAIL A PUBLISH. It is wrapped, because ``missing_ok`` covers
+    only the missing file and a locked or read-only one raises. Nothing in the
+    analytics path may cost a site its publish, and the ``.assetsignore`` line above
+    is what makes swallowing safe rather than merely convenient. The counter WRITE on
+    the other branch is deliberately NOT wrapped: the config is about to name that
+    file as ``main``, and wrangler fails a deploy on a missing ``main``, so a swallow
+    there would trade a clear error for a confusing one."""
     # SL-1 — RESOLVED against the artifact, not predicted from the engine name. A
     # static svelte site builds on adapter-static: its output is ``build`` and it emits
     # no ``_worker.js``, so it must deploy assets-only exactly as react does. Answering
@@ -503,7 +511,29 @@ def _write_deploy_files(
         # A leftover from an earlier counting publish into this same working dir. The
         # config about to be written names no ``main``, so an entry left here is a
         # salt uploaded as an ordinary static asset.
-        entry_path.unlink(missing_ok=True)
+        #
+        # FAILURE-SOFT, and this is the one delete on the publish path so it is worth
+        # saying why it may swallow. ``missing_ok`` covers only the missing file; a
+        # read-only file, a Windows lock held by another process, and a directory
+        # sitting where the entry should be all raise ``PermissionError`` — and an
+        # unwrapped raise here fails the whole publish of a site that is otherwise
+        # perfectly fine, over analytics the site is not even using.
+        #
+        # Swallowing is safe ONLY because of the line above: ``.assetsignore`` names
+        # the entry on every assets-only publish, and it is written BEFORE this runs.
+        # So a delete that fails leaves the file on disk and still excluded from the
+        # upload, which is the whole point of keeping that line unconditional. Move
+        # the ``.assetsignore`` write after this block and the swallow stops being
+        # safe.
+        try:
+            entry_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning(
+                "sites.workers: could not remove the stale analytics entry at %s — "
+                "publishing anyway; .assetsignore still excludes it from the upload",
+                entry_path,
+                exc_info=True,
+            )
     Path(project_dir, _CONFIG_FILENAME).write_text(
         _wrangler_jsonc(
             name,

--- a/tests/cloud/jobs/test_provision_site.py
+++ b/tests/cloud/jobs/test_provision_site.py
@@ -317,7 +317,12 @@ async def test_workers_mode_deploys_via_wrangler_not_put_worker(
 
     calls: list[dict[str, Any]] = []
 
-    async def _fake_deploy(site_id: str, project_dir: str, *, d1_database_id: str | None = None):
+    # ``**_`` so a keyword the real ``deploy_workers`` grows does not fail this double
+    # for a reason unrelated to what it asserts. SA-2 added ``analytics_entitled``; this
+    # test is about the D1 id reaching the wrangler lane, not about the counter.
+    async def _fake_deploy(
+        site_id: str, project_dir: str, *, d1_database_id: str | None = None, **_: object
+    ):
         calls.append({"site_id": site_id, "d1": d1_database_id, "dir": project_dir})
         return "https://paw-site-x.acct.workers.dev"
 

--- a/tests/ee/sites/test_sites_analytics_gate.py
+++ b/tests/ee/sites/test_sites_analytics_gate.py
@@ -230,6 +230,33 @@ def test_the_entry_is_deleted_when_a_counting_site_publishes_free(tmp_path):
     assert not (project / analytics_worker.ENTRY_FILENAME).exists()
 
 
+def test_a_delete_that_cannot_run_does_not_fail_the_publish(tmp_path):
+    """FAILURE-SOFT ON THE ONE DELETE. ``missing_ok`` covers the absent file and
+    nothing else: a read-only entry, a Windows lock held by another process, and a
+    directory sitting where the entry should be all raise ``PermissionError``. This
+    runs on every free publish, and nothing in the analytics path may cost a site
+    its publish.
+
+    A real directory rather than a patched ``unlink``, because the failure being
+    guarded against is one the filesystem produces, and a patch would prove only
+    that the ``except`` clause names the exception the patch was told to raise. The
+    same condition raises ``PermissionError`` on Windows and ``IsADirectoryError``
+    on POSIX; both are ``OSError``, which is what the wrap catches.
+
+    THE PUBLISH IS STILL SAFE, which is the second half and the reason swallowing
+    is allowed at all: the file survives, and ``.assetsignore`` still names it, so
+    wrangler does not upload it and the salt does not ship."""
+    project = _build_html_project(tmp_path)
+    blocker = project / analytics_worker.ENTRY_FILENAME
+    blocker.mkdir()
+
+    cfg = _write(project, entitled=False)
+
+    assert cfg == PRE_ANALYTICS_HTML_CONFIG
+    assert blocker.is_dir(), "the delete must actually have failed for this to prove anything"
+    assert analytics_worker.ENTRY_FILENAME in (project / ".assetsignore").read_text().splitlines()
+
+
 def test_the_assetsignore_names_the_entry_even_when_nothing_counts(tmp_path):
     """The second line of defence behind that delete. Naming a file that is not there
     costs nothing; not naming one that IS there costs the salt."""

--- a/tests/ee/sites/test_sites_analytics_gate.py
+++ b/tests/ee/sites/test_sites_analytics_gate.py
@@ -1,0 +1,478 @@
+# tests/ee/sites/test_sites_analytics_gate.py — SA-2, the gate in front of the Paw
+# Sites pageview counter: who gets counted, the switch that stops everyone being
+# counted, and the salt that must not reach the local server.
+#
+# Created 2026-09-02 (feat/sites-analytics-gate).
+#
+# SA-1 wired the counter onto EVERY assets-only publish. Cloudflare bills a Worker
+# invocation and serves a static asset for free, so that spent money on sites paying
+# nothing — this file is the proof it no longer does, and the proof rests on three
+# separate claims that are easy to confuse for one another:
+#
+#   1. THE PREDICATE IS RIGHT. ``entitlements.site_analytics_entitled`` is the one
+#      function both the publish (SA-2) and the read endpoint (SA-4) gate on, so its
+#      edges — a lapsed subscription, an org key on a site, a legacy tier name — are
+#      asserted directly rather than only through a deploy.
+#   2. THE PUBLISH PATH ACTUALLY CALLS IT. A correct predicate nothing consults is the
+#      bug this slice exists to fix, and ``_write_deploy_files`` defaults to counting.
+#      So the gate is asserted END TO END through ``sites_service.publish``, where the
+#      Site document and its plan are real. A unit test on the deploy writer alone
+#      would pass just as happily against a publish path that never passed the flag.
+#   3. THE OFF SHAPE IS THE PRE-ANALYTICS SHAPE. Not "close to it" — the kill switch
+#      exists to be pulled during an incident, and a rollback that leaves an unfamiliar
+#      config behind is not a rollback. The config is compared against a literal of the
+#      pre-SA-1 recipe rather than against a list of keys that must be absent.
+#
+# The kill switch's own reason is worth restating where a reader will meet it: if this
+# Cloudflare account turns out to be on the Workers FREE plan, a config carrying a
+# ``main`` draws on a 100,000 request/day ACCOUNT-WIDE ceiling, and breaching it stops
+# sites being served rather than degrading analytics. Every published site goes dark
+# together. The mitigation has to be faster than a deploy, which is why it is an
+# environment variable and why "byte for byte" is a real requirement rather than
+# tidiness.
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.billing import site_plans  # noqa: E402
+from pocketpaw_ee.cloud.entitlements import service as entitlements  # noqa: E402
+from pocketpaw_ee.sites import analytics_worker, local_server, workers_deploy  # noqa: E402
+from pocketpaw_ee.sites import service as sites_service  # noqa: E402
+
+SITE_ID = "507f1f77bcf86cd799439011"
+WORKER_NAME = f"paw-site-{SITE_ID}"
+
+# The exact assets-only config an un-analytics build produced — the pre-SA-1 recipe,
+# transcribed. Written out in full rather than derived, because the whole claim of the
+# kill switch is that it restores THIS and a derivation would restore whatever the
+# current code happens to produce.
+PRE_ANALYTICS_HTML_CONFIG = {
+    "name": WORKER_NAME,
+    "compatibility_date": "2024-09-23",
+    "workers_dev": True,
+    "assets": {"directory": "."},
+}
+
+
+def _build_html_project(tmp_path: Path) -> Path:
+    """A built html site — ``static_output_rel("html")`` is ``"."``, so the static tree
+    IS the project dir. Smaller than SA-1's fixture on purpose: nothing here is about
+    the routing rules, and a second copy of that fixture would drift from it."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "index.html").write_text("<!doctype html><html><body><h1>hi</h1></body></html>")
+    (tmp_path / "about.html").write_text("<!doctype html><html><body><h1>about</h1></body></html>")
+    (tmp_path / "styles.css").write_text("h1{color:#111}")
+    return tmp_path
+
+
+def _write(project: Path, *, entitled: bool) -> dict:
+    """Run the real deploy-file write for an html site and return the parsed config."""
+    workers_deploy._write_deploy_files(
+        str(project), WORKER_NAME, "html", None, site_id=SITE_ID, analytics_entitled=entitled
+    )
+    return json.loads((project / "wrangler.jsonc").read_text())
+
+
+# ── 1. the predicate ─────────────────────────────────────────────────────────
+#
+# Named for what each case COSTS, not for the input it takes, because that is what
+# makes a wrong answer recognisable when one of these goes red.
+
+
+def test_a_free_site_is_not_entitled_to_analytics():
+    """The whole point of the slice. Counting a free site's traffic bills a Worker
+    invocation against no revenue, so the floor tier buys nothing here — unlike the
+    custom-domain allowance, which free genuinely does include."""
+    assert (
+        entitlements.site_analytics_entitled(plan_tier="free", subscription_status="active")
+        is False
+    )
+
+
+def test_a_paid_site_with_an_active_subscription_is_entitled():
+    assert (
+        entitlements.site_analytics_entitled(plan_tier="site", subscription_status="active") is True
+    )
+    assert (
+        entitlements.site_analytics_entitled(plan_tier="staff", subscription_status="active")
+        is True
+    )
+
+
+def test_a_lapsed_paid_site_is_not_entitled():
+    """Cancellation never resets ``plan_tier``, so a cancelled site still reads as
+    ``site``. Gating on the tier alone would keep counting it forever. ``pending`` is
+    the same shape from the other end — a checkout that was opened and never paid."""
+    for status in ("cancelled", "pending", "none", None, ""):
+        assert (
+            entitlements.site_analytics_entitled(plan_tier="site", subscription_status=status)
+            is False
+        ), f"a {status!r} subscription bought analytics"
+
+
+def test_an_unset_or_unknown_tier_is_not_entitled():
+    """Fail closed on every unknown. An absent tier is a site that never chose one; a
+    typo'd or retired key is a document nobody can vouch for. Both are free."""
+    for tier in (None, "", "enterprise", "Site", "analytics"):
+        assert (
+            entitlements.site_analytics_entitled(plan_tier=tier, subscription_status="active")
+            is False
+        ), f"the {tier!r} tier bought analytics"
+
+
+def test_an_org_key_stored_on_a_site_is_not_entitled():
+    """``studio`` and ``agency`` DO resell analytics, and they are still refused here.
+    An org flat is bought once for many sites and its key is not a legal
+    ``Site.plan_tier``, so finding one on a single site means a bug, a hand-edit or a
+    replayed webhook. ``site_scoped_tier`` refuses it, which is what keeps this
+    predicate from reading an org-wide entitlement off one site's field."""
+    for tier in ("studio", "agency"):
+        assert site_plans.ANALYTICS_FEATURE in site_plans.get_site_plan(tier).cloudflare_features
+        assert (
+            entitlements.site_analytics_entitled(plan_tier=tier, subscription_status="active")
+            is False
+        ), f"the org-scoped {tier!r} key entitled a single site"
+
+
+def test_a_legacy_tier_key_still_resolves():
+    """``Site.plan_tier`` holds ``pro`` / ``business`` in production and nothing
+    rewrites a document on read. A site that has been paying since before the 2026-08-22
+    rekey must not lose its analytics for holding the name it was sold under."""
+    assert (
+        entitlements.site_analytics_entitled(plan_tier="pro", subscription_status="active") is True
+    )
+    assert (
+        entitlements.site_analytics_entitled(plan_tier="basic", subscription_status="active")
+        is False
+    )
+
+
+def test_the_catalog_still_pairs_the_feature_name_with_the_paid_tiers():
+    """``ANALYTICS_FEATURE`` names a member of ``_SITE_PLAN_CF_FEATURES``, and the two
+    are written separately — the constant so seams can read it, the map so the catalog
+    stays flat and readable. Renaming one without the other would entitle nobody, and
+    every test above would still pass because they all go through the same constant."""
+    assert site_plans.ANALYTICS_FEATURE == "analytics"
+    entitled = {
+        tier.key
+        for tier in site_plans.list_site_plans()
+        if site_plans.ANALYTICS_FEATURE in tier.cloudflare_features
+    }
+    assert entitled == {"site", "staff", "studio", "agency"}
+
+
+# ── 2. the deploy shape ──────────────────────────────────────────────────────
+
+
+def test_a_free_publish_writes_no_counter(tmp_path):
+    """The cost claim, at the artifact. No ``main`` (nothing invokes a Worker), no
+    dataset binding (nothing could write a row), no routing rules, and no entry on
+    disk carrying a salt."""
+    project = _build_html_project(tmp_path)
+    cfg = _write(project, entitled=False)
+
+    assert "main" not in cfg
+    assert "analytics_engine_datasets" not in cfg
+    assert "run_worker_first" not in cfg["assets"]
+    assert not (project / analytics_worker.ENTRY_FILENAME).exists()
+
+
+def test_a_free_publish_emits_exactly_the_pre_analytics_config(tmp_path):
+    """Stronger than the absence checks above, and the one that catches a key nobody
+    thought to assert about. The free config is the pre-SA-1 recipe entire — including
+    an ``assets`` block of nothing but ``directory``, because a free site has no entry
+    for an ``ASSETS`` binding to point at."""
+    cfg = _write(_build_html_project(tmp_path), entitled=False)
+    assert cfg == PRE_ANALYTICS_HTML_CONFIG
+
+
+def test_a_paid_publish_writes_the_counting_config(tmp_path):
+    """The other half: narrowing the gate until nothing counts would satisfy every
+    assertion above. A ``site``-tier publish gets the full SA-1 shape."""
+    project = _build_html_project(tmp_path)
+    cfg = _write(project, entitled=True)
+
+    assert cfg["main"] == analytics_worker.ENTRY_FILENAME
+    assert cfg["assets"]["binding"] == "ASSETS"
+    assert cfg["assets"]["run_worker_first"]
+    assert cfg["analytics_engine_datasets"] == [
+        {
+            "binding": analytics_worker.DATASET_BINDING,
+            "dataset": analytics_worker.dataset_name(),
+        }
+    ]
+    entry = project / analytics_worker.ENTRY_FILENAME
+    assert entry.is_file()
+    assert SITE_ID in entry.read_text()
+
+
+def test_the_entry_is_deleted_when_a_counting_site_publishes_free(tmp_path):
+    """THE DOWNGRADE. A publish reuses the pocket's working dir, so the entry a paid
+    publish wrote is still sitting there when the same site publishes free. The new
+    config names no ``main``, so wrangler would upload that leftover as an ordinary
+    static asset and serve the per-publish salt from a config that mentions nothing.
+
+    Asserted as a sequence rather than as a fresh dir, because the fresh-dir version
+    passes against code that simply never writes the file."""
+    project = _build_html_project(tmp_path)
+    _write(project, entitled=True)
+    assert (project / analytics_worker.ENTRY_FILENAME).is_file()
+
+    _write(project, entitled=False)
+    assert not (project / analytics_worker.ENTRY_FILENAME).exists()
+
+
+def test_the_assetsignore_names_the_entry_even_when_nothing_counts(tmp_path):
+    """The second line of defence behind that delete. Naming a file that is not there
+    costs nothing; not naming one that IS there costs the salt."""
+    project = _build_html_project(tmp_path)
+    _write(project, entitled=False)
+
+    lines = (project / ".assetsignore").read_text().splitlines()
+    assert analytics_worker.ENTRY_FILENAME in lines
+    assert "wrangler.jsonc" in lines
+
+
+# ── 3. the kill switch ───────────────────────────────────────────────────────
+
+
+def test_the_kill_switch_restores_the_pre_analytics_config_for_a_paid_site(tmp_path, monkeypatch):
+    """The incident path. With the switch set, a site that IS entitled deploys the
+    config an un-analytics build produced — byte for byte, so an operator pulling it
+    gets the shape that was proven before analytics existed rather than a near miss."""
+    monkeypatch.setenv("PAW_SITES_ANALYTICS_DISABLED", "1")
+    project = _build_html_project(tmp_path)
+
+    cfg = _write(project, entitled=True)
+
+    assert cfg == PRE_ANALYTICS_HTML_CONFIG
+    assert not (project / analytics_worker.ENTRY_FILENAME).exists()
+
+
+def test_the_killed_config_is_byte_for_byte_the_free_one(tmp_path, monkeypatch):
+    """Compared as TEXT, not as parsed JSON. Key order, indentation and the trailing
+    newline are all part of what a rollback restores, and a dict comparison sees none
+    of them."""
+    paid = _build_html_project(tmp_path / "paid")
+    free = _build_html_project(tmp_path / "free")
+
+    workers_deploy._write_deploy_files(
+        str(free), WORKER_NAME, "html", None, site_id=SITE_ID, analytics_entitled=False
+    )
+    free_text = (free / "wrangler.jsonc").read_text()
+
+    monkeypatch.setenv("PAW_SITES_ANALYTICS_DISABLED", "true")
+    workers_deploy._write_deploy_files(
+        str(paid), WORKER_NAME, "html", None, site_id=SITE_ID, analytics_entitled=True
+    )
+
+    assert (paid / "wrangler.jsonc").read_text() == free_text
+
+
+def test_the_kill_switch_reads_the_value_not_the_presence(monkeypatch):
+    """An operator who writes ``=false`` means false. A switch read as
+    ``bool(os.environ.get(...))`` fires on every value including that one, which is a
+    bad way to learn how a kill switch parses during an incident."""
+    for raw in ("1", "true", "TRUE", "yes", "on", " true "):
+        monkeypatch.setenv("PAW_SITES_ANALYTICS_DISABLED", raw)
+        assert analytics_worker.counting_disabled() is True, f"{raw!r} did not disable"
+    for raw in ("", "0", "false", "no", "off"):
+        monkeypatch.setenv("PAW_SITES_ANALYTICS_DISABLED", raw)
+        assert analytics_worker.counting_disabled() is False, f"{raw!r} disabled"
+    monkeypatch.delenv("PAW_SITES_ANALYTICS_DISABLED", raising=False)
+    assert analytics_worker.counting_disabled() is False
+
+
+def test_the_two_halves_of_the_decision_are_independent(monkeypatch):
+    """``counting_enabled`` is an AND, and both halves have to be able to say no on
+    their own: the entitlement answers to billing and is per site, the switch answers
+    to an incident and is global."""
+    monkeypatch.delenv("PAW_SITES_ANALYTICS_DISABLED", raising=False)
+    assert analytics_worker.counting_enabled(entitled=True) is True
+    assert analytics_worker.counting_enabled(entitled=False) is False
+
+    monkeypatch.setenv("PAW_SITES_ANALYTICS_DISABLED", "1")
+    assert analytics_worker.counting_enabled(entitled=True) is False
+    assert analytics_worker.counting_enabled(entitled=False) is False
+
+
+# ── 4. the publish path actually consults the gate ───────────────────────────
+#
+# The tests above drive ``_write_deploy_files`` directly, which defaults to counting.
+# Every one of them would pass against a publish path that never passed the flag at
+# all, so the gate is worth nothing until it is asserted where the Site document is.
+
+
+class _FakeGenerator:
+    """Stand-in for the SvelteKit generator — never touches Bun or workerd."""
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+def _recording_deployer(seen: dict):
+    async def _deploy(site_id: str, project_dir: str, *, analytics_entitled=..., **_: object):
+        # A sentinel default rather than a bool: "the publish path passed nothing" and
+        # "the publish path passed False" must not read the same, and they would if the
+        # fake defaulted to False.
+        seen["analytics_entitled"] = analytics_entitled
+        return f"https://paw-site-{site_id}.acct.workers.dev"
+
+    return _deploy
+
+
+async def _publish(pocket_id: str, deployer):
+    return await sites_service.publish(
+        workspace_id="ws-analytics-gate",
+        user_id="u1",
+        pocket_id=pocket_id,
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Gate Site",
+        _generator=_FakeGenerator(),
+        _bundle_reader=lambda d: b"unused-in-workers-mode",
+        _workers_deploy=deployer,
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_publish_path_passes_a_resolved_entitlement(beanie_test_db, monkeypatch):
+    """A FIRST publish has no Site document yet — the row is inserted after the deploy —
+    so "no document" has to resolve to free. It does, and the value reaching the
+    deployer is an explicit False rather than the parameter's own default."""
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "workers")
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    seen: dict = {}
+
+    await _publish("pk-gate-free", _recording_deployer(seen))
+
+    assert seen["analytics_entitled"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_paying_site_republishes_with_the_counter(beanie_test_db, monkeypatch):
+    """The same publish path, on a site whose document says it is paying. Two publishes
+    because the first is what creates the document — which is also the honest shape of
+    the product rule: a site's history begins at the publish that first carried a
+    counter, and upgrading backfills nothing."""
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "workers")
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    seen: dict = {}
+
+    site = await _publish("pk-gate-paid", _recording_deployer(seen))
+    assert seen["analytics_entitled"] is False
+
+    doc = await sites_service._SiteDoc.find_one({"_id": site.id})
+    assert doc is not None
+    doc.plan_tier = "site"
+    doc.subscription_status = "active"
+    await doc.save()
+
+    await _publish("pk-gate-paid", _recording_deployer(seen))
+
+    assert seen["analytics_entitled"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_site_republishes_without_the_counter(beanie_test_db, monkeypatch):
+    """The seam that pays for itself. ``plan_tier`` still says ``site`` after a
+    cancellation — nothing rewrites it — so a publish path reading the tier alone would
+    keep billing us for a customer who stopped paying."""
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "workers")
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    seen: dict = {}
+
+    site = await _publish("pk-gate-lapsed", _recording_deployer(seen))
+    doc = await sites_service._SiteDoc.find_one({"_id": site.id})
+    assert doc is not None
+    doc.plan_tier = "site"
+    doc.subscription_status = "cancelled"
+    await doc.save()
+
+    await _publish("pk-gate-lapsed", _recording_deployer(seen))
+
+    assert seen["analytics_entitled"] is False
+
+
+# ── 5. the salt does not reach the local server ──────────────────────────────
+
+
+def _get(url: str):
+    """Fetch ``url``, treating an HTTP error as a result — a 404 is the assertion."""
+    req = urllib.request.Request(url)  # noqa: S310 - localhost
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - localhost
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+@pytest.fixture
+def server(tmp_path, monkeypatch):
+    """A freshly-rooted local static server, torn down afterwards. The server is a
+    process singleton that captures its served root at startup, so resetting it is what
+    makes this test's root the one actually served."""
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(tmp_path / "sites"))
+
+    previous = local_server._server
+    local_server._server = None
+    try:
+        yield local_server
+    finally:
+        started = local_server._server
+        if started is not None:
+            started.shutdown()
+            started.server_close()
+        local_server._server = previous
+
+
+def test_the_local_server_does_not_serve_the_generated_entry(server, tmp_path):
+    """THE SALT IS THE POINT. ``deploy_local`` copies the whole static-output tree, and
+    for an html site that tree IS the project dir — so after a workers publish into the
+    same working dir the generated entry is sitting in it, carrying the per-publish
+    secret the visitor hash is built on. A readable salt turns that hash into a
+    confirmation oracle: recompute from a candidate IP and user-agent, compare.
+
+    Asserted OVER HTTP rather than by listing the copied dir, because "was it copied"
+    and "is it served" are different questions and only the second one is the exposure.
+    The page beside it is fetched too — an ignore that swallowed the site would pass a
+    404-only test."""
+    project = _build_html_project(tmp_path / "project")
+    workers_deploy._write_deploy_files(
+        str(project), WORKER_NAME, "html", None, site_id=SITE_ID, analytics_entitled=True
+    )
+    secret = project / analytics_worker.ENTRY_FILENAME
+    assert secret.is_file(), "the fixture must actually have an entry to leak"
+
+    url = server.deploy_local("site-gate-1", str(project), engine="html")
+
+    assert _get(f"{url}{analytics_worker.ENTRY_FILENAME}")[0] == 404
+    status, body = _get(url)
+    assert status == 200
+    assert b"<h1>hi</h1>" in body
+
+
+def test_the_local_server_does_not_serve_the_deploy_config(server, tmp_path):
+    """The rest of the scaffold travels with the entry. ``wrangler.jsonc`` is deploy
+    plumbing a visitor has no business fetching, and Cloudflare already excludes it from
+    what it uploads — this is the local target agreeing with the deployed one."""
+    project = _build_html_project(tmp_path / "project")
+    workers_deploy._write_deploy_files(
+        str(project), WORKER_NAME, "html", None, site_id=SITE_ID, analytics_entitled=True
+    )
+
+    url = server.deploy_local("site-gate-2", str(project), engine="html")
+
+    assert _get(f"{url}wrangler.jsonc")[0] == 404
+    assert _get(f"{url}.assetsignore")[0] == 404
+    assert _get(f"{url}styles.css")[0] == 200

--- a/tests/mutations/fault_ladder.json
+++ b/tests/mutations/fault_ladder.json
@@ -128,8 +128,8 @@
   {
     "label": "a failed workers deploy is swallowed, so the site's URL is re-stamped for a deploy that never happened",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "        url = await deploy_w(site_id, build.project_dir, engine=engine)",
-    "replace": "        try:\n            url = await deploy_w(site_id, build.project_dir, engine=engine)\n        except Exception:\n            url = \"\"",
+    "find": "        url = await deploy_w(\n            site_id, build.project_dir, engine=engine, analytics_entitled=counts_pageviews\n        )",
+    "replace": "        try:\n            url = await deploy_w(\n                site_id, build.project_dir, engine=engine, analytics_entitled=counts_pageviews\n            )\n        except Exception:\n            url = \"\"",
     "tests": [
       "tests/ee/sites/test_fault_ladder_deploy.py"
     ]

--- a/tests/mutations/sites_analytics_gate.json
+++ b/tests/mutations/sites_analytics_gate.json
@@ -1,0 +1,102 @@
+[
+  {
+    "label": "the plan is never consulted — every site is entitled to analytics, so a free site is counted at a billed Worker invocation against no revenue",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    return site_plan_catalog.ANALYTICS_FEATURE in tier.cloudflare_features",
+    "replace": "    return True",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "the subscription is ignored — a cancelled site keeps its counter forever, because cancellation never resets plan_tier",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    if tier is None or not _subscription_is_active(subscription_status):\n        return False",
+    "replace": "    if tier is None:\n        return False",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "an ORG key stored on a site resolves — one site is handed the analytics an org flat buys for twenty-five",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    tier = site_plan_catalog.site_scoped_tier(plan_tier)\n    if tier is None or not _subscription_is_active(subscription_status):",
+    "replace": "    tier = site_plan_catalog.get_site_plan(plan_tier)\n    if tier is None or not _subscription_is_active(subscription_status):",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "the publish path stops passing the resolved entitlement — the deploy writer's counting default wins and the gate is dead code",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            site_id, build.project_dir, engine=engine, analytics_entitled=counts_pageviews",
+    "replace": "            site_id, build.project_dir, engine=engine",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "the kill switch does nothing — the one mitigation for a Workers-free-plan ceiling breach needs a deploy instead of an env var",
+    "file": "ee/pocketpaw_ee/sites/analytics_worker.py",
+    "find": "    return entitled and not counting_disabled()",
+    "replace": "    return entitled",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "the kill switch fires on any value including =false, so an operator who explicitly disables it turns the feature off",
+    "file": "ee/pocketpaw_ee/sites/analytics_worker.py",
+    "find": "    return os.environ.get(_DISABLED_ENV, \"\").strip().lower() in _TRUTHY",
+    "replace": "    return bool(os.environ.get(_DISABLED_ENV, \"\"))",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "the un-analytics config keeps the ASSETS binding — the kill switch restores a shape that is nearly the pre-analytics one, which is not a rollback",
+    "file": "ee/pocketpaw_ee/sites/workers_deploy.py",
+    "find": "                        \"assets\": {\"directory\": output_rel},",
+    "replace": "                        \"assets\": {\"binding\": \"ASSETS\", \"directory\": output_rel},",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "a stale entry survives a paid-to-free republish — wrangler uploads it as an ordinary asset and the per-publish hash salt is downloadable",
+    "file": "ee/pocketpaw_ee/sites/workers_deploy.py",
+    "find": "        entry_path.unlink(missing_ok=True)",
+    "replace": "        pass",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "the server-worker branch stops being excluded — a ripple / dynamic svelte deploy names our counter as main over SvelteKit's own worker",
+    "file": "ee/pocketpaw_ee/sites/workers_deploy.py",
+    "find": "    count_pageviews = not emits_worker and analytics_worker.counting_enabled(",
+    "replace": "    count_pageviews = analytics_worker.counting_enabled(",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_counter.py",
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "the local server copies the deploy scaffold again — it serves the generated entry, and with it the salt that makes the visitor hash irreversible",
+    "file": "ee/pocketpaw_ee/sites/local_server.py",
+    "find": "    shutil.copytree(src, dest, ignore=shutil.ignore_patterns(*_DEPLOY_SCAFFOLD_NAMES))",
+    "replace": "    shutil.copytree(src, dest)",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "the ignore list drops the generated entry and keeps only the wrangler config — the salt is served while the copy looks filtered",
+    "file": "ee/pocketpaw_ee/sites/local_server.py",
+    "find": "_DEPLOY_SCAFFOLD_NAMES = (\n    analytics_worker.ENTRY_FILENAME,\n",
+    "replace": "_DEPLOY_SCAFFOLD_NAMES = (\n",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  }
+]

--- a/tests/mutations/sites_analytics_gate.json
+++ b/tests/mutations/sites_analytics_gate.json
@@ -72,6 +72,26 @@
     ]
   },
   {
+    "label": "the stale-entry delete stops being failure-soft — a locked or read-only entry fails the whole publish of a site that is not even using analytics",
+    "file": "ee/pocketpaw_ee/sites/workers_deploy.py",
+    "find": "        try:\n            entry_path.unlink(missing_ok=True)\n        except OSError:",
+    "replace": "        if True:\n            entry_path.unlink(missing_ok=True)\n        elif False:",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py"
+    ]
+  },
+  {
+    "label": "the assetsignore is written AFTER the delete, so a failed delete leaves an entry with nothing excluding it and the salt ships",
+    "file": "ee/pocketpaw_ee/sites/workers_deploy.py",
+    "find": "    (out_dir / \".assetsignore\").write_text(\"\\n\".join(ignore_lines) + \"\\n\")",
+    "replace": "    (out_dir / \".assetsignore\").write_text(\"\")",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_gate.py",
+      "tests/ee/sites/test_sites_analytics_counter.py",
+      "tests/ee/sites/test_workers_deploy.py"
+    ]
+  },
+  {
     "label": "the server-worker branch stops being excluded — a ripple / dynamic svelte deploy names our counter as main over SvelteKit's own worker",
     "file": "ee/pocketpaw_ee/sites/workers_deploy.py",
     "find": "    count_pageviews = not emits_worker and analytics_worker.counting_enabled(",


### PR DESCRIPTION
Second slice of visitor analytics for Paw Sites. **Stacked on #2042** — review that one first, and merge it with `--rebase` rather than `--squash`.

Plan and design: qbtrix/paw-workspace#184.

## What changes

SA-1 wired a pageview counter into every assets-only publish regardless of plan. This gates it on the `analytics` entitlement, adds an operator kill switch, and closes two ways the hash salt could have leaked.

A free site now publishes the pre-analytics config byte for byte: no `main`, no dataset binding, no routing rules, and an `assets` block of nothing but `directory`. The two shapes are built as separate literals rather than one dict with keys popped off it, so what a free config contains is something a reader can see rather than replay.

## One predicate, because two seams have to agree

```python
site_analytics_entitled(*, plan_tier, subscription_status) -> bool
```

The publish path decides whether the deployed config carries a counter at all. The read endpoint in a later slice decides whether a site's numbers may be served. A site whose publish counted but whose read refuses is a customer paying for a blank chart; the reverse serves numbers the site was never entitled to gather. So it is one function, and it reads a new exported `ANALYTICS_FEATURE` constant against the resolved plan row rather than touching the raw feature dict.

Tier **and** active subscription, matching every other paid capability here. Reading the tier alone is the bug that module exists to prevent, since cancellation leaves `plan_tier` on the paid key.

Free sites are not counted, which is deliberate: a Worker invocation is billed and a static asset is not, so counting free traffic spends real money against no revenue. The consequence is that upgrading does not backfill. A site's history begins at the publish that first carried a counter, and that belongs on screen in the UI slice.

## The kill switch

`PAW_SITES_ANALYTICS_DISABLED` restores the pre-analytics config at the next publish with no code change.

It exists for a specific failure. Requests to static assets are free and unlimited; putting a `main` in the path makes them billable. If the Cloudflare account is on the Workers Free plan, that starts consuming a 100,000 request per day account-wide ceiling, and breaching it stops serving sites rather than degrading analytics. The mitigation has to be faster than a deploy.

It reads truthy spellings rather than `bool(os.environ.get(...))`, which would fire on `=0` and `=false`. That is the wrong direction to be surprising in.

Both this and SA-1's `PAW_SITES_ANALYTICS_DATASET` are now documented in the configuration reference, including what they do **not** do: neither rewrites an already-deployed site, so pulling the switch during an incident still means republishing the affected sites.

## Two salt leaks closed

Neither was in the original slice. Both are the same class of problem, where a file carrying the per-publish hash salt escapes into something that serves it.

**A republish from paid to free.** A publish reuses the pocket's working directory. The old counter entry stayed on disk while the new config named no `main`, so wrangler would have uploaded it as an ordinary static asset and served the salt publicly. It is now deleted when counting is off.

**The local preview server.** `local_server.deploy_local` copies the whole project directory and serves it, deploy scaffold included. It now ignores the entry. Reach was loopback, so a developer's own machine rather than the internet.

The delete is failure-soft, and that is safe only because `.assetsignore` still names the entry on every assets-only publish and is written first. A failed delete leaves the file on disk and still excluded from the upload. That dependency is written where someone moving the `.assetsignore` write would see it, with a mutation that moves it and proves the tests catch it.

The counter *write* on the other branch is deliberately left unwrapped: the config is about to name that file as `main`, and wrangler fails on a missing `main`, so swallowing there would trade a clear error for a confusing one.

## Verification

```
uv run pytest tests/ee/sites tests/cloud/sites tests/cloud/jobs/test_provision_site.py -q
1739 passed, 4 skipped
```

All 13 mutations caught on the new plan. `mutate.py --validate` clean at 868 anchors across 70 plans. SA-1's cost-floor mutation still passes, so the routing rules were not widened.

## Known

`_site_counts_pageviews` calls `find_one` unwrapped. A database error there would fail a publish, but `_stamp_free_badge` performs an identical read unconditionally a few lines earlier on a fail-closed path, so any database failure kills the publish before this read is reached. A guard would be unreachable in every scenario the badge read survives. Flagging it rather than adding a second guard that no test could reach.
