### PR TITLE
Chat runs bill nobody, because the proxy is never told whose they are

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -712,4 +712,11 @@ ignore_imports = [
     "pocketpaw.tools.builtin.studio_flow_tool -> pocketpaw_ee.cloud.chat.agent_service",
     "pocketpaw.tools.builtin.studio_flow_tool -> pocketpaw_ee.cloud.studio.schemas",
     "pocketpaw.tools.builtin.studio_flow_tool -> pocketpaw_ee.cloud.studio.service",
+    # Proxy spend attribution: both agent backends stamp the paying workspace on
+    # a LiteLLM proxy request, and the workspace comes from the same run-identity
+    # ContextVar the Library verbs above read. One lazy try/except runtime import
+    # inside a function, caught broadly on purpose — the module top-level imports
+    # only stdlib, and a community install has no workspaces to bill, so it
+    # returns None and the request goes out untagged exactly as before.
+    "pocketpaw.agents.spend_attribution -> pocketpaw_ee.cloud.chat.agent_service",
 ]

--- a/src/pocketpaw/agents/deep_agents.py
+++ b/src/pocketpaw/agents/deep_agents.py
@@ -8,6 +8,28 @@ Uses the Deep Agents SDK (pip install deepagents) which provides:
 
 Requires: pip install deepagents
 
+Updated 2026-09-02 (feat/proxy-spend-by-workspace): a run on the ``litellm``
+provider now tells the proxy which workspace pays for it, by putting the
+workspace id in the request body's ``user`` field. The API key on the request is
+``settings.litellm_api_key`` — the DEPLOYMENT's key, one for the whole install —
+so the billing cutover's per-tenant spend read, which filters on the tenant's own
+virtual key, matched nothing this backend ever sent. Sibling change in
+``pydantic_ai``; the chain and its proxy-side preconditions are documented once,
+in ``agents/spend_attribution.py``.
+
+Two halves, and the second is the load-bearing one:
+
+  * ``_build_model`` sets ``model_kwargs["user"]``. ChatLiteLLM spreads
+    ``model_kwargs`` into the completion call, so it rides the wire as the
+    OpenAI ``user`` field.
+  * ``_get_or_create_agent`` keys the compiled-graph cache on the same value.
+    ``_build_model`` runs per turn, but ``create_deep_agent`` BAKES the model
+    into the graph and this backend hands back the cached graph whenever the key
+    matches — so without it in the key, one instance serving two workspaces would
+    bill the second one's runs to the first. Both sides read
+    ``_proxy_end_user()``, so they cannot disagree about the value. The sibling
+    backend has no such hazard: it passes the id per run, not per agent.
+
 Updated 2026-09-02 (fix/deep-agents-usage-parity): THE RUNS ON THIS BACKEND
 BILLED ZERO, all of them. The ``token_usage`` event added by MCG-11 below was
 built for the prompt-cache A/B and carried only what that needed, so it reached
@@ -97,6 +119,7 @@ from typing import Any
 
 from pocketpaw.agents.backend import _DEFAULT_IDENTITY, BackendInfo, Capability
 from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.agents.spend_attribution import end_user_id_for
 from pocketpaw.config import Settings
 from pocketpaw.tools.policy import ToolPolicy
 
@@ -884,6 +907,22 @@ class DeepAgentsBackend:
             provider = "anthropic"
         return provider, model_str.strip() or "claude-sonnet-4-6"
 
