### PR TITLE
Read a tenant's proxy spend by customer, so chat can be billed at all

### DIFF
--- a/docs/deployment/litellm-billing-cutover.md
+++ b/docs/deployment/litellm-billing-cutover.md
@@ -13,9 +13,38 @@ There are three modes, set by `POCKETPAW_LITELLM_SPEND_MODE`:
 
 Both sweeps run on the same five minute heartbeat.
 
+## Before anything: the proxy has to record who a request was for
+
+Spend is attributed to a workspace by the `user` field each request carries, which
+the proxy stores on the spend row as its `end_user`. Every chat request sets it.
+Nothing else does, and nothing else can: chat authenticates with the deployment's
+own key, so a read filtered by a tenant's virtual key cannot see a chat run at all.
+
+Two things on the proxy have to be true, and neither is visible from our side.
+
+**End-user cost tracking must be on.** `disable_end_user_cost_tracking` drops the
+id on the way to the spend row. It does not error; the rows simply arrive
+anonymous, and everything downstream reports zero.
+
+**The proxy must serve `/spend/logs/v2`.** That is the only spend route that
+filters on `end_user`. On a proxy too old to have it, each sweep logs a failed
+customer read and falls back to the per-key read, which bills media and Studio and
+nothing else.
+
+Check both before you go further:
+
+```bash
+curl -s -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  "$LITELLM_BASE/spend/logs/v2?start_date=$(date -u -d yesterday +%F)&end_date=$(date -u +%F)&page_size=5" \
+  | head -c 400
+```
+
+Rows should come back with a populated `end_user`. Empty ids on rows you know came
+from chat mean the tracking switch, not the endpoint.
+
 ## Do not flip straight to `live`
 
-Two things go wrong if you do, and neither announces itself.
+Three things go wrong if you do, and none of them announces itself.
 
 **The whole history gets billed at once.** Spend ingestion skips rows older than
 a per-tenant high-water mark, and that mark is empty until something ingests. On
@@ -30,12 +59,41 @@ only tenants that hold a proxy key. In `live` the per-run sweep is off for
 everyone, so a workspace without a key is charged by nothing. Its usage is free
 and silently so.
 
+**Anything the proxy cannot attribute is free.** This is the one that bit us. For
+as long as `live` was on, chat was billed to nobody: the ingest read spend by
+virtual key, chat sends the deployment key, and the two never met. The sweep
+reported `ingested spend for 3/3 tenants -> 0 credits` the whole time and no part
+of it was lying. Every tick now also counts the window's spend rows that no swept
+workspace claims, and says so:
+
+```
+spend_attribution_coverage: [...] 41 of 128 proxy spend row(s) belong to NO swept
+workspace — that spend is being served and not billed
+```
+
+Treat a non-zero count as blocking. It is the number that tells you whether the
+meter you are about to trust alone can see what people are actually spending.
+
 ## The procedure
 
 **1. Run `shadow` for a while.** It reads proxy spend and the ledger over the same
 window and records a reconciliation row per tenant with the delta and a
 `coverage_gap` verdict. It moves no money. This is how you find out whether the
 two meters agree before you trust one of them alone.
+
+Shadow also runs the attribution-coverage check, so this is where you see whether
+anything is falling through before it costs you. Watch two numbers, not one: the
+per-tenant `delta`, and `unattributed`.
+
+```python
+from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
+await run_cutover_sweep(mode="shadow")
+# {'tenants': 3, 'processed': 3, 'gaps': 0, 'credits': 0, 'unattributed': 0}
+```
+
+`unattributed` must be zero, and a zero you got while a count was failing does not
+count — the log line says `INCOMPLETE` in that case rather than reporting a
+finding.
 
 **2. Drain the per-run sweep.** Let it run until no completed run is still
 unbilled. A run left unbilled at the moment you flip is billed by neither meter:
@@ -90,6 +148,24 @@ people pay and it is worth knowing before support asks.
 `credit_usd`, so the conversion is still `round(cost * markup / credit_usd)` and
 charges are still whole credits worth a cent each. A run costing less than a cent
 still rounds to one.
+
+**Chat is billed at all, which it was not before.** If you ran `live` before the
+attribution fix, chat was free for everyone. Turning this on is not a price rise
+in the rate-card sense, but it will look like one on the first invoice after it,
+and it is the change support will hear about.
+
+## A note on trusting the `user` field
+
+LiteLLM's own documentation warns that a caller can declare any `user` it likes,
+and the proxy will attribute the cost to whatever it says. That would be a way for
+one tenant to charge another.
+
+It does not reach us, because the field is not ours to forward: both agent backends
+set it from the run's own bound identity at the point the model is built, and no
+part of a customer's request body is passed through to the proxy. The warning
+becomes ours the moment either of those stops being true — if a tenant is ever
+handed a proxy key to call directly, or a request body is ever proxied verbatim,
+the id has to move to a header set server-side.
 
 ## Rolling back
 

--- a/ee/pocketpaw_ee/catalog/admin_client.py
+++ b/ee/pocketpaw_ee/catalog/admin_client.py
@@ -26,6 +26,14 @@
 #                              the proxy treats as admin view), so it returns exactly
 #                              that tenant's daily activity. Powers the billing usage
 #                              graph (the WorkspaceUsage transform in cloud.billing.usage).
+#   * GET  /spend/logs/v2?end_user=&start_date=&end_date= — the spend rows for one
+#                              CUSTOMER (LiteLLM's word for the ``user`` field on a
+#                              request) rather than one virtual key. Date-bounded and
+#                              paginated; this client walks every page. This is the
+#                              read that makes chat billable: a chat request carries
+#                              the deployment key, so the per-key read above cannot
+#                              see it, and only the workspace id the request carries
+#                              in its ``user`` field can.
 #   * POST /key/delete       — revoke keys (used by the live-check teardown so a
 #                              throwaway probe key never lingers on the proxy).
 #
@@ -38,6 +46,15 @@
 # Updated 2026-06-29 (feat/billing-usage-endpoint): added ``user_daily_activity`` —
 #   the per-key DAILY usage read (GET /user/daily/activity) that backs the billing
 #   usage graph. Walks pagination internally and returns the merged daily records.
+# Updated 2026-09-02 (feat/proxy-spend-ingest-by-customer): added
+#   ``spend_logs_by_end_user`` and ``spend_log_count`` over /spend/logs/v2. The
+#   per-KEY read was the only spend read this client had, and chat never sends a
+#   tenant key — it sends the deployment master key — so in ``live`` mode chat
+#   billed zero for everyone while the proxy's own log showed real dollars. These
+#   two read by the customer id the request carries instead, which is the only
+#   attribution a chat row has. ``spend_log_count`` exists for the sweep's coverage
+#   check: it asks for one row and reads the ``total``, which is how unattributed
+#   spend becomes visible rather than merely uncharged.
 
 from __future__ import annotations
 
@@ -251,6 +268,136 @@ class LiteLLMAdminClient:
                 max_pages,
             )
         return results
