### PR TITLE
Serve a site's visitor numbers, and say when there are none

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -97,6 +97,13 @@ rebuild — dynamic-source split + input-keyspace confinement) and GET
 /sites/by-pocket/{id}/native-artifact (serve the armed build's body_html + css
 for shadow render — per-GET arm-build cost, path-traversal-guarded CSS reader).
 
+Updated: 2026-09-02 (SA-4) — documented the Sites — Visitor Analytics section:
+GET /sites/{site_id}/analytics, the read half of the pageview counter SA-1/SA-2
+deploy. The response leads with a status because three different customer
+situations otherwise render as the same panel of zeros (not on a plan that buys
+analytics, on one but not republished since, and genuinely no traffic), and a
+FAILED read is an error response rather than a fourth status so an outage cannot
+arrive looking like a quiet week. Every metric is null unless the status is ok.
 Updated: 2026-08-24 (SP-2) — GET /sites/by-pocket/{id}/native-artifact has two
 response shapes now. A cold miss no longer builds in the API container (there is
 no bun there, so it 5xx'd as sites.generator_failed on every cold preview); it
@@ -1582,6 +1589,100 @@ Errors:
 | 404 | `pocket.not_found` | Unknown pocket id. |
 | 403 | `pocket.access_denied` | The caller lacks access to the pocket. |
 | 503 | `sites.preview_build_unavailable` | The armed build could not be QUEUED (the job queue is unreachable). Retryable. A failed enqueue is deliberately an error rather than a pending response — a job id for a job nobody will run makes a client poll forever. A build that queues and then FAILS is not an error here: it comes back `200` with `build_status: "failed"` and a rung in `build_reason`. |
+
+## Sites — Visitor Analytics
+
+SA-4. `GET /sites/{site_id}/analytics` serves a published site's visitor numbers
+for the builder's Analytics panel. The rows come from Cloudflare Workers Analytics
+Engine, written by the pageview counter a paid site's publish deploys in front of
+it (SA-1/SA-2). Source: `ee/pocketpaw_ee/sites/router.py`.
+
+Authenticated, workspace-scoped, `fabric.read`, and behind the same `sites` plan
+feature as the rest of the router. Tenant-scoped on the request context, so a site
+in another workspace is a `404` — the same as every sibling per-site read.
+
+### `GET /sites/{site_id}/analytics`
+
+| Query | Type | Default | Notes |
+|-------|------|---------|-------|
+| `window` | string | `7d` | One of `24h`, `7d`, `30d`, `90d`. Anything else is a `422`. The set is closed because the Analytics Engine SQL endpoint has no parameter binding, so this is a query-safety control rather than only input validation. `90d` is the longest window that can return anything: Cloudflare retains the rows for three months. |
+
+**Read `status` first.** Three different customer situations produce an empty
+panel, and they are three different sentences:
+
+| `status` | Means | What fixes it |
+|----------|-------|---------------|
+| `ok` | A counter is up and the numbers are real. **They may legitimately be zero.** | Nothing — this is a report about the site's traffic. |
+| `not_entitled` | The site's plan does not include analytics, so nothing was ever recorded. | Upgrading the site's plan, then republishing. |
+| `never_counted` | The plan includes it, but no publish has yet deployed a counter. Nothing is recording. | Republishing the site. Upgrading alone does **not** backfill — history begins at the publish that first carried a counter, because no rows exist before it. |
+
+**A failed read is not a status.** If the Analytics Engine query fails, the
+endpoint returns an **error response**, never a `200` carrying zeros. A client that
+maps an unknown status to "no data" would otherwise render a Cloudflare outage as a
+quiet week, which is the one failure this shape exists to prevent.
+
+**Every metric is `null` unless `status` is `ok`.** Not `0` — a client that renders
+the numbers without reading the status shows blanks rather than a confident zero.
+
+Response `200`:
+
+```json
+{
+  "site_id": "68b6f2c1a4d3e50012ab34cd",
+  "window": "7d",
+  "status": "ok",
+  "counting_since": "2026-08-14T10:22:41+00:00",
+  "retention_days": 90,
+  "pageviews": 1280,
+  "visitors": 431,
+  "top_pages":  [{"label": "/",         "pageviews": 800, "visitors": 300}],
+  "referrers":  [{"label": "(direct)",  "pageviews": 700, "visitors": 190}],
+  "countries":  [{"label": "US",        "pageviews": 900, "visitors": 320}],
+  "devices": null,
+  "unrecorded": ["devices"]
+}
+```
+
+- `counting_since` is when this site's visitors started being counted, ISO-8601 in
+  UTC, and `null` when nothing is counting. It is what makes an honest chart
+  possible: the series begins here, not at the site's creation, and a window
+  reaching further back is reaching into time nobody recorded.
+- `retention_days` is `90`. On the wire so a UI can explain why the earliest date it
+  offers is the one it offers, rather than looking like it lost the data.
+- Each breakdown is a **top-10** list ordered by pageviews. Its `visitors` is a
+  distinct count **within that row** and does **not** sum to the response total: one
+  visitor who reads three pages is one visitor overall and one visitor on each of
+  three rows. Summing the column gives a number that means nothing.
+- A blank dimension is **named, never dropped** — `(direct)` for a referrer (a direct
+  visit or a same-site link), `(unknown)` for a country Cloudflare could not
+  geolocate. Dropping those rows would inflate every remaining share.
+- `unrecorded` names the dimensions the stored row cannot answer **at all**, as
+  opposed to answered-and-empty. A dimension listed here is `null` rather than `[]`,
+  because an empty list reads as "none of these exist" and an omitted field is
+  indistinguishable from a version skew.
+
+**A visitor is per-day.** The counter identifies a visitor by a salted one-way hash
+that rotates at UTC midnight and never leaves a cookie, so somebody who returns
+tomorrow counts as two visitors. That is the privacy design rather than a rounding
+error, and no join across days is possible even in principle.
+
+**Sampling is accounted for.** Analytics Engine downsamples a hot index and reports
+the rate per row, so the aggregates weight by it. A plain row count would
+under-report precisely the busiest sites.
+
+**Cached for 60 seconds per site and window.** Analytics Engine bills read queries
+against a small daily account-wide allowance, and this panel's usage pattern is
+somebody reloading it. The cache is in-process, so a second API replica keeps its
+own; only successful reads are cached, so an outage is not extended past its end.
+
+Errors:
+
+| HTTP | Code | When |
+|------|------|------|
+| 404 | `site.not_found` | Unknown, malformed, or cross-tenant site id. |
+| 422 | `sites.invalid_analytics_window` | `window` is not one of the four accepted values. |
+| 422 | `sites.cloudflare_error` | The Analytics Engine query failed — a non-2xx, an unparseable body, or a `200` with no data array. Includes Cloudflare's own message. A `403` here usually means the API token is missing the **Account Analytics Read** permission, which is a different scope from the ones the deploy paths use. |
+| 422 | `sites.cloudflare_unconfigured` | `PAW_CF_ACCOUNT_ID` / `PAW_CF_API_TOKEN` / `PAW_CF_ZONE_ID` are not all set. |
 
 ## Ship — Managed Deploys
 

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -4,6 +4,15 @@
 # harden ingest without a second store. SiteDomain tracks the Cloudflare-for-
 # SaaS hostname lifecycle the Domains panel polls.
 #
+# Updated 2026-09-02 (SA-4 — the visitor-analytics read): added
+# ``analytics_since``, the UTC stamp of the first publish that actually deployed a
+# pageview counter. It is the ONLY thing on this document that separates "this site
+# has never recorded anything" from "this site is recording and nobody visited" —
+# ``deployed_at`` says a publish happened, not that it carried a counter. The read
+# endpoint reports those two as different states rather than serving 0 for both,
+# which is the whole point of the field. None on every pre-existing row, and None
+# reads as "not counting yet", so no migration.
+#
 # Updated 2026-08-12 (sites Settings consolidation): added the owner's CLIENT
 # record — ``client_name`` / ``client_contact`` / ``client_notes`` and a
 # ``client_invoices`` list of ``SiteInvoice``. TWO BILLING RELATIONSHIPS NOW MEET
@@ -274,6 +283,30 @@ class Site(TimestampedDocument):
     # flips True) — never on a preview/edit build, never on a plain updatedAt bump.
     # None until the pocket has been deployed at least once (old rows read null).
     deployed_at: datetime | None = None
+    # SA-4: when this site's visitors STARTED being counted (UTC) — the first
+    # publish that actually deployed a pageview counter, and never re-stamped after.
+    #
+    # It exists so the analytics read can tell "nothing was ever recorded" apart from
+    # "recorded, and genuinely nobody visited". Nothing else on this document can:
+    # ``deployed_at`` says a publish happened, not that it carried a counter, and a
+    # site upgraded an hour ago looks identical to a quiet site that has been counting
+    # for a month. Serving 0 for both is the exact failure the analytics read exists
+    # to avoid, so the two states get a field between them rather than a guess.
+    #
+    # WRITTEN FROM WHAT THE DEPLOY LEFT ON DISK, not from a second copy of the
+    # counting rule — see ``sites.service.publish``. That rule has three parts (the
+    # plan, the operator kill switch, and whether the engine emits its own worker),
+    # all resolved inside ``workers_deploy._write_deploy_files``, and re-deriving it
+    # here would be a fourth place for them to disagree.
+    #
+    # None on every site that has never counted, which is every row written before
+    # this field existed. That reads as "not counting yet" — correct for all of them,
+    # so there is no migration.
+    #
+    # FIRST-SET-WINS. It is "since", not "last": a site that lapses and renews keeps
+    # its original stamp, because recording really did begin then, and the retention
+    # window (three months) is shorter than most such gaps anyway.
+    analytics_since: datetime | None = None
     # Canonical deployed URL. LOCAL mode: the localhost URL the per-site static
     # server serves. CF mode: "" in v1 (reached via custom domain).
     url: str = ""

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -5,13 +5,15 @@
 # SaaS hostname lifecycle the Domains panel polls.
 #
 # Updated 2026-09-02 (SA-4 — the visitor-analytics read): added
-# ``analytics_since``, the UTC stamp of the first publish that actually deployed a
-# pageview counter. It is the ONLY thing on this document that separates "this site
-# has never recorded anything" from "this site is recording and nobody visited" —
+# ``analytics_since``, which says whether this site's visitors are being counted and,
+# if so, when that started. It is the ONLY thing on this document that separates "this
+# site has never recorded anything" from "this site is recording and nobody visited" —
 # ``deployed_at`` says a publish happened, not that it carried a counter. The read
-# endpoint reports those two as different states rather than serving 0 for both,
-# which is the whole point of the field. None on every pre-existing row, and None
-# reads as "not counting yet", so no migration.
+# endpoint reports those two as different states rather than serving 0 for both, which
+# is the whole point of the field. It is SET by a publish that deploys a counter and
+# CLEARED by one that does not, so a site that lapsed and re-upgraded cannot report a
+# stale start date over months nothing was recording. None on every pre-existing row,
+# and None reads as "not counting yet", so no migration.
 #
 # Updated 2026-08-12 (sites Settings consolidation): added the owner's CLIENT
 # record — ``client_name`` / ``client_contact`` / ``client_notes`` and a
@@ -283,8 +285,9 @@ class Site(TimestampedDocument):
     # flips True) — never on a preview/edit build, never on a plain updatedAt bump.
     # None until the pocket has been deployed at least once (old rows read null).
     deployed_at: datetime | None = None
-    # SA-4: when this site's visitors STARTED being counted (UTC) — the first
-    # publish that actually deployed a pageview counter, and never re-stamped after.
+    # SA-4: when this site's visitors STARTED being counted (UTC), and None whenever
+    # they are not being counted at all. Read it as a state rather than as history —
+    # "counting is on, and it began at this stamp".
     #
     # It exists so the analytics read can tell "nothing was ever recorded" apart from
     # "recorded, and genuinely nobody visited". Nothing else on this document can:
@@ -293,19 +296,33 @@ class Site(TimestampedDocument):
     # for a month. Serving 0 for both is the exact failure the analytics read exists
     # to avoid, so the two states get a field between them rather than a guess.
     #
-    # WRITTEN FROM WHAT THE DEPLOY LEFT ON DISK, not from a second copy of the
-    # counting rule — see ``sites.service.publish``. That rule has three parts (the
-    # plan, the operator kill switch, and whether the engine emits its own worker),
-    # all resolved inside ``workers_deploy._write_deploy_files``, and re-deriving it
-    # here would be a fourth place for them to disagree.
+    # WRITTEN FROM WHAT THE DEPLOY LEFT ON DISK, not from a second copy of the counting
+    # rule — see ``sites.service._deploy_site_doc``. That rule has three parts (the
+    # plan, the operator kill switch, and whether the engine emits its own worker), all
+    # resolved inside ``workers_deploy._write_deploy_files``, and re-deriving it here
+    # would be a fourth place for them to disagree.
     #
-    # None on every site that has never counted, which is every row written before
-    # this field existed. That reads as "not counting yet" — correct for all of them,
-    # so there is no migration.
+    # THE WRITE RULE HAS TWO HALVES:
+    #   * a publish that DEPLOYED a counter sets it to now if it is None, and otherwise
+    #     leaves it alone. First-set-wins WITHIN a counting era, so an ordinary
+    #     republish does not restart a paying site's history.
+    #   * a publish that deployed NO counter sets it back to None. Nothing is recording,
+    #     so there is no "since".
     #
-    # FIRST-SET-WINS. It is "since", not "last": a site that lapses and renews keeps
-    # its original stamp, because recording really did begin then, and the retention
-    # window (three months) is shorter than most such gaps anyway.
+    # CLEARING IS THE HALF THAT MAKES THE FIELD TRUSTWORTHY. A site that counted in
+    # June, dropped to free in July and re-upgraded today is entitled again — but no
+    # publish has carried a counter since the lapse, so nothing is recording. Against a
+    # stamp that was never cleared the read would answer "counting since June, and
+    # nobody visited", which is the invented zero this whole slice exists to prevent.
+    # Cleared, ``entitled AND analytics_since is None`` is exactly "you have not
+    # republished", with nothing left to guess.
+    #
+    # The price is that a lapse loses the earlier era's start date, and that is the
+    # right way round: Cloudflare drops the rows after three months, so a stamp older
+    # than the retention window already points at data that is gone.
+    #
+    # None on every row written before this field existed, which reads as "not counting
+    # yet" — correct for all of them, so there is no migration.
     analytics_since: datetime | None = None
     # Canonical deployed URL. LOCAL mode: the localhost URL the per-site static
     # server serves. CF mode: "" in v1 (reached via custom domain).

--- a/ee/pocketpaw_ee/sites/cloudflare_client.py
+++ b/ee/pocketpaw_ee/sites/cloudflare_client.py
@@ -15,6 +15,11 @@
 #   * Browser Rendering (SC-1) — screenshot a deployed site's live URL so its
 #     gallery card can show the page instead of a title and three pills; see
 #     capture_screenshot.
+#   * Workers Analytics Engine (SA-4) — run one SQL query against the pageview
+#     dataset a published site writes into, so the dashboard can serve real visitor
+#     numbers; see query_analytics_sql. It is the one method here whose request body
+#     is RAW SQL and whose success response is NOT the Cloudflare envelope, and it
+#     needs an ``Account Analytics Read`` token scope the deploy paths do not.
 # httpx-based; account id + token come from settings (env), not per-tenant rows
 # in v1. Non-2xx raises a CloudError so the standard envelope applies.
 #
@@ -131,6 +136,16 @@
 # The body is Cloudflare describing OUR request; the token only ever lives in a
 # request header, so nothing secret rides along.
 
+# Updated 2026-09-02 (SA-4 — the visitor-analytics read): added
+# ``query_analytics_sql``. It breaks two of this module's own conventions on purpose
+# and says so at the method: the request body is raw SQL rather than JSON (the
+# endpoint has no parameter binding, so nothing user-controlled may be interpolated),
+# and a SUCCESSFUL query answers ``{meta, data, rows}`` with no ``success`` key — so
+# ``_unwrap`` would raise on every good response and is deliberately not used on that
+# path. The failure branch still shares ``_error_detail``, which matters here because
+# the required token scope (``Account Analytics Read``) is one the deploy token does
+# not carry and a missing scope arrives as a 403.
+#
 from __future__ import annotations
 
 import json
@@ -589,3 +604,67 @@ class CloudflareClient:
             raise ValidationError("sites.cloudflare_error", "D1 query statement failed")
         rows = first.get("results")
         return [r for r in rows if isinstance(r, dict)] if isinstance(rows, list) else []
+
+    async def query_analytics_sql(self, sql: str) -> list[dict]:
+        """Run ONE SQL query against Workers Analytics Engine and return its rows
+        (SA-4 — the read half of Paw Sites visitor analytics).
+
+        POSTs to ``/accounts/{acct}/analytics_engine/sql``. Two things about this
+        endpoint are unlike every other method on this client, and both are load-
+        bearing rather than trivia:
+
+        * **The body is RAW SQL, not JSON.** Cloudflare's own example is
+          ``curl ... --data "SELECT ..."``. There is no parameter binding, so the
+          caller MUST NOT interpolate anything a user controls into the statement.
+          ``sites.service`` builds the only statements that reach here, and the one
+          value it substitutes is a site id it has already round-tripped through
+          ``ObjectId`` — 24 hex characters, checked again at the call site.
+        * **The response is NOT the Cloudflare success envelope.** A query answers
+          ``{"meta": [...], "data": [...], "rows": N}`` with no ``success`` key at
+          all, so ``_unwrap`` cannot read it: that helper raises on a body whose
+          ``success`` is absent, which would turn every SUCCESSFUL query into a
+          Cloudflare error. Only the failure branch is shared, through
+          ``_error_detail``.
+
+        Returns the ``data`` rows as a list of dicts. An empty ``data`` is a real,
+        legitimate answer — the query matched nothing — and is returned as ``[]``.
+
+        FAIL-CLOSED, and here that is the whole requirement rather than a habit. A
+        non-2xx, a body that is not JSON, and a 2xx whose ``data`` is missing or not
+        a list all raise ValidationError. The alternative — returning ``[]`` — would
+        render a customer's dashboard as "0 visitors" when the truth is "the read
+        failed", and a panel that reports an outage as a quiet week is worse than one
+        that reports nothing at all.
+
+        The API token needs ``Account Analytics Read``, which is a DIFFERENT
+        permission from the Workers and SSL scopes the deploy paths use. A token
+        without it answers 403, and ``_error_detail`` puts Cloudflare's own sentence
+        (and its code) in the raised message so the missing scope is diagnosable
+        rather than a bare status."""
+        url = f"{_CF_API}/accounts/{self._account_id}/analytics_engine/sql"
+        async with self._client() as client:
+            resp = await client.post(
+                url, content=sql.encode("utf-8"), headers={"Content-Type": "text/plain"}
+            )
+        if resp.status_code // 100 != 2:
+            raise ValidationError(
+                "sites.cloudflare_error",
+                f"Analytics Engine SQL {resp.status_code}: {_error_detail(resp)}",
+            )
+        try:
+            body = resp.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValidationError(
+                "sites.cloudflare_error",
+                "Analytics Engine returned a non-JSON body for a SQL query.",
+            ) from exc
+        rows = body.get("data") if isinstance(body, dict) else None
+        if not isinstance(rows, list):
+            # A 2xx with no ``data`` array is a contract break, not an empty result:
+            # an empty result IS a ``data`` of ``[]``. Reporting it as no rows would
+            # manufacture the zeros this method exists to never manufacture.
+            raise ValidationError(
+                "sites.cloudflare_error",
+                "Analytics Engine returned no data array for a SQL query.",
+            )
+        return [r for r in rows if isinstance(r, dict)]

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -2,6 +2,16 @@
 # plane. Distinct request and response shapes per the cloud 4-file rules.
 # Created: 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.5).
 #
+# Updated 2026-09-02 (SA-4 — the visitor-analytics read): added
+# ``SiteAnalyticsResponse`` / ``SiteAnalyticsBreakdown`` and the three
+# ``ANALYTICS_STATUS_*`` constants, backing GET /sites/{site_id}/analytics. The
+# shape is a discriminated one because the alternative renders three different
+# customer situations as the same panel of zeros: not on a plan that buys
+# analytics, on one but never republished since, and genuinely no traffic. Every
+# metric is None unless the status says the numbers are real, and a FAILED read is
+# not a status value at all — it is an error response, so an outage can never arrive
+# looking like a quiet week.
+#
 # Updated 2026-08-24 (SP-2 — draft preview joins the ephemeral build lane):
 # ``NativeArtifactResponse`` gained ``build_status`` / ``build_reason`` /
 # ``build_job_id`` and defaulted ``body_html`` / ``css`` to empty strings. A cold
@@ -887,3 +897,86 @@ class SiteAssetDeleteRequest(BaseModel):
     """The storage key to remove. Validated against the site's own prefix."""
 
     key: str
+
+
+# ── SA-4: the visitor-analytics read ────────────────────────────────────────
+#
+# ``status`` is a CLOSED vocabulary and the most important field on the response.
+# Four outcomes are possible and three of them would otherwise render identically
+# as a panel full of zeros, which is the specific failure this slice exists to
+# prevent: "your plan does not include this", "you have not published since you
+# upgraded", and "nobody visited" are three different sentences to a customer, and
+# only one of them is about their traffic.
+#
+#   ``ok``            — counted, and the numbers below are real. They may be zero.
+#   ``not_entitled``  — this site's plan does not buy analytics. Nothing was ever
+#                       recorded, and nothing can be until the plan changes.
+#   ``never_counted`` — entitled, but no publish has yet deployed a counter, so
+#                       there is nothing to read. Republishing starts it. Upgrading
+#                       does NOT backfill: history begins at that publish.
+#
+# The FOURTH outcome — the read itself failed — is deliberately NOT a status value.
+# It surfaces as an error response, because a failed read is not a report about the
+# site's traffic and must not arrive on the same shape as one. A client that
+# defaults an unknown status to "no data" would otherwise turn a Cloudflare outage
+# into a quiet week.
+ANALYTICS_STATUS_OK = "ok"
+ANALYTICS_STATUS_NOT_ENTITLED = "not_entitled"
+ANALYTICS_STATUS_NEVER_COUNTED = "never_counted"
+
+
+class SiteAnalyticsBreakdown(BaseModel):
+    """One row of a breakdown — a page, a referrer host, a country, a device class.
+
+    ``visitors`` is a distinct count within this row and does NOT sum to the
+    response's total: one visitor who reads three pages is one visitor overall and
+    one visitor on each of three rows. A UI that adds a column here gets a number
+    that means nothing, so the field is named for the row rather than for the total.
+    """
+
+    label: str
+    pageviews: int
+    visitors: int
+
+
+class SiteAnalyticsResponse(BaseModel):
+    """Visitor analytics for one site over one window (GET
+    /sites/{site_id}/analytics).
+
+    Shaped after ``cloud.mission_control.dto.AnalyticsResponse`` and it inherits that
+    model's one rule about absence: a metric that is not known is None, never 0. Here
+    that rule is load-bearing rather than cosmetic — see ``status`` above. Every
+    metric field is None unless ``status`` is ``ok``, so a client that renders the
+    numbers without reading the status shows blanks rather than a confident zero.
+
+    ``counting_since`` is the ISO stamp of the publish that first deployed a counter,
+    and it is what makes an honest chart possible: the series does not begin at the
+    site's creation, it begins here, and a window that reaches further back is
+    reaching into time nobody recorded. None when nothing has ever counted.
+
+    ``unrecorded`` names the dimensions the stored row cannot answer AT ALL, as
+    opposed to answered-and-empty. It is empty today for pages, referrers and
+    countries, and carries ``"devices"``: the row a published site writes holds the
+    path, the referrer host, the country and a per-day visitor hash, and nothing
+    about the device. The user-agent is read at the edge only to reject bots and to
+    salt that hash, and the hash is one-way, so no device breakdown can be recovered
+    from data already stored either. Naming it beats returning an empty list that a
+    chart would render as "no devices", and beats omitting the field, which a client
+    cannot tell from a version skew.
+    """
+
+    site_id: str
+    window: str
+    status: str
+    counting_since: str | None = None
+    # Retention is three months at Cloudflare, so a window is capped there and a
+    # series older than this is gone rather than empty. On the wire so a UI can say
+    # why the earliest date it can offer is the one it offers.
+    retention_days: int = 90
+    pageviews: int | None = None
+    visitors: int | None = None
+    top_pages: list[SiteAnalyticsBreakdown] | None = None
+    referrers: list[SiteAnalyticsBreakdown] | None = None
+    countries: list[SiteAnalyticsBreakdown] | None = None
+    devices: list[SiteAnalyticsBreakdown] | None = None
+    unrecorded: list[str] = []

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -3,6 +3,15 @@
 # and gated by the same plan feature (fabric) + action (fabric.write/read) as
 # the Leads surface (Task 3.4). Mirrors the leads router's context/deps wiring.
 #
+# Updated 2026-09-02 (SA-4 — the visitor-analytics read): GET
+# ``/sites/{site_id}/analytics``, the read half of the counter SA-1/SA-2 deploy.
+# Gated ``fabric.read`` and tenant-scoped through the service's ``_load`` like the
+# per-site reads beside it. Its response leads with a ``status`` because THREE
+# different customer situations otherwise render as the same panel of zeros — not
+# on a plan that buys analytics, on one but not republished since, and genuinely no
+# traffic — and a FAILED read is an error response rather than a fourth status, so
+# an outage cannot arrive looking like a quiet week.
+#
 # Updated 2026-08-31 (feat/sites-public-asset-uploads): three endpoints for the
 # site's PUBLIC asset rail — POST/GET/DELETE ``/sites/by-pocket/{pocket_id}/assets``.
 # A site could not display an image the owner supplied: the source map the generator
@@ -227,7 +236,16 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+)
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.deps import require_action_any_workspace, require_plan_feature
@@ -248,6 +266,7 @@ from pocketpaw_ee.sites.dto import (
     NativeArtifactResponse,
     PublishRequest,
     RequestPublishResponse,
+    SiteAnalyticsResponse,
     SiteAssetDeleteRequest,
     SiteAssetListResponse,
     SiteAssetResponse,
@@ -965,6 +984,36 @@ async def get_site_entitlements(
     lookup.
     """
     return await sites_service.site_entitlements(workspace_id=ctx.workspace_id, site_id=site_id)
+
+
+@router.get("/sites/{site_id}/analytics", response_model=SiteAnalyticsResponse)
+async def site_analytics(
+    site_id: str,
+    window: str = Query(default="7d", description="24h | 7d | 30d | 90d"),
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> SiteAnalyticsResponse:
+    """This site's visitor numbers over one window, for the builder's Analytics panel.
+
+    ``status`` is the field to read FIRST, and the response is shaped so a client that
+    ignores it shows blanks rather than confident zeros. Three situations produce an
+    empty panel and they are three different sentences to the customer: the plan does
+    not include analytics, it does but nothing has been published since (so nothing was
+    ever recorded), or a counter is up and genuinely nobody visited. Only the last is
+    about their traffic.
+
+    A read that FAILS is an error response, never a status — see the service. A client
+    that defaults an unknown status to "no data" would otherwise render a Cloudflare
+    outage as a quiet week.
+
+    ``window`` is validated against a closed set (a bad one is a 422), which is a SQL
+    control and not only input hygiene: the Analytics Engine endpoint takes raw text
+    with no parameter binding. Tenant-scoped like every sibling per-site read, so a
+    cross-tenant or missing site is a 404.
+    """
+    return await sites_service.site_analytics(
+        workspace_id=ctx.workspace_id, site_id=site_id, window=window
+    )
 
 
 @router.get("/sites/{site_id}/client", response_model=SiteClientResponse)

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,26 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-09-02 (SA-4 — the visitor-analytics read): the read half of the feature
+# SA-1/SA-2 built. Two things landed here.
+#
+# ``site_analytics`` aggregates a site's pageview rows out of Workers Analytics Engine
+# and answers ``SiteAnalyticsResponse``. Its governing rule is that it NEVER INVENTS A
+# ZERO: not entitled, entitled-but-never-counted, counting-and-genuinely-quiet, and a
+# read that failed are four different answers to a customer, and three of them would
+# otherwise render as the same panel of zeros. The first three are ``status`` values
+# with every metric left None; the fourth is an exception, so a Cloudflare outage
+# cannot arrive shaped like a quiet week. It gates on the SAME
+# ``entitlements.site_analytics_entitled`` the publish path reads, never a second copy.
+#
+# ``_deploy_site_doc`` now stamps ``Site.analytics_since``, which is what makes the
+# second of those states knowable. The value is read off WHAT THE DEPLOY LEFT ON DISK
+# (the generated entry ``workers_deploy`` writes or deletes) rather than re-derived
+# from the plan, because the counting rule already lives in three places and a fourth
+# would be one more thing to disagree. Set on a publish that deployed a counter,
+# CLEARED on one that did not — a site that lapsed and re-upgraded is entitled with no
+# stamp, which is exactly "you have not republished yet".
+#
 # Updated 2026-09-02 (feat/sites-analytics-gate, SA-2): the workers deploy now carries
 # whether THIS site's plan buys the visitor pageview counter. SA-1 wired that counter
 # onto every assets-only publish; a Worker invocation is billed where a static asset is
@@ -2835,6 +2855,10 @@ async def _deploy_site_doc(
         mode = "wfp"
 
     url = ""
+    # SA-4: did THIS deploy actually leave a pageview counter in front of the site?
+    # Only the workers branch can, so every other target answers False without asking.
+    # ``analytics_since`` is written from this below.
+    counter_deployed = False
     if mode == "local":
         from pocketpaw_ee.sites import local_server
 
@@ -2871,6 +2895,22 @@ async def _deploy_site_doc(
         url = await deploy_w(
             site_id, build.project_dir, engine=engine, analytics_entitled=counts_pageviews
         )
+        # SA-4: and read back what the deploy ACTUALLY did, from the artifact rather
+        # than from ``counts_pageviews``. The counting rule has three parts — the plan
+        # (above), the operator kill switch, and whether the engine emits its own
+        # worker — and only the last two are resolved inside
+        # ``workers_deploy._write_deploy_files``. Re-deriving the answer here would put
+        # a fourth copy of that rule in the tree, and the field this feeds exists
+        # precisely to be trusted when the copies disagree.
+        #
+        # The generated entry is the artifact of the decision: written when counting is
+        # on, deleted when it is off. ``is_file`` rather than ``exists`` so the one case
+        # where the delete legitimately fails — a directory sitting on the entry's name,
+        # which ``_write_deploy_files`` swallows — reads as no counter, which is what
+        # wrangler will actually deploy.
+        from pocketpaw_ee.sites import analytics_worker
+
+        counter_deployed = Path(build.project_dir, analytics_worker.ENTRY_FILENAME).is_file()
     else:  # "wfp"
         cf = cloudflare or _cf_client()
         bundle = bundle_reader(build.project_dir)
@@ -2925,6 +2965,10 @@ async def _deploy_site_doc(
             script_name=site_id,
             deployed=True,
             deployed_at=now,
+            # SA-4: the stamp says counting is ON and began here. A first publish that
+            # deployed no counter records None, which the read reports as "nothing has
+            # been recorded yet" rather than as a quiet week.
+            analytics_since=now if counter_deployed else None,
             # Record WHICH target this deploy used, not which one was configured. The
             # custom-domain lane needs "does this site have its own route-addressable
             # Worker", and PAW_CF_DEPLOY_MODE cannot answer it at request time.
@@ -2956,6 +3000,18 @@ async def _deploy_site_doc(
         doc.deployed_at = now
         doc.deploy_target = mode
         doc.url = url
+        # SA-4, and unlike ``deployed_at`` this is NOT "last" — it is "since", so a
+        # republish that keeps counting keeps the original stamp. First-set-wins holds
+        # only WITHIN a counting era: a publish that carried no counter clears the field
+        # outright, because nothing is recording and there is no "since" to report.
+        #
+        # Clearing is what closes the lapse hole. A site that counted in June, dropped
+        # to free in July and re-upgraded today is entitled again, but no publish has
+        # carried a counter since the lapse. Left stamped, the read would answer
+        # "counting since June, and nobody visited" over months in which nothing was
+        # recording at all — the invented zero this feature exists to avoid. Cleared,
+        # entitled-with-no-stamp is exactly "you have not republished".
+        doc.analytics_since = (doc.analytics_since or now) if counter_deployed else None
         # The deploy may have moved (local → workers, or a new sites domain), so
         # re-assert the site's own host on every publish. Idempotent and additive:
         # a host already present is not duplicated, and a custom domain appended by
@@ -4305,6 +4361,12 @@ async def finalize_provisioned_site(site: _SiteDoc, *, url: str, deploy_target: 
     site.deployed = True
     site.deployed_at = datetime.now(UTC)
     site.url = url
+    # SA-4: this lane deploys no pageview counter and says so outright —
+    # ``provision_deploy`` passes ``analytics_entitled=False`` because a dynamic site's
+    # ``main`` is already SvelteKit's own worker. So the honest value here is None: a
+    # site that stood up through this job is not recording, whatever an earlier static
+    # publish may have left on the field.
+    site.analytics_since = None
     if deploy_target:
         site.deploy_target = deploy_target
     await site.save()

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -997,6 +997,7 @@ import json
 import logging
 import re
 import secrets
+import time
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -1024,10 +1025,15 @@ from pocketpaw_ee.cloud.models.site import SiteInvoice as _SiteInvoiceDoc
 from pocketpaw_ee.sites.build_state import claim_precondition
 from pocketpaw_ee.sites.domain import HostnameStatus
 from pocketpaw_ee.sites.dto import (
+    ANALYTICS_STATUS_NEVER_COUNTED,
+    ANALYTICS_STATUS_NOT_ENTITLED,
+    ANALYTICS_STATUS_OK,
     AuditFinding,
     AuditResponse,
     DevPreviewResponse,
     DomainStatusResponse,
+    SiteAnalyticsBreakdown,
+    SiteAnalyticsResponse,
     SiteClientResponse,
     SiteClientUpdate,
     SiteDataRowsResponse,
@@ -5071,6 +5077,392 @@ async def domain_status(
     await site.save()
     return DomainStatusResponse(
         hostname=dom.hostname, cname_target=dom.cname_target, status=status.value
+    )
+
+
+# ── SA-4: the visitor-analytics read ────────────────────────────────────────
+#
+# THE ONE RULE GOVERNING EVERYTHING BELOW: never invent a zero. Four situations can
+# produce an empty-looking dashboard and they are four different sentences to the
+# customer —
+#
+#   1. this plan does not buy analytics                    → ``not_entitled``
+#   2. it does, but nothing has ever been recorded         → ``never_counted``
+#   3. counting, and genuinely nobody visited              → ``ok`` with real zeros
+#   4. the read itself failed                              → an EXCEPTION, never a status
+#
+# Only the third is a report about traffic. Rendering the first two as "0 visitors"
+# tells a customer their marketing is not working when the truth is that they have not
+# upgraded, or have not republished since they did. And the fourth is deliberately not
+# a status value at all: a client that maps an unfamiliar status to "no data" would
+# turn a Cloudflare outage into a quiet week, so a failed read leaves as a CloudError
+# and arrives as an error response.
+#
+# THE WINDOWS ARE A CLOSED SET, and that is a SQL-injection control rather than a UX
+# choice. The Analytics Engine SQL endpoint takes raw text with no parameter binding
+# (see ``cloudflare_client.query_analytics_sql``), so nothing user-controlled may be
+# interpolated into a statement. A caller's ``window`` selects a row from this table
+# and never reaches the SQL; the only other substitution is the site id, which has
+# already round-tripped through ``ObjectId`` and is re-checked at the call site.
+#
+# Retention at Cloudflare is THREE MONTHS, so ``90d`` is the longest window that can
+# return anything and there is no point offering more.
+_ANALYTICS_WINDOWS: dict[str, int] = {"24h": 1, "7d": 7, "30d": 30, "90d": 90}
+_ANALYTICS_DEFAULT_WINDOW = "7d"
+
+# Cloudflare drops a row three months after it is written. On the wire (see
+# ``SiteAnalyticsResponse.retention_days``) so a UI can say why the earliest date it
+# offers is the one it offers, rather than looking like it lost the data.
+_ANALYTICS_RETENTION_DAYS = 90
+
+# How many rows a breakdown returns. A top-N list, not a full inventory: a site with
+# four thousand paths would otherwise send four thousand rows to render ten.
+_ANALYTICS_BREAKDOWN_LIMIT = 10
+
+# THE CACHE. A dashboard reload must not be a Cloudflare round trip: Analytics Engine
+# bills READ queries and the free allowance is 10,000 a day for the whole account,
+# which four people leaning on F5 can spend by lunchtime. One entry per (site, window)
+# holding the assembled response.
+#
+# Sixty seconds, chosen against what the data can actually do rather than picked round.
+# The counter writes a row per pageview with no aggregation delay, so a shorter TTL
+# buys freshness that visitors cannot produce; a longer one starts to feel stale on the
+# release-day reload this panel exists for.
+#
+# IN-PROCESS AND DELIBERATELY NOT SHARED. A second API replica keeps its own, so the
+# worst case is one query set per replica per minute rather than one per account —
+# still far under the allowance, and it costs no Redis dependency on a read whose whole
+# value is being cheap. Bounded so a workspace with thousands of sites cannot grow it
+# without limit.
+#
+# ONLY SUCCESSES ARE CACHED. A failed read raises, and caching a failure would extend a
+# Cloudflare blip into a minute of errors for everyone.
+_ANALYTICS_CACHE_TTL_SECONDS = 60.0
+_ANALYTICS_CACHE_MAX_ENTRIES = 512
+_analytics_cache: dict[tuple[str, str, str], tuple[float, SiteAnalyticsResponse]] = {}
+
+
+def _analytics_cache_get(key: tuple[str, str, str]) -> SiteAnalyticsResponse | None:
+    """The cached response for this (workspace, site, window), or None.
+
+    ``monotonic`` rather than wall time so an NTP correction or a DST jump cannot make
+    an entry look hours old — or hours in the future, which would pin it forever."""
+    hit = _analytics_cache.get(key)
+    if hit is None:
+        return None
+    expires_at, response = hit
+    if time.monotonic() >= expires_at:
+        _analytics_cache.pop(key, None)
+        return None
+    return response
+
+
+def _analytics_cache_put(key: tuple[str, str, str], response: SiteAnalyticsResponse) -> None:
+    """Cache one assembled response, evicting expired entries first.
+
+    The eviction sweep is what keeps this bounded without an LRU: entries expire in a
+    minute anyway, so dropping the dead ones is almost always enough. The hard cap
+    behind it clears the whole map rather than choosing a victim — at this size the
+    next request simply re-queries, and a correct dumb policy beats a clever one on a
+    cache whose entries are worth a fraction of a cent each."""
+    if len(_analytics_cache) >= _ANALYTICS_CACHE_MAX_ENTRIES:
+        now = time.monotonic()
+        for stale in [k for k, (expires_at, _) in _analytics_cache.items() if now >= expires_at]:
+            _analytics_cache.pop(stale, None)
+        if len(_analytics_cache) >= _ANALYTICS_CACHE_MAX_ENTRIES:
+            _analytics_cache.clear()
+    _analytics_cache[key] = (time.monotonic() + _ANALYTICS_CACHE_TTL_SECONDS, response)
+
+
+def _analytics_int(row: dict, key: str) -> int:
+    """One numeric cell out of an Analytics Engine row.
+
+    The SQL API answers JSON, and an aggregate comes back as a number or — for the
+    64-bit sums — as a STRING holding one, which is how ClickHouse-shaped APIs avoid
+    JavaScript's integer limit. Both are read; anything else is 0 rather than a 500,
+    because a malformed cell in one breakdown row must not cost the whole panel.
+
+    A missing key is 0 too, and that is safe HERE and only here: this runs after the
+    caller has established that the read SUCCEEDED. The "never invent a zero" rule is
+    about the four states above, not about a cell inside a row that really came back.
+
+    A string is parsed as an INTEGER FIRST and only then as a float. Going through
+    ``float`` unconditionally would round every count above 2^53 to the nearest even —
+    which is precisely the range the string encoding exists to protect, so the shortcut
+    would corrupt exactly the values it was written to handle."""
+    raw = row.get(key)
+    if isinstance(raw, bool):
+        return 0
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    if isinstance(raw, str):
+        text = raw.strip()
+        try:
+            return int(text)
+        except ValueError:
+            pass
+        try:
+            return int(float(text))
+        except ValueError:
+            return 0
+    return 0
+
+
+def _analytics_label(row: dict, key: str, *, empty: str) -> str:
+    """One label cell, with the name an empty one is reported under.
+
+    A blank is a REAL answer for most of these dimensions and must not be dropped: an
+    empty referrer is a direct visit, an empty country is a request Cloudflare could
+    not geolocate. Silently discarding those rows would inflate every remaining
+    percentage — the classic way a chart lies without a single wrong number in it."""
+    raw = row.get(key)
+    text = raw.strip() if isinstance(raw, str) else ""
+    return text or empty
+
+
+def _analytics_breakdown(
+    rows: list[dict], *, label_key: str, empty: str
+) -> list[SiteAnalyticsBreakdown]:
+    """Map query rows onto breakdown rows, in the order the query returned them."""
+    return [
+        SiteAnalyticsBreakdown(
+            label=_analytics_label(row, label_key, empty=empty),
+            pageviews=_analytics_int(row, "pageviews"),
+            visitors=_analytics_int(row, "visitors"),
+        )
+        for row in rows
+    ]
+
+
+def _analytics_sql(*, select: str, site_id: str, days: int, group: str = "", limit: int = 0) -> str:
+    """Build ONE Analytics Engine statement over this site's pageview rows.
+
+    EVERY value interpolated here is one this module controls: ``site_id`` is
+    re-validated as a 24-character hex ObjectId immediately below, ``days`` comes from
+    ``_ANALYTICS_WINDOWS``, and ``select`` / ``group`` are literals written in this
+    file. Nothing a request carries reaches the statement, which is the contract the
+    SQL endpoint demands — it has no parameter binding, so a caller that interpolates a
+    request value has written an injection.
+
+    ``SUM(_sample_interval)`` rather than ``COUNT()``: Analytics Engine downsamples a
+    hot index and exposes the sampling rate per row, so a plain count under-reports
+    exactly the busiest sites — the ones most likely to notice. Distinct visitors are
+    counted the way they are stored, on the per-day hash in ``blob4``, so a visitor who
+    returns tomorrow counts twice. That is the privacy design rather than a defect: the
+    salt rotates at UTC midnight, so no join across days is possible even in principle.
+    """
+    if not re.fullmatch(r"[0-9a-f]{24}", site_id):
+        # Belt and braces behind ``_load``'s ObjectId round-trip. This is the last
+        # place before raw SQL, and the cost of being wrong is an injected query
+        # against the account's whole analytics dataset.
+        raise ValidationError("sites.invalid_site_id", "site_id is not a site identifier")
+    from pocketpaw_ee.sites import analytics_worker
+
+    parts = [
+        f"SELECT {select}",
+        f"FROM {analytics_worker.dataset_name()}",
+        f"WHERE index1 = '{site_id}' AND timestamp > NOW() - INTERVAL '{int(days)}' DAY",
+    ]
+    if group:
+        parts.append(f"GROUP BY {group}")
+        parts.append("ORDER BY pageviews DESC")
+    if limit:
+        parts.append(f"LIMIT {int(limit)}")
+    parts.append("FORMAT JSON")
+    return "\n".join(parts)
+
+
+# The dimensions a stored row can answer, and the blob each sits in. The layout is a
+# CONTRACT with ``analytics_worker`` — Analytics Engine columns are positional and have
+# no names, so reading the wrong blob silently reports referrers as countries.
+#
+# ``blob5`` is a DEVICE CLASS that may or may not be there. A row written before SA-3
+# has four blobs and a row written after has five; Analytics Engine has no schema and
+# answers an empty string for a blob a row never carried, so both shapes arrive here in
+# one window and neither may crash. See ``_analytics_devices`` for what an empty one
+# means and why it is bucketed rather than dropped.
+_ANALYTICS_DIMENSIONS: tuple[tuple[str, str, str], ...] = (
+    ("top_pages", "blob1", "(unknown)"),
+    ("referrers", "blob2", "(direct)"),
+    ("countries", "blob3", "(unknown)"),
+    ("devices", "blob5", "unknown"),
+)
+
+
+async def site_analytics(
+    *,
+    workspace_id: str,
+    site_id: str,
+    window: str = _ANALYTICS_DEFAULT_WINDOW,
+    _cloudflare: Any | None = None,
+) -> SiteAnalyticsResponse:
+    """Visitor analytics for ONE site over ONE window (GET /sites/{id}/analytics).
+
+    Tenant-scoped through ``_load``, so a missing, malformed or cross-tenant site id is
+    a 404 exactly as it is on every sibling per-site read. That check runs FIRST — a
+    caller must not be able to learn that another workspace's site exists by watching
+    which error comes back.
+
+    Entitlement is resolved through ``entitlements.site_analytics_entitled``, the SAME
+    predicate the publish path gates the counter on. Not a second copy: a site whose
+    publish counted but whose read refuses is a customer paying for a blank chart, and
+    the reverse serves numbers a site was never entitled to gather.
+
+    THE FOUR OUTCOMES, and why three of them return no numbers at all:
+
+    * NOT ENTITLED — nothing was ever recorded and nothing can be until the plan
+      changes. The metrics stay None so a UI that renders them without reading the
+      status shows blanks rather than a confident zero.
+    * NEVER COUNTED — entitled, but ``analytics_since`` is None, which after the SA-4
+      write rule means precisely "no publish has deployed a counter, so nothing is
+      recording". Republishing starts it; upgrading does not backfill, because the rows
+      do not exist to backfill from.
+    * OK — a counter is up. The numbers are real, and they may legitimately be zero.
+    * THE READ FAILED — this raises. ``query_analytics_sql`` is fail-closed by design
+      and its ValidationError travels out of here untouched, because a failed read is
+      not a report about the site's traffic and must not arrive shaped like one.
+
+    ``devices`` may come back None with ``"devices"`` in ``unrecorded`` — see
+    ``_analytics_devices``.
+    """
+    doc = await _load(workspace_id, site_id)
+
+    window = window.strip() or _ANALYTICS_DEFAULT_WINDOW
+    days = _ANALYTICS_WINDOWS.get(window)
+    if days is None:
+        raise ValidationError(
+            "sites.invalid_analytics_window",
+            f"window must be one of: {', '.join(sorted(_ANALYTICS_WINDOWS))}",
+        )
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    entitled = entitlements_service.site_analytics_entitled(
+        plan_tier=getattr(doc, "plan_tier", None),
+        subscription_status=getattr(doc, "subscription_status", None),
+    )
+    if not entitled:
+        return _analytics_empty(site_id, window, ANALYTICS_STATUS_NOT_ENTITLED, None)
+
+    since = getattr(doc, "analytics_since", None)
+    if since is None:
+        # Exactly "counting is off", after the write rule that CLEARS this field on a
+        # publish carrying no counter. Nothing to query, and querying anyway would
+        # spend a billed read to confirm an emptiness whose reason is already known.
+        return _analytics_empty(site_id, window, ANALYTICS_STATUS_NEVER_COUNTED, None)
+
+    # The cache is checked AFTER the two states above, which cost nothing to recompute,
+    # and after ``_load``, so a cached entry can never answer a cross-tenant request.
+    cache_key = (workspace_id, site_id, window)
+    cached = _analytics_cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    cf = _cloudflare or _cf_client()
+    totals_rows = await cf.query_analytics_sql(
+        _analytics_sql(
+            select="SUM(_sample_interval) AS pageviews, COUNT(DISTINCT blob4) AS visitors",
+            site_id=site_id,
+            days=days,
+        )
+    )
+    # An aggregate with no GROUP BY answers exactly one row. No rows at all means the
+    # window held no data — a real answer, and the ``ok``-with-zeros state rather than a
+    # failure. A failure would already have raised out of the client.
+    totals = totals_rows[0] if totals_rows else {}
+
+    breakdowns: dict[str, list[SiteAnalyticsBreakdown]] = {}
+    for field, blob, empty in _ANALYTICS_DIMENSIONS:
+        rows = await cf.query_analytics_sql(
+            _analytics_sql(
+                select=(
+                    f"{blob} AS label, SUM(_sample_interval) AS pageviews, "
+                    "COUNT(DISTINCT blob4) AS visitors"
+                ),
+                site_id=site_id,
+                days=days,
+                group="label",
+                limit=_ANALYTICS_BREAKDOWN_LIMIT,
+            )
+        )
+        breakdowns[field] = _analytics_breakdown(rows, label_key="label", empty=empty)
+
+    devices, unrecorded = _analytics_devices(breakdowns["devices"])
+    response = SiteAnalyticsResponse(
+        site_id=site_id,
+        window=window,
+        status=ANALYTICS_STATUS_OK,
+        counting_since=_analytics_iso(since),
+        retention_days=_ANALYTICS_RETENTION_DAYS,
+        pageviews=_analytics_int(totals, "pageviews"),
+        visitors=_analytics_int(totals, "visitors"),
+        top_pages=breakdowns["top_pages"],
+        referrers=breakdowns["referrers"],
+        countries=breakdowns["countries"],
+        devices=devices,
+        unrecorded=unrecorded,
+    )
+    _analytics_cache_put(cache_key, response)
+    return response
+
+
+def _analytics_devices(
+    rows: list[SiteAnalyticsBreakdown],
+) -> tuple[list[SiteAnalyticsBreakdown] | None, list[str]]:
+    """Split the device breakdown into what to serve and what to declare unrecorded.
+
+    THE ROW SHAPE CHANGED UNDER THIS READER, which is why this is its own function. A
+    pageview row written before SA-3's device class holds four blobs; one written after
+    holds five. Analytics Engine has no schema and no column names — a blob a row never
+    carried reads as an empty string — so both shapes arrive here together inside a
+    single window, and neither may crash.
+
+    An EMPTY device label is therefore ambiguous in one direction only: it is a row that
+    recorded nothing about the device, whether because it predates the change or because
+    the class could not be determined. Either way it belongs in the ``unknown`` bucket
+    rather than being discarded, since discarding it would rescale every real device's
+    share against a smaller total.
+
+    When EVERY row is unknown the dimension is not answered-and-empty, it is
+    unanswerable: SA-3 has not landed, or nothing has been published since it did. That
+    returns None plus ``"devices"`` in ``unrecorded``, which a client renders as "not
+    recorded" instead of as a chart of one bar called unknown. An empty list would read
+    as "no devices", and omitting the field is indistinguishable from a version skew.
+    """
+    if not rows or all(row.label == "unknown" for row in rows):
+        return None, ["devices"]
+    return rows, []
+
+
+def _analytics_iso(moment: datetime) -> str:
+    """A stored stamp as an ISO-8601 string in UTC.
+
+    Mongo stores a datetime with no zone, so a value written as tz-aware reads back
+    NAIVE. Putting that on the wire bare would let a client read a UTC instant as its
+    own local time — a silent several-hour lie about when counting started, which is
+    the very value a chart's x-axis begins at.
+    """
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    return moment.astimezone(UTC).isoformat()
+
+
+def _analytics_empty(
+    site_id: str, window: str, status: str, since: datetime | None
+) -> SiteAnalyticsResponse:
+    """A response carrying a STATUS and no numbers.
+
+    Every metric is left at its None default rather than zeroed, and that is the point
+    of the shape: a client that renders the numbers without reading the status shows
+    blanks, which is honest, instead of zeros, which are a claim about traffic nobody
+    measured.
+    """
+    return SiteAnalyticsResponse(
+        site_id=site_id,
+        window=window,
+        status=status,
+        counting_since=_analytics_iso(since) if since is not None else None,
+        retention_days=_ANALYTICS_RETENTION_DAYS,
     )
 
 

--- a/tests/ee/sites/test_cloudflare_client.py
+++ b/tests/ee/sites/test_cloudflare_client.py
@@ -18,6 +18,14 @@
 # create_database(): a successful create returns the uuid at ``result.uuid``, and
 # a Cloudflare error envelope (success:false or non-2xx) fails closed by raising
 # ValidationError with code ``sites.cloudflare_error``.
+# Updated 2026-09-02 (SA-4 — the visitor-analytics read): added coverage for
+# query_analytics_sql(), which breaks two of this module's conventions on purpose —
+# the body is raw SQL rather than JSON, and a SUCCESSFUL query answers
+# ``{meta, data, rows}`` with no ``success`` key, so ``_unwrap`` would raise on every
+# good response. Both are pinned here because either is one line of house-style
+# tidying away from breaking every read. It is fail-closed on a non-2xx, a non-JSON
+# body, and a 2xx with no data array: returning [] would render a Cloudflare outage
+# as a customer's quiet week.
 from __future__ import annotations
 
 import json
@@ -562,3 +570,129 @@ async def test_deletes_still_fail_closed_on_a_real_error(method: str, arg: str):
     with pytest.raises(ValidationError) as exc:
         await getattr(client, method)(arg)
     assert exc.value.code == "sites.cloudflare_error"
+
+
+# ── SA-4: the Analytics Engine SQL API ──────────────────────────────────────
+#
+# The one method on this client whose request body is RAW SQL and whose SUCCESS
+# response is NOT the Cloudflare envelope. Both are asserted here because both are easy
+# to "fix" back into the house style, and either fix breaks every query: sending JSON
+# gets a 400, and running the good response through ``_unwrap`` raises on the missing
+# ``success`` key so every successful read would surface as a Cloudflare error.
+
+
+@pytest.mark.asyncio
+async def test_analytics_sql_posts_the_raw_statement():
+    """The endpoint takes the statement as the body, not as a JSON field. Also pins the
+    URL — the account-scoped ``analytics_engine/sql`` path, which is a different surface
+    from the Workers ones above and needs a token scope they do not."""
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["method"] = request.method
+        seen["body"] = request.content
+        return httpx.Response(200, json={"meta": [], "data": [{"pageviews": 3}], "rows": 1})
+
+    client = _client(handler)
+    rows = await client.query_analytics_sql("SELECT 1 FROM ds FORMAT JSON")
+
+    assert rows == [{"pageviews": 3}]
+    assert seen["method"] == "POST"
+    assert seen["url"].endswith("/accounts/acct_1/analytics_engine/sql")
+    assert seen["body"] == b"SELECT 1 FROM ds FORMAT JSON"
+
+
+@pytest.mark.asyncio
+async def test_analytics_sql_reads_a_body_with_no_success_key():
+    """A successful query answers ``{meta, data, rows}`` and no ``success``. Running it
+    through this module's ``_unwrap`` would raise on every good response — the failure
+    would look like a Cloudflare outage and be one line of "consistency" away."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "meta": [{"name": "pageviews", "type": "UInt64"}],
+                "data": [{"pageviews": "12"}, {"pageviews": "7"}],
+                "rows": 2,
+            },
+        )
+
+    client = _client(handler)
+    assert await client.query_analytics_sql("SELECT 1") == [{"pageviews": "12"}, {"pageviews": "7"}]
+
+
+@pytest.mark.asyncio
+async def test_analytics_sql_returns_an_empty_result_as_empty():
+    """``data: []`` is a REAL answer — the query matched nothing — and is the only shape
+    that may come back as no rows. Everything else that produces no rows raises."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"meta": [], "data": [], "rows": 0})
+
+    client = _client(handler)
+    assert await client.query_analytics_sql("SELECT 1") == []
+
+
+@pytest.mark.asyncio
+async def test_analytics_sql_fails_closed_on_a_missing_scope():
+    """FAIL-CLOSED IS THE WHOLE REQUIREMENT HERE, not a habit. Returning ``[]`` on a
+    failure would render a customer's dashboard as "0 visitors" when the truth is "the
+    read failed", and a panel reporting an outage as a quiet week is worse than one
+    reporting nothing.
+
+    403 specifically, because the token scope this needs (``Account Analytics Read``) is
+    NOT one the deploy paths carry — so this is the first thing that goes wrong in a new
+    environment, and Cloudflare's own sentence has to survive into the message."""
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            json={
+                "success": False,
+                "errors": [{"code": 9109, "message": "Unauthorized to access"}],
+            },
+        )
+
+    client = _client(handler)
+    with pytest.raises(ValidationError) as exc:
+        await client.query_analytics_sql("SELECT 1")
+
+    assert exc.value.code == "sites.cloudflare_error"
+    assert "403" in exc.value.message
+    assert "Unauthorized to access" in exc.value.message
+
+
+@pytest.mark.asyncio
+async def test_analytics_sql_fails_closed_on_a_non_json_body():
+    """The SQL endpoint answers text/plain for some errors, and a body that will not
+    parse is not an empty result."""
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="Code: 62. DB::Exception: Syntax error")
+
+    client = _client(handler)
+    with pytest.raises(ValidationError) as exc:
+        await client.query_analytics_sql("SELECT nonsense")
+    assert exc.value.code == "sites.cloudflare_error"
+
+
+@pytest.mark.asyncio
+async def test_analytics_sql_fails_closed_on_a_2xx_with_no_data_array():
+    """A 200 whose body has no ``data`` list is a contract break, not an empty result —
+    an empty result IS a ``data`` of ``[]``. Reporting it as no rows would manufacture
+    exactly the zeros this method exists never to manufacture."""
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    for body in ({"meta": [], "rows": 0}, {"data": None}, {"data": {"pageviews": 1}}, []):
+
+        def handler(request: httpx.Request, _body=body) -> httpx.Response:
+            return httpx.Response(200, json=_body)
+
+        client = _client(handler)
+        with pytest.raises(ValidationError) as exc:
+            await client.query_analytics_sql("SELECT 1")
+        assert exc.value.code == "sites.cloudflare_error", body