+    def _proxy_end_user(self) -> str | None:
+        """The workspace id to bill this run's proxy requests to, or None.
+
+        The single source for both users of the value — the model kwarg in
+        ``_build_model`` and the compiled-graph cache key in
+        ``_get_or_create_agent``. They are two expressions of one fact (which
+        tenant this graph's model charges), and a graph cached under a different
+        answer than the model carries is a cross-tenant billing error, so they
+        read the same call rather than each deciding for themselves.
+
+        None off the proxy path and None outside a cloud chat dispatch; see
+        ``spend_attribution`` for both.
+        """
+        provider, _model = self._parse_provider_model()
+        return end_user_id_for(provider)
+
     def _build_model(self) -> Any:
         """Build the LangChain chat model with proper provider configuration.
 
@@ -955,7 +994,18 @@ class DeepAgentsBackend:
             # accept ``use_responses_api``.
             base = (self.settings.litellm_api_base or "http://localhost:4000").rstrip("/")
             kwargs["api_base"] = base
+            # The DEPLOYMENT's proxy key, shared by every workspace — which is
+            # why the request also has to say who it is FOR. ``model_kwargs`` is
+            # the only way in: ChatLiteLLM drops unknown top-level kwargs
+            # silently (the same trap the thinking flag below documents) but
+            # spreads ``model_kwargs`` into the completion call, so ``user``
+            # reaches the proxy as the standard OpenAI end-user field.
             kwargs["api_key"] = self.settings.litellm_api_key or "not-needed"
+            end_user = self._proxy_end_user()
+            if end_user:
+                model_kwargs = dict(kwargs.get("model_kwargs") or {})
+                model_kwargs["user"] = end_user
+                kwargs["model_kwargs"] = model_kwargs
             if not model:
                 model = self.settings.litellm_model or ""
 
@@ -1081,6 +1131,14 @@ class DeepAgentsBackend:
             tuple(skills),
             tuple(memory),
             is_pocket_session,
+            # In the key because the MODEL is baked into the compiled graph and
+            # the model now carries a tenant id (``_build_model`` sets
+            # ``model_kwargs["user"]`` on the proxy path). Everything else here
+            # shapes behaviour; this one decides who gets billed, so leaving it
+            # out would let a graph compiled for one workspace charge its runs to
+            # another. ``None`` off the proxy path and outside a cloud chat
+            # dispatch, which keys exactly as before.
+            self._proxy_end_user(),
         )
         if self._cached_agent is not None and self._cached_model_key == model_key:
             return self._cached_agent

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -320,6 +320,29 @@ meter faithfully billed them zero. Three things carry the fix:
 same object either way, but only a completed run has a response to read the
 model name off, so the caller supplies it. The abnormal path falls back to the
 resolved model — no mid-stream event carries one.
+
+Updated 2026-09-02 (feat/proxy-spend-by-workspace) — **a proxy request now says
+which workspace pays for it.** Every run on the ``litellm`` provider carries the
+workspace id in the request body's ``user`` field, via the per-run
+``openai_user`` model setting. Nothing about the run changes; the proxy stamps
+the id onto its spend row's ``end_user`` column, which is what makes the row
+findable by tenant.
+
+It had to be findable by something. The comment in ``_resolve_openai_compatible``
+said the key this backend sends is "the tenant's virtual key" and it never was —
+it is ``settings.litellm_api_key``, one deployment-wide key — so the billing
+cutover's per-tenant spend read (``/spend/logs?api_key=<tenant key>``) matched no
+chat row at all. In ``live`` mode, where per-run metering is gated off so exactly
+one meter charges, that made chat free: production logged ``ingested spend for
+3/3 tenants -> 0 credits`` against runs the proxy had priced in real dollars. The
+comment is corrected in the same change, because a wrong comment at the seam is
+how this survived review.
+
+Per-RUN, beside ``usage_limits`` and ``max_tokens``, for the reason those are:
+``AgentPool`` shares one cached agent across runs, so anything belonging to THIS
+run cannot live on it. The full chain, its two proxy-side preconditions, and why
+the id is the workspace rather than the session are in
+``agents/spend_attribution.py``.
 """
 
 from __future__ import annotations
@@ -334,6 +357,7 @@ from typing import Any
 
 from pocketpaw.agents.backend import _DEFAULT_IDENTITY, BackendInfo, Capability
 from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.agents.spend_attribution import end_user_id_for
 from pocketpaw.config import Settings
 from pocketpaw.tools.policy import ToolPolicy
 
@@ -938,6 +962,51 @@ class PydanticAIBackend:
             logger.debug("Could not resolve a max output token cap", exc_info=True)
             return None
 