+
+    async def _spend_logs_v2(
+        self,
+        *,
+        start_date: str,
+        end_date: str,
+        end_user: str | None,
+        page: int,
+        page_size: int,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """One page of GET /spend/logs/v2. Returns ``(rows, total_matching)``.
+
+        ``/spend/logs/v2`` is the paginated, date-bounded successor to
+        ``/spend/logs`` (which the proxy's own docstring now marks deprecated for
+        exactly the reason our per-key read warns about — it is unpaginated and
+        scans). It is also the only spend route that filters on ``end_user``.
+
+        Dates are ``YYYY-MM-DD HH:MM:SS`` or ``YYYY-MM-DD``; BOTH are required —
+        the proxy 400s without them, so there is no unbounded form of this call to
+        fall into by accident.
+        """
+        params: dict[str, Any] = {
+            "start_date": start_date,
+            "end_date": end_date,
+            "page": page,
+            "page_size": page_size,
+            # Oldest first, so a caller that stops early keeps a contiguous
+            # prefix rather than a hole in the middle of its window.
+            "sort_by": "startTime",
+            "sort_order": "asc",
+        }
+        if end_user is not None:
+            params["end_user"] = end_user
+
+        async with self._client() as client:
+            resp = await client.get(f"{self._base_url}/spend/logs/v2", params=params)
+        body = self._json_or_raise(resp, "/spend/logs/v2")
+
+        data = body.get("data")
+        rows = [r for r in data if isinstance(r, dict)] if isinstance(data, list) else []
+        try:
+            total = int(body["total"])
+        except (KeyError, TypeError, ValueError):
+            # A proxy build that omits or mangles ``total``. Fall back to what this
+            # page actually returned rather than to zero: zero reads as an empty
+            # window, which would make the coverage check report perfect attribution
+            # over data it never saw — the exact shape of the bug it exists to catch.
+            total = len(rows)
+        return rows, total
+
+    async def spend_logs_by_end_user(
+        self,
+        *,
+        end_user: str,
+        start_date: str,
+        end_date: str,
+        page_size: int = 100,
+    ) -> list[dict[str, Any]]:
+        """The spend rows one CUSTOMER accrued over a window, across every key.
+
+        ``end_user`` is the value the request carried in its ``user`` field — for
+        us, the workspace id. This is the read that makes a chat run billable:
+        chat authenticates with the deployment's master key, so ``spend_logs``
+        (filtered by a tenant's virtual key) returns nothing for it no matter how
+        much it cost.
+
+        Rows carry the same fields the per-key read returns and the ingest already
+        parses — ``request_id``, ``spend``, ``startTime``, ``model``, token counts.
+        They do NOT carry the nested ``prompt_tokens_details``, so the cached-token
+        figure degrades to zero on this path; that number is reporting, not money,
+        and the charge comes from ``spend``.
+
+        Walks every page. ``page_size`` is capped at 100 by the proxy.
+        """
+        if not end_user:
+            raise LiteLLMAdminError(
+                "spend_logs_by_end_user requires end_user (an unscoped read returns "
+                "every tenant's spend)"
+            )
+
+        rows: list[dict[str, Any]] = []
+        page = 1
+        # Defensive ceiling. 100 rows/page x 200 pages is 20k spend rows for ONE
+        # workspace in ONE window — far past any real sweep, and it bounds a proxy
+        # that misreports ``total``.
+        max_pages = 200
+        while page <= max_pages:
+            batch, total = await self._spend_logs_v2(
+                start_date=start_date,
+                end_date=end_date,
+                end_user=end_user,
+                page=page,
+                page_size=page_size,
+            )
+            rows.extend(batch)
+            if not batch or len(rows) >= total:
+                break
+            page += 1
+        else:
+            logger.warning(
+                "LiteLLM /spend/logs/v2 still had pages for end_user=%s after %d — "
+                "stopping (spend may be truncated and will be re-read next sweep)",
+                end_user,
+                max_pages,
+            )
+        return rows
+
+    async def spend_log_count(
+        self,
+        *,
+        start_date: str,
+        end_date: str,
+        end_user: str | None = None,
+    ) -> int:
+        """How many spend rows a window holds, optionally for one customer.
+
+        Asks for a single row and reads the ``total`` the proxy reports, so the
+        cost is one small request whatever the window holds. The sweep's coverage
+        check subtracts the per-customer counts from the unfiltered one; what is
+        left is spend no workspace claimed, which is the failure mode that
+        otherwise presents as silence.
+        """
+        _rows, total = await self._spend_logs_v2(
+            start_date=start_date,
+            end_date=end_date,
+            end_user=end_user,
+            page=1,
+            page_size=1,
+        )
+        return total
 
     async def delete_keys(self, keys: list[str]) -> dict[str, Any]:
         """POST /key/delete — revoke the given virtual keys. Used by the live-check

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
@@ -14,6 +14,13 @@
 #                  ledger (the BC-3 sweep is gated OFF in ``metering.sweeper`` when
 #                  the mode is live, so exactly one meter charges).
 #
+# Every non-off tick ALSO runs an attribution-coverage check: how many of the
+# window's proxy spend rows belong to no swept workspace. It debits nothing and
+# cannot fail the sweep. It is here because the failure it watches for is the one
+# this sweep cannot see from the inside — when chat spend was attributed to nobody,
+# every per-tenant read succeeded and this job logged a confident
+# ``3/3 tenants -> 0 credits`` for as long as it was left on.
+#
 # Runs on the SAME schedule as the BC-3 metering sweep — the in-process 5-minute
 # heartbeat (``ee.extensions._sweeper_loop``) and the Tier 2 worker boot
 # (``chat.runs.worker._startup``). Mirrors that sweep's shape: tenant-agnostic
@@ -31,6 +38,11 @@
 # tenant never wedges the whole sweep — the same isolation the BC-3 sweep uses.
 #
 # Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new entity.
+# Updated 2026-09-02 (feat/proxy-spend-ingest-by-customer): added the
+#   attribution-coverage check to both the shadow and live branches, and put
+#   ``unattributed`` in the summary dict so a caller sees it without reading logs.
+#   In shadow it is the go/no-go signal — flipping to live while rows are
+#   unattributed converts a reporting gap into free service.
 
 from __future__ import annotations
 
@@ -64,7 +76,16 @@ async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
     sweep (it is retried next tick).
     """
     resolved = mode if mode is not None else provisioning_service.spend_mode()
-    summary = {"tenants": 0, "processed": 0, "failed": 0, "gaps": 0, "credits": 0}
+    summary = {
+        "tenants": 0,
+        "processed": 0,
+        "failed": 0,
+        "gaps": 0,
+        "credits": 0,
+        # Spend rows in the trailing window that no swept workspace claims. Zero is
+        # the healthy value; anything else is served-and-unbilled compute.
+        "unattributed": 0,
+    }
 
     if resolved == "off":
         # Nothing to do — BC-3 bills as today.
@@ -72,6 +93,18 @@ async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
 
     workspaces = await provisioning_service.list_provisioned_workspaces()
     summary["tenants"] = len(workspaces)
+
+    # BEFORE the empty-tenant early return, deliberately. A deployment with no
+    # provisioned tenants and real proxy traffic is the loudest version of the
+    # failure this check exists for, and returning first would be the one case
+    # where it says nothing.
+    coverage_until = datetime.now(UTC)
+    summary["unattributed"] = (
+        await provisioning_service.spend_attribution_coverage(
+            workspaces, since=coverage_until - _SHADOW_WINDOW, until=coverage_until
+        )
+    ).unattributed_rows
+
     if not workspaces:
         return summary
 
@@ -120,11 +153,13 @@ async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
                 )
         logger.info(
             "run_cutover_sweep[live]: ingested spend for %d/%d tenants -> %d credits, "
-            "%d failed (LiteLLM is the sole meter; BC-3 gated off)",
+            "%d failed, %d unattributed row(s) in the trailing window "
+            "(LiteLLM is the sole meter; BC-3 gated off)",
             summary["processed"],
             summary["tenants"],
             summary["credits"],
             summary["failed"],
+            summary["unattributed"],
         )
         return summary
 

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
@@ -23,6 +23,10 @@
 #                           and the coverage-gap verdict. Carries NO debit — shadow
 #                           only reads + compares. The Beanie persistence twin is
 #                           ``models.spend_reconciliation.SpendReconciliation``.
