### PR TITLE
Make the LiteLLM billing cutover safe to flip

### DIFF
--- a/docs/deployment/litellm-billing-cutover.md
+++ b/docs/deployment/litellm-billing-cutover.md
@@ -1,0 +1,100 @@
+# Cutting billing over to LiteLLM
+
+How to move from per-run metering to LiteLLM as the single meter, without
+double-billing anyone or handing out free usage.
+
+There are three modes, set by `POCKETPAW_LITELLM_SPEND_MODE`:
+
+| mode | who charges | debits |
+|---|---|---|
+| `off` (default) | per-run metering prices each run locally | yes |
+| `shadow` | per-run metering still charges; LiteLLM spend is read and compared | no, the compare debits nothing |
+| `live` | LiteLLM only; the per-run sweep returns 0 without charging | yes, from proxy spend |
+
+Both sweeps run on the same five minute heartbeat.
+
+## Do not flip straight to `live`
+
+Two things go wrong if you do, and neither announces itself.
+
+**The whole history gets billed at once.** Spend ingestion skips rows older than
+a per-tenant high-water mark, and that mark is empty until something ingests. On
+the first live sweep the guard is bypassed and every row the proxy returns is
+charged. Those rows include every chat run the per-run meter already billed, under
+a different idempotency key, so the ledger's uniqueness index cannot recognise
+them as duplicates. There is no run id on the proxy key's metadata to match
+against either, which is why row-level de-duplication does not exist.
+
+**Unprovisioned workspaces stop being billed at all.** The cutover sweep iterates
+only tenants that hold a proxy key. In `live` the per-run sweep is off for
+everyone, so a workspace without a key is charged by nothing. Its usage is free
+and silently so.
+
+## The procedure
+
+**1. Run `shadow` for a while.** It reads proxy spend and the ledger over the same
+window and records a reconciliation row per tenant with the delta and a
+`coverage_gap` verdict. It moves no money. This is how you find out whether the
+two meters agree before you trust one of them alone.
+
+**2. Drain the per-run sweep.** Let it run until no completed run is still
+unbilled. A run left unbilled at the moment you flip is billed by neither meter:
+the per-run sweep no-ops in `live`, and its proxy rows predate the cutover mark
+so ingestion skips them.
+
+**3. Check who is provisioned.**
+
+```python
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+await provisioning.list_provisioned_workspaces()
+```
+
+Compare that against the workspaces you expect to bill. Provision any that are
+missing, or accept that they will be free.
+
+**4. Stamp the cutover mark, dry run first.**
+
+```python
+report = await provisioning.prepare_spend_cutover(dry_run=True)
+# CutoverPreparation(cutover_at=..., provisioned=N, seeded=N, already_marked=0, dry_run=True)
+```
+
+`seeded` is how many tenants would get a mark. `already_marked` are tenants that
+have already ingested; those are left alone, because moving a live mark forward
+would drop the spend between the old mark and now.
+
+When the numbers look right, run it for real:
+
+```python
+report = await provisioning.prepare_spend_cutover()
+```
+
+That instant is the seam. Per-run metering owns every run before it; LiteLLM owns
+every proxy row after it.
+
+**5. Set the mode.**
+
+```
+POCKETPAW_LITELLM_SPEND_MODE=live
+```
+
+## What changes for customers
+
+**Everything routed through the proxy is billed, not just chat.** Per-run metering
+charged one row per chat run. Proxy spend includes every call the proxy served,
+so embeddings, title generation and any other internal traffic now reach the
+wallet. That is real cost and arguably belongs there, but it is a change in what
+people pay and it is worth knowing before support asks.
+
+**The rate card is unchanged.** Live mode reuses the same `billing_markup` and
+`credit_usd`, so the conversion is still `round(cost * markup / credit_usd)` and
+charges are still whole credits worth a cent each. A run costing less than a cent
+still rounds to one.
+
+## Rolling back
+
+Set the mode back to `off`. Per-run metering resumes for runs going forward.
+
+Runs that stayed unbilled while `live` was in effect are **not** back-billed. The
+cutover mark also stays where it is, so a later return to `live` picks up from
+that mark rather than replaying history, which is the behaviour you want.

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
@@ -8,6 +8,9 @@
 #                           provisioned with, resolved from runtime settings. The
 #                           declarative knobs the proxy enforces per tenant.
 #   * ``ProvisionResult`` — the outcome of ``ensure_tenant_key``: the workspace,