+    def _run_model_settings(self) -> Any:
+        """The ``model_settings`` for THIS run, or None to send none.
+
+        Two per-run values live here, both of which the cached agent must not
+        carry: the output-token cap resolved for the model this run picked, and
+        the id of the workspace that pays for it.
+
+        ``openai_user`` is pydantic-ai's name for the OpenAI ``user`` body field.
+        Our LiteLLM proxy reads it as the request's end-user and stamps it on the
+        spend row, which is the only thing that makes a chat run's cost
+        attributable to a tenant — the API key on the request is the deployment's,
+        shared by every workspace. It is set ONLY on the ``litellm`` provider;
+        ``spend_attribution.end_user_id_for`` owns that decision and the reasoning.
+
+        Returns None when neither value applies, so the run sends no
+        ``model_settings`` at all rather than an empty dict — byte-for-byte the
+        behaviour before either setting existed.
+        """
+        settings: dict[str, Any] = {}
+
+        max_output = self._resolve_max_output_tokens()
+        if max_output:
+            settings["max_tokens"] = max_output
+
+        # The provider is re-parsed rather than threaded down because
+        # ``_resolve_max_output_tokens`` already parses it the same way; the two
+        # cannot disagree about which model this run resolved.
+        provider, _model = self._parse_provider_model()
+        end_user = end_user_id_for(provider)
+        if end_user:
+            settings["openai_user"] = end_user
+
+        if not settings:
+            return None
+
+        # Returned as a plain dict rather than through
+        # ``OpenAIChatModelSettings``, which is where ``openai_user`` is
+        # declared. Both are TypedDicts — identical at runtime — but importing
+        # the OpenAI-flavoured one pulls in ``pydantic_ai.models.openai`` and
+        # therefore the ``openai`` SDK, on EVERY run including an
+        # ``anthropic``-only install that has no reason to carry it. The key is
+        # only ever present on the ``litellm`` path, which is OpenAI-compatible
+        # by definition, so the model that reads it always understands it.
+        return settings
+
     def _build_model(self, model_spec: str | None = None) -> Any:
         """Build the pydantic-ai model client for the configured provider."""
         provider, model = self._parse_provider_model(model_spec)
@@ -1044,9 +1113,16 @@ class PydanticAIBackend:
             base = (self.settings.litellm_api_base or "http://localhost:4000").rstrip("/")
             if not base.endswith("/v1"):
                 base = f"{base}/v1"