--- a/tests/ee/sites/test_sites_analytics_read.py
+++ b/tests/ee/sites/test_sites_analytics_read.py
@@ -1,0 +1,785 @@
+# tests/ee/sites/test_sites_analytics_read.py — SA-4, the read half of Paw Sites
+# visitor analytics: GET /sites/{site_id}/analytics and the aggregation behind it.
+#
+# Created 2026-09-02 (feat/sites-analytics-read).
+#
+# THE REQUIREMENT THIS WHOLE FILE EXISTS FOR: never invent a zero. Four situations can
+# leave a dashboard looking empty and they are four different sentences to a customer:
+#
+#   1. this plan does not buy analytics
+#   2. it does, but no publish has deployed a counter, so nothing was ever recorded
+#   3. a counter is up, and genuinely nobody visited
+#   4. the read itself failed
+#
+# Only the third is a report about their traffic. Serving 0 for the first two tells
+# someone their marketing is dead when the truth is they have not upgraded, or have not
+# republished since they did. And the fourth is deliberately NOT a status value: a
+# client that maps an unfamiliar status to "no data" would render a Cloudflare outage
+# as a quiet week, so a failed read is an error response. Each of the four is asserted
+# here, and asserted as DISTINGUISHABLE rather than merely as "not a crash".
+#
+# THE ROW SHAPE IS A MOVING TARGET, which the device tests are about. SA-3 appends a
+# device class at ``blobs[4]`` in a separate slice that may or may not land. A row
+# written before it has four blobs and one written after has five, Analytics Engine has
+# no schema and answers an empty string for a blob a row never carried, so BOTH shapes
+# arrive inside one window. Neither may crash, and neither may silently miscount — an
+# empty device is bucketed as unknown rather than dropped, because dropping it rescales
+# every other device's share.
+#
+# The Cloudflare client is FAKED at the seam that speaks HTTP (``query_analytics_sql``)
+# rather than at the service function, so everything between the route and the wire —
+# the entitlement gate, the SQL, the row mapping, the cache — is real code under test.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound, ValidationError  # noqa: E402
+from pocketpaw_ee.sites import service as sites_service  # noqa: E402
+
+SITE_TIER = "site"
+
+
+class _FakeAnalyticsCF:
+    """A Cloudflare client that answers SQL from a scripted table.
+
+    Faked at ``query_analytics_sql`` — the one method that speaks HTTP — so the SQL
+    text, the row mapping, the status decision and the cache are all real code here.
+    Every statement is recorded, which is how the injection and window tests assert on
+    what was actually sent rather than on what the caller meant to send.
+    """
+
+    def __init__(self, rows_by_blob: dict[str, list[dict]] | None = None, totals=None) -> None:
+        self.rows_by_blob = rows_by_blob or {}
+        self.totals = totals
+        self.queries: list[str] = []
+
+    async def query_analytics_sql(self, sql: str) -> list[dict]:
+        self.queries.append(sql)
+        if "GROUP BY" not in sql:
+            return [] if self.totals is None else [self.totals]
+        for blob, rows in self.rows_by_blob.items():
+            if f"{blob} AS label" in sql:
+                return rows
+        return []
+
+
+class _ExplodingCF:
+    """A client whose read fails the way the real one does — see
+    ``cloudflare_client.query_analytics_sql``, which is fail-closed on a non-2xx, a
+    non-JSON body, and a 2xx with no data array."""
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    async def query_analytics_sql(self, sql: str) -> list[dict]:
+        self.queries.append(sql)
+        raise ValidationError(
+            "sites.cloudflare_error", "Analytics Engine SQL 503: service unavailable"
+        )
+
+
+def _rows(*pairs: tuple[str, int, int]) -> list[dict]:
+    return [{"label": label, "pageviews": pv, "visitors": v} for label, pv, v in pairs]
+
+
+async def _seed_site(
+    *,
+    workspace_id: str = "ws-read",
+    pocket_id: str = "pk-read",
+    plan_tier: str | None = SITE_TIER,
+    subscription_status: str | None = "active",
+    counting_since: datetime | None = None,
+) -> Any:
+    """Insert a Site document directly.
+
+    Built rather than published because every case here is about the state of a row a
+    publish has ALREADY produced — the publish path's own writes are asserted in
+    test_sites_analytics_since.py, and going through it would make each of these tests
+    depend on a build, a deploy and a badge stamper that have nothing to do with the
+    read.
+    """
+    from bson import ObjectId
+    from pocketpaw_ee.cloud.models.site import Site
+
+    doc = Site(
+        id=ObjectId(),
+        workspace=workspace_id,
+        pocket_id=pocket_id,
+        owner="u1",
+        name="Read Site",
+        deployed=True,
+        plan_tier=plan_tier,
+        subscription_status=subscription_status,
+        analytics_since=counting_since,
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture(autouse=True)
+def _empty_cache():
+    """Clear the read cache around every test.
+
+    It is process-global, so without this a response assembled by one test would be
+    served to the next — which would also hide a cache bug behind whichever test ran
+    first."""
+    sites_service._analytics_cache.clear()
+    yield
+    sites_service._analytics_cache.clear()
+
+
+# ── 1. the four outcomes ─────────────────────────────────────────────────────
+#
+# Named for the CUSTOMER SITUATION rather than for the input, because the failure being
+# guarded against is one where all four render the same and only the wording of the
+# assertion tells you which one broke.
+
+
+@pytest.mark.asyncio
+async def test_a_site_whose_plan_does_not_buy_analytics_says_so(beanie_test_db):
+    """State 1. Nothing was ever recorded and nothing can be until the plan changes, so
+    every metric is None — a UI that renders the numbers without reading the status
+    shows blanks rather than a confident zero."""
+    site = await _seed_site(plan_tier="free", counting_since=datetime.now(UTC))
+    cf = _FakeAnalyticsCF()
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.status == "not_entitled"
+    assert out.pageviews is None
+    assert out.visitors is None
+    assert out.counting_since is None
+    assert cf.queries == [], "an unentitled site must not spend a billed read"
+
+
+@pytest.mark.asyncio
+async def test_an_entitled_site_that_has_never_counted_says_so(beanie_test_db):
+    """State 2, and the state the ``analytics_since`` field exists to make knowable.
+    The site is paying; no publish has deployed a counter, so there is nothing to read
+    and republishing is the fix. Distinguishable from state 3 below, which is the whole
+    point."""
+    site = await _seed_site(counting_since=None)
+    cf = _FakeAnalyticsCF()
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.status == "never_counted"
+    assert out.pageviews is None
+    assert out.counting_since is None
+    assert cf.queries == [], "there is nothing recorded to query"
+
+
+@pytest.mark.asyncio
+async def test_a_counting_site_with_no_traffic_reports_a_real_zero(beanie_test_db):
+    """State 3. A counter IS up, the query really ran, and it really found nothing.
+    THIS is the only state in which a zero is honest — and it carries
+    ``counting_since``, so the panel can say how long that zero has been true."""
+    began = datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+    site = await _seed_site(counting_since=began)
+    cf = _FakeAnalyticsCF(totals={"pageviews": 0, "visitors": 0})
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.status == "ok"
+    assert out.pageviews == 0
+    assert out.visitors == 0
+    assert out.counting_since == began.isoformat()
+    assert cf.queries, "state 3 is the one that actually queries"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_read_raises_rather_than_reporting_a_quiet_week(beanie_test_db):
+    """State 4, and the reason it is NOT a status value. A Cloudflare outage arriving on
+    the same shape as a report would be read by any client as zero traffic — silently,
+    and exactly when the customer is least able to tell.
+
+    The status vocabulary is asserted as CLOSED here too: were a failure ever added to
+    it, this test is what fails."""
+    site = await _seed_site(counting_since=datetime.now(UTC))
+    cf = _ExplodingCF()
+
+    with pytest.raises(CloudError) as exc:
+        await sites_service.site_analytics(
+            workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+        )
+
+    assert exc.value.code == "sites.cloudflare_error"
+    assert "not_entitled" not in str(exc.value)
+    from pocketpaw_ee.sites import dto
+
+    assert {
+        dto.ANALYTICS_STATUS_OK,
+        dto.ANALYTICS_STATUS_NOT_ENTITLED,
+        dto.ANALYTICS_STATUS_NEVER_COUNTED,
+    } == {"ok", "not_entitled", "never_counted"}
+
+
+@pytest.mark.asyncio
+async def test_the_four_outcomes_are_actually_distinguishable(beanie_test_db):
+    """The claim the four tests above make INDIVIDUALLY, asserted as a set. Each one
+    alone would pass against an implementation that answered the same thing for two of
+    them, and "your plan does not include this" collapsing into "nobody visited" is the
+    exact failure this slice exists to prevent."""
+    began = datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+    unentitled = await _seed_site(pocket_id="pk-d1", plan_tier="free", counting_since=began)
+    never = await _seed_site(pocket_id="pk-d2", counting_since=None)
+    quiet = await _seed_site(pocket_id="pk-d3", counting_since=began)
+    # A FOURTH site for the outage, not a re-read of ``quiet``. A site read successfully
+    # a moment ago is cached, so a Cloudflare failure inside the TTL is correctly served
+    # from the cache and never reaches the client — real behaviour, and it would make
+    # this assertion pass or fail on cache timing rather than on the status vocabulary.
+    broken = await _seed_site(pocket_id="pk-d4", counting_since=began)
+
+    async def _read(site, cf):
+        return await sites_service.site_analytics(
+            workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+        )
+
+    a = await _read(unentitled, _FakeAnalyticsCF())
+    b = await _read(never, _FakeAnalyticsCF())
+    c = await _read(quiet, _FakeAnalyticsCF(totals={"pageviews": 0, "visitors": 0}))
+
+    assert len({a.status, b.status, c.status}) == 3
+    # And the fourth is not on the same axis at all.
+    with pytest.raises(CloudError):
+        await _read(broken, _ExplodingCF())
+
+
+# ── 2. real aggregates ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_site_with_traffic_returns_its_aggregates(beanie_test_db):
+    """The endpoint's actual job. Totals plus the three dimensions the stored row
+    carries, in the order the query returned them (the SQL sorts by pageviews)."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(
+        totals={"pageviews": 1280, "visitors": 431},
+        rows_by_blob={
+            "blob1": _rows(("/", 800, 300), ("/pricing", 480, 210)),
+            "blob2": _rows(("news.ycombinator.com", 300, 260), ("", 700, 190)),
+            "blob3": _rows(("US", 900, 320), ("DE", 380, 111)),
+        },
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.status == "ok"
+    assert (out.pageviews, out.visitors) == (1280, 431)
+    assert [(r.label, r.pageviews, r.visitors) for r in out.top_pages] == [
+        ("/", 800, 300),
+        ("/pricing", 480, 210),
+    ]
+    assert [r.label for r in out.countries] == ["US", "DE"]
+
+
+@pytest.mark.asyncio
+async def test_an_empty_referrer_is_reported_as_direct_and_never_dropped(beanie_test_db):
+    """A blank referrer is a REAL answer — a direct visit or a same-site link, which the
+    counting Worker deliberately writes as empty. Dropping the row would inflate every
+    remaining referrer's share, which is how a chart lies without a single wrong number
+    in it."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(
+        totals={"pageviews": 10, "visitors": 8},
+        rows_by_blob={"blob2": _rows(("", 7, 6), ("example.com", 3, 2))},
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert [(r.label, r.pageviews) for r in out.referrers] == [("(direct)", 7), ("example.com", 3)]
+
+
+@pytest.mark.asyncio
+async def test_a_64_bit_sum_arriving_as_a_string_is_still_a_number(beanie_test_db):
+    """ClickHouse-shaped APIs serialise 64-bit aggregates as JSON STRINGS to survive
+    JavaScript's integer limit, so ``SUM(_sample_interval)`` can arrive quoted. Read as
+    text it would reach the wire as a string on a field typed ``int`` and 500 the
+    endpoint for exactly the busiest sites."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(
+        totals={"pageviews": "9007199254740993", "visitors": "12"},
+        rows_by_blob={"blob1": [{"label": "/", "pageviews": "5", "visitors": "4"}]},
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.pageviews == 9007199254740993
+    assert out.visitors == 12
+    assert out.top_pages[0].pageviews == 5
+
+
+# ── 3. the row shape SA-3 is changing under this reader ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_four_blob_row_reads_as_devices_unrecorded(beanie_test_db):
+    """The row shape shipped by SA-1. There is no fifth blob, so Analytics Engine
+    answers an empty string for it and no device is knowable. Reported as
+    ``devices: None`` plus ``"devices"`` in ``unrecorded`` — a client renders "not
+    recorded", where an empty list would render "no devices" and an omitted field is
+    indistinguishable from a version skew."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(
+        totals={"pageviews": 40, "visitors": 20},
+        rows_by_blob={"blob1": _rows(("/", 40, 20)), "blob5": _rows(("", 40, 20))},
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.status == "ok"
+    assert out.devices is None
+    assert out.unrecorded == ["devices"]
+    assert out.pageviews == 40, "the rest of the panel is unaffected"
+
+
+@pytest.mark.asyncio
+async def test_a_five_blob_row_reads_its_device_class(beanie_test_db):
+    """The shape SA-3 writes. The same reader, no version flag, and ``unrecorded`` goes
+    empty on its own the moment real device rows exist."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(
+        totals={"pageviews": 100, "visitors": 60},
+        rows_by_blob={"blob5": _rows(("mobile", 70, 44), ("desktop", 30, 16))},
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert [(r.label, r.pageviews) for r in out.devices] == [("mobile", 70), ("desktop", 30)]
+    assert out.unrecorded == []
+
+
+@pytest.mark.asyncio
+async def test_both_row_shapes_in_one_window_bucket_the_old_rows_as_unknown(beanie_test_db):
+    """THE CASE THAT ACTUALLY HAPPENS on the day SA-3 deploys: a seven-day window spans
+    the change, so four-blob and five-blob rows come back together. The old rows must be
+    BUCKETED, not dropped — dropping them would rescale mobile and desktop against a
+    smaller total and quietly overstate both."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(
+        totals={"pageviews": 100, "visitors": 60},
+        rows_by_blob={"blob5": _rows(("", 55, 30), ("mobile", 30, 20), ("desktop", 15, 10))},
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    labels = {r.label: r.pageviews for r in out.devices}
+    assert labels == {"unknown": 55, "mobile": 30, "desktop": 15}
+    assert sum(labels.values()) == out.pageviews
+    assert out.unrecorded == []
+
+
+# ── 4. tenancy, windows and the SQL ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_another_workspaces_site_is_a_404(beanie_test_db):
+    """Matches every sibling per-site read. The tenancy check runs BEFORE the
+    entitlement one, so a caller cannot learn that another workspace's site exists —
+    let alone what it is paying — by watching which error comes back."""
+    site = await _seed_site(workspace_id="ws-owner", counting_since=datetime.now(UTC))
+    cf = _FakeAnalyticsCF(totals={"pageviews": 5, "visitors": 5})
+
+    with pytest.raises(NotFound):
+        await sites_service.site_analytics(
+            workspace_id="ws-intruder", site_id=str(site.id), _cloudflare=cf
+        )
+    assert cf.queries == []
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_site_id_is_a_404_and_never_reaches_the_sql(beanie_test_db):
+    """``_load`` guards the ObjectId cast, so a malformed id is "no such site" rather
+    than a 500 — and, on this endpoint specifically, never becomes a fragment of a raw
+    SQL statement."""
+    cf = _FakeAnalyticsCF()
+    with pytest.raises(NotFound):
+        await sites_service.site_analytics(
+            workspace_id="ws-read", site_id="' OR 1=1 --", _cloudflare=cf
+        )
+    assert cf.queries == []
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_window_is_refused_before_any_query(beanie_test_db):
+    """THE WINDOW IS A SQL CONTROL, not only input hygiene. The Analytics Engine
+    endpoint takes raw text with no parameter binding, so a window that reached the
+    statement would be an injection. It selects a row from a closed table instead, and
+    anything else is a 422 raised before a client is even built."""
+    site = await _seed_site(counting_since=datetime.now(UTC))
+    cf = _FakeAnalyticsCF(totals={"pageviews": 1, "visitors": 1})
+
+    with pytest.raises(ValidationError):
+        await sites_service.site_analytics(
+            workspace_id="ws-read",
+            site_id=str(site.id),
+            window="7d' OR '1'='1",
+            _cloudflare=cf,
+        )
+    assert cf.queries == []
+
+
+@pytest.mark.asyncio
+async def test_the_window_selects_the_interval_and_the_site_scopes_the_query(beanie_test_db):
+    """Every statement is scoped to THIS site's index and to the requested window. The
+    index filter is the tenancy boundary inside a dataset every site shares, so a
+    missing one would serve another customer's numbers with no error anywhere."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(totals={"pageviews": 1, "visitors": 1})
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="30d", _cloudflare=cf
+    )
+
+    assert out.window == "30d"
+    assert cf.queries
+    for sql in cf.queries:
+        assert f"index1 = '{site.id}'" in sql
+        assert "INTERVAL '30' DAY" in sql
+    # Sampling is accounted for. A plain COUNT() under-reports precisely the busiest
+    # sites, which are the ones that would notice.
+    assert "SUM(_sample_interval)" in cf.queries[0]
+
+
+@pytest.mark.asyncio
+async def test_the_default_window_is_seven_days(beanie_test_db):
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(totals={"pageviews": 1, "visitors": 1})
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.window == "7d"
+    assert "INTERVAL '7' DAY" in cf.queries[0]
+    assert out.retention_days == 90, "three months at Cloudflare, on the wire so a UI can say why"
+
+
+@pytest.mark.asyncio
+async def test_a_naive_stored_stamp_reaches_the_wire_as_utc(beanie_test_db):
+    """Mongo stores a datetime with no zone, so a stamp written as tz-aware reads back
+    NAIVE. On the wire bare it would be read as the client's local time — a silent
+    several-hour lie about when counting began, on the exact value a chart's x-axis
+    starts at."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, 9, 0))
+    cf = _FakeAnalyticsCF(totals={"pageviews": 1, "visitors": 1})
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.counting_since is not None
+    assert out.counting_since.endswith("+00:00")
+    assert datetime.fromisoformat(out.counting_since) == datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+
+
+# ── 5. the cache ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_second_read_inside_the_window_costs_no_cloudflare_query(beanie_test_db):
+    """Analytics Engine bills READ queries against a small daily allowance, and this
+    panel's whole usage pattern is somebody reloading it. Asserted on the query log
+    rather than on a timing, so it says what it means."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(totals={"pageviews": 12, "visitors": 9})
+
+    first = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+    sent = len(cf.queries)
+    second = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert len(cf.queries) == sent, "the reload re-queried Cloudflare"
+    assert second.pageviews == first.pageviews == 12
+
+
+@pytest.mark.asyncio
+async def test_each_window_is_cached_separately(beanie_test_db):
+    """A cache keyed on the site alone would serve the 7-day numbers for a 90-day
+    request — the same panel, a different question, and no error anywhere to notice
+    it."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(totals={"pageviews": 3, "visitors": 3})
+
+    week = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="7d", _cloudflare=cf
+    )
+    quarter = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="90d", _cloudflare=cf
+    )
+
+    assert (week.window, quarter.window) == ("7d", "90d")
+    assert any("INTERVAL '90' DAY" in sql for sql in cf.queries)
+
+
+@pytest.mark.asyncio
+async def test_the_cache_never_answers_a_different_tenant(beanie_test_db):
+    """TENANCY BEATS THE CACHE. Two workspaces cannot share a site id in practice, but a
+    key that omitted the workspace would make that assumption load-bearing across a
+    process that serves every tenant — and the tenancy check runs first regardless, so a
+    cached entry can never short-circuit it."""
+    site = await _seed_site(workspace_id="ws-owner", counting_since=datetime.now(UTC))
+    cf = _FakeAnalyticsCF(totals={"pageviews": 77, "visitors": 40})
+
+    await sites_service.site_analytics(
+        workspace_id="ws-owner", site_id=str(site.id), _cloudflare=cf
+    )
+    with pytest.raises(NotFound):
+        await sites_service.site_analytics(
+            workspace_id="ws-intruder", site_id=str(site.id), _cloudflare=cf
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_expired_entry_is_re_queried(beanie_test_db):
+    """The TTL actually expires. Driven by rewriting the stored deadline rather than by
+    sleeping — a real wait would add a minute to the suite to prove arithmetic."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(totals={"pageviews": 12, "visitors": 9})
+
+    await sites_service.site_analytics(workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf)
+    sent = len(cf.queries)
+    key = ("ws-read", str(site.id), "7d")
+    _, cached = sites_service._analytics_cache[key]
+    sites_service._analytics_cache[key] = (0.0, cached)
+
+    await sites_service.site_analytics(workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf)
+
+    assert len(cf.queries) > sent
+
+
+@pytest.mark.asyncio
+async def test_a_failed_read_is_not_cached(beanie_test_db):
+    """Caching a failure would turn a Cloudflare blip into a minute of errors for
+    everyone who reloads, and would hold the panel dark after the outage ended."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+
+    with pytest.raises(CloudError):
+        await sites_service.site_analytics(
+            workspace_id="ws-read", site_id=str(site.id), _cloudflare=_ExplodingCF()
+        )
+
+    healthy = _FakeAnalyticsCF(totals={"pageviews": 5, "visitors": 4})
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=healthy
+    )
+
+    assert out.status == "ok"
+    assert healthy.queries, "the recovery read must reach Cloudflare"
+
+
+@pytest.mark.asyncio
+async def test_the_cache_is_bounded(beanie_test_db):
+    """A workspace with thousands of sites must not grow this without limit. The policy
+    is deliberately dumb — sweep the expired, and clear if that was not enough — because
+    an entry is worth a fraction of a cent and the next request simply re-queries."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cap = sites_service._ANALYTICS_CACHE_MAX_ENTRIES
+    for i in range(cap + 5):
+        sites_service._analytics_cache[("ws-x", f"site-{i}", "7d")] = (
+            float("inf"),
+            sites_service._analytics_empty(f"site-{i}", "7d", "ok", None),
+        )
+
+    await sites_service.site_analytics(
+        workspace_id="ws-read",
+        site_id=str(site.id),
+        _cloudflare=_FakeAnalyticsCF(totals={"pageviews": 1, "visitors": 1}),
+    )
+
+    assert len(sites_service._analytics_cache) <= cap
+
+
+# ── 6. over HTTP ─────────────────────────────────────────────────────────────
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "member") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    """Member of the test workspace — ``fabric.read`` is member-tier."""
+
+    def __init__(self, workspace_id: str) -> None:
+        self.id = "user-test-1"
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id)]
+
+
+def _build_app(workspace_id: str) -> FastAPI:
+    """The sites router behind stubbed auth, mirroring test_router.py.
+
+    No plan patch here — the tree's conftest already patches ``get_workspace_plan``, and
+    a second patch on the same target unwinds in the wrong order and leaks a mock across
+    test trees. See test_router.py's own note.
+    """
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.sites.router import router as sites_router
+
+    fake_user = _FakeUser(workspace_id)
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(sites_router, prefix="/api/v1")
+
+    async def _ctx() -> RequestContext:
+        return RequestContext(
+            user_id=str(fake_user.id),
+            workspace_id=workspace_id,
+            request_id="test",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[current_active_user] = lambda: fake_user
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(beanie_test_db):
+    app = _build_app("ws-http")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_serves_the_aggregates(client, monkeypatch):
+    """End to end through the route, which is where the response MODEL is enforced —
+    the service tests above would pass against a DTO the wire cannot serialise."""
+    site = await _seed_site(
+        workspace_id="ws-http", counting_since=datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+    )
+    cf = _FakeAnalyticsCF(
+        totals={"pageviews": 210, "visitors": 88},
+        rows_by_blob={"blob1": _rows(("/", 210, 88))},
+    )
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+
+    resp = await client.get(f"/api/v1/sites/{site.id}/analytics?window=7d")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["pageviews"] == 210
+    assert body["visitors"] == 88
+    assert body["window"] == "7d"
+    assert body["counting_since"].startswith("2026-08-01T09:00:00")
+    assert body["top_pages"][0]["label"] == "/"
+    assert body["devices"] is None
+    assert body["unrecorded"] == ["devices"]
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_404s_a_cross_tenant_site(client):
+    """Same as the sibling per-site endpoints. Asserted over HTTP because the mapping
+    from ``NotFound`` to a 404 lives in the error handler, not in the service."""
+    site = await _seed_site(workspace_id="ws-somebody-else", counting_since=datetime.now(UTC))
+
+    resp = await client.get(f"/api/v1/sites/{site.id}/analytics")
+
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_reports_an_outage_as_an_error_not_as_zero(client, monkeypatch):
+    """The end-to-end form of state 4, and the one that matters most on the wire. A
+    5xx is unmissable; a 200 carrying zeros is indistinguishable from a quiet week to
+    every client that will ever be written against this."""
+    site = await _seed_site(workspace_id="ws-http", counting_since=datetime.now(UTC))
+    monkeypatch.setattr(sites_service, "_cf_client", _ExplodingCF)
+
+    resp = await client.get(f"/api/v1/sites/{site.id}/analytics")
+
+    assert resp.status_code >= 400, resp.text
+    assert "pageviews" not in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_refuses_an_unknown_window(client):
+    site = await _seed_site(workspace_id="ws-http", counting_since=datetime.now(UTC))
+
+    resp = await client.get(f"/api/v1/sites/{site.id}/analytics?window=all-time")
+
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_states_the_plan_case_without_numbers(client):
+    """What a free site's panel is built from. A 200 rather than a 402: the site exists
+    and the answer is a real one — "not on this plan" — which the UI turns into an
+    upgrade prompt rather than an error."""
+    site = await _seed_site(
+        workspace_id="ws-http", plan_tier="free", counting_since=datetime.now(UTC)
+    )
+
+    resp = await client.get(f"/api/v1/sites/{site.id}/analytics")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "not_entitled"
+    assert body["pageviews"] is None
+    assert body["top_pages"] is None
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_distinguishes_never_counted_from_a_quiet_week(client, monkeypatch):
+    """The two states a customer is most likely to confuse, side by side over HTTP.
+    Same status code, same shape, and the only thing separating "republish to start
+    counting" from "nobody came" is the field this test reads."""
+    never = await _seed_site(workspace_id="ws-http", pocket_id="pk-h1", counting_since=None)
+    quiet = await _seed_site(
+        workspace_id="ws-http",
+        pocket_id="pk-h2",
+        counting_since=datetime.now(UTC) - timedelta(days=30),
+    )
+    monkeypatch.setattr(
+        sites_service,
+        "_cf_client",
+        lambda: _FakeAnalyticsCF(totals={"pageviews": 0, "visitors": 0}),
+    )
+
+    a = (await client.get(f"/api/v1/sites/{never.id}/analytics")).json()
+    b = (await client.get(f"/api/v1/sites/{quiet.id}/analytics")).json()
+
+    assert a["status"] == "never_counted"
+    assert a["pageviews"] is None
+    assert b["status"] == "ok"
+    assert b["pageviews"] == 0

