### PR TITLE
Bill a run when it finishes, not on the next sweep tick

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/executor.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/executor.py
@@ -32,6 +32,13 @@ class InProcessExecutor:
     async def _guarded(self, spec: RunSpec) -> None:
         try:
             await execute_run(spec)
+            # Bill immediately rather than waiting for the sweep tick, so the
+            # wallet and the usage meter are current the moment the run ends.
+            # Best-effort by construction: it swallows its own failures and the
+            # sweeper remains the backstop for anything it misses.
+            from pocketpaw_ee.cloud.metering.service import bill_run_now
+
+            await bill_run_now(spec.run_id)
         except Exception:
             logger.exception("in-process run %s crashed", spec.run_id)
 

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -132,6 +132,11 @@ async def execute_run_job(ctx: dict[str, Any], spec_dict: dict[str, Any]) -> Non
     spec = RunSpec.model_validate(spec_dict)
     logger.info("worker: starting run %s", spec.run_id)
     await execute_run(spec)
+    # Same as the in-process executor: charge at completion so the balance is not
+    # a sweep interval behind. Idempotent, best-effort, sweeper still the backstop.
+    from pocketpaw_ee.cloud.metering.service import bill_run_now
+
+    await bill_run_now(spec.run_id)
 
 
 async def _startup(ctx: dict[str, Any]) -> None:

--- a/ee/pocketpaw_ee/cloud/metering/service.py
+++ b/ee/pocketpaw_ee/cloud/metering/service.py
@@ -59,6 +59,15 @@
 # rather than mutating + saving the foreign document itself.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-3): new entity.
+# Updated 2026-09-02 (feat/bill-on-completion): added ``bill_run_now``, called by
+#   both run executors the moment ``execute_run`` returns. Nothing charged at
+#   completion before, so the wallet, the allowance meter and the activity list
+#   were all a sweep interval stale after every run — a customer who checked
+#   immediately saw the state from before their own message. The sweeper is
+#   unchanged and is still the backstop: ``bill_run`` is idempotent on
+#   ``run:{run_id}``, so a run billed at completion is a no-op on the tick, and a
+#   run this misses is picked up by it. Gated OFF in the WU-F ``live`` mode for
+#   the same reason the sweep is — exactly one meter charges.
 # Updated 2026-06-24 (B3 review fix): ``bill_run`` no longer does
 # ``run_doc.billed=True; run_doc.save()`` directly (a foreign cross-entity write).
 # It now delegates the flag write to ``chat.runs.service.mark_billed(run_id)``.
@@ -291,6 +300,60 @@ def load_rate_card() -> RateCard:
 # ---------------------------------------------------------------------------
 
 