-            # The proxy is the auth boundary: this is the tenant's virtual key,
-            # not an upstream provider key. A placeholder keeps the OpenAI client
-            # happy on proxies configured without auth.
+            # The proxy is the auth boundary, so this is a PROXY credential
+            # rather than an upstream provider key. It is the DEPLOYMENT's key,
+            # one for the whole install — not the tenant's. This comment used to
+            # say the opposite, and the billing cutover was built on the claim:
+            # its per-tenant spend read filters ``/spend/logs`` by the tenant's
+            # virtual key, which no chat request has ever sent, so in ``live``
+            # mode chat billed zero for everyone. Attribution rides on the
+            # request's ``user`` field instead (see ``_run_model_settings``).
+            # A placeholder keeps the OpenAI client happy on proxies configured
+            # without auth.
             return (
                 base,
                 self.settings.litellm_api_key or "not-needed",
@@ -2157,14 +2233,13 @@ class PydanticAIBackend:
                 kwargs["usage_limits"] = UsageLimits(request_limit=max_turns)
 
             # Per-RUN like ``usage_limits`` above, and for the same reason: the
-            # cached agent is shared across runs, while the cap is a property of
-            # the model THIS run resolved. The fast-model path builds its own
-            # model and is unaffected.
-            max_output = self._resolve_max_output_tokens()
-            if max_output:
-                from pydantic_ai.settings import ModelSettings
-
-                kwargs["model_settings"] = ModelSettings(max_tokens=max_output)
+            # cached agent is shared across runs, while these are properties of
+            # the model and the tenant THIS run resolved. The fast-model path
+            # swaps the model but reuses these settings, which is what keeps a
+            # run that downshifts mid-flight attributed to the same workspace.
+            run_settings = self._run_model_settings()
+            if run_settings:
+                kwargs["model_settings"] = run_settings
 
             # Hand the SDK the ledger built above. Per-RUN like ``usage_limits``
             # and ``model_settings``: the cached agent is shared across runs, so

--- a/src/pocketpaw/agents/spend_attribution.py
+++ b/src/pocketpaw/agents/spend_attribution.py
@@ -1,0 +1,123 @@
+"""Tag a proxy request with the workspace that should pay for it.
+
+Created 2026-09-02 (feat/proxy-spend-by-workspace).
+
+WHY THIS EXISTS
+---------------
+Cloud chat was unbillable, and the failure was silent.
+
+The LiteLLM billing cutover reads a tenant's spend as
+``GET /spend/logs?api_key=<the tenant's virtual key>``. That works for the two
+paths that actually send the tenant's key — Studio and the media MCP server —
+and for nothing else. Both agent backends send
+``settings.litellm_api_key``, which is the DEPLOYMENT's key, not any tenant's.
+So a chat run's spend row is stamped with the deployment key, the per-tenant read
+never matches it, and in ``live`` mode (where per-run metering is gated off so
+exactly one meter charges) every chat run bills zero. Observed in production:
+``ingested spend for 3/3 tenants -> 0 credits`` while the proxy's own log showed
+real dollars for the same runs.
+
+Handing each backend a per-tenant key would fix it and would keep the same shape
+of hole: attribution would depend on a provisioning step, and a workspace that
+missed that step would be free rather than loud. So the id rides on the REQUEST
+instead. LiteLLM calls this an end-user (or customer); it needs no key, nothing
+to provision, and a request that somehow carries no id shows up as unattributed
+spend an operator can see rather than spend nobody is charged for.
+
+THE CHAIN, END TO END
+---------------------
+Every hop below was read in the pinned ``litellm`` and ``pydantic-ai`` sources
+rather than assumed, because a break at any one of them is invisible — it does
+not error, it bills nothing:
+
+1. The backend puts the workspace id in the request body's ``user`` field
+   (pydantic-ai's ``openai_user`` model setting; ChatLiteLLM's ``model_kwargs``).
+2. The proxy's ``get_end_user_id_from_request_body`` reads ``user`` (its check 3)
+   and binds ``UserAPIKeyAuth.end_user_id``.
+3. That becomes ``litellm_params["user_api_key_end_user_id"]``, which
+   ``get_end_user_id_for_cost_tracking`` turns into the spend row's ``end_user``
+   column.
+4. The cutover ingest reads it back with
+   ``GET /spend/logs/v2?end_user=<workspace>``.
+
+TWO DEPLOYMENT PRECONDITIONS, both on the proxy and neither visible from here:
+
+* ``litellm.disable_end_user_cost_tracking`` must stay off. It is the one switch
+  that drops the id at step 3, and it drops it silently.
+* A default customer budget (``litellm_settings.max_end_user_budget`` and its
+  kin) now applies to these ids, because they are customers as far as the proxy
+  is concerned. Unset by default; set it and it becomes a second, quieter budget
+  next to the per-key one.
+
+WHAT THE ID IS
+--------------
+The workspace, and nothing finer. The credit ledger's grain is the workspace —
+``credits.debit`` takes one — so a session- or user-scoped id would attribute
+spend the ledger cannot spend against, and a composite would have to be parsed
+back apart at ingest. The proxy's ``end_user`` is one opaque string; this keeps
+it the same string the wallet is keyed on.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# The provider names whose requests reach our own LiteLLM proxy. Attribution is
+# only added for these.
+#
+# Deliberately NOT ``openai_compatible``, even though an operator can point that
+# provider at the proxy too. The id is a tenant identifier, and the difference
+# between the two providers is whether we know where the request lands: on
+# ``litellm`` it lands on infrastructure we run, and on ``openai_compatible`` it
+# lands wherever the base URL says. Sending workspace ids to an arbitrary
+# third-party endpoint to save an operator one config line is the wrong trade.
+# An operator who routes the proxy through ``openai_compatible`` gets no
+# attribution and, per the ingest's coverage check, gets told so.
+_PROXY_PROVIDERS = frozenset({"litellm"})
+
+
+def is_proxy_provider(provider: str | None) -> bool:
+    """Whether ``provider`` routes through our LiteLLM proxy."""
+    return (provider or "").strip().lower() in _PROXY_PROVIDERS
+
+
+def current_workspace_id() -> str | None:
+    """The workspace this run belongs to, or None when there isn't one.
+
+    Reads the agent-identity ContextVar the cloud run loop binds
+    (``attach_agent_identity``, set before the agent stream is driven, so it is
+    visible from inside the backend's generator). None on a community install
+    with no EE package, and None for any run outside a cloud chat dispatch — a
+    CLI turn, a background job, a direct backend test. Those have no workspace to
+    bill, so an untagged request is correct there, not a miss.
+
+    Never raises. An attribution tag is not worth failing a run over, and the
+    ingest's coverage check is what makes a silent None visible.
+    """
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_workspace_id as _current
+
+        workspace = _current()
+    except Exception:  # noqa: BLE001 — see the docstring; this must never raise
+        return None
+    workspace = (workspace or "").strip()
+    return workspace or None
+
+
+def end_user_id_for(provider: str | None) -> str | None:
+    """The ``user`` value to put on this run's request, or None to send none.
+
+    None whenever the request is not going to our proxy, or the run has no
+    workspace. Callers should omit the field entirely on None rather than send an
+    empty string: the proxy treats ``""`` as an id, which would pool every
+    untagged run under one blank customer and make the coverage check read as
+    fully attributed.
+    """
+    if not is_proxy_provider(provider):
+        return None
+    return current_workspace_id()
+
+
+__all__ = ["current_workspace_id", "end_user_id_for", "is_proxy_provider"]

--- a/src/pocketpaw/agents/spend_attribution.py
+++ b/src/pocketpaw/agents/spend_attribution.py
@@ -49,6 +49,19 @@ TWO DEPLOYMENT PRECONDITIONS, both on the proxy and neither visible from here:
   is concerned. Unset by default; set it and it becomes a second, quieter budget
   next to the per-key one.
 
+THE ID IS OURS TO SET, NOT A CALLER'S TO DECLARE
+------------------------------------------------
+LiteLLM's own cost-tracking documentation warns that a caller can put any ``user``
+it likes in a request body and the proxy will attribute the cost to whatever it
+says — one tenant could bill another.
+
+That warning does not reach us, and it is worth writing down WHY so the exemption
+is not assumed later. The field is set here, from the run's own bound identity, at
+the point the model is built; no part of a customer's request body is forwarded to
+the proxy. Both conditions have to hold. If a tenant is ever handed a proxy key to
+call directly, or a request body is ever proxied verbatim, this becomes a
+spoofing surface and the id has to move to a header the server sets.
+
 WHAT THE ID IS
 --------------
 The workspace, and nothing finer. The credit ledger's grain is the workspace —

--- a/tests/test_proxy_spend_attribution.py
+++ b/tests/test_proxy_spend_attribution.py
@@ -1,0 +1,294 @@
+"""A proxy request has to say which workspace pays for it.
+
+Created 2026-09-02 (feat/proxy-spend-by-workspace).
+
+The bug these pin, stated once: both agent backends send
+``settings.litellm_api_key`` — one key for the whole deployment — so the billing
+cutover's per-tenant spend read (``/spend/logs?api_key=<the tenant's virtual
+key>``) matched no chat row at all. In ``live`` mode, where per-run metering is
+gated off so exactly one meter charges, chat therefore billed zero for everyone.
+Production logged ``ingested spend for 3/3 tenants -> 0 credits`` against runs
+the proxy had priced in real dollars, and nothing anywhere errored.
+
+Nothing about a run's behaviour changes here. What changes is that the request
+carries the workspace id, which is the only thing that later makes its cost
+attributable. So these tests assert on the wire-bound value and on the two ways
+it can silently go missing: sent for the wrong provider, or cached from another
+tenant's run.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from pocketpaw.agents import spend_attribution
+from pocketpaw.agents.deep_agents import DeepAgentsBackend
+from pocketpaw.agents.pydantic_ai import PydanticAIBackend
+from pocketpaw.config import Settings
+
+_EE_IDENTITY_MODULE = "pocketpaw_ee.cloud.chat.agent_service"
+
+
+@pytest.fixture
+def bound_workspace(monkeypatch):
+    """Bind a workspace the way a cloud chat dispatch does, without needing EE.
+
+    The backends import ``end_user_id_for`` at module scope, and it resolves
+    ``current_workspace_id`` from this module's globals on every call, so one
+    patch here reaches both backends.
+    """
+
+    def _bind(workspace: str | None) -> None:
+        monkeypatch.setattr(spend_attribution, "current_workspace_id", lambda: workspace)
+
+    return _bind
+
+
+def _settings(**over) -> Settings:
+    base = {
+        "litellm_api_base": "http://example.local",
+        "litellm_api_key": "sk-deployment-wide",
+    }
+    base.update(over)
+    return Settings(**base)
+
+
+# ===========================================================================
+# The helper — where the "which id, and when" decision actually lives.
+# ===========================================================================
+
+
+def test_only_our_own_proxy_gets_a_tenant_id():
+    # The id names a paying tenant. It goes to infrastructure we run and nowhere
+    # else — ``openai_compatible`` is excluded on purpose even though an operator
+    # CAN point it at the proxy, because its base URL can equally be a third
+    # party we would be handing customer identifiers to.
+    assert spend_attribution.is_proxy_provider("litellm") is True
+    for elsewhere in ("openai", "openai_compatible", "openrouter", "anthropic", "ollama"):
+        assert spend_attribution.is_proxy_provider(elsewhere) is False, elsewhere
+
+
+def test_no_id_is_sent_off_the_proxy_path_even_with_a_workspace(bound_workspace):
+    bound_workspace("ws_alpha")
+    assert spend_attribution.end_user_id_for("litellm") == "ws_alpha"
+    assert spend_attribution.end_user_id_for("openai") is None
+    assert spend_attribution.end_user_id_for("openrouter") is None
+
+
+@pytest.mark.parametrize("blank", ["", "   ", None])
+def test_a_blank_workspace_is_no_workspace(monkeypatch, blank):
+    """``user=""`` is not "unattributed" to the proxy — it is a customer named
+    empty string. Every untagged run would pool under it, and the ingest's
+    coverage check would then read as fully attributed while nobody was billed.
+
+    Asserted at ``current_workspace_id`` because that is the ONE place the
+    normalisation lives; a second guard downstream would let a mutation to
+    either one survive.
+    """
+    fake = types.ModuleType(_EE_IDENTITY_MODULE)
+    fake.current_workspace_id = lambda: blank  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, _EE_IDENTITY_MODULE, fake)
+
+    assert spend_attribution.current_workspace_id() is None
+    assert spend_attribution.end_user_id_for("litellm") is None
+
+
+def test_a_community_install_with_no_ee_package_tags_nothing(monkeypatch):
+    # The identity ContextVar lives in the EE package. A community install has no
+    # workspaces to bill, so the absence is correct, not a miss.
+    monkeypatch.setitem(sys.modules, _EE_IDENTITY_MODULE, None)
+    assert spend_attribution.current_workspace_id() is None
+
+
+def test_a_broken_identity_lookup_never_fails_the_run(monkeypatch):
+    """Attribution is worth less than the run it rides on.
+
+    If this raised, a fault in the identity layer would take out chat itself —
+    trading a billing gap (which the ingest's coverage check surfaces) for an
+    outage (which it cannot).
+    """
+    fake = types.ModuleType(_EE_IDENTITY_MODULE)
+
+    def _explode() -> str:
+        raise RuntimeError("identity layer unavailable (simulated)")
+
+    fake.current_workspace_id = _explode  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, _EE_IDENTITY_MODULE, fake)
+
+    assert spend_attribution.current_workspace_id() is None
+
+
+def test_the_workspace_comes_from_the_run_identity(monkeypatch):
+    fake = types.ModuleType(_EE_IDENTITY_MODULE)
+    fake.current_workspace_id = lambda: "ws_from_identity"  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, _EE_IDENTITY_MODULE, fake)
+
+    assert spend_attribution.current_workspace_id() == "ws_from_identity"
+
+
+def test_the_real_identity_contextvar_is_the_one_we_read():
+    """Against the actual EE module, not a stand-in — the stand-ins above would
+    keep passing if ``attach_agent_identity`` renamed what it publishes."""
+    ee = pytest.importorskip(_EE_IDENTITY_MODULE)
+
+    tokens = ee.attach_agent_identity(workspace_id="ws_real", user_id="user_real")
+    try:
+        assert spend_attribution.current_workspace_id() == "ws_real"
+    finally:
+        ee.detach_agent_identity(tokens)
+
+    assert spend_attribution.current_workspace_id() is None
+
+
+# ===========================================================================
+# pydantic_ai — the id rides on per-run model settings.
+# ===========================================================================
+
+
+def _pyd_settings(backend_settings: Settings) -> dict:
+    backend = PydanticAIBackend(backend_settings)
+    return dict(backend._run_model_settings() or {})
+
+
+def test_pydantic_ai_names_the_paying_workspace_on_the_proxy(bound_workspace):
+    bound_workspace("ws_alpha")
+    out = _pyd_settings(_settings(pydantic_ai_model="litellm:gpt-5.2"))
+    assert out.get("openai_user") == "ws_alpha"
+
+
+def test_pydantic_ai_sends_no_tenant_id_to_a_third_party(bound_workspace):
+    bound_workspace("ws_alpha")
+    for spec in ("openai:gpt-5.2", "openrouter:x/y", "openai_compatible:z"):
+        out = _pyd_settings(_settings(pydantic_ai_model=spec))
+        assert "openai_user" not in out, spec
+
+
+def test_pydantic_ai_keeps_the_output_cap_alongside_the_tenant_id(bound_workspace):
+    """Both are per-run settings and they share one dict. An earlier shape set
+    ``model_settings`` only when a cap resolved, so adding the id there would
+    have dropped it on every model without a cap."""
+    bound_workspace("ws_alpha")
+    backend = PydanticAIBackend(_settings(pydantic_ai_model="litellm:gpt-5.2"))
+    backend._resolve_max_output_tokens = lambda: 4096  # type: ignore[method-assign]
+
+    out = dict(backend._run_model_settings() or {})
+
+    assert out.get("max_tokens") == 4096
+    assert out.get("openai_user") == "ws_alpha"
+
+
+def test_pydantic_ai_sends_no_settings_at_all_when_neither_applies(bound_workspace):
+    # Byte-for-byte the behaviour before either setting existed: no
+    # ``model_settings`` key on the run rather than an empty dict.
+    bound_workspace(None)
+    backend = PydanticAIBackend(_settings(pydantic_ai_model="litellm:gpt-5.2"))
+    backend._resolve_max_output_tokens = lambda: None  # type: ignore[method-assign]
+
+    assert backend._run_model_settings() is None
+
+
+def test_pydantic_ai_uses_the_setting_name_the_sdk_maps_to_the_user_field():
+    """``openai_user`` is pydantic-ai's spelling of the OpenAI ``user`` body
+    field. Nothing in our code enforces that mapping — the SDK does — so this
+    pins the name against an upgrade that renames or drops it, which would
+    otherwise stop attribution silently on the next dependency bump."""
+    from pydantic_ai.models.openai import OpenAIChatModelSettings
+
+    assert "openai_user" in OpenAIChatModelSettings.__annotations__
+
+
+# ===========================================================================
+# deep_agents — the id is baked into the model, so the graph cache must move.
+# ===========================================================================
+
+
+def _deep_model_kwargs(backend_settings: Settings) -> dict:
+    backend = DeepAgentsBackend(backend_settings)
+    backend._sdk_available = True
+    model = backend._build_model()
+    return dict(getattr(model, "model_kwargs", {}) or {})
+
+
+def test_deep_agents_names_the_paying_workspace_on_the_proxy(bound_workspace):
+    bound_workspace("ws_alpha")
+    mk = _deep_model_kwargs(_settings(deep_agents_model="litellm:litellm_proxy/gpt-5.2"))
+    assert mk.get("user") == "ws_alpha"
+
+
+def test_deep_agents_sends_nothing_when_there_is_no_workspace(bound_workspace):
+    bound_workspace(None)
+    mk = _deep_model_kwargs(_settings(deep_agents_model="litellm:litellm_proxy/gpt-5.2"))
+    assert "user" not in mk
+
+
+def test_deep_agents_sends_no_tenant_id_to_a_third_party(bound_workspace):
+    bound_workspace("ws_alpha")
+    for spec in ("openrouter:x/y", "openai_compatible:z"):
+        backend = DeepAgentsBackend(
+            _settings(
+                deep_agents_model=spec,
+                openai_compatible_base_url="http://third.party",
+                openrouter_api_key="sk-openrouter",
+                openai_compatible_api_key="sk-compatible",
+            )
+        )
+        backend._sdk_available = True
+        model = backend._build_model()
+        mk = dict(getattr(model, "model_kwargs", {}) or {})
+        assert "user" not in mk, spec
+
+
+def test_deep_agents_tenant_id_survives_the_thinking_flag(bound_workspace):
+    """Both write ``model_kwargs`` and the thinking block runs second. It copies
+    the dict rather than replacing it; if that ever changes, the tenant id is
+    what gets dropped, and it gets dropped only on deployments that disable
+    thinking — the kind of gap nobody finds by reading."""
+    bound_workspace("ws_alpha")
+    mk = _deep_model_kwargs(
+        _settings(
+            deep_agents_model="litellm:litellm_proxy/deepseek-v4-flash",
+            deep_agents_disable_thinking=True,
+        )
+    )
+    assert mk.get("user") == "ws_alpha"
+    assert mk.get("extra_body") == {"thinking": {"type": "disabled"}}
+
+
+def test_deep_agents_never_serves_one_workspaces_graph_to_another(monkeypatch, bound_workspace):
+    """The cross-tenant billing hazard, and the reason the cache key moved.
+
+    ``create_deep_agent`` bakes the model — tenant id and all — into the compiled
+    graph, while ``AgentPool`` drives runs through one cached instance. Without
+    the id in the key, the second workspace's runs are charged to the first, and
+    every observable thing about the run still looks right.
+    """
+    import deepagents
+
+    compiled: list = []
+
+    def _capture(**kwargs):
+        compiled.append(kwargs.get("model"))
+        return object()
+
+    monkeypatch.setattr(deepagents, "create_deep_agent", _capture)
+
+    backend = DeepAgentsBackend(_settings(deep_agents_model="litellm:litellm_proxy/gpt-5.2"))
+    backend._sdk_available = True
+
+    def _agent_for(workspace: str):
+        bound_workspace(workspace)
+        return backend._get_or_create_agent(backend._build_model(), "you are an agent")
+
+    first = _agent_for("ws_alpha")
+    again = _agent_for("ws_alpha")
+    second = _agent_for("ws_beta")
+
+    assert again is first, "the same workspace must still reuse its compiled graph"
+    assert second is not first, "a second workspace was served the first's graph"
+
+    assert len(compiled) == 2
+    assert compiled[0].model_kwargs.get("user") == "ws_alpha"
+    assert compiled[1].model_kwargs.get("user") == "ws_beta"