+#   * ``SpendCoverage``   — the outcome of one attribution-coverage check: how many
+#                           proxy spend rows a window holds versus how many any
+#                           tenant claims. The difference is spend nobody is billed
+#                           for, which is the failure this whole seam presents as.
 #   * ``SpendCredits``    — the per-tenant spend rate card: USD-cost markup + the
 #                           per-credit USD denomination. Mirrors metering's
 #                           ``RateCard`` shape deliberately so proxy-spend and
@@ -33,6 +37,12 @@
 # ``SpendReconciliation`` — the value object returned by the shadow-mode compare
 # (``service.reconcile_tenant_spend``). Distinct from the Beanie doc of the same
 # concept; this is the framework-free shape the sweep logs + the doc is built from.
+# Updated 2026-09-02 (feat/proxy-spend-ingest-by-customer): added ``SpendCoverage``
+# — what ``service.spend_attribution_coverage`` returns. It exists because the bug
+# that motivated this branch was invisible: chat spend was attributed to nobody, the
+# per-tenant reads all succeeded, and the sweep logged a confident
+# ``3/3 tenants -> 0 credits``. A count of rows no tenant claims is the one number
+# that would have said so on the first tick.
 
 from __future__ import annotations
 
@@ -137,6 +147,35 @@ class CutoverPreparation:
     seeded: int
     already_marked: int
     dry_run: bool
+
+
+@dataclass(frozen=True)
+class SpendCoverage:
+    """How much of a window's proxy spend any tenant actually claims.
+
+    ``total_rows`` is every spend row the proxy recorded in the window;
+    ``attributed_rows`` is the sum of the per-tenant counts over the workspaces
+    checked. ``unattributed_rows`` is the remainder — requests that reached the
+    proxy carrying no workspace, or one nobody is sweeping.
+
+    Any non-zero remainder is a billing hole, and reading it as a ROW count rather
+    than a dollar amount is deliberate: a count needs one cheap request per tenant
+    and answers the question that matters ("is anything falling through?") without
+    pretending to be an invoice. The reconciliation compare is where amounts belong.
+
+    ``degraded`` marks a check that could not complete — a proxy that failed one of
+    the counts. The remainder is then unreliable and must not be read as a verdict,
+    which is a distinction the log line has to keep: "no gap" and "could not tell"
+    look identical in a bare zero.
+    """
+
+    window_start: str
+    window_end: str
+    total_rows: int
+    attributed_rows: int
+    unattributed_rows: int
+    workspaces_checked: int
+    degraded: bool
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -77,11 +77,48 @@
 #      ``<=`` (dropped a distinct boundary row on a later sweep → under-bill); it
 #      is now strict ``<`` with the ``litellm:{request_id}`` ledger dedup as the
 #      exactly-once guard at the boundary. See the inline note at the loop.