--- a/tests/ee/sites/test_sites_analytics_read.py
+++ b/tests/ee/sites/test_sites_analytics_read.py
@@ -783,3 +783,83 @@ async def test_the_endpoint_distinguishes_never_counted_from_a_quiet_week(client
     assert a["pageviews"] is None
     assert b["status"] == "ok"
     assert b["pageviews"] == 0
+
+
+# ── 7. gaps the first mutation sweep found ───────────────────────────────────
+#
+# Each of these was written because a mutation ESCAPED — the code was already right
+# and nothing would have noticed it going wrong. The failures they pin are all of one
+# family: a guard that is load-bearing but whose absence changes nothing any OTHER test
+# looks at.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing", ["totals", "breakdown"])
+async def test_a_failure_on_ONE_query_still_fails_the_whole_read(beanie_test_db, failing):
+    """A read is FIVE queries — totals plus four breakdowns — and a swallow on ANY ONE of
+    them is the outage-as-quiet-week failure wearing a smaller hat. A panel whose totals
+    are real and whose referrer chart is silently empty is worse than an error, because
+    nothing on screen says a query failed.
+
+    BOTH DIRECTIONS, because a client that fails on every query does not distinguish
+    them and that is precisely how the first sweep's mutation escaped: a try/except
+    around the totals call alone left every assertion in this file passing, since the
+    breakdown loop went on raising. Each half here has to fail on its own."""
+
+    class _FailsOne:
+        def __init__(self, which: str) -> None:
+            self.which = which
+            self.queries: list[str] = []
+
+        async def query_analytics_sql(self, sql: str) -> list[dict]:
+            self.queries.append(sql)
+            is_breakdown = "GROUP BY" in sql
+            if (self.which == "breakdown") == is_breakdown:
+                raise ValidationError("sites.cloudflare_error", "Analytics Engine SQL 500")
+            return [] if is_breakdown else [{"pageviews": 500, "visitors": 200}]
+
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+
+    with pytest.raises(CloudError):
+        await sites_service.site_analytics(
+            workspace_id="ws-read", site_id=str(site.id), _cloudflare=_FailsOne(failing)
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_sql_builder_refuses_anything_that_is_not_a_site_id(beanie_test_db):
+    """THE LAST GUARD IN FRONT OF RAW SQL, asserted directly on the builder.
+
+    Every path that reaches it today goes through ``_load``, which round-trips the id
+    through ``ObjectId`` — so removing this check breaks no end-to-end test, which is
+    why the mutation escaped. It stays because the cost of the next caller not having
+    done that round-trip is an injected query against the account's whole analytics
+    dataset, and a guard nothing tests is a guard somebody deletes."""
+    with pytest.raises(ValidationError):
+        sites_service._analytics_sql(select="1", site_id="' OR 1=1 --", days=7)
+    with pytest.raises(ValidationError):
+        sites_service._analytics_sql(select="1", site_id="507F1F77BCF86CD799439011", days=7)
+    with pytest.raises(ValidationError):
+        sites_service._analytics_sql(select="1", site_id="507f1f77bcf86cd7994390", days=7)
+
+    ok = sites_service._analytics_sql(select="1", site_id="507f1f77bcf86cd799439011", days=7)
+    assert "507f1f77bcf86cd799439011" in ok
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_honours_a_window_other_than_the_default(client, monkeypatch):
+    """The route must FORWARD the window, not merely accept it. A handler that dropped
+    it would answer 200 with correct-looking numbers for the wrong period — and every
+    service test would still pass, because they call the service directly.
+
+    Asserted on the response AND on the SQL, so a route that echoed the parameter back
+    without using it is caught too."""
+    site = await _seed_site(workspace_id="ws-http", counting_since=datetime(2026, 6, 1, tzinfo=UTC))
+    cf = _FakeAnalyticsCF(totals={"pageviews": 9, "visitors": 4})
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+
+    resp = await client.get(f"/api/v1/sites/{site.id}/analytics?window=90d")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["window"] == "90d"
+    assert cf.queries and all("INTERVAL '90' DAY" in sql for sql in cf.queries)

--- a/tests/ee/sites/test_sites_analytics_since.py
+++ b/tests/ee/sites/test_sites_analytics_since.py
@@ -1,0 +1,299 @@
+# tests/ee/sites/test_sites_analytics_since.py — SA-4, the stamp that says a Paw Site
+# is currently counting its visitors and when that started: ``Site.analytics_since``.
+#
+# Created 2026-09-02 (feat/sites-analytics-read).
+#
+# The read endpoint has to tell FOUR situations apart, and three of them would
+# otherwise render as the same panel of zeros. This field is what makes the second one
+# knowable:
+#
+#   1. the plan does not buy analytics
+#   2. it does, but no publish has ever deployed a counter — nothing was recorded
+#   3. it does, a counter is up, and genuinely nobody visited
+#   4. the read itself failed
+#
+# Nothing else on the document can separate 2 from 3. ``deployed_at`` says a publish
+# happened, not that it carried a counter, so a site upgraded an hour ago is
+# indistinguishable from a quiet site that has been counting for a month.
+#
+# TWO CLAIMS ARE ASSERTED HERE AND THEY ARE EASY TO CONFUSE.
+#
+# THE FIRST is that the stamp follows THE DEPLOY, not the plan. The counting rule has
+# three parts — the site's plan, the operator kill switch, and whether the engine emits
+# its own worker — and only the plan is visible at the publish seam. So the value is
+# read off what the deploy left on disk, and the test for it drives an entitled site
+# whose deploy wrote no counter and asserts no stamp. A publish path that re-derived
+# the answer from the plan would fail exactly that case and pass every other one.
+#
+# THE SECOND is that the stamp is CLEARED by a publish that carries no counter. It is
+# tempting to make the field write-once — it is called "since", after all — and that is
+# the bug the paid → free → paid test exists to catch. A site that counted in June,
+# dropped to free in July and re-upgraded today is entitled again with a June stamp,
+# and yet nothing has recorded since the lapse because no publish has carried a
+# counter. Left write-once, the read answers "counting since June, and nobody visited"
+# over months in which nothing was counting at all. Cleared, entitled-with-no-stamp is
+# exactly "you have not republished".
+#
+# The clock is FROZEN per publish rather than left to wall time. Windows' clock ticks
+# about every 15.6 ms, so two publishes in one test can share a timestamp and a
+# ``t2 > t1`` assertion would be flaky for reasons that have nothing to do with the
+# code under test.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.sites import analytics_worker  # noqa: E402
+from pocketpaw_ee.sites import service as sites_service  # noqa: E402
+
+
+class _FrozenClock(datetime):
+    """A ``datetime`` whose ``now`` is scripted. Subclassed rather than mocked so every
+    other use of the name inside ``sites.service`` — parsing, arithmetic, construction
+    — keeps working while the publish path is patched."""
+
+    _t: datetime = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+
+    @classmethod
+    def now(cls, tz=None):  # noqa: ARG003 - the publish path always passes UTC
+        return cls._t
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Freeze ``sites.service``'s clock and hand the test the dial."""
+    monkeypatch.setattr(sites_service, "datetime", _FrozenClock)
+
+    def _set(moment: datetime) -> datetime:
+        _FrozenClock._t = moment
+        return moment
+
+    _set(datetime(2026, 6, 1, 12, 0, tzinfo=UTC))
+    return _set
+
+
+class _FakeGenerator:
+    """Stand-in for the SvelteKit generator — never touches Bun or workerd. Unlike the
+    gate suite's, it returns a REAL directory, because the whole point of this file is
+    what the deploy leaves in it."""
+
+    def __init__(self, project_dir: Path) -> None:
+        self._project_dir = project_dir
+
+    async def build(self, **_kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir=str(self._project_dir), ripple_version="0.2.0")
+
+
+def _deployer(*, writes_counter: bool, seen: dict | None = None):
+    """A workers deployer that reproduces the ONE disk effect the real one has:
+    ``_write_deploy_files`` writes the generated entry when counting is on and deletes
+    it when counting is off.
+
+    ``writes_counter`` is deliberately INDEPENDENT of ``analytics_entitled``. The
+    publish seam only knows the plan, and the deploy resolves two more things (the
+    operator kill switch, and whether the engine already emits its own worker) — so a
+    test has to be able to say "entitled, and yet no counter was deployed" or the claim
+    that the stamp follows the artifact cannot be tested at all."""
+
+    async def _deploy(site_id: str, project_dir: str, *, analytics_entitled=False, **_: object):
+        if seen is not None:
+            seen["analytics_entitled"] = analytics_entitled
+        entry = Path(project_dir) / analytics_worker.ENTRY_FILENAME
+        if writes_counter:
+            entry.write_text("// a counter", encoding="utf-8")
+        else:
+            entry.unlink(missing_ok=True)
+        return f"https://paw-site-{site_id}.acct.workers.dev"
+
+    return _deploy
+
+
+async def _publish(pocket_id: str, project_dir: Path, deployer):
+    return await sites_service.publish(
+        workspace_id="ws-analytics-since",
+        user_id="u1",
+        pocket_id=pocket_id,
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Since Site",
+        _generator=_FakeGenerator(project_dir),
+        _bundle_reader=lambda d: b"unused-in-workers-mode",
+        _workers_deploy=deployer,
+    )
+
+
+async def _mark_paid(site_id, *, status: str = "active") -> None:
+    doc = await sites_service._SiteDoc.find_one({"_id": site_id})
+    assert doc is not None
+    doc.plan_tier = "site"
+    doc.subscription_status = status
+    await doc.save()
+
+
+async def _stamp(site_id):
+    """The stored stamp, re-attached to UTC.
+
+    Mongo stores a datetime with no zone, so a value written as tz-aware reads back
+    NAIVE and compares unequal to the moment it was written. That is a property of the
+    store rather than of this feature, and it is the same reason the read endpoint
+    normalises before ``isoformat()`` — a bare naive stamp on the wire would be read as
+    the client's local time."""
+    doc = await sites_service._SiteDoc.find_one({"_id": site_id})
+    assert doc is not None
+    stamped = doc.analytics_since
+    if stamped is not None and stamped.tzinfo is None:
+        stamped = stamped.replace(tzinfo=UTC)
+    return stamped
+
+
+@pytest.fixture(autouse=True)
+def _workers_mode(monkeypatch):
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "workers")
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_a_publish_that_deploys_a_counter_stamps_the_start(beanie_test_db, tmp_path, clock):
+    """The happy case. A site is paying, the deploy put a counter in front of it, so the
+    document records the moment recording began — which is what lets the read draw a
+    series that starts where the data does instead of at the site's creation."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    site = await _publish("pk-since-a", project, _deployer(writes_counter=False))
+    await _mark_paid(site.id)
+
+    moment = clock(datetime(2026, 6, 2, 9, 30, tzinfo=UTC))
+    await _publish("pk-since-a", project, _deployer(writes_counter=True))
+
+    assert await _stamp(site.id) == moment
+
+
+@pytest.mark.asyncio
+async def test_a_publish_that_deploys_no_counter_leaves_it_unset(beanie_test_db, tmp_path, clock):
+    """A free site's first publish. None is the honest value and it is what the read
+    reports as ``never_counted`` — "nothing has been recorded", not "a quiet week"."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    site = await _publish("pk-since-free", project, _deployer(writes_counter=False))
+
+    assert await _stamp(site.id) is None
+
+
+@pytest.mark.asyncio
+async def test_the_stamp_follows_the_deploy_and_not_the_plan(beanie_test_db, tmp_path, clock):
+    """THE CLAIM THE FIELD RESTS ON. The site is entitled and the publish seam passes
+    that entitlement, and yet the deploy carried no counter — which is what the operator
+    kill switch does, and what a SvelteKit site does by emitting its own worker. Nothing
+    is recording, so nothing may be stamped.
+
+    A publish path that stamped from ``site_analytics_entitled`` would pass every other
+    test in this file and fail this one, which is the point of it."""
+    project = tmp_path / "project"
+    project.mkdir()
+    seen: dict = {}
+
+    site = await _publish("pk-since-killed", project, _deployer(writes_counter=False))
+    await _mark_paid(site.id)
+
+    clock(datetime(2026, 6, 3, 9, 0, tzinfo=UTC))
+    await _publish("pk-since-killed", project, _deployer(writes_counter=False, seen=seen))
+
+    assert seen["analytics_entitled"] is True, "the fixture must actually be entitled"
+    assert await _stamp(site.id) is None
+
+
+@pytest.mark.asyncio
+async def test_a_republish_that_keeps_counting_keeps_the_original_stamp(
+    beanie_test_db, tmp_path, clock
+):
+    """FIRST-SET-WINS WITHIN A COUNTING ERA. It is "since", not "last": re-stamping on
+    every publish would move the start of the series forward and hide the history that
+    is still sitting in the dataset."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    site = await _publish("pk-since-again", project, _deployer(writes_counter=False))
+    await _mark_paid(site.id)
+
+    first = clock(datetime(2026, 6, 4, 8, 0, tzinfo=UTC))
+    await _publish("pk-since-again", project, _deployer(writes_counter=True))
+    assert await _stamp(site.id) == first
+
+    clock(datetime(2026, 6, 20, 8, 0, tzinfo=UTC))
+    await _publish("pk-since-again", project, _deployer(writes_counter=True))
+
+    assert await _stamp(site.id) == first
+
+
+@pytest.mark.asyncio
+async def test_a_lapse_clears_the_stamp_and_the_re_upgrade_starts_a_new_era(
+    beanie_test_db, tmp_path, clock
+):
+    """PAID → FREE → PAID, the sequence the whole clearing rule exists for.
+
+    After the middle publish nothing is counting, so a stamp would be a claim about
+    recording that is not happening. After the third, recording has started again — at
+    the NEW date, because the June rows the old stamp pointed at were never joined to
+    the September ones and, at three months' retention, are on their way out anyway."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    site = await _publish("pk-since-lapse", project, _deployer(writes_counter=False))
+    await _mark_paid(site.id)
+
+    june = clock(datetime(2026, 6, 5, 10, 0, tzinfo=UTC))
+    await _publish("pk-since-lapse", project, _deployer(writes_counter=True))
+    assert await _stamp(site.id) == june
+
+    # The subscription lapses. ``plan_tier`` is NOT reset by a cancellation — nothing
+    # rewrites it — so this is the shape a real lapsed site has on disk.
+    await _mark_paid(site.id, status="cancelled")
+    clock(datetime(2026, 7, 5, 10, 0, tzinfo=UTC))
+    await _publish("pk-since-lapse", project, _deployer(writes_counter=False))
+    assert await _stamp(site.id) is None, "a publish with no counter must clear the stamp"
+
+    await _mark_paid(site.id)
+    september = clock(datetime(2026, 9, 2, 10, 0, tzinfo=UTC))
+    await _publish("pk-since-lapse", project, _deployer(writes_counter=True))
+
+    assert await _stamp(site.id) == september
+
+
+@pytest.mark.asyncio
+async def test_a_local_deploy_never_stamps_even_with_a_stale_entry_on_disk(
+    beanie_test_db, tmp_path, clock, monkeypatch
+):
+    """THE REUSED WORKING DIRECTORY. A publish builds into the pocket's stable working
+    dir, so the entry a workers publish wrote is still sitting there when the same site
+    publishes to the local target. Only the workers branch can put a counter in front of
+    a site, so the presence of that file says nothing on any other target — and a stamp
+    taken from it would report a localhost preview as a live counting site."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / analytics_worker.ENTRY_FILENAME).write_text("// stale", encoding="utf-8")
+
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
+
+    site = await sites_service.publish(
+        workspace_id="ws-analytics-since",
+        user_id="u1",
+        pocket_id="pk-since-local",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Since Site",
+        _generator=_FakeGenerator(project),
+        _bundle_reader=lambda d: b"unused",
+        _local_deploy=lambda site_id, project_dir: f"http://127.0.0.1:8788/{site_id}/",
+    )
+
+    assert (project / analytics_worker.ENTRY_FILENAME).is_file(), "the stale entry must survive"
+    assert await _stamp(site.id) is None

--- a/tests/ee/sites/test_sites_analytics_since.py
+++ b/tests/ee/sites/test_sites_analytics_since.py
@@ -177,6 +177,38 @@ async def test_a_publish_that_deploys_a_counter_stamps_the_start(beanie_test_db,
 
 
 @pytest.mark.asyncio
+async def test_a_first_publish_that_deploys_a_counter_stamps_on_insert(
+    beanie_test_db, tmp_path, clock, monkeypatch
+):
+    """THE INSERT BRANCH, which the other tests here never reach.
+
+    Every case above publishes twice — the first publish is what creates the document,
+    and a first publish resolves the plan against a document that does not exist yet, so
+    it can never be entitled. That leaves the insert's stamp untested: a mutation
+    hard-coding it to None escaped the first sweep, because the second publish takes the
+    UPDATE branch and repairs it.
+
+    It is reachable in production through the charge-first lane: ``activate_site``
+    stamps the plan on payment confirmation and THEN deploys, so the deploy can carry a
+    counter for a site whose row is being inserted by that same deploy. Without the
+    stamp here that site reads as ``never_counted`` until something unrelated happens to
+    republish it.
+
+    Driven by making the deploy's artifact the source of truth — the deployer writes the
+    entry — rather than by reproducing the whole charge-first sequence, which is
+    ``activate_site``'s own tree and would test that seam instead of this one."""
+    project = tmp_path / "project"
+    project.mkdir()
+    moment = clock(datetime(2026, 6, 10, 11, 0, tzinfo=UTC))
+
+    site = await _publish("pk-since-first", project, _deployer(writes_counter=True))
+
+    doc = await sites_service._SiteDoc.find_one({"_id": site.id})
+    assert doc is not None, "this must be the INSERT branch"
+    assert await _stamp(site.id) == moment
+
+
+@pytest.mark.asyncio
 async def test_a_publish_that_deploys_no_counter_leaves_it_unset(beanie_test_db, tmp_path, clock):
     """A free site's first publish. None is the honest value and it is what the read
     reports as ``never_counted`` — "nothing has been recorded", not "a quiet week"."""

--- a/tests/mutations/sites_analytics_read.json
+++ b/tests/mutations/sites_analytics_read.json
@@ -1,0 +1,256 @@
+[
+  {
+    "label": "an unentitled site is served real numbers — a free site sees analytics it never paid for, and the read disagrees with the publish that refused to deploy its counter",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not entitled:\n        return _analytics_empty(site_id, window, ANALYTICS_STATUS_NOT_ENTITLED, None)",
+    "replace": "    if False:\n        return _analytics_empty(site_id, window, ANALYTICS_STATUS_NOT_ENTITLED, None)",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "never-counted collapses into ok — a site that has not republished since upgrading is told nobody visited, which is the invented zero this whole slice exists to prevent",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        return _analytics_empty(site_id, window, ANALYTICS_STATUS_NEVER_COUNTED, None)",
+    "replace": "        return _analytics_empty(site_id, window, ANALYTICS_STATUS_OK, None)",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the empty states carry zeros instead of nulls — every one of the three renders as a panel of confident zeros, whatever the status says",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        counting_since=_analytics_iso(since) if since is not None else None,\n        retention_days=_ANALYTICS_RETENTION_DAYS,\n    )",
+    "replace": "        counting_since=_analytics_iso(since) if since is not None else None,\n        retention_days=_ANALYTICS_RETENTION_DAYS,\n        pageviews=0,\n        visitors=0,\n        top_pages=[],\n    )",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a failed Cloudflare read is swallowed into an ok-with-zeros response — an outage arrives on the customer's dashboard looking exactly like a quiet week",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    cf = _cloudflare or _cf_client()\n    totals_rows = await cf.query_analytics_sql(\n        _analytics_sql(\n            select=\"SUM(_sample_interval) AS pageviews, COUNT(DISTINCT blob4) AS visitors\",\n            site_id=site_id,\n            days=days,\n        )\n    )",
+    "replace": "    cf = _cloudflare or _cf_client()\n    try:\n        totals_rows = await cf.query_analytics_sql(\n            _analytics_sql(\n                select=\"SUM(_sample_interval) AS pageviews, COUNT(DISTINCT blob4) AS visitors\",\n                site_id=site_id,\n                days=days,\n            )\n        )\n    except CloudError:\n        totals_rows = []",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the SQL client returns [] on a non-2xx instead of raising — the same outage-as-quiet-week failure, one layer lower, where it looks like ordinary defensive code",
+    "file": "ee/pocketpaw_ee/sites/cloudflare_client.py",
+    "find": "        if resp.status_code // 100 != 2:\r\n            raise ValidationError(\r\n                \"sites.cloudflare_error\",\r\n                f\"Analytics Engine SQL {resp.status_code}: {_error_detail(resp)}\",\r\n            )",
+    "replace": "        if resp.status_code // 100 != 2:\r\n            return []",
+    "tests": [
+      "tests/ee/sites/test_cloudflare_client.py",
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a 2xx with no data array reads as an empty result — a contract break is reported as zero traffic rather than as a failure",
+    "file": "ee/pocketpaw_ee/sites/cloudflare_client.py",
+    "find": "        if not isinstance(rows, list):",
+    "replace": "        if False:",
+    "tests": [
+      "tests/ee/sites/test_cloudflare_client.py"
+    ]
+  },
+  {
+    "label": "the SQL body is sent as JSON instead of raw text — the endpoint has no JSON form, so every read fails against the real Cloudflare while the fake in the service tests never notices",
+    "file": "ee/pocketpaw_ee/sites/cloudflare_client.py",
+    "find": "                url, content=sql.encode(\"utf-8\"), headers={\"Content-Type\": \"text/plain\"}",
+    "replace": "                url, json={\"sql\": sql}",
+    "tests": [
+      "tests/ee/sites/test_cloudflare_client.py"
+    ]
+  },
+  {
+    "label": "the query drops its site filter — every site in the account is aggregated into one customer's dashboard, which is a cross-tenant data leak with no error anywhere",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        f\"WHERE index1 = '{site_id}' AND timestamp > NOW() - INTERVAL '{int(days)}' DAY\",",
+    "replace": "        f\"WHERE timestamp > NOW() - INTERVAL '{int(days)}' DAY\",",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the window is interpolated raw instead of resolving to a day count — the caller's string reaches a SQL endpoint that has no parameter binding",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    days = _ANALYTICS_WINDOWS.get(window)\n    if days is None:",
+    "replace": "    days = _ANALYTICS_WINDOWS.get(window, window)\n    if days is None:",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the site id is no longer re-checked before it reaches raw SQL — the last guard in front of an unbound statement is gone",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not re.fullmatch(r\"[0-9a-f]{24}\", site_id):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the tenancy read is dropped — another workspace's site answers with its numbers instead of a 404",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    doc = await _load(workspace_id, site_id)\n\n    window = window.strip() or _ANALYTICS_DEFAULT_WINDOW",
+    "replace": "    doc = await _SiteDoc.find_one({\"_id\": ObjectId(site_id)})\n\n    window = window.strip() or _ANALYTICS_DEFAULT_WINDOW",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "COUNT() replaces SUM(_sample_interval) — Analytics Engine downsamples a hot index, so the busiest sites are under-reported by exactly the sampling rate",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            select=\"SUM(_sample_interval) AS pageviews, COUNT(DISTINCT blob4) AS visitors\",",
+    "replace": "            select=\"COUNT() AS pageviews, COUNT(DISTINCT blob4) AS visitors\",",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a device row with no class is dropped instead of bucketed — rows written before the device class rescale mobile and desktop against a smaller total and overstate both",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not rows or all(row.label == \"unknown\" for row in rows):\n        return None, [\"devices\"]\n    return rows, []",
+    "replace": "    kept = [row for row in rows if row.label != \"unknown\"]\n    if not kept:\n        return None, [\"devices\"]\n    return kept, []",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "an all-unknown device breakdown is served as a real one — a four-blob row shape renders as a chart of one bar called unknown instead of saying the dimension is not recorded",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not rows or all(row.label == \"unknown\" for row in rows):",
+    "replace": "    if not rows:",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a blank breakdown label is dropped rather than named — direct visits vanish from the referrer chart and every remaining share is inflated",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    text = raw.strip() if isinstance(raw, str) else \"\"\n    return text or empty",
+    "replace": "    text = raw.strip() if isinstance(raw, str) else \"\"\n    return text",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a 64-bit count arriving as a JSON string goes through float — the value is rounded to the nearest even above 2^53, corrupting exactly the counts the string encoding exists to protect",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        text = raw.strip()\n        try:\n            return int(text)\n        except ValueError:\n            pass",
+    "replace": "        text = raw.strip()\n        if False:\n            pass",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the cache is never read — every dashboard reload spends billed Analytics Engine queries against a 10,000/day account-wide allowance",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    cached = _analytics_cache_get(cache_key)\n    if cached is not None:\n        return cached",
+    "replace": "    cached = None\n    if cached is not None:\n        return cached",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the cache is keyed on the site alone — a 90-day request is served the 7-day numbers, same panel, different question, no error",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    cache_key = (workspace_id, site_id, window)",
+    "replace": "    cache_key = (workspace_id, site_id, \"\")",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "cache entries never expire — a site's numbers freeze at whatever the first read of the process returned",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if time.monotonic() >= expires_at:\n        _analytics_cache.pop(key, None)\n        return None",
+    "replace": "    if False:\n        _analytics_cache.pop(key, None)\n        return None",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the cache grows without bound — a workspace with thousands of sites has no ceiling on the map",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if len(_analytics_cache) >= _ANALYTICS_CACHE_MAX_ENTRIES:\n        now = time.monotonic()",
+    "replace": "    if False:\n        now = time.monotonic()",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a counting publish never stamps analytics_since — every entitled site reads as never_counted forever, so the read reports 'republish to start counting' at a site that is already counting",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        doc.analytics_since = (doc.analytics_since or now) if counter_deployed else None",
+    "replace": "        doc.analytics_since = None",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_since.py",
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the stamp is never cleared — a site that lapsed and re-upgraded reports counting since its old start date over months in which nothing was recording at all",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        doc.analytics_since = (doc.analytics_since or now) if counter_deployed else None\n",
+    "replace": "        doc.analytics_since = doc.analytics_since or (now if counter_deployed else None)\n",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_since.py"
+    ]
+  },
+  {
+    "label": "the stamp is re-set on every counting publish — 'since' silently becomes 'last', so an ordinary republish moves the start of the series forward and hides history still sitting in the dataset",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        doc.analytics_since = (doc.analytics_since or now) if counter_deployed else None\n        # The deploy may have moved",
+    "replace": "        doc.analytics_since = now if counter_deployed else None\n        # The deploy may have moved",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_since.py"
+    ]
+  },
+  {
+    "label": "the stamp is derived from the plan rather than from what the deploy left on disk — a fourth copy of the counting rule, so the kill switch and the engine's own worker both stamp a site that is not counting",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        counter_deployed = Path(build.project_dir, analytics_worker.ENTRY_FILENAME).is_file()",
+    "replace": "        counter_deployed = counts_pageviews",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_since.py"
+    ]
+  },
+  {
+    "label": "a stale entry left in the reused working dir stamps a non-workers deploy — a localhost preview is recorded as a live counting site",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    counter_deployed = False\n    if mode == \"local\":",
+    "replace": "    counter_deployed = True\n    if mode == \"local\":",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_since.py"
+    ]
+  },
+  {
+    "label": "a first publish that deploys a counter inserts no stamp — the site counts from day one and the read calls it never_counted until something happens to republish it",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            analytics_since=now if counter_deployed else None,",
+    "replace": "            analytics_since=None,",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_since.py"
+    ]
+  },
+  {
+    "label": "a naive stored stamp reaches the wire without its zone — a client reads a UTC instant as local time, so the chart's x-axis silently starts hours off",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if moment.tzinfo is None:\n        moment = moment.replace(tzinfo=UTC)\n    return moment.astimezone(UTC).isoformat()",
+    "replace": "    return moment.isoformat()",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the route stops forwarding the requested window — every panel reads the default seven days whatever the customer picked",
+    "file": "ee/pocketpaw_ee/sites/router.py",
+    "find": "        workspace_id=ctx.workspace_id, site_id=site_id, window=window\n    )",
+    "replace": "        workspace_id=ctx.workspace_id, site_id=site_id\n    )",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  }
+]