### PR DESCRIPTION
Chat has been free.

Both agent backends authenticate to the LiteLLM proxy with `settings.litellm_api_key`. That is the deployment's key, one for the whole install, not any tenant's. A comment in `pydantic_ai.py` said the opposite, and the billing cutover was built on that claim: it reads a tenant's spend by filtering `/spend/logs` on the tenant's own virtual key, which no chat request has ever sent.

In `off` mode nothing showed, because per-run metering was doing the billing. In `live`, where the per-run sweep is gated off so exactly one meter charges, the one meter was filtering out the product's main cost centre. The deployment logged this while it was on:

```
run_cutover_sweep: ingested spend for 3/3 tenants -> 0 credits, 0 failed
(LiteLLM is the sole meter; BC-3 gated off)
```

Three tenants, all reads succeeding, real dollars on the proxy's own log for the same runs. Nothing errored, because nothing was wrong with the read. It was scoped to the wrong thing.

## Why not just send the tenant's key

That fixes it and keeps the shape of the hole. Attribution would depend on a provisioning step, and a workspace that missed the step would be free rather than loud, which is exactly the state we were just in.

So the id rides on the request instead. LiteLLM calls it an end-user, or a customer; it needs no key and nothing to provision, and a request that somehow carries no id shows up as unattributed spend rather than as spend nobody is charged for. That count is the second PR.