+#   * ``CutoverPreparation`` — the outcome of ``prepare_spend_cutover``: how many
+#                           tenants are provisioned, how many were stamped with the
+#                           billing seam, and how many already had a mark.
 #                           its virtual key, and ``created`` (True only on a real
 #                           first mint, False on the idempotent already-exists
 #                           path) so callers can gate a one-time side effect on it.
@@ -114,6 +117,26 @@ class SpendIngestResult:
     cost_usd: float
     cached_tokens: int
     balance_after: int
+
+
+@dataclass(frozen=True)
+class CutoverPreparation:
+    """The outcome of stamping the billing-cutover mark on every tenant.
+
+    ``provisioned`` is how many tenants have a live proxy key at all — the only
+    ones ``live`` mode bills, which is why a workspace with no key must be
+    provisioned BEFORE the flip or its usage becomes free. ``seeded`` is how many
+    had no high-water mark and got one; ``already_marked`` how many were left
+    alone because ingestion had already begun for them (overwriting a live mark
+    would skip real spend). ``cutover_at`` is the ISO instant stamped, and it is
+    the seam: BC-3 owns every run before it, LiteLLM every proxy row after.
+    """
+
+    cutover_at: str
+    provisioned: int
+    seeded: int
+    already_marked: int
+    dry_run: bool
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -48,6 +48,16 @@
 # exception) which a system-job caller logs + retries, never a bare HTTPException.
 #
 # Created 2026-06-26 (integration/model-catalog-v2, MCG-8): new entity.
+# Updated 2026-09-02 (feat/litellm-spend-cutover): two changes that make ``live``
+#   safe to flip. ``prepare_spend_cutover`` stamps the high-water mark on every
+#   provisioned tenant, so the first live sweep bills FORWARD instead of charging
+#   the whole proxy history — which would have re-billed every chat run BC-3
+#   already charged, under a key BC-1 cannot dedup against. And the high-water
+#   skip now compares PARSED instants rather than raw ISO strings: the proxy emits
+#   naive, Z-suffixed and offset-bearing shapes interchangeably, and a naive
+#   timestamp is a string PREFIX of the offset-bearing form of the SAME instant,
+#   so a boundary row was silently dropped by the meter that is meant to be the
+#   only one charging. See docs/deployment/litellm-billing-cutover.md.
 # Updated 2026-06-26 (feat/litellm-billing-cutover, WU-F): three changes for the
 # billing cutover from per-run metering (BC-3) to LiteLLM as the single meter,
 # done through a safe shadow-compare phase.