+#
+# Updated 2026-09-02 (feat/proxy-spend-ingest-by-customer): ``ingest_tenant_spend``
+# now reads a tenant's spend BY CUSTOMER as well as by virtual key.
+#
+# The per-key read could never see a chat run. Both agent backends authenticate
+# with ``settings.litellm_api_key`` — the DEPLOYMENT's key — so a chat row is
+# stamped with that key and ``/spend/logs?api_key=<tenant key>`` does not match it.
+# With ``live`` gating BC-3's per-run metering off so exactly one meter charges,
+# the one meter was reading a filter that excludes the product's main cost centre:
+# production logged ``ingested spend for 3/3 tenants -> 0 credits`` against runs the
+# proxy had priced in dollars. Nothing errored, because nothing was wrong with the
+# read — it was scoped to the wrong thing.
+#
+# The companion change puts the workspace id in each request's ``user`` field, which
+# the proxy records as the row's ``end_user``. This side reads it back with
+# ``GET /spend/logs/v2?end_user=<workspace>``. Four things worth knowing:
+#
+#   * BOTH reads run, and their rows are merged by ``request_id``. The customer read
+#     should be a superset today (Studio and the media MCP server tag ``user`` as
+#     well as sending the tenant key), but "should be" is not a thing to assume when
+#     the failure mode is an under-bill, and a row seen twice is billed once —
+#     ``litellm:{request_id}`` is the ledger key either way.
+#   * The customer read is DATE-BOUNDED, so it needs a window rather than the
+#     high-water mark alone. It starts a short overlap BEFORE the mark
+#     (``_SPEND_READ_OVERLAP``) and, for a tenant with no mark at all, at the key
+#     doc's ``createdAt`` — the point from which this deployment has been the tenant's
+#     proxy, and so the earliest spend that can be theirs.
+#   * Rows from the customer read BYPASS the high-water skip. The mark exists to
+#     bound an unbounded read; this read is already bounded, and honouring the mark
+#     here would re-introduce the exact bug WU-F fixed at the boundary — a row that
+#     lands late with a ``startTime`` older than the mark would be skipped forever.
+#     Exactly-once still holds: it always came from the ledger key, never the mark.
+#   * A workspace with no provisioned key still returns a zero result, because the
+#     high-water mark lives on that document and there is nowhere else to keep it.
+#     The sweep only iterates provisioned tenants, so this is not a hole so much as
+#     the edge of the map — and the sweep's coverage check is what makes spend
+#     outside it visible.
 
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from pocketpaw_ee.catalog.admin_client import LiteLLMAdminClient, LiteLLMAdminError
@@ -91,6 +128,7 @@ from pocketpaw_ee.cloud.llm_provisioning.domain import (
     CutoverPreparation,
     KeyBudget,
     ProvisionResult,
+    SpendCoverage,
     SpendCredits,
     SpendIngestResult,
     SpendReconciliation,
@@ -125,6 +163,21 @@ _BC3_COMPUTE_SPEND_CAUSE = "compute_spend"
 # The key-alias prefix the proxy stamps on a tenant's virtual key, for operator
 # legibility in the proxy admin UI + spend logs.
 _KEY_ALIAS_PREFIX = "ws-"
+
+# How far BEFORE the high-water mark the customer-scoped read starts.
+#
+# Proxy spend rows are written when a call COMPLETES but stamped with when it
+# STARTED, and the write is batched, so a row can appear after the mark has already
+# moved past its ``startTime``. A date-bounded read that began exactly at the mark
+# would never see it. The overlap re-reads a few minutes of settled rows each
+# sweep — they cost one ``is_recorded`` lookup apiece and debit nothing — to buy
+# back rows that would otherwise be lost silently and permanently.
+_SPEND_READ_OVERLAP = timedelta(minutes=15)
+
+# The timestamp format /spend/logs/v2 parses. It also accepts a bare date; second
+# precision keeps the window tight enough that the overlap above is the only
+# deliberate re-read.
+_PROXY_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
 # ---------------------------------------------------------------------------
@@ -501,6 +554,103 @@ def _cached_tokens(row: dict[str, Any]) -> int:
     return _int(row.get("cache_read_input_tokens") or row.get("cached_tokens"))
 
 
+def _proxy_window(start: datetime, end: datetime) -> tuple[str, str]:
+    """Format a window the way /spend/logs/v2 parses it."""
+    return (
+        _as_aware(start).strftime(_PROXY_DATE_FORMAT),  # type: ignore[union-attr]
+        _as_aware(end).strftime(_PROXY_DATE_FORMAT),  # type: ignore[union-attr]
+    )
+
+
+def _customer_read_window(doc: LiteLLMTenantKey, *, now: datetime) -> tuple[datetime, datetime]:
+    """The window the customer-scoped spend read should cover for ``doc``.
+
+    Starts an overlap before the high-water mark, or — when nothing has ever been
+    ingested for this tenant — at the moment we provisioned their key, which is the
+    earliest instant any spend on this proxy can be theirs. That start is
+    deliberately NOT "the beginning of time": a tenant whose mark was seeded by
+    ``prepare_spend_cutover`` has one, and a tenant without one is new, so an
+    unbounded start could only ever reach back into spend some other meter already
+    charged.
+    """
+    mark = _parse_iso(doc.last_spend_ingest_ts)
+    if mark is not None:
+        return mark - _SPEND_READ_OVERLAP, now
+    created = _as_aware(doc.createdAt)
+    return (created if created is not None else now - _SPEND_READ_OVERLAP), now
+
+
+async def _read_tenant_spend_rows(
+    workspace: str,
+    doc: LiteLLMTenantKey,
+    client: LiteLLMAdminClient,
+) -> list[tuple[dict[str, Any], bool]]:
+    """Every spend row that could belong to ``workspace``, from both reads.
+
+    Returns ``(row, honour_high_water_mark)`` pairs. The flag is True only for
+    rows from the per-KEY read, which is unbounded and needs the mark to stop it
+    re-walking the tenant's whole history; the customer-scoped rows carry their
+    own window and must not be filtered again (see the loop's note).
+
+    Merged on ``request_id``, key-read rows yielding to customer-read ones — the
+    two overlap wherever a caller both sends the tenant key and tags ``user``,
+    which is what Studio and the media server do. A row with no ``request_id``
+    cannot be de-duplicated OR billed, so it is passed through and rejected once,
+    loudly, in the loop.
+
+    A failure of the customer read does not sink the key read, or vice versa. One
+    of them returning nothing is normal; both being skipped because the other
+    raised would turn a partial outage into a total one, and the sweep retries.
+    """
+    customer_rows: list[dict[str, Any]] = []
+    since, until = _customer_read_window(doc, now=datetime.now(UTC))
+    start_date, end_date = _proxy_window(since, until)
+    try:
+        customer_rows = await client.spend_logs_by_end_user(
+            end_user=workspace, start_date=start_date, end_date=end_date
+        )
+    except Exception:
+        logger.exception(
+            "llm_provisioning: customer-scoped spend read failed for workspace=%s over "
+            "[%s,%s] — falling back to the per-key read alone this sweep, which does "
+            "NOT see chat. A 404 here means the proxy predates /spend/logs/v2; every "
+            "other error is worth reading, because this is the read that bills chat",
+            workspace,
+            start_date,
+            end_date,
+        )
+
+    key_rows: list[dict[str, Any]] = []
+    if doc.litellm_key:
+        try:
+            key_rows = await client.spend_logs(api_key=doc.litellm_key)
+        except Exception:
+            logger.exception(
+                "llm_provisioning: per-key spend read failed for workspace=%s — "
+                "continuing with the customer-scoped rows alone this sweep",
+                workspace,
+            )
+
+    merged: list[tuple[dict[str, Any], bool]] = [(row, False) for row in customer_rows]
+    seen = {rid for row in customer_rows if (rid := _row_id(row)) is not None}
+    for row in key_rows:
+        rid = _row_id(row)
+        if rid is not None and rid in seen:
+            continue
+        merged.append((row, True))
+
+    logger.debug(
+        "llm_provisioning: workspace=%s spend rows — %d by customer over [%s,%s], "
+        "%d additional by key",
+        workspace,
+        len(customer_rows),
+        start_date,
+        end_date,
+        len(merged) - len(customer_rows),
+    )
+    return merged
+
+
 async def ingest_tenant_spend(
     workspace: str,
     *,
@@ -510,9 +660,14 @@ async def ingest_tenant_spend(
     """Read ``workspace``'s LiteLLM proxy spend and debit it to the EXISTING credit
     ledger, exactly once per spend row.
 
-    Reads GET /spend/logs?api_key=<tenant key>, keeps only rows NEWER than the
-    stored ``last_spend_ingest_ts`` high-water mark, converts each row's USD
-    ``spend`` to integer credits via the rate card, and debits the wallet with
+    Reads the tenant's spend TWICE and merges it: once by customer
+    (``GET /spend/logs/v2?end_user=<workspace>``, which is the only read that sees
+    a chat run, because chat authenticates with the deployment key) and once by
+    virtual key (``GET /spend/logs?api_key=<tenant key>``, which predates it and
+    stays as a safety net). Rows are merged on ``request_id``; the key-read rows are
+    the ones still bounded by the stored ``last_spend_ingest_ts`` high-water mark.
+    Then it converts each row's USD ``spend`` to integer credits via the rate card,
+    and debits the wallet with
     ``credits.service.debit(..., cause="litellm_spend",
     idempotency_key="litellm:{request_id}", allow_negative=True)``. BC-1's unique
     ``(workspace, idempotency_key)`` index makes a re-ingested row a ledger no-op
@@ -547,7 +702,7 @@ async def ingest_tenant_spend(
     card = spend_card if spend_card is not None else load_spend_credits()
     client = admin_client if admin_client is not None else LiteLLMAdminClient()
 
-    rows = await client.spend_logs(api_key=doc.litellm_key)
+    rows = await _read_tenant_spend_rows(workspace, doc, client)
 
     high_water = doc.last_spend_ingest_ts
     # Compare PARSED instants, not the raw strings. LiteLLM emits naive,
@@ -569,7 +724,7 @@ async def ingest_tenant_spend(
     cached_total = 0
 
     # Oldest first so the high-water mark advances monotonically.
-    for row in sorted(rows, key=lambda r: _row_start_time(r) or ""):
+    for row, honour_mark in sorted(rows, key=lambda pair: _row_start_time(pair[0]) or ""):
         start_ts = _row_start_time(row)
         # WU-F boundary fix — skip rows STRICTLY older than the high-water mark
         # only. The previous ``start_ts <= high_water`` dropped a DISTINCT row that
@@ -581,8 +736,21 @@ async def ingest_tenant_spend(
         # unique index), so an already-ingested boundary row no-ops while a new
         # boundary row bills exactly once. The mark stays an optimisation that bounds
         # the read; the per-row request_id is the real exactly-once guard.
+        #
+        # ``honour_mark`` is False for the customer-scoped rows, which arrive
+        # already bounded by their own window. Applying the mark to those would
+        # re-create the boundary bug this paragraph describes, in its worst form:
+        # a row written late, with a ``startTime`` behind a mark that has already
+        # advanced, would be skipped on this sweep AND on every sweep after it.
+        # Nothing is lost by skipping the skip — the ledger key, not the mark, is
+        # what makes a row bill exactly once.
         start_dt = _parse_iso(start_ts)
-        if high_water_dt is not None and start_dt is not None and start_dt < high_water_dt:
+        if (
+            honour_mark
+            and high_water_dt is not None
+            and start_dt is not None
+            and start_dt < high_water_dt
+        ):
             continue
 
         rows_read += 1
@@ -843,6 +1011,113 @@ async def reconcile_tenant_spend(
     )
 
 
+async def spend_attribution_coverage(
+    workspaces: list[str],
+    *,
+    since: datetime,
+    until: datetime,
+    admin_client: LiteLLMAdminClient | None = None,
+) -> SpendCoverage:
+    """Count the window's spend rows that NO tenant claims. Debits nothing.
+
+    Asks the proxy how many spend rows the window holds in total, then how many it
+    holds per workspace, and reports the difference. Each count is one request that
+    returns a single row and reads the reported ``total``, so the whole check costs
+    ``len(workspaces) + 1`` small calls however much spend the window contains.
+
+    This exists because of how the bug it watches for presented. Chat spend was
+    attributed to no tenant for the entire time ``live`` was on; every per-tenant
+    read succeeded, every sweep logged a healthy ``3/3 tenants``, and the only
+    visible symptom was a number nobody had a reason to disbelieve: zero credits.
+    A remainder here is the one signal that distinguishes "nobody spent anything"
+    from "we are not looking where the spending is".
+
+    Never raises. A failed count sets ``degraded`` and leaves the remainder
+    untrustworthy rather than taking the sweep down with it — the sweep's job is to
+    bill, and this is an observation of the sweep, not part of it.
+    """
+    client = admin_client if admin_client is not None else LiteLLMAdminClient()
+    start_date, end_date = _proxy_window(since, until)
+
+    degraded = False
+    total_rows = 0
+    try:
+        total_rows = await client.spend_log_count(start_date=start_date, end_date=end_date)
+    except Exception:
+        degraded = True
+        logger.exception(
+            "llm_provisioning.spend_attribution_coverage: could not read the window "
+            "total over [%s,%s] — coverage is unknown this tick, NOT clean",
+            start_date,
+            end_date,
+        )
+
+    attributed_rows = 0
+    for workspace in workspaces:
+        try:
+            attributed_rows += await client.spend_log_count(
+                start_date=start_date, end_date=end_date, end_user=workspace
+            )
+        except Exception:
+            degraded = True
+            logger.exception(
+                "llm_provisioning.spend_attribution_coverage: could not count rows for "
+                "workspace=%s — coverage is unknown this tick, NOT clean",
+                workspace,
+            )
+
+    # Clamped at zero. The two counts are separate queries against a table that is
+    # still being written, so a row landing between them can make the per-tenant sum
+    # exceed the total. A negative remainder is a race, not a surplus, and reporting
+    # one would train an operator to ignore the number.
+    unattributed = max(0, total_rows - attributed_rows)
+
+    coverage = SpendCoverage(
+        window_start=start_date,
+        window_end=end_date,
+        total_rows=total_rows,
+        attributed_rows=attributed_rows,
+        unattributed_rows=unattributed,
+        workspaces_checked=len(workspaces),
+        degraded=degraded,
+    )
+
+    if degraded:
+        logger.warning(
+            "llm_provisioning.spend_attribution_coverage: [%s,%s] INCOMPLETE — "
+            "%d/%d rows attributed across %d workspace(s); at least one count failed, "
+            "so the %d unattributed is a floor, not a finding",
+            start_date,
+            end_date,
+            attributed_rows,
+            total_rows,
+            len(workspaces),
+            unattributed,
+        )
+    elif unattributed:
+        logger.warning(
+            "llm_provisioning.spend_attribution_coverage: [%s,%s] %d of %d proxy spend "
+            "row(s) belong to NO swept workspace — that spend is being served and not "
+            "billed. Usual cause: requests reaching the proxy without a ``user`` field "
+            "naming the workspace",
+            start_date,
+            end_date,
+            unattributed,
+            total_rows,
+        )
+    else:
+        logger.info(
+            "llm_provisioning.spend_attribution_coverage: [%s,%s] all %d proxy spend "
+            "row(s) attributed across %d workspace(s)",
+            start_date,
+            end_date,
+            total_rows,
+            len(workspaces),
+        )
+
+    return coverage
+
+
 __all__ = [
     "ensure_tenant_key",
     "get_tenant_key",
@@ -853,6 +1128,7 @@ __all__ = [
     "prepare_spend_cutover",
     "reconcile_gap_threshold",
     "reconcile_tenant_spend",
+    "spend_attribution_coverage",
     "spend_ingest_enabled",
     "spend_mode",
     "warn_legacy_spend_bool_once",

--- a/tests/cloud/catalog/test_admin_client.py
+++ b/tests/cloud/catalog/test_admin_client.py
@@ -16,6 +16,12 @@
 # Created 2026-06-26 (integration/model-catalog-v2, MCG-8).
 # Updated 2026-06-29 (feat/billing-usage-endpoint): added user_daily_activity tests
 #   (scoping params, pagination merge, empty-key raise, master-key bearer).
+# Updated 2026-09-02 (feat/proxy-spend-ingest-by-customer): added the
+#   spend_logs_by_end_user / spend_log_count tests — the CUSTOMER-scoped read over
+#   /spend/logs/v2. It is the only read that can see a chat run's cost, because
+#   chat authenticates with the deployment master key rather than a tenant's
+#   virtual key, so the per-key read above returns nothing for it however much it
+#   cost.
 
 from __future__ import annotations
 
@@ -230,3 +236,150 @@ async def test_non_2xx_raises_admin_error_with_detail():
         await client.generate_key(key_alias="ws-w1")
     assert "401" in str(exc.value)
     assert "Invalid master key" in str(exc.value)
+
+
+# ===========================================================================
+# The CUSTOMER-scoped read. Chat's only attribution.
+# ===========================================================================
+
+
+async def test_spend_by_end_user_scopes_and_bounds_the_read():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"request_id": "r1", "spend": 0.04, "startTime": "2026-09-02T10:00:00"}],
+                "total": 1,
+                "page": 1,
+                "page_size": 100,
+                "total_pages": 1,
+            },
+        )
+
+    client = _client(handler, api_key="sk-master")
+    out = await client.spend_logs_by_end_user(
+        end_user="ws_alpha",
+        start_date="2026-09-02 00:00:00",
+        end_date="2026-09-02 12:00:00",
+    )
+
+    assert [r["request_id"] for r in out] == ["r1"]
+    assert "/spend/logs/v2" in captured["url"]
+    assert "end_user=ws_alpha" in captured["url"]
+    # Both dates ride along. The proxy 400s without them, so there is no
+    # unbounded form of this call to fall into by accident.
+    assert "start_date=" in captured["url"]
+    assert "end_date=" in captured["url"]
+    # Oldest first, so stopping early leaves a contiguous prefix rather than a
+    # hole in the middle of the window.
+    assert "sort_order=asc" in captured["url"]
+
+
+async def test_spend_by_end_user_walks_every_page():
+    """A busy tenant's window does not fit one page, and the proxy caps page_size
+    at 100. A single-page read would under-bill silently — the rows it never
+    fetched look exactly like rows that do not exist."""
+    pages = {
+        "1": [{"request_id": "r1", "spend": 0.01}, {"request_id": "r2", "spend": 0.01}],
+        "2": [{"request_id": "r3", "spend": 0.01}],
+    }
+    seen_pages: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        page = request.url.params.get("page", "1")
+        seen_pages.append(page)
+        return httpx.Response(200, json={"data": pages.get(page, []), "total": 3})
+
+    client = _client(handler)
+    out = await client.spend_logs_by_end_user(
+        end_user="ws_alpha",
+        start_date="2026-09-02 00:00:00",
+        end_date="2026-09-02 12:00:00",
+        page_size=2,
+    )
+
+    assert [r["request_id"] for r in out] == ["r1", "r2", "r3"]
+    assert seen_pages == ["1", "2"]
+
+
+async def test_spend_by_end_user_stops_on_an_empty_page():
+    """Defensive against a proxy that overstates ``total``. Without this the walk
+    spins to its page ceiling on every sweep for a tenant with no spend."""
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        return httpx.Response(200, json={"data": [], "total": 999})
+
+    client = _client(handler)
+    out = await client.spend_logs_by_end_user(
+        end_user="ws_alpha", start_date="2026-09-02 00:00:00", end_date="2026-09-02 12:00:00"
+    )
+
+    assert out == []
+    assert len(calls) == 1
+
+
+async def test_spend_by_end_user_requires_an_end_user():
+    # Unscoped, this returns every tenant's spend and the caller would bill one
+    # workspace for all of it.
+    client = _client(lambda r: httpx.Response(200, json={"data": [], "total": 0}))
+    with pytest.raises(LiteLLMAdminError):
+        await client.spend_logs_by_end_user(
+            end_user="", start_date="2026-09-02 00:00:00", end_date="2026-09-02 12:00:00"
+        )
+
+
+async def test_spend_log_count_reads_the_total_without_fetching_the_rows():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json={"data": [{"request_id": "r1"}], "total": 4210})
+
+    client = _client(handler)
+    total = await client.spend_log_count(
+        start_date="2026-09-02 00:00:00", end_date="2026-09-02 12:00:00"
+    )
+
+    assert total == 4210
+    # One row asked for, four thousand reported. The coverage check runs every
+    # sweep, so it must not depend on the size of the window it measures.
+    assert "page_size=1" in captured["url"]
+    # No customer filter — this is the denominator the per-tenant counts are
+    # subtracted from.
+    assert "end_user" not in captured["url"]
+
+
+async def test_spend_log_count_can_scope_to_one_customer():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "end_user=ws_alpha" in str(request.url)
+        return httpx.Response(200, json={"data": [], "total": 7})
+
+    client = _client(handler)
+    assert (
+        await client.spend_log_count(
+            start_date="2026-09-02 00:00:00",
+            end_date="2026-09-02 12:00:00",
+            end_user="ws_alpha",
+        )
+        == 7
+    )
+
+
+async def test_a_missing_total_falls_back_to_the_rows_returned():
+    # A proxy build that omits ``total`` must not make every window read as empty,
+    # which would report full coverage while nothing was attributed.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"request_id": "r1"}, {"request_id": "r2"}]})
+
+    client = _client(handler)
+    assert (
+        await client.spend_log_count(
+            start_date="2026-09-02 00:00:00", end_date="2026-09-02 12:00:00"
+        )
+        == 2
+    )

--- a/tests/cloud/llm_provisioning/test_spend_by_customer.py
+++ b/tests/cloud/llm_provisioning/test_spend_by_customer.py
@@ -1,0 +1,448 @@
+# tests/cloud/llm_provisioning/test_spend_by_customer.py — proves the ingest can
+# see a chat run's cost, and says so when it cannot see something else.
+#
+# THE BUG. Both agent backends authenticate to the proxy with
+# ``settings.litellm_api_key``, the DEPLOYMENT's key. The cutover ingest read a
+# tenant's spend as ``/spend/logs?api_key=<that tenant's virtual key>``, which no
+# chat request has ever carried. With ``live`` gating BC-3's per-run metering off
+# so exactly one meter charges, the one meter was filtering out the product's main
+# cost centre. Production logged ``ingested spend for 3/3 tenants -> 0 credits``
+# against runs the proxy had priced in dollars, and nothing errored — the read was
+# correct, it was just scoped to the wrong thing.
+#
+# These tests are written against that shape rather than against the new code:
+#
+#   * a spend row that carries ONLY an ``end_user`` — a chat row — is billed;
+#   * a row both reads return is billed ONCE;
+#   * a row that lands late, behind an already-advanced high-water mark, is still
+#     billed, because the customer read is window-bounded and must not be filtered
+#     by the mark a second time;
+#   * the per-key read still bills what only it can see, so this is additive;
+#   * either read failing leaves the other one working;
+#   * and the coverage check counts rows no workspace claims, which is the only
+#     signal that separates "nobody spent anything" from "we are not looking where
+#     the spending is".
+#
+# Uses the shared ``mongo_db`` + autouse ``recording_bus`` fixtures from
+# tests/cloud/conftest.py. A FAKE admin client stands in for the proxy.
+#
+# Created 2026-09-02 (feat/proxy-spend-ingest-by-customer): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.catalog.admin_client import LiteLLMAdminError
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.llm_provisioning import cutover_sweeper
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+
+WS = "ws_customer_spend"
+
+# Pinned so credits never depend on ambient settings: round(usd * 250).
+SPEND = SpendCredits(markup=2.5, credit_usd=0.01)
+
+
+class FakeAdmin:
+    """In-memory stand-in for LiteLLMAdminClient, with BOTH spend reads.
+
+    ``key_rows`` is what ``/spend/logs?api_key=`` returns — the rows a tenant's own
+    virtual key accrued. ``customer_rows`` is what ``/spend/logs/v2?end_user=``
+    returns — every row tagged with the workspace, whichever key paid for it. A
+    chat row appears only in the second.
+
+    ``counts`` drives the coverage check: ``None`` is the unfiltered total, a
+    workspace id its own count.
+    """
+
+    def __init__(
+        self,
+        *,
+        key_rows: list[dict] | None = None,
+        customer_rows: list[dict] | None = None,
+        counts: dict[str | None, int] | None = None,
+        fail_customer_read: bool = False,
+        fail_key_read: bool = False,
+        fail_counts_for: set[str | None] | None = None,
+    ) -> None:
+        self.key_rows = key_rows or []
+        self.customer_rows = customer_rows or []
+        self.counts = counts or {}
+        self.fail_customer_read = fail_customer_read
+        self.fail_key_read = fail_key_read
+        self.fail_counts_for = fail_counts_for or set()
+        self.windows: list[tuple[str, str]] = []
+        self.count_calls: list[str | None] = []
+
+    async def generate_key(self, **kwargs):
+        return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **kwargs}
+
+    async def spend_logs(self, *, api_key: str):
+        if self.fail_key_read:
+            raise LiteLLMAdminError("per-key read failed (simulated)")
+        return list(self.key_rows)
+
+    async def spend_logs_by_end_user(self, *, end_user, start_date, end_date, page_size=100):
+        self.windows.append((start_date, end_date))
+        if self.fail_customer_read:
+            raise LiteLLMAdminError("customer read failed (simulated)")
+        return list(self.customer_rows)
+
+    async def spend_log_count(self, *, start_date, end_date, end_user=None):
+        self.count_calls.append(end_user)
+        if end_user in self.fail_counts_for:
+            raise LiteLLMAdminError("count failed (simulated)")
+        return self.counts.get(end_user, 0)
+
+
+async def _provision(workspace: str = WS) -> LiteLLMTenantKey:
+    await provisioning.ensure_tenant_key(workspace, budget=KeyBudget(), admin_client=FakeAdmin())
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+    assert doc is not None
+    return doc
+
+
+def _row(rid: str, *, usd: float = 0.04, at: str = "2026-09-02T10:00:00") -> dict:
+    return {"request_id": rid, "spend": usd, "startTime": at, "model": "gpt-5.2"}
+
+
+async def _debits_for(workspace: str, rid: str) -> list[CreditLedgerEntry]:
+    return await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == workspace,
+        CreditLedgerEntry.idempotency_key == f"litellm:{rid}",
+    ).to_list()
+
+
+# ===========================================================================
+# The bug: a chat run's cost.
+# ===========================================================================
+
+
+async def test_a_chat_row_is_billed_even_though_no_tenant_key_paid_for_it(mongo_db):
+    """The whole point. A chat request rides the deployment's master key, so it
+    appears in NO tenant's per-key spend log — only under the workspace it named
+    in its ``user`` field. Before the customer read, this row billed nothing."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(key_rows=[], customer_rows=[_row("req-chat")])
+
+    result = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    assert result.rows_billed == 1
+    assert result.credits_debited == 10  # round(0.04 * 250)
+    assert await credits.balance(WS) == 990
+
+
+async def test_a_row_both_reads_return_is_billed_exactly_once(mongo_db):
+    """Studio and the media server send the tenant key AND tag ``user``, so their
+    rows come back from both reads. Merging on ``request_id`` keeps the row count
+    honest; the ledger key is what makes the money exactly-once either way."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    shared = _row("req-both")
+    admin = FakeAdmin(key_rows=[shared], customer_rows=[dict(shared)])
+
+    result = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    assert result.rows_read == 1, "the same row was counted twice"
+    assert result.credits_debited == 10
+    assert await credits.balance(WS) == 990
+    assert len(await _debits_for(WS, "req-both")) == 1
+
+
+async def test_the_key_read_still_bills_what_only_it_can_see(mongo_db):
+    """Additive, not a replacement. A row on the tenant key with no ``user`` tag
+    would vanish if the customer read had replaced the key read, and vanishing is
+    what this branch exists to stop."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(key_rows=[_row("req-untagged")], customer_rows=[])
+
+    result = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    assert result.credits_debited == 10
+    assert len(await _debits_for(WS, "req-untagged")) == 1
+
+
+async def test_a_late_row_behind_the_mark_is_still_billed(mongo_db):
+    """Spend rows are stamped with when a call STARTED and written when it ENDED,
+    in batches — so a row can surface after the high-water mark has moved past its
+    own timestamp. The key read has to honour the mark (it is unbounded and would
+    otherwise re-walk history), but the customer read is already window-bounded,
+    and filtering it by the mark as well would drop that row on this sweep and on
+    every sweep after it. Silently, and forever.
+    """
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    doc = await _provision()
+    doc.last_spend_ingest_ts = "2026-09-02T12:00:00+00:00"
+    await doc.save()
+
+    late = _row("req-late", at="2026-09-02T11:30:00")  # behind the mark
+    admin = FakeAdmin(key_rows=[late], customer_rows=[dict(late)])
+
+    result = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    assert result.rows_billed == 1, "a late row was dropped by the high-water mark"
+    assert len(await _debits_for(WS, "req-late")) == 1
+
+
+async def test_a_row_already_ingested_is_not_billed_again_by_the_overlap(mongo_db):
+    """The flip side of the test above. The customer read deliberately re-reads a
+    few minutes before the mark, so settled rows come back every sweep — and must
+    move no money when they do."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(customer_rows=[_row("req-settled")])
+
+    first = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+    second = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    assert first.credits_debited == 10
+    assert second.credits_debited == 0
+    assert await credits.balance(WS) == 990
+    assert len(await _debits_for(WS, "req-settled")) == 1
+
+
+# ===========================================================================
+# The window the customer read asks for.
+# ===========================================================================
+
+
+async def test_an_unmarked_tenant_reads_from_when_we_provisioned_them(mongo_db):
+    """Not from the beginning of time. A tenant with no mark is one we have never
+    ingested for, and the earliest spend that can be theirs is the moment their key
+    doc was created — reaching further back could only pick up spend some other
+    meter already charged."""
+    doc = await _provision()
+    doc.createdAt = datetime(2026, 8, 20, 9, 0, 0, tzinfo=UTC)
+    doc.last_spend_ingest_ts = None
+    await doc.save()
+
+    admin = FakeAdmin(customer_rows=[])
+    await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    start, _end = admin.windows[0]
+    assert start == "2026-08-20 09:00:00"
+
+
+async def test_a_marked_tenant_reads_from_just_before_its_mark(mongo_db):
+    await _provision()
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
+    doc.last_spend_ingest_ts = "2026-09-02T12:00:00+00:00"
+    await doc.save()
+
+    admin = FakeAdmin(customer_rows=[])
+    await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    start, _end = admin.windows[0]
+    expected = datetime(2026, 9, 2, 12, 0, 0, tzinfo=UTC) - provisioning._SPEND_READ_OVERLAP
+    assert start == expected.strftime("%Y-%m-%d %H:%M:%S")
+
+
+# ===========================================================================
+# One read failing must not take the other down.
+# ===========================================================================
+
+
+async def test_a_failing_customer_read_leaves_the_key_read_billing(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(key_rows=[_row("req-key")], fail_customer_read=True)
+
+    result = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    assert result.credits_debited == 10
+    assert len(await _debits_for(WS, "req-key")) == 1
+
+
+async def test_a_failing_key_read_leaves_the_customer_read_billing(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(customer_rows=[_row("req-customer")], fail_key_read=True)
+
+    result = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    assert result.credits_debited == 10
+    assert len(await _debits_for(WS, "req-customer")) == 1
+
+
+# ===========================================================================
+# Coverage — the number that would have said something was wrong.
+# ===========================================================================
+
+
+async def test_coverage_counts_the_rows_no_workspace_claims(mongo_db):
+    admin = FakeAdmin(counts={None: 10, "ws_a": 4, "ws_b": 3})
+
+    coverage = await provisioning.spend_attribution_coverage(
+        ["ws_a", "ws_b"],
+        since=datetime(2026, 9, 2, tzinfo=UTC),
+        until=datetime(2026, 9, 3, tzinfo=UTC),
+        admin_client=admin,
+    )
+
+    assert coverage.total_rows == 10
+    assert coverage.attributed_rows == 7
+    assert coverage.unattributed_rows == 3
+    assert coverage.workspaces_checked == 2
+    assert coverage.degraded is False
+    # The unfiltered total plus one count per workspace, and nothing more — this
+    # runs on every sweep tick.
+    assert admin.count_calls == [None, "ws_a", "ws_b"]
+
+
+async def test_full_attribution_reports_no_gap(mongo_db):
+    admin = FakeAdmin(counts={None: 7, "ws_a": 4, "ws_b": 3})
+
+    coverage = await provisioning.spend_attribution_coverage(
+        ["ws_a", "ws_b"],
+        since=datetime(2026, 9, 2, tzinfo=UTC),
+        until=datetime(2026, 9, 3, tzinfo=UTC),
+        admin_client=admin,
+    )
+
+    assert coverage.unattributed_rows == 0
+    assert coverage.degraded is False
+
+
+async def test_a_failed_count_is_reported_as_unknown_not_as_clean(mongo_db):
+    """ "No gap" and "could not tell" look identical in a bare zero. The check that
+    exists to catch a silent failure must not fail silently itself."""
+    admin = FakeAdmin(counts={None: 10, "ws_a": 4}, fail_counts_for={"ws_b"})
+
+    coverage = await provisioning.spend_attribution_coverage(
+        ["ws_a", "ws_b"],
+        since=datetime(2026, 9, 2, tzinfo=UTC),
+        until=datetime(2026, 9, 3, tzinfo=UTC),
+        admin_client=admin,
+    )
+
+    assert coverage.degraded is True
+    assert coverage.attributed_rows == 4  # ws_b's rows are simply unknown
+
+
+async def test_coverage_never_reports_a_negative_remainder(mongo_db):
+    # The total and the per-tenant counts are separate queries against a table
+    # still being written. A row landing between them is a race, not a surplus.
+    admin = FakeAdmin(counts={None: 2, "ws_a": 5})
+
+    coverage = await provisioning.spend_attribution_coverage(
+        ["ws_a"],
+        since=datetime(2026, 9, 2, tzinfo=UTC),
+        until=datetime(2026, 9, 3, tzinfo=UTC),
+        admin_client=admin,
+    )
+
+    assert coverage.unattributed_rows == 0
+
+
+async def test_coverage_never_raises_into_the_sweep(mongo_db):
+    """It is an observation OF the sweep, not part of it. Billing must not stop
+    because the thing watching billing could not reach the proxy."""
+    admin = FakeAdmin(fail_counts_for={None, "ws_a"})
+
+    coverage = await provisioning.spend_attribution_coverage(
+        ["ws_a"],
+        since=datetime(2026, 9, 2, tzinfo=UTC),
+        until=datetime(2026, 9, 3, tzinfo=UTC),
+        admin_client=admin,
+    )
+
+    assert coverage.degraded is True
+    assert coverage.total_rows == 0
+
+
+# ===========================================================================
+# The sweep surfaces it.
+# ===========================================================================
+
+
+@pytest.mark.parametrize("mode", ["shadow", "live"])
+async def test_the_sweep_reports_unattributed_rows_in_every_billing_mode(
+    mongo_db, monkeypatch, mode
+):
+    """Live is where it costs money; shadow is where it is a go/no-go. Flipping to
+    live while rows are unattributed converts a reporting gap into free service, so
+    the number has to be on screen BEFORE the flip, not after."""
+    await _provision()
+
+    from pocketpaw_ee.cloud.llm_provisioning.domain import SpendCoverage
+
+    async def _coverage(workspaces, *, since, until, admin_client=None):
+        return SpendCoverage(
+            window_start="w0",
+            window_end="w1",
+            total_rows=9,
+            attributed_rows=4,
+            unattributed_rows=5,
+            workspaces_checked=len(workspaces),
+            degraded=False,
+        )
+
+    monkeypatch.setattr(provisioning, "spend_attribution_coverage", _coverage)
+    monkeypatch.setattr(
+        cutover_sweeper.provisioning_service, "spend_attribution_coverage", _coverage
+    )
+
+    summary = await cutover_sweeper.run_cutover_sweep(mode=mode)
+
+    assert summary["unattributed"] == 5
+
+
+async def test_the_sweep_checks_coverage_even_with_no_provisioned_tenants(mongo_db, monkeypatch):
+    """A deployment serving traffic with nothing provisioned is the loudest form of
+    this failure, and it is exactly the case the tenant loop returns early on."""
+    seen: dict = {}
+
+    from pocketpaw_ee.cloud.llm_provisioning.domain import SpendCoverage
+
+    async def _coverage(workspaces, *, since, until, admin_client=None):
+        seen["called"] = True
+        return SpendCoverage(
+            window_start="w0",
+            window_end="w1",
+            total_rows=12,
+            attributed_rows=0,
+            unattributed_rows=12,
+            workspaces_checked=0,
+            degraded=False,
+        )
+
+    monkeypatch.setattr(
+        cutover_sweeper.provisioning_service, "spend_attribution_coverage", _coverage
+    )
+
+    summary = await cutover_sweeper.run_cutover_sweep(mode="live")
+
+    assert seen.get("called") is True
+    assert summary["tenants"] == 0
+    assert summary["unattributed"] == 12
+
+
+async def test_off_mode_still_sweeps_nothing_and_checks_nothing(mongo_db, monkeypatch):
+    # ``off`` means BC-3 bills as it always has. The coverage check talks to the
+    # proxy, so it must not start doing that on a deployment that has not opted in.
+    called: dict = {}
+
+    async def _coverage(workspaces, *, since, until, admin_client=None):
+        called["yes"] = True
+        raise AssertionError("coverage must not run in off mode")
+
+    monkeypatch.setattr(
+        cutover_sweeper.provisioning_service, "spend_attribution_coverage", _coverage
+    )
+
+    summary = await cutover_sweeper.run_cutover_sweep(mode="off")
+
+    assert called == {}
+    assert summary["unattributed"] == 0


### PR DESCRIPTION
Stacked on #2047. Review that one first; this is the half that reads back what it writes.

The ingest read a tenant's spend as `/spend/logs?api_key=<the tenant's virtual key>`. Chat authenticates with the deployment's key, so a chat row is stamped with that key and the per-tenant filter never matched it. The base PR puts the workspace in each request's `user` field, which the proxy records as the row's `end_user`. This reads it back through `/spend/logs/v2`, the only spend route that filters on it.

## Both reads, merged

The customer read should be a superset today. Studio and the media server tag `user` as well as sending the tenant key, so their rows come back from either one. But "should be" is not a thing to assume when the failure mode is an under-bill, so the per-key read stays and the two merge on `request_id`. A row seen twice is billed once, which was always the ledger key's job and never the high-water mark's.

## The window, and why its rows skip the mark

`/spend/logs/v2` is date-bounded, so the customer read needs a window rather than the mark alone. It starts a short overlap before the mark, or at the key doc's `createdAt` for a tenant that has never been ingested. Not the beginning of time: a tenant without a mark is new, and reaching further back could only pick up spend some other meter already charged.

Its rows then bypass the mark on the way through. Spend rows are stamped with when a call started and written when it ended, in batches, so a row can surface after the mark has already moved past its own timestamp. The key read has to honour the mark because it is unbounded and would otherwise re-walk history. Filtering the customer read by it as well would drop that late row on this sweep and on every sweep after it. There is a test for exactly that, and it fails if you flip the flag.

## The number that would have said something was wrong

Every non-`off` tick now counts the window's spend rows that no swept workspace claims:

```
spend_attribution_coverage: [...] 41 of 128 proxy spend row(s) belong to NO swept
workspace — that spend is being served and not billed
```

It is one small request per tenant plus one, whatever the window holds, because it asks for a single row and reads the reported total. It debits nothing and cannot fail the sweep.

A failed count reports `INCOMPLETE` rather than a clean zero. "No gap" and "could not tell" look identical in a bare zero, and the check that exists to catch a silent failure should not fail silently itself.

It runs before the empty-tenant early return on purpose. A deployment serving traffic with nothing provisioned is the loudest form of this failure and is exactly the case the tenant loop returns early on.

## Runbook

`docs/deployment/litellm-billing-cutover.md` gains the two proxy-side preconditions, a curl to check both, the coverage number as a go/no-go before flipping, and a note on why LiteLLM's self-declared-`user` warning does not reach us.

It also says the thing support will hear about: if you ran `live` before this, chat was free, and the first invoice after will look like a price rise.

## Tests

18 new in `tests/cloud/llm_provisioning/test_spend_by_customer.py`, 7 more on the admin client. Mutation-checked both ways: dropping the customer read fails 6, and honouring the mark on customer rows fails the late-row test alone.

Related cloud suites: 211 pass here, 365 across billing and chat. `mutate.py --validate`: 876 anchors clean.

## Before flipping the mode back on

`POCKETPAW_LITELLM_SPEND_MODE` should stay `off` until both PRs are deployed. Right now `live` bills nobody for chat.
