### PR TITLE
Let the sweep cadence be configured, not edited

### DIFF
--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -120,10 +120,55 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from contextlib import suppress
 from typing import Any
 
 _run_sweeper_logger = logging.getLogger(__name__)
+
+# Heartbeat cadence for the sweep loop below. 300s is the historical value and
+# stays the default; it was hardcoded, while every sibling sweeper in the
+# codebase (fabric_ingest, mandates, decisions) already reads its interval from
+# env. Made configurable for the same reason they are: this loop is the ONLY
+# thing between a finished run and a visible charge, so an operator tuning
+# billing latency should not have to edit source.
+#
+# The floor is deliberate. Each tick queries unbilled runs, iterates every
+# provisioned tenant and, in the LiteLLM cutover modes, calls the proxy admin API
+# once per tenant. A one-second interval would hammer the proxy rather than speed
+# anything up, so a lower value is clamped and logged rather than honoured.
+_DEFAULT_SWEEP_INTERVAL_SECONDS = 300
+_MIN_SWEEP_INTERVAL_SECONDS = 30
+_ENV_SWEEP_INTERVAL = "POCKETPAW_SWEEPER_INTERVAL_SECONDS"
+
+
+def _sweep_interval_seconds() -> int:
+    """Read the sweep cadence from env, default 300s, floored at 30s."""
+    raw = os.environ.get(_ENV_SWEEP_INTERVAL, "").strip()
+    if not raw:
+        return _DEFAULT_SWEEP_INTERVAL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        _run_sweeper_logger.warning(
+            "%s=%r is not an int — falling back to %ds",
+            _ENV_SWEEP_INTERVAL,
+            raw,
+            _DEFAULT_SWEEP_INTERVAL_SECONDS,
+        )
+        return _DEFAULT_SWEEP_INTERVAL_SECONDS
+    if value < _MIN_SWEEP_INTERVAL_SECONDS:
+        _run_sweeper_logger.warning(
+            "%s=%d is below the %ds floor — clamping. Each tick hits the proxy "
+            "admin API once per provisioned tenant.",
+            _ENV_SWEEP_INTERVAL,
+            value,
+            _MIN_SWEEP_INTERVAL_SECONDS,
+        )
+        return _MIN_SWEEP_INTERVAL_SECONDS
+    return value
+
+
 _sweeper_task: asyncio.Task[None] | None = None
 _xproc_consumer_task: asyncio.Task[None] | None = None
 
@@ -136,9 +181,12 @@ async def _sweeper_loop() -> None:
     from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
     from pocketpaw_ee.sites.pending_sweeper import sweep_pending_sites
 
+    interval = _sweep_interval_seconds()
+    _run_sweeper_logger.info("sweeper loop started (interval=%ds)", interval)
+
     while True:
         try:
-            await asyncio.sleep(300)
+            await asyncio.sleep(interval)
             await sweep_stale_runs()
         except asyncio.CancelledError:
             raise

--- a/tests/cloud/test_sweeper_interval.py
+++ b/tests/cloud/test_sweeper_interval.py
@@ -1,0 +1,63 @@
+# tests/cloud/test_sweeper_interval.py — the sweep heartbeat's cadence knob.
+#
+# This loop is the only thing between a finished run and a visible charge:
+# nothing bills at run completion, so a customer sees a charge one tick after the
+# run ends. The interval was hardcoded at 300 while every sibling sweeper in the
+# codebase already read its own from env, which meant tuning billing latency
+# required editing source.
+#
+# The floor is the part worth testing rather than the happy path. Each tick
+# queries unbilled runs, iterates every provisioned tenant, and in the LiteLLM
+# cutover modes calls the proxy admin API once per tenant — so a one-second
+# interval hammers the proxy instead of speeding anything up.
+#
+# Created 2026-09-02 (chore/sweeper-interval): new test.
+
+import pytest
+from pocketpaw_ee.extensions import (
+    _DEFAULT_SWEEP_INTERVAL_SECONDS,
+    _ENV_SWEEP_INTERVAL,
+    _MIN_SWEEP_INTERVAL_SECONDS,
+    _sweep_interval_seconds,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv(_ENV_SWEEP_INTERVAL, raising=False)
+
+
+def test_unset_keeps_the_historical_cadence():
+    # 300s is what the loop did before it was configurable; making it tunable
+    # must not silently change any existing deployment's behaviour.
+    assert _sweep_interval_seconds() == 300
+    assert _DEFAULT_SWEEP_INTERVAL_SECONDS == 300
+
+
+def test_a_valid_value_is_honoured(monkeypatch):
+    monkeypatch.setenv(_ENV_SWEEP_INTERVAL, "60")
+    assert _sweep_interval_seconds() == 60
+
+
+def test_below_the_floor_is_clamped_not_honoured(monkeypatch):
+    monkeypatch.setenv(_ENV_SWEEP_INTERVAL, "1")
+    assert _sweep_interval_seconds() == _MIN_SWEEP_INTERVAL_SECONDS
+
+
+def test_exactly_the_floor_is_allowed(monkeypatch):
+    monkeypatch.setenv(_ENV_SWEEP_INTERVAL, str(_MIN_SWEEP_INTERVAL_SECONDS))
+    assert _sweep_interval_seconds() == _MIN_SWEEP_INTERVAL_SECONDS
+
+
+@pytest.mark.parametrize("raw", ["abc", "", "   ", "5m", "300.5"])
+def test_an_unparseable_value_falls_back_rather_than_crashing_boot(monkeypatch, raw):
+    # This runs at process start. A typo in an env var must not stop the sweeps
+    # from running at all — that would silently halt billing.
+    monkeypatch.setenv(_ENV_SWEEP_INTERVAL, raw)
+    assert _sweep_interval_seconds() == _DEFAULT_SWEEP_INTERVAL_SECONDS
+
+
+def test_a_longer_interval_is_allowed(monkeypatch):
+    # There is no ceiling: a deployment that wants an hourly sweep may have one.
+    monkeypatch.setenv(_ENV_SWEEP_INTERVAL, "3600")
+    assert _sweep_interval_seconds() == 3600


### PR DESCRIPTION
The heartbeat was hardcoded at 300 seconds while every sibling sweeper in the codebase (fabric ingest, mandates, decisions) already read its interval from env.

`POCKETPAW_SWEEPER_INTERVAL_SECONDS` now sets it, defaulting to the same 300 so no existing deployment changes behaviour.

Values below 30 seconds are clamped and logged rather than honoured. Each tick queries unbilled runs, iterates every provisioned tenant, and in the LiteLLM cutover modes calls the proxy admin API once per tenant, so a one-second interval hammers the proxy instead of speeding anything up. An unparseable value falls back rather than crashing, because this resolves at process start and a typo must not stop the sweeps from running at all.

Ten tests, weighted toward the floor and the fallback rather than the happy path.

Worth saying plainly: this reduces the delay between a run finishing and a charge appearing. It does not remove it, and it does nothing for a user who checks urgently and cannot tell whether the page is current. `pocketpaw#2045` is the real fix for that, billing at completion so there is no interval to wait for. This stays useful as an operational knob for the sweeps that remain genuinely periodic.