### PR DESCRIPTION
Fourth slice of visitor analytics for Paw Sites: the numbers become readable. **Stacked on #2043**, and a sibling of #2049 rather than stacked on it — both branch from the gate and touch disjoint files. Merge the base with `--rebase`, not `--squash`.

Plan and design: qbtrix/paw-workspace#184.

## The endpoint

`GET /sites/{site_id}/analytics?window=7d`, gated on `fabric.read`, tenant-scoped, with windows drawn from a closed set of `24h`, `7d`, `30d` and `90d`.

```json
{"site_id": "...", "window": "7d", "status": "ok",
 "counting_since": "2026-08-14T10:22:41+00:00", "retention_days": 90,
 "pageviews": 1280, "visitors": 431,
 "top_pages": [{"label": "/", "pageviews": 800, "visitors": 300}],
 "referrers": [...], "countries": [...],
 "devices": null, "unrecorded": ["devices"]}
```

## Three situations that are not the same, and one that is not a status

A panel of zeros can mean three completely different things to a customer, and only one of them is about their traffic. So `status` is a closed vocabulary: `ok`, `not_entitled`, or `never_counted`. Every metric stays null unless the status is `ok`.

A failed read is deliberately **not** a status value. It raises, because a Cloudflare outage is not a report about the site's traffic and must not arrive on the same shape as one. A client that defaulted an unknown status to "no data" would otherwise turn an outage into a quiet week.