## What this does

On the `litellm` provider only, both backends put the workspace id in the request body's `user` field. The proxy stamps it onto the spend row's `end_user` column. Nothing else about a run changes.

`pydantic_ai` passes it per run, in the same `model_settings` dict as the output-token cap, for the reason that one is per run: `AgentPool` shares one cached agent across runs, so anything belonging to this run cannot live on it.

`deep_agents` is the one with a hazard. It bakes the model into the compiled graph, so the same value also joins the graph cache key. Without that, one instance serving two workspaces charges the second one's runs to the first, and every observable thing about the run still looks right. Both sides read one method so they cannot disagree about the value.

The wrong comment is corrected in the same change. A wrong comment at the seam is how this survived review.

## Two things on the proxy that this cannot check

`disable_end_user_cost_tracking` drops the id on the way to the spend row. It does not error; rows just arrive anonymous.

A default customer budget (`max_end_user_budget` and friends) now applies to these ids, because they are customers as far as the proxy is concerned. Unset by default.

Both are in the runbook in the follow-up PR.

## Chain

Every hop was read in the pinned `litellm` 1.83.0 and `pydantic-ai` sources rather than assumed, because a break at any one of them bills nothing and says nothing:

1. `user` in the body
2. `get_end_user_id_from_request_body` check 3, binding `UserAPIKeyAuth.end_user_id`
3. `get_end_user_id_for_cost_tracking` writing `SpendLogs.end_user`
4. `/spend/logs/v2?end_user=` reading it back

LiteLLM's docs confirm `user` as the documented mechanism, and warn that a caller can declare any id it likes. That warning does not reach us: the field is set from the run's bound identity when the model is built, and no customer request body is forwarded. Both conditions are written down next to the code, because the exemption stops holding the moment either changes.

## Tests

19 new, in `tests/test_proxy_spend_attribution.py`. The two worth reading are the provider gate (a tenant id never goes to a third party) and the deep_agents cache key, which fails without the fix by handing workspace B the graph compiled for workspace A.

Existing backend suites: 244 pass. `mutate.py --validate`: 876 anchors clean.

## Alone, this changes no bill

Tagging without the reading side finds nothing, and the reading side without tagging sees nothing. Stacked PR does the reading.