@@ -78,6 +88,7 @@ from pocketpaw_ee.catalog.admin_client import LiteLLMAdminClient, LiteLLMAdminEr
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.credits import service as credits_service
 from pocketpaw_ee.cloud.llm_provisioning.domain import (
+    CutoverPreparation,
     KeyBudget,
     ProvisionResult,
     SpendCredits,
@@ -293,6 +304,76 @@ async def list_provisioned_workspaces() -> list[str]:
     return [d.workspace for d in docs if d.litellm_key]
 
 
+async def prepare_spend_cutover(
+    *,
+    at: datetime | None = None,
+    dry_run: bool = False,
+) -> CutoverPreparation:
+    """Stamp the billing-cutover mark so ``live`` mode bills forward, not backward.
+
+    **Run this before setting POCKETPAW_LITELLM_SPEND_MODE=live.** Without it the
+    first live sweep bills each tenant's ENTIRE ``/spend/logs`` history in one
+    debit run, because ``ingest_tenant_spend`` skips rows older than
+    ``last_spend_ingest_ts`` and that field is ``None`` until something ingests.
+    Worse than the size of that bill is its overlap: those rows include every text
+    chat run BC-3 already charged, under a different idempotency key
+    (``litellm:{request_id}`` vs ``run:{run_id}``), so BC-1's unique index cannot
+    dedup them. The module header calls row-level dedup against BC-3 a deliberate
+    product decision rather than a default, and there is no ``run_id`` on the key
+    metadata to dedup against in any case.
+
+    Stamping a mark makes the seam clean instead of overlapping: **BC-3 owns every
+    run before ``at``, LiteLLM owns every proxy row after it.**
+
+    Only tenants with NO mark are stamped. A tenant already ingesting has a live
+    high-water mark, and moving it forward would silently drop the spend between
+    the old mark and ``at``.
+
+    ORDER MATTERS, and the ordering is the operator's to get right:
+
+      1. Let the BC-3 sweep drain, so no completed run is still unbilled. The
+         sweep no-ops entirely once the mode is ``live``, and a run left unbilled
+         at the flip whose proxy rows predate ``at`` is billed by NEITHER meter.
+      2. Call this (``dry_run=True`` first to see the counts).
+      3. Confirm ``provisioned`` matches the number of workspaces you expect to
+         bill. **Live mode bills provisioned tenants only** — a workspace with no
+         proxy key is swept by nothing and its usage is free.
+      4. Set the mode to ``live``.
+
+    ``at`` defaults to now (UTC). ``dry_run`` reports what would be stamped and
+    writes nothing.
+    """
+    at = at or datetime.now(tz=UTC)
+    cutover_at = at.isoformat()
+
+    docs = await LiteLLMTenantKey.find(LiteLLMTenantKey.litellm_key != None).to_list()  # noqa: E711
+    provisioned = [d for d in docs if d.litellm_key]
+
+    unmarked = [d for d in provisioned if not d.last_spend_ingest_ts]
+    already = len(provisioned) - len(unmarked)
+
+    if not dry_run:
+        for doc in unmarked:
+            doc.last_spend_ingest_ts = cutover_at
+            await doc.save()
+
+    logger.info(
+        "prepare_spend_cutover: %s cutover_at=%s provisioned=%d seeded=%d already_marked=%d",
+        "DRY RUN — nothing written" if dry_run else "stamped",
+        cutover_at,
+        len(provisioned),
+        len(unmarked),
+        already,
+    )
+    return CutoverPreparation(
+        cutover_at=cutover_at,
+        provisioned=len(provisioned),
+        seeded=len(unmarked),
+        already_marked=already,
+        dry_run=dry_run,
+    )
+
+
 async def ensure_tenant_key(
     workspace: str,
     *,
@@ -469,7 +550,17 @@ async def ingest_tenant_spend(
     rows = await client.spend_logs(api_key=doc.litellm_key)
 
     high_water = doc.last_spend_ingest_ts
+    # Compare PARSED instants, not the raw strings. LiteLLM emits naive,
+    # Z-suffixed and offset-bearing ``startTime`` shapes interchangeably, and
+    # lexicographic ordering across those is wrong in both directions: a naive
+    # "2026-09-02T14:00:00" sorts BELOW an aware "2026-09-02T14:00:00+00:00"
+    # despite being the same instant, so a mark written in one shape silently
+    # re-reads or silently skips rows written in the other. Every other timestamp
+    # in this module already goes through ``_parse_iso``; this one did not, and a
+    # seeded cutover mark makes that latent bug load-bearing.
+    high_water_dt = _parse_iso(high_water)
     newest_ts = high_water
+    newest_dt = high_water_dt
 
     rows_read = 0
     rows_billed = 0
@@ -490,12 +581,15 @@ async def ingest_tenant_spend(
         # unique index), so an already-ingested boundary row no-ops while a new
         # boundary row bills exactly once. The mark stays an optimisation that bounds
         # the read; the per-row request_id is the real exactly-once guard.
-        if high_water is not None and start_ts is not None and start_ts < high_water:
+        start_dt = _parse_iso(start_ts)
+        if high_water_dt is not None and start_dt is not None and start_dt < high_water_dt:
             continue
 
         rows_read += 1
-        if newest_ts is None or (start_ts is not None and start_ts > newest_ts):
+        advances = newest_dt is None or (start_dt is not None and start_dt > newest_dt)
+        if start_ts is not None and advances:
             newest_ts = start_ts
+            newest_dt = start_dt
 
         cost_usd = _num(row.get("spend"))
         cached_total += _cached_tokens(row)
@@ -756,6 +850,7 @@ __all__ = [
     "list_provisioned_workspaces",
     "load_key_budget",
     "load_spend_credits",
+    "prepare_spend_cutover",
     "reconcile_gap_threshold",
     "reconcile_tenant_spend",
     "spend_ingest_enabled",

--- a/tests/cloud/llm_provisioning/test_billing_cutover.py
+++ b/tests/cloud/llm_provisioning/test_billing_cutover.py
@@ -569,3 +569,153 @@ async def test_high_water_boundary_same_second_rows_both_billed_once(mongo_db):
         ).to_list()
         assert len(entries) == 1, f"{rid} must have exactly one ledger row"
         assert entries[0].amount_delta == delta
+
+
+# ===========================================================================
+# CUTOVER PREPARATION — the mark that makes ``live`` bill forward, not backward.
+# ===========================================================================
+
+
+async def _key_doc(workspace: str):
+    from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+
+    return await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+
+
+async def test_prepare_cutover_seeds_only_unmarked_tenants(mongo_db):
+    # Two tenants: one already ingesting (has a high-water mark), one fresh.
+    # Moving a live mark forward would silently drop the spend between the old
+    # mark and the cutover, so an already-marked tenant must be left alone.
+    other = "ws_cutover_other"
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+    await provisioning.ensure_tenant_key(other, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    existing = await _key_doc(other)
+    existing.last_spend_ingest_ts = "2026-01-01T00:00:00+00:00"
+    await existing.save()
+
+    at = datetime(2026, 9, 2, 12, 0, 0, tzinfo=UTC)
+    result = await provisioning.prepare_spend_cutover(at=at)
+
+    assert result.provisioned == 2
+    assert result.seeded == 1
+    assert result.already_marked == 1
+    assert result.dry_run is False
+
+    assert (await _key_doc(WS)).last_spend_ingest_ts == at.isoformat()
+    # Untouched — its own mark still governs.
+    assert (await _key_doc(other)).last_spend_ingest_ts == "2026-01-01T00:00:00+00:00"
+
+
+async def test_prepare_cutover_dry_run_writes_nothing(mongo_db):
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    result = await provisioning.prepare_spend_cutover(
+        at=datetime(2026, 9, 2, 12, 0, 0, tzinfo=UTC), dry_run=True
+    )
+
+    assert result.seeded == 1  # what it WOULD have stamped
+    assert result.dry_run is True
+    assert (await _key_doc(WS)).last_spend_ingest_ts is None  # nothing written
+
+
+async def test_without_a_mark_live_rebills_the_whole_history(mongo_db):
+    """The reason prepare_spend_cutover exists, stated as a failing scenario.
+
+    ``ingest_tenant_spend`` skips rows older than the high-water mark, and that
+    mark is None until something ingests. So the FIRST live sweep bills every row
+    /spend/logs returns — including rows for chat runs BC-3 already charged under
+    a different idempotency key, which BC-1's unique index therefore cannot dedup.
+    """
+    await credits.grant(WS, 10_000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    rows = [
+        # Ancient history: already billed by BC-3 under ``run:{run_id}``.
+        {"request_id": "req-old-1", "spend": 0.40, "startTime": "2026-01-05T10:00:00"},
+        {"request_id": "req-old-2", "spend": 0.40, "startTime": "2026-02-05T10:00:00"},
+        # After the cutover instant — genuinely LiteLLM's to bill.
+        {"request_id": "req-new", "spend": 0.04, "startTime": "2026-09-02T13:00:00"},
+    ]
+
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    orig, orig_load = svc.LiteLLMAdminClient, svc.load_spend_credits
+    svc.LiteLLMAdminClient = lambda *a, **k: FakeAdmin(spend_rows=rows)  # type: ignore[assignment]
+    svc.load_spend_credits = lambda: SPEND  # type: ignore[assignment]
+    try:
+        # NO cutover mark — every row bills. 0.40+0.40+0.04 = 0.84 usd -> 210 credits.
+        result = await provisioning.ingest_tenant_spend(WS)
+    finally:
+        svc.LiteLLMAdminClient, svc.load_spend_credits = orig, orig_load  # type: ignore[assignment]
+
+    assert result.rows_billed == 3, "history was billed, which is the bug"
+    assert result.credits_debited == 210
+
+
+async def test_a_cutover_mark_bills_only_what_came_after_it(mongo_db):
+    """The fix, on the same rows: BC-3 owns everything before the seam."""
+    await credits.grant(WS, 10_000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    rows = [
+        {"request_id": "req-old-1", "spend": 0.40, "startTime": "2026-01-05T10:00:00"},
+        {"request_id": "req-old-2", "spend": 0.40, "startTime": "2026-02-05T10:00:00"},
+        {"request_id": "req-new", "spend": 0.04, "startTime": "2026-09-02T13:00:00"},
+    ]
+
+    await provisioning.prepare_spend_cutover(at=datetime(2026, 9, 2, 12, 0, 0, tzinfo=UTC))
+
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    orig, orig_load = svc.LiteLLMAdminClient, svc.load_spend_credits
+    svc.LiteLLMAdminClient = lambda *a, **k: FakeAdmin(spend_rows=rows)  # type: ignore[assignment]
+    svc.load_spend_credits = lambda: SPEND  # type: ignore[assignment]
+    try:
+        result = await provisioning.ingest_tenant_spend(WS)
+    finally:
+        svc.LiteLLMAdminClient, svc.load_spend_credits = orig, orig_load  # type: ignore[assignment]
+
+    assert result.rows_billed == 1, "only the post-cutover row is LiteLLM's to bill"
+    assert result.credits_debited == 10  # round(0.04 * 250)
+
+    # And the historical rows produced no ledger movement at all.
+    for rid in ("req-old-1", "req-old-2"):
+        entries = await CreditLedgerEntry.find(
+            CreditLedgerEntry.workspace == WS,
+            CreditLedgerEntry.idempotency_key == f"litellm:{rid}",
+        ).to_list()
+        assert entries == [], f"{rid} was billed despite predating the cutover"
+
+
+async def test_high_water_compares_instants_not_strings(mongo_db):
+    """A naive row at the SAME instant as an offset-bearing mark must not vanish.
+
+    ``prepare_spend_cutover`` writes an offset-bearing mark
+    (``...T12:00:00+00:00``) while LiteLLM frequently emits NAIVE timestamps
+    (``...T12:00:00``). Under the old raw-string comparison the naive form is a
+    prefix of the aware one, so it sorts BELOW it and the row was silently
+    skipped — dropped by a meter that is supposed to be the only one charging.
+    """
+    await credits.grant(WS, 10_000, cause="top_up", idempotency_key="seed")
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    at = datetime(2026, 9, 2, 12, 0, 0, tzinfo=UTC)
+    await provisioning.prepare_spend_cutover(at=at)
+    assert (await _key_doc(WS)).last_spend_ingest_ts == "2026-09-02T12:00:00+00:00"
+
+    # Same instant as the mark, naive — a prefix of the mark as a string.
+    rows = [{"request_id": "req-boundary", "spend": 0.04, "startTime": "2026-09-02T12:00:00"}]
+
+    import pocketpaw_ee.cloud.llm_provisioning.service as svc
+
+    orig, orig_load = svc.LiteLLMAdminClient, svc.load_spend_credits
+    svc.LiteLLMAdminClient = lambda *a, **k: FakeAdmin(spend_rows=rows)  # type: ignore[assignment]
+    svc.load_spend_credits = lambda: SPEND  # type: ignore[assignment]
+    try:
+        result = await provisioning.ingest_tenant_spend(WS)
+    finally:
+        svc.LiteLLMAdminClient, svc.load_spend_credits = orig, orig_load  # type: ignore[assignment]
+
+    assert result.rows_billed == 1, "a boundary row was dropped by a string compare"
+    assert result.credits_debited == 10


### PR DESCRIPTION
Flipping `POCKETPAW_LITELLM_SPEND_MODE=live` today would go badly in two ways, and neither announces itself. This makes the flip safe and writes down the order to do it in.

## What would have happened

**The whole history gets billed at once.** Spend ingestion skips rows older than a per-tenant high-water mark, and that mark is empty until something ingests. On the first live sweep the guard is bypassed and every row the proxy returns is charged, including every chat run per-run metering already billed. Those carry a different idempotency key, so the ledger's uniqueness index cannot recognise them as duplicates, and there is no run id on the proxy key metadata to match against. The module header already called row-level dedup "a deliberate product decision, NOT a default".

**Unprovisioned workspaces stop being billed at all.** The cutover sweep iterates only tenants holding a proxy key, and in live the per-run sweep is off for everyone. A workspace with no key is charged by nothing, silently.

## What this adds

`prepare_spend_cutover` stamps the mark on every provisioned tenant, turning the overlap into a seam: per-run metering owns everything before the instant, LiteLLM everything after. Only tenants with no mark are stamped, since moving a live mark forward would drop the spend between the old mark and now. A dry run reports counts without writing.

The second change is the comparison. The high-water skip compared raw ISO strings while every other timestamp in the module goes through the parser, and the proxy emits naive, Z-suffixed and offset-bearing shapes interchangeably. A naive timestamp is a string prefix of the offset-bearing form of the same instant, so it sorts below it and the row was silently dropped. Seeding a mark would have turned that latent bug load-bearing.

## Verification

Six new tests, and two of them are the ones that matter:

| test | proves |
|---|---|
| `test_without_a_mark_live_rebills_the_whole_history` | 3 rows billed, 210 credits, the bug as it stands |
| `test_a_cutover_mark_bills_only_what_came_after_it` | 1 row billed, 10 credits, historical rows produce no ledger movement |

The boundary fix is proven by mutation rather than assertion: restoring the string comparison turns `test_high_water_compares_instants_not_strings` red, and the parse version green.

- `pytest tests/cloud/llm_provisioning tests/cloud/metering tests/cloud/billing tests/cloud/credits` — 349 passed
- `scripts/mutate.py --validate` — 876 anchors across 70 plans, unchanged
- ruff check and format clean

## The runbook

`docs/deployment/litellm-billing-cutover.md` did not exist. Two steps in it are easy to miss and both cost money:

Drain the per-run sweep before flipping, or a run left unbilled at the moment of the flip is billed by neither meter. The per-run sweep no-ops in live, and the run's proxy rows predate the mark so ingestion skips them.

Check who is provisioned, because live bills provisioned tenants only.

It also records what changes for customers. Proxy spend covers every call the proxy served, not just chat runs, so embeddings and title generation now reach the wallet. That is real cost and arguably belongs there, but it is a change in what people pay. The rate card is unchanged, so charges are still whole credits worth a cent each.