`Site.analytics_since` is what separates "you upgraded but have not republished" from "you are counting and nobody visited". Nothing else on the document could: a publish timestamp says a publish happened, not that it carried a counter. It is set when a publish deploys a counter and cleared when one does not, so "entitled with no stamp" means exactly `never_counted` with no guessing. It is written from what the deploy actually did rather than from a second copy of the counting rule, which has three parts and does not need a fourth place to disagree with itself.

`devices` is null with `unrecorded` naming it. The stored row has no device field on this branch. #2049 appends one, and this reader already tolerates both row shapes, so nothing here changes when that lands.

## Three fixes to the draft this branch started from

The first commit is a checkpoint I committed from an interrupted session. It had been reviewed but never run, and reviewing it is not the same as running it.

**A 64-bit count could be silently corrupted.** The SQL API returns large aggregates as JSON strings, which is how ClickHouse-shaped APIs avoid JavaScript's integer limit. The draft parsed them through `float`, which rounds anything above 2^53 to the nearest even number, corrupting precisely the range the string encoding exists to protect. Integers are now parsed as integers first. `bool` is rejected explicitly, since it subclasses `int` in Python.

A zero for a malformed cell inside a row is still fine, and that is not a contradiction of the rule above: that path runs only once the read has succeeded. The never-invent-zeros rule is about the four situations, not about one cell in a row that really came back.

**The client method had no tests.** Six now pin the two house conventions it deliberately breaks, either of which is one tidying pass away from breaking every read.

**A mutation plan silently covered nothing.** `cloudflare_client.py` has CRLF endings in an otherwise-LF tree, and the mutation runner reads raw bytes, so a plain-newline anchor matches nothing and aborts the plan while still reading as covered.

## Verification

```
uv run pytest tests/ee/sites tests/cloud/sites -p no:cacheprovider -q
1777 passed, 4 skipped
```

Mutation sweep: 28 of 28 caught. Four escaped on the first run and have tests now.  `mutate.py --validate` clean at 896 anchors across 71 plans.

## Known

**Clearing the stamp on the provisioning lane is reasoned, not asserted.** That lane provisions dynamic sites, which carry no counter, so null is the honest value. No test covers it because reaching that path means standing up the durable provision job.

**A first load is five sequential Cloudflare queries per site.** Behind the sixty-second cache that sits well inside the read allowance, but several sites opened at once each pay five round trips. Batching them into one grouped query is possible and was not done: the query gets considerably harder to read for a saving nothing currently needs.