+async def bill_run_now(run_id: str) -> BillResult | None:
+    """Bill one run the moment it finishes, so the wallet is not a sweep behind.
+
+    Called by the two run executors right after ``execute_run`` returns. Without
+    it nothing charges until the next five-minute tick, which means the balance,
+    the allowance meter and the activity list are all stale for a whole interval
+    after every run — and a customer who checks immediately sees the state from
+    before their own message, with nothing on screen saying so.
+
+    **This does not replace the sweeper, and must not.** It is an optimisation on
+    top of it. ``bill_run`` is idempotent on ``run:{run_id}``, so a run billed
+    here is a no-op when the sweep later reaches it, and a run this misses (a
+    crash between the terminal write and this call, an executor path that does
+    not reach here, a transient failure below) is still picked up on the next
+    tick. That is why every failure here is swallowed: the cost of losing this
+    optimisation is five minutes, and the cost of raising is failing a run that
+    already succeeded.
+
+    Returns the ``BillResult`` when it billed, or ``None`` when it deliberately
+    did nothing — the run is missing, already billed, or LiteLLM is the sole
+    meter.
+    """
+    # Lazy import — same reason the sweeper does it: avoids a
+    # metering <-> llm_provisioning module-load cycle.
+    from pocketpaw_ee.cloud.llm_provisioning import service as provisioning_service
+
+    try:
+        # WU-F single-meter gate, identical to the sweeper's. In ``live`` LiteLLM
+        # is the sole meter and per-run metering must not charge, at completion
+        # any more than on a tick.
+        if provisioning_service.spend_mode() == "live":
+            return None
+
+        doc = await ChatRunDoc.find_one(ChatRunDoc.run_id == run_id)
+        if doc is None:
+            logger.debug(
+                "metering.bill_run_now: run=%s not found — leaving it to the sweep", run_id
+            )
+            return None
+        if doc.billed:
+            return None
+        if doc.status not in _TERMINAL_STATES_FOR_IMMEDIATE_BILLING:
+            # Not finished (or finished in a state the sweeper owns). The sweep
+            # picks it up once it settles.
+            return None
+
+        return await bill_run(doc)
+    except Exception:
+        # Never let billing fail a run that already succeeded. The sweeper is the
+        # backstop and this run keeps ``billed=False`` until it runs.
+        logger.exception("metering.bill_run_now: run=%s failed — the sweep will retry it", run_id)
+        return None
+
+
 async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) -> BillResult:
     """Bill ``run_doc``'s compute cost to its workspace wallet, exactly once.
 
@@ -382,8 +445,14 @@ async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) ->
     )
 
 
+# The states a finished run can be in. Mirrors the sweeper's ``_TERMINAL_STATES``
+# — kept as its own constant here rather than imported so the metering entity
+# does not depend on its own sweeper module.
+_TERMINAL_STATES_FOR_IMMEDIATE_BILLING = ("completed", "interrupted", "failed", "cancelled")
+
 __all__ = [
     "bill_run",
+    "bill_run_now",
     "load_rate_card",
     "resolve_cost",
     "run_moment",

--- a/tests/cloud/metering/test_compute_meter.py
+++ b/tests/cloud/metering/test_compute_meter.py
@@ -501,3 +501,114 @@ async def test_a_long_context_run_bills_the_long_context_tier(mongo_db):
 
     assert result.cost_usd == 1.50
     assert result.credits_charged == 375
+
+
+# ===========================================================================
+# BILL AT COMPLETION — the wallet should not be a sweep interval behind.
+# ===========================================================================
+
+
+async def test_bill_run_now_charges_without_waiting_for_a_sweep(mongo_db):
+    # The point of the whole thing: a finished run is charged immediately, so a
+    # customer who opens billing straight after chatting sees their own message.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _make_run(run_id="r-now", usage={"total_cost_usd": 0.04})
+
+    result = await metering.bill_run_now("r-now")
+
+    assert result is not None
+    assert result.debited is True
+    assert result.credits_charged == 10  # round(0.04 * 250)
+    assert await credits.balance(WS) == 990
+
+    doc = await ChatRunDoc.find_one(ChatRunDoc.run_id == "r-now")
+    assert doc.billed is True
+
+
+async def test_the_sweeper_does_not_charge_again_for_a_run_billed_at_completion(mongo_db):
+    """The money invariant. Completion billing is an optimisation ON TOP of the
+    sweep, not a replacement, so both running must still charge exactly once."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _make_run(run_id="r-once", usage={"total_cost_usd": 0.04})
+
+    await metering.bill_run_now("r-once")
+    assert await credits.balance(WS) == 990
+
+    # The sweep reaches it later and must move nothing.
+    swept = await sweep_unbilled_runs(rate_card=RATE)
+    assert swept == 0
+    assert await credits.balance(WS) == 990
+
+    entries = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "run:r-once",
+    ).to_list()
+    assert len(entries) == 1
+
+
+async def test_an_already_billed_run_is_left_alone(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _make_run(run_id="r-done", usage={"total_cost_usd": 0.04}, billed=True)
+
+    assert await metering.bill_run_now("r-done") is None
+    assert await credits.balance(WS) == 1000
+
+
+async def test_a_run_still_in_flight_is_left_to_the_sweep(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _make_run(run_id="r-running", status="running", usage={"total_cost_usd": 0.04})
+
+    assert await metering.bill_run_now("r-running") is None
+    assert await credits.balance(WS) == 1000
+
+
+async def test_a_missing_run_is_not_an_error(mongo_db):
+    # A crash between the terminal write and this call leaves nothing to bill.
+    assert await metering.bill_run_now("r-nope") is None
+
+
+async def test_live_mode_gates_completion_billing_off(mongo_db, monkeypatch):
+    """The single-meter guarantee has to hold at completion too, not just on the
+    tick. Otherwise flipping to ``live`` would silently double-charge every run:
+    LiteLLM from proxy spend, and this from the run doc."""
+    import pocketpaw_ee.cloud.llm_provisioning.service as provisioning
+
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _make_run(run_id="r-live", usage={"total_cost_usd": 0.04})
+    monkeypatch.setattr(provisioning, "spend_mode", lambda: "live")
+
+    assert await metering.bill_run_now("r-live") is None
+    assert await credits.balance(WS) == 1000
+
+    doc = await ChatRunDoc.find_one(ChatRunDoc.run_id == "r-live")
+    assert doc.billed is False, "live mode must not flip the flag either"
+
+
+async def test_a_billing_failure_never_propagates_into_the_run(mongo_db, monkeypatch):
+    """A run that already succeeded must not be failed by its own accounting.
+    Swallowing here is safe precisely because the sweeper retries."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _make_run(run_id="r-boom", usage={"total_cost_usd": 0.04})
+
+    async def _explode(*a, **k):
+        raise RuntimeError("ledger unreachable (simulated)")
+
+    monkeypatch.setattr(metering, "bill_run", _explode)
+
+    assert await metering.bill_run_now("r-boom") is None  # no raise
+
+    # Still unbilled, so the sweep will pick it up.
+    doc = await ChatRunDoc.find_one(ChatRunDoc.run_id == "r-boom")
+    assert doc.billed is False
+
+
+async def test_a_run_missed_at_completion_is_still_swept(mongo_db):
+    # Completion billing is best-effort; the sweeper remains the backstop and
+    # must still charge a run that never reached bill_run_now.
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _make_run(run_id="r-missed", usage={"total_cost_usd": 0.04})
+
+    swept = await sweep_unbilled_runs(rate_card=RATE)
+
+    assert swept == 1
+    assert await credits.balance(WS) == 990


### PR DESCRIPTION
Nothing charged when a run finished. Billing happened only on a five minute sweep, so the wallet, the allowance meter and the activity list were all stale for up to five minutes after every run.

The part that makes it a bug rather than a delay: a customer who opens billing straight after chatting sees the state from **before their own message**, and nothing on screen says the page is behind. Shortening the sweep interval narrows that window. It does not close it, and it still tells nobody.

Both run executors now bill the moment `execute_run` returns, so the charge lands in milliseconds.

## The sweeper is untouched, and that is what makes this safe

`bill_run` is idempotent on `run:{run_id}`. A run billed at completion is a no-op when the sweep reaches it, and a run this misses is picked up on the next tick exactly as before.

That is also why every failure here is swallowed. Losing this optimisation costs five minutes; raising would fail a run that already succeeded.

| test | asserts |
|---|---|
| `test_the_sweeper_does_not_charge_again_for_a_run_billed_at_completion` | one ledger row, balance moves once |
| `test_a_run_missed_at_completion_is_still_swept` | the backstop still works |
| `test_a_billing_failure_never_propagates_into_the_run` | a simulated ledger outage leaves `billed=False` and does not raise |

## The live-mode gate is load-bearing

Without it, flipping `POCKETPAW_LITELLM_SPEND_MODE=live` would silently double-charge every run: once from proxy spend, once from the run doc. The test asserts live leaves the `billed` flag alone too, not just the wallet, since flipping the flag would hide the run from the meter that is supposed to own it.

## Why the hook is at the call sites

`execute_run` has several early returns, so a single trailing call would miss most paths. A wrapper around it would have caught them all, but 89 test references invoke or monkeypatch that function directly, and billing inside it would have made every one of those tests write to the ledger. Two call sites cover every production path without that blast radius.

## Verification

- `pytest tests/cloud/metering tests/cloud/runs tests/cloud/billing tests/cloud/credits tests/cloud/llm_provisioning tests/cloud/chat` — 690 passed, 2 failed
- Those two failures are `test_execute_run_marks_cloud_chat_run_for_jail_fail_closed` and `test_execute_run_threads_surface_meta_into_ctx`, both about surface tool deny-lists. **Confirmed identical on pristine `origin/dev`**, so they are pre-existing and unrelated
- `scripts/mutate.py --validate` — 876 anchors across 70 plans, unchanged
- ruff check and format clean

## What this does not fix

A billing page that is **already open** when the run finishes still will not update itself. This makes the data current at fetch time; it does not push. Worth a follow-up, either a refetch when the tab regains focus or a last-updated line so the page is honest about its age.
