### PR TITLE
Say what analytics costs, and why upgrading does not backfill

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,21 @@
 docs/api-reference.md — Hand-maintained reference for cloud REST endpoints
 that are not covered by the per-endpoint Mintlify pages under docs/api/.
 
+Updated: 2026-09-02 (SA-7) — finished the Visitor Analytics section with the two
+things a reader could not get from the endpoint's own fields. First, what the
+`analytics` grant actually buys: which tiers carry it, that it needs an active
+subscription and not only a tier, and that UPGRADING DOES NOT BACKFILL — the
+consequence customers hit, and one the `never_counted` row alone does not explain,
+since it reads as a temporary state rather than as a permanent hole in the history.
+Also recorded that `svelte` and `ripple` sites do not count at all yet, which is
+otherwise indistinguishable from a site that simply has not been republished.
+Second, `GET /sites/{site_id}/entitlements`, which was undocumented in this file
+entirely — it is the pre-check that lets a panel disable itself before the call, and
+the section says plainly that it does NOT supersede the analytics `status`, because
+entitlement cannot tell "your plan excludes this" from "you have not republished".
+The `retention_days` bullet stopped naming the number, which invited clients to copy
+it; the field is the source of truth and the note now says so.
+
 Updated: 2026-08-18 (fix/sites-html-refine-names-the-edit-tool) — documented
 `edit_html_file`, the html track's chat edit tool. It shipped in db083bfc without
 reaching this file, so the section below still said html had no edit tool and was
@@ -1647,8 +1662,12 @@ Response `200`:
   UTC, and `null` when nothing is counting. It is what makes an honest chart
   possible: the series begins here, not at the site's creation, and a window
   reaching further back is reaching into time nobody recorded.
-- `retention_days` is `90`. On the wire so a UI can explain why the earliest date it
-  offers is the one it offers, rather than looking like it lost the data.
+- `retention_days` is how far back the data goes, and it is on the wire so a UI can
+  explain why the earliest date it offers is the one it offers, rather than looking
+  like it lost the data. **Read the field; do not copy the number into a client.**
+  Cloudflare keeps a row for three months and there is no rollup store behind it, so
+  anything older is gone rather than summarised — and a client holding its own `90`
+  will keep displaying it after the day that stops being true.
 - Each breakdown is a **top-10** list ordered by pageviews. Its `visitors` is a
   distinct count **within that row** and does **not** sum to the response total: one
   visitor who reads three pages is one visitor overall and one visitor on each of
@@ -1683,6 +1702,84 @@ Errors:
 | 422 | `sites.invalid_analytics_window` | `window` is not one of the four accepted values. |
 | 422 | `sites.cloudflare_error` | The Analytics Engine query failed — a non-2xx, an unparseable body, or a `200` with no data array. Includes Cloudflare's own message. A `403` here usually means the API token is missing the **Account Analytics Read** permission, which is a different scope from the ones the deploy paths use. |
 | 422 | `sites.cloudflare_unconfigured` | `PAW_CF_ACCOUNT_ID` / `PAW_CF_API_TOKEN` / `PAW_CF_ZONE_ID` are not all set. |
+
+### What the `analytics` grant buys
+
+Visitor counting is a **paid grant on the site's own plan**, not a floor one. It rides
+the `analytics` member of the plan's Cloudflare feature set, and it needs the tier
+**and** an active subscription — a cancelled site keeps its `plan_tier` string, so
+reading the tier alone would keep counting for a site that stopped paying.
+
+| Per-site tier | Monthly | Buys analytics |
+|---------------|---------|----------------|
+| `free` | $0 | no |
+| `site` | $7 | yes |
+| `staff` | $19 | yes |
+
+The legacy keys resolve to what they always paid for: `basic` reads as `free`, `pro`
+as `site`, `business` as `staff`. The org-scoped tiers (`studio`, `agency`) are not
+legal values for a site's own `plan_tier`, and one appearing there resolves to the
+free floor rather than to its own capabilities.
+
+**Upgrading does not backfill, and this is the thing customers hit.** A site's history
+begins at the publish that first deployed a counter, because nothing existed to record
+before it. Buying the plan changes what the next publish deploys; it cannot create
+rows for the weeks that went uncounted. The sequence that works is upgrade, then
+republish — and until that republish the endpoint answers `never_counted`, which is
+the panel's cue to ask for a republish rather than to draw a flat line at zero.
+
+The same applies in reverse. A publish that deploys no counter clears
+`counting_since`, so a site that lapsed to free and later re-upgraded reports
+`never_counted` until it is republished, rather than claiming a start date from an era
+that stopped recording months ago.
+
+**Not every engine carries a counter yet.** Sites built by the `html` and `react`
+generators deploy as assets-only Workers and take the counter. Sites built by `svelte`
+or `ripple` already deploy their own server worker, and a second entry cannot be put in
+front of it from a config key, so they do not count regardless of plan. Such a site is
+entitled and still answers `never_counted` however often it is republished. The
+[engineering note](design/2026-09-02-sites-visitor-analytics.md) carries the table and
+what is planned.
+
+### `GET /sites/{site_id}/entitlements` — the pre-check
+
+Same auth, same tenant scoping, same `404` on a cross-tenant site. It answers what the
+site may do, so a surface can disable a control and name the reason instead of
+offering a button that 402s.
+
+Response `200`:
+
+```json
+{
+  "site_id": "68b6f2c1a4d3e50012ab34cd",
+  "plan_tier": "site",
+  "subscription_active": true,
+  "badge_required": false,
+  "custom_domain": true,
+  "max_domained_sites": null,
+  "domained_sites_used": 2,
+  "domain_slots_available": true,
+  "analytics": true,
+  "concierge_entitled": false,
+  "concierge_enabled": false
+}
+```
+
+- `analytics` says whether this site's plan buys visitor counting. It is resolved by
+  the same predicate the publish path gates the counter on, so a site whose publish
+  counted cannot be a site whose read refuses.
+- `subscription_active` separates a lapsed paid site from one that never had the
+  capability. The tier stays recorded; only the payment stopped, and the UI should say
+  which.
+- `max_domained_sites` is `null` for uncapped. It reports what the plan grants, while
+  `domain_slots_available` reports what the gate will actually do — they differ when
+  enforcement is off.
+
+**`analytics` is a pre-check, not the answer.** The analytics endpoint's `status` stays
+authoritative, because entitlement alone cannot separate "your plan does not include
+this" from "it does, and you have not republished since you upgraded". Those are two
+different sentences and two different buttons. Use this field to disable the panel
+before the call; use `status` to decide what the panel says.
 
 ## Ship — Managed Deploys
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,8 +8,10 @@ things a reader could not get from the endpoint's own fields. First, what the
 subscription and not only a tier, and that UPGRADING DOES NOT BACKFILL — the
 consequence customers hit, and one the `never_counted` row alone does not explain,
 since it reads as a temporary state rather than as a permanent hole in the history.
-Also recorded that `svelte` and `ripple` sites do not count at all yet, which is
-otherwise indistinguishable from a site that simply has not been republished.
+Also recorded which builds cannot count at all yet, which is otherwise
+indistinguishable from a site that simply has not been republished. That is a
+BUILD-shape question and not an engine one: a static svelte build deploys assets-only
+and counts, a dynamic one does not.
 Second, `GET /sites/{site_id}/entitlements`, which was undocumented in this file
 entirely — it is the pre-check that lets a panel disable itself before the call, and
 the section says plainly that it does NOT supersede the analytics `status`, because
@@ -1733,13 +1735,15 @@ The same applies in reverse. A publish that deploys no counter clears
 `never_counted` until it is republished, rather than claiming a start date from an era
 that stopped recording months ago.
 
-**Not every engine carries a counter yet.** Sites built by the `html` and `react`
-generators deploy as assets-only Workers and take the counter. Sites built by `svelte`
-or `ripple` already deploy their own server worker, and a second entry cannot be put in
-front of it from a config key, so they do not count regardless of plan. Such a site is
-entitled and still answers `never_counted` however often it is republished. The
-[engineering note](design/2026-09-02-sites-visitor-analytics.md) carries the table and
-what is planned.
+**Not every build carries a counter yet.** The counter rides the assets-only deploy
+path, and whether a site takes that path is decided by its **build output** rather than
+by its engine: `html`, `react` and a *static* `svelte` build all deploy assets-only and
+count. A build that emits its own `_worker.js` — a *dynamic* `svelte` build, or any
+`ripple` build — cannot take a second entry in front of that worker, so it does not
+count regardless of plan. Such a site is entitled and still answers `never_counted`
+however often it is republished. The
+[engineering note](design/2026-09-02-sites-visitor-analytics.md) has the full table,
+and notes that #2049 closes most of this gap.
 
 ### `GET /sites/{site_id}/entitlements` — the pre-check
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,10 +8,13 @@ things a reader could not get from the endpoint's own fields. First, what the
 subscription and not only a tier, and that UPGRADING DOES NOT BACKFILL — the
 consequence customers hit, and one the `never_counted` row alone does not explain,
 since it reads as a temporary state rather than as a permanent hole in the history.
-Also recorded which builds cannot count at all yet, which is otherwise
-indistinguishable from a site that simply has not been republished. That is a
-BUILD-shape question and not an engine one: a static svelte build deploys assets-only
-and counts, a dynamic one does not.
+Also recorded how a site counts and the one case that still cannot, which is
+otherwise indistinguishable from a site nobody has republished. WRITTEN FOR THE STATE
+AFTER #2049, which merges first: every engine counts, in one of two shapes chosen by
+the BUILD rather than the engine name, and the row carries a device class. The
+`devices: null` example this section used to show was retired for the same reason —
+it is a real response, but only for a site that has not republished since, so leading
+with it taught clients that the field is always null.
 Second, `GET /sites/{site_id}/entitlements`, which was undocumented in this file
 entirely — it is the pre-check that lets a panel disable itself before the call, and
 the section says plainly that it does NOT supersede the analytics `status`, because
@@ -1655,8 +1658,8 @@ Response `200`:
   "top_pages":  [{"label": "/",         "pageviews": 800, "visitors": 300}],
   "referrers":  [{"label": "(direct)",  "pageviews": 700, "visitors": 190}],
   "countries":  [{"label": "US",        "pageviews": 900, "visitors": 320}],
-  "devices": null,
-  "unrecorded": ["devices"]
+  "devices":    [{"label": "desktop",   "pageviews": 760, "visitors": 250}],
+  "unrecorded": []
 }
 ```
 
@@ -1680,7 +1683,11 @@ Response `200`:
 - `unrecorded` names the dimensions the stored row cannot answer **at all**, as
   opposed to answered-and-empty. A dimension listed here is `null` rather than `[]`,
   because an empty list reads as "none of these exist" and an omitted field is
-  indistinguishable from a version skew.
+  indistinguishable from a version skew. In practice the only dimension that can
+  appear here is `devices`, and it means **this site has not published a counter that
+  records devices yet** rather than a permanent gap. It clears once the site is
+  republished and takes traffic. Render the name, not a chart of one bar called
+  unknown.
 
 **A visitor is per-day.** The counter identifies a visitor by a salted one-way hash
 that rotates at UTC midnight and never leaves a cookie, so somebody who returns
@@ -1735,15 +1742,18 @@ The same applies in reverse. A publish that deploys no counter clears
 `never_counted` until it is republished, rather than claiming a start date from an era
 that stopped recording months ago.
 
-**Not every build carries a counter yet.** The counter rides the assets-only deploy
-path, and whether a site takes that path is decided by its **build output** rather than
-by its engine: `html`, `react` and a *static* `svelte` build all deploy assets-only and
-count. A build that emits its own `_worker.js` — a *dynamic* `svelte` build, or any
-`ripple` build — cannot take a second entry in front of that worker, so it does not
-count regardless of plan. Such a site is entitled and still answers `never_counted`
-however often it is republished. The
-[engineering note](design/2026-09-02-sites-visitor-analytics.md) has the full table,
-and notes that #2049 closes most of this gap.
+**Every engine counts, in one of two shapes.** A build with no server entry (`html`,
+`react`, a *static* `svelte` site) gets a counter that serves the page through the
+`ASSETS` binding. A build that emits its own `_worker.js` (`ripple`, a *dynamic*
+`svelte` site) gets a shim that imports that worker, counts, and returns its response
+untouched. Which shape a site gets is decided by its **build output**, not by its
+engine name, which is why `svelte` appears on both sides.
+
+One case still does not count, and it is not an engine: a dynamic site provisioned
+through the durable provision job, which cannot resolve a plan from what it holds. Such
+a site is entitled and still answers `never_counted` however often it is republished.
+The [engineering note](design/2026-09-02-sites-visitor-analytics.md) has the table and
+the tracking issue.
 
 ### `GET /sites/{site_id}/entitlements` — the pre-check
 

--- a/docs/api/configuration-reference.mdx
+++ b/docs/api/configuration-reference.mdx
@@ -9,6 +9,14 @@ tags: ["api", "configuration"]
 
 {/*
   docs/api/configuration-reference.mdx
+  Updated 2026-09-02 (docs/sites-analytics, SA-7) — EXTENDED the SA-2 section below
+  rather than adding a second one, with the two operator facts the variables alone do
+  not carry. The READ needs an Account Analytics Read token scope that the deploy
+  paths do not use, so a publish-only token deploys counters and then 403s every
+  read — a failure that looks like broken analytics rather than like a missing
+  permission. And these knobs govern html/react sites only: svelte and ripple deploy
+  their own server worker and carry no counter, so setting either variable does
+  nothing for them.
   Updated 2026-09-02 (feat/sites-analytics-shim, SA-3) — the "Paw Sites — visitor
   analytics" section now says which engines count and what the off shape is on each
   branch. SA-2's kill-switch row said the off shape has "no main", which was true
@@ -294,3 +302,24 @@ again.
 |---------|-------------|------|---------|-------------|
 | — | `PAW_SITES_ANALYTICS_DISABLED` | boolean | unset (off) | **Operator kill switch.** Truthy (`1`, `true`, `yes`, `on`; case-insensitive) makes the next publish of **every** site emit the pre-analytics config shape: no Analytics Engine binding, no `run_worker_first` rules, and no generated counter file. On an assets-only site that means no `main` at all; on a `ripple` or dynamic `svelte` site `main` goes back to naming SvelteKit's own `_worker.js` directly, which is the config that shipped before analytics existed. Paid sites included — it overrides the plan entitlement, it does not consult it. It exists for one failure: if the Cloudflare account is on the **Workers Free plan**, a `main` in the request path starts consuming a 100,000 request/day ceiling that is **account-wide**, and breaching that stops Cloudflare serving the Workers behind it rather than degrading analytics. Every published site goes dark together, so the mitigation has to be faster than a code change and a release. Already-deployed sites keep counting until they are republished, so pulling this switch during an incident means republishing the affected sites. Any other value, including `0` and `false`, leaves analytics on. |
 | — | `PAW_SITES_ANALYTICS_DATASET` | string | `paw_site_pageviews` | The Cloudflare Analytics Engine dataset the counter writes into. One dataset for all sites, partitioned by site id in `indexes[0]` — Analytics Engine is queried by index, and a dataset per site would need provisioning per site for no gain. Override it so a dev or staging publish cannot pollute the production dataset. An empty or whitespace-only value falls back to the default rather than emitting an empty dataset name, which wrangler accepts and Cloudflare does not. Changing it does not migrate existing rows: sites published against the old dataset keep writing there until they are republished, and Analytics Engine retains data for three months. |
+
+### The token scope the read needs
+
+Serving a site's numbers back through `GET /sites/{site_id}/analytics` queries the
+Analytics Engine SQL API, and that call needs an **Account Analytics Read**
+permission on `PAW_CF_API_TOKEN`. It is a different scope from the Workers and SSL
+permissions the deploy paths use, so a token minted for publishing alone will deploy
+counters happily and then fail every read.
+
+A token without it answers `403`, which surfaces as `sites.cloudflare_error` with
+Cloudflare's own message attached. Sites that count perfectly well while the
+dashboard cannot read them is the exact shape this failure takes, so check the scope
+before looking anywhere else.
+
+### Which sites this applies to
+
+Only sites whose engine deploys as an assets-only Worker — `html` and `react`.
+`svelte` and `ripple` sites deploy their own server worker and carry no counter
+regardless of plan or of these variables. The cost model and the rest of the
+engineering detail are in the
+[visitor analytics design note](https://github.com/pocketpaw/pocketpaw/blob/dev/docs/design/2026-09-02-sites-visitor-analytics.md).

--- a/docs/api/configuration-reference.mdx
+++ b/docs/api/configuration-reference.mdx
@@ -14,9 +14,10 @@ tags: ["api", "configuration"]
   not carry. The READ needs an Account Analytics Read token scope that the deploy
   paths do not use, so a publish-only token deploys counters and then 403s every
   read — a failure that looks like broken analytics rather than like a missing
-  permission. And these knobs govern html/react sites only: svelte and ripple deploy
-  their own server worker and carry no counter, so setting either variable does
-  nothing for them.
+  permission. And these knobs only reach a site that deploys assets-only, which is a
+  BUILD-shape question rather than an engine one: html, react and a STATIC svelte
+  build all count, while a dynamic svelte or any ripple build emits its own
+  _worker.js, carries no counter, and is unaffected by either variable.
   Updated 2026-09-02 (feat/sites-analytics-shim, SA-3) — the "Paw Sites — visitor
   analytics" section now says which engines count and what the off shape is on each
   branch. SA-2's kill-switch row said the off shape has "no main", which was true
@@ -318,8 +319,9 @@ before looking anywhere else.
 
 ### Which sites this applies to
 
-Only sites whose engine deploys as an assets-only Worker — `html` and `react`.
-`svelte` and `ripple` sites deploy their own server worker and carry no counter
-regardless of plan or of these variables. The cost model and the rest of the
-engineering detail are in the
+Only sites that deploy as an assets-only Worker, which is decided by the **build
+output** rather than by the engine: `html`, `react` and a *static* `svelte` build all
+qualify. A build that emits its own `_worker.js` — a *dynamic* `svelte` build, or any
+`ripple` build — carries no counter regardless of plan, so neither variable changes
+anything for it. The cost model and the rest of the engineering detail are in the
 [visitor analytics design note](https://github.com/pocketpaw/pocketpaw/blob/dev/docs/design/2026-09-02-sites-visitor-analytics.md).

--- a/docs/api/configuration-reference.mdx
+++ b/docs/api/configuration-reference.mdx
@@ -9,15 +9,13 @@ tags: ["api", "configuration"]
 
 {/*
   docs/api/configuration-reference.mdx
-  Updated 2026-09-02 (docs/sites-analytics, SA-7) — EXTENDED the SA-2 section below
-  rather than adding a second one, with the two operator facts the variables alone do
-  not carry. The READ needs an Account Analytics Read token scope that the deploy
-  paths do not use, so a publish-only token deploys counters and then 403s every
-  read — a failure that looks like broken analytics rather than like a missing
-  permission. And these knobs only reach a site that deploys assets-only, which is a
-  BUILD-shape question rather than an engine one: html, react and a STATIC svelte
-  build all count, while a dynamic svelte or any ripple build emits its own
-  _worker.js, carries no counter, and is unaffected by either variable.
+  Updated 2026-09-02 (docs/sites-analytics, SA-7) — EXTENDED the SA-2/SA-3 section
+  below rather than adding a second one, with the one operator fact the variables
+  alone do not carry: the READ needs an Account Analytics Read token scope that the
+  deploy paths do not use, so a publish-only token deploys counters and then 403s
+  every read — a failure that looks like broken analytics rather than like a missing
+  permission. Deliberately adds nothing about which engines count. The SA-3 entry below
+  already answers that, and this branch merges AFTER it.
   Updated 2026-09-02 (feat/sites-analytics-shim, SA-3) — the "Paw Sites — visitor
   analytics" section now says which engines count and what the off shape is on each
   branch. SA-2's kill-switch row said the off shape has "no main", which was true
@@ -317,11 +315,5 @@ Cloudflare's own message attached. Sites that count perfectly well while the
 dashboard cannot read them is the exact shape this failure takes, so check the scope
 before looking anywhere else.
 
-### Which sites this applies to
-
-Only sites that deploy as an assets-only Worker, which is decided by the **build
-output** rather than by the engine: `html`, `react` and a *static* `svelte` build all
-qualify. A build that emits its own `_worker.js` — a *dynamic* `svelte` build, or any
-`ripple` build — carries no counter regardless of plan, so neither variable changes
-anything for it. The cost model and the rest of the engineering detail are in the
+The cost model and the rest of the engineering detail are in the
 [visitor analytics design note](https://github.com/pocketpaw/pocketpaw/blob/dev/docs/design/2026-09-02-sites-visitor-analytics.md).

--- a/docs/design/2026-09-02-sites-visitor-analytics.md
+++ b/docs/design/2026-09-02-sites-visitor-analytics.md
@@ -5,9 +5,13 @@
      rather than given away (the cost model, with its derivation, so nobody has to
      re-derive it), which BUILDS actually carry a counter today, and what the privacy
      model is in enough detail to defend it.
-     The counter question is per-build and not per-engine, which the first draft of
-     this file got wrong: resolve_emits_server_worker reads the build output, so a
-     static svelte site deploys assets-only and counts while a dynamic one does not.
+     WRITTEN FOR THE STATE AFTER #2049, which merges before this branch does. That
+     slice adds the wrapper shim and the device blob, so every engine counts and the
+     row carries five blobs. Two earlier drafts of this file were wrong about that:
+     the first said svelte never counts (the gate reads the BUILD, and a static svelte
+     site deploys assets-only), the second said a build with its own worker never
+     counts at all (the shim imports that worker and wraps its fetch). Describe the
+     merged state, not this branch's snapshot.
      The cost numbers are Cloudflare's published prices as of this date, with the URL
      against each one. They move; re-check before quoting them at a customer. -->
 
@@ -83,48 +87,59 @@ public host receives — become billed invocations under any rule shape. They ar
 counted as pageviews (the entry only records a 200 or a 304), but they are billed.
 That is inherent to putting a server in front of a static site.
 
-## Which sites actually count today
+## How a site counts, and which one still does not
 
-The counter rides the **assets-only** deploy branch, and only that branch.
-`workers_deploy._write_deploy_files` gates on
-`not emits_worker and analytics_worker.counting_enabled(entitled=...)`, where
-`emits_worker` comes from `engines.resolve_emits_server_worker(project_dir, engine)`.
+`workers_deploy._write_deploy_files` decides whether to count with
+`analytics_worker.counting_enabled(entitled=...)`, and decides *which shape* of counter
+to write from `engines.resolve_emits_server_worker(project_dir, engine)`.
 
-**That question is asked of the BUILD, not of the engine.**
+**That second question is asked of the BUILD, not of the engine.**
 `resolve_emits_server_worker` looks for a `_worker.js` on disk in the build output and
-answers False when there is not one, even for an engine that usually emits one. So the
-row to read is the build shape, not the engine name:
+answers False when there is not one, even for an engine that usually emits one. It
+tests for existence rather than for being a file, because adapter-cloudflare emits
+`_worker.js` as a *directory* once an app is large enough. So the row to read is the
+build shape, not the engine name:
 
-| Build | `_worker.js` in the output | Carries a counter |
-|-------|---------------------------|-------------------|
-| `html` | never | yes |
-| `react` | never | yes |
-| `svelte`, static | no | yes |
-| `svelte`, dynamic | yes | **no** |
-| `ripple` | always | **no** |
+| Build | `_worker.js` in the output | How it counts |
+|-------|---------------------------|---------------|
+| `html` | never | assets-only counter as `main` |
+| `react` | never | assets-only counter as `main` |
+| `svelte`, static | no | assets-only counter as `main` |
+| `svelte`, dynamic | yes | wrapper shim as `main` |
+| `ripple` | always | wrapper shim as `main` |
 
-`svelte` spans both rows because SL-1 split the track across two adapters, chosen by a
+**Every build counts. The two column values are two shapes, not a yes and a no.**
+
+A build with no server entry gets `analytics_worker.build_entry_js`: a counter that
+serves the page through the `ASSETS` binding and becomes `main`, because there was no
+`main` before it.
+
+A build that emits its own `_worker.js` cannot take a counter in front of it from a
+config key, so `analytics_worker.build_shim_js` generates a module that imports that
+worker, spreads it, overrides `fetch`, counts a delivered response and returns it
+untouched. The shim becomes `main` in place of `_worker.js`. The adapter's file is
+never edited, because the adapter rewrites it on every build and an edit would survive
+exactly until the next one. The spread is load-bearing rather than decorative: it
+forwards any other handler the adapter grows (`scheduled`, `queue`, `email`) instead
+of dropping it, which an object literal naming only `fetch` would do.
+
+One asymmetry in the shim is worth knowing. Counting is failure-soft on both shapes,
+but the **delegation is deliberately not wrapped in a try**: a throw from the site's
+own worker is the site's failure and surfaces exactly as it would with no shim in
+front of it. Failure-soft governs the counting, which is worth nothing next to the
+page. It does not mean swallowing the page's own errors.
+
+`svelte` spans two rows because SL-1 split the track across two adapters, chosen by a
 property of the build rather than by the engine name. `engines.expects_server_worker`
 returns `None` for it for exactly that reason: either answer is legitimate, so only
 the artifact can say. Asking the engine name instead would point `main` at a
 `build/_worker.js` that does not exist and fail the deploy outright, which is the
 failure that predicate was introduced to prevent.
 
-For a dynamic build the config's `main` is already SvelteKit's own worker, and a
-second entry cannot be bolted in front of it from a config key. That is why those
-builds do not count here.
-
-**The consequence to know about, and its bounds:** a site whose build emits its own
-worker is entitled to analytics on a paid tier and still reports `never_counted`
-however often it is republished. The entitlement says the plan buys the capability; it
-does not say this build shape can deliver it.
-
-That gap is already being closed rather than left open. #2049 adds a wrapper shim that
-makes `ripple` and dynamic `svelte` count, and it is a **sibling** of this branch
-rather than an ancestor, which is why nothing here reflects it. What remains open
-after #2049 is narrower: a dynamic site provisioned through the durable provision job,
-which passes `analytics_entitled=False` unconditionally, since that function holds a
-site id and a directory and cannot resolve a plan. That case is tracked as SA-8.
+**What is still open.** One case does not count, and it is not an engine: a dynamic
+site provisioned through the durable provision job. That path calls
+`deploy_workers(..., analytics_entitled=False)` unconditionally, because it holds a
+site id and a directory and cannot resolve a plan from either. Tracked as SA-8.
 
 ## Retention: three months, and then it is gone
 
@@ -177,7 +192,7 @@ that file would otherwise upload it as an ordinary asset.
 
 ### What the row holds
 
-Four blobs and one index, and that is the entire record of a visit:
+Five blobs and one index, and that is the entire record of a visit:
 
 | Written as | Queried as | Contents |
 |------------|------------|----------|
@@ -186,6 +201,7 @@ Four blobs and one index, and that is the entire record of a visit:
 | `blobs[1]` | `blob2` | referrer **host** only, empty for a direct visit or a same-site link |
 | `blobs[2]` | `blob3` | `request.cf.country` |
 | `blobs[3]` | `blob4` | the visitor hash |
+| `blobs[4]` | `blob5` | device class: `desktop`, `mobile`, `tablet` or `unknown` |
 | `doubles[0]` | `double1` | `1`, the pageview |
 
 The two columns are the same fields under two names, and mixing them up is the way
@@ -195,19 +211,35 @@ no names at all**, so a query that reads the wrong slot reports referrers as cou
 and raises nothing. Reordering the write without changing the reader in the same PR
 does exactly that.
 
-**No user-agent string is retained.** The user-agent is read at the edge for two jobs
-and then discarded: rejecting bots, and salting the visitor hash. Nothing derived from
-it reaches the row.
+**No user-agent string is retained**, and the device class does not change that. The
+user-agent is read at the edge for three jobs and then discarded: rejecting bots,
+salting the visitor hash, and deriving one of four coarse labels. Only the label
+lands. Four values is a ceiling rather than a first pass — the user-agent is the
+highest-entropy thing this Worker touches, and the row's privacy claim survives only
+while what lands in it cannot single anyone out.
 
-That is also why the read endpoint answers `devices: null` with `"devices"` in
-`unrecorded`. The dimension is not empty, it is unanswerable — no stored row carries
-device information, and because the hash is one-way it cannot be recovered from rows
-already written either. The reader already queries `blob5` for a device class so that
-a later slice can start writing one without a reader change; until such rows exist,
-every label is `unknown` and the dimension is reported as unrecorded rather than drawn
-as a chart of one bar. Analytics Engine has no schema, so a slot no row ever carried
-reads as an empty string instead of failing, which is what lets both row shapes arrive
-in one window without either crashing the read.
+Two details of that classifier are worth not rediscovering. Tablet is tested **first**,
+because a tablet's user-agent is a superset of a phone's on both platforms that matter:
+an iPad announces `iPad` beside `Mobile`, and an Android tablet is an Android that
+omits `Mobile`. Testing mobile first files every iPad under mobile. And desktop is a
+**positive** match on a platform token rather than the fallback, so an unrecognised
+string lands on `unknown` instead of quietly inflating the one number a site owner is
+most likely to act on.
+
+The device class arrived in #2049 and was **appended** at `blobs[4]` rather than
+inserted anywhere more logical. Inserting it earlier would have silently re-labelled
+every row already in the dataset, and the retention window is three months.
+Analytics Engine has no schema and no backfill, so rows written before that slice carry
+four blobs forever, and a slot no row carried reads as an empty string rather than
+failing. Both shapes therefore arrive in one window and neither may crash the read.
+
+That is what `unrecorded` is for. When every device label in a window is empty, the
+reader returns `devices: null` with `"devices"` in `unrecorded` rather than a chart of
+one bar called unknown. Read it as **"this site has not published a counter that
+records devices yet"** rather than as a permanent gap: it clears once the site is
+republished and takes traffic. An empty list would read as "no devices", and an omitted
+field is indistinguishable from a version skew, which is why the dimension is named
+rather than dropped.
 
 ## The read side, briefly
 

--- a/docs/design/2026-09-02-sites-visitor-analytics.md
+++ b/docs/design/2026-09-02-sites-visitor-analytics.md
@@ -3,8 +3,11 @@
      in sites/service.py. Records the three things a field list cannot show and that
      the customer-facing API reference is the wrong place for: WHY counting is sold
      rather than given away (the cost model, with its derivation, so nobody has to
-     re-derive it), which engines actually carry a counter today, and what the privacy
+     re-derive it), which BUILDS actually carry a counter today, and what the privacy
      model is in enough detail to defend it.
+     The counter question is per-build and not per-engine, which the first draft of
+     this file got wrong: resolve_emits_server_worker reads the build output, so a
+     static svelte site deploys assets-only and counts while a dynamic one does not.
      The cost numbers are Cloudflare's published prices as of this date, with the URL
      against each one. They move; re-check before quoting them at a customer. -->
 
@@ -82,26 +85,46 @@ That is inherent to putting a server in front of a static site.
 
 ## Which sites actually count today
 
-The counter rides the **assets-only** deploy branch, and only that branch:
-
-| Engine | Emits its own `_worker.js` | Carries a counter |
-|--------|---------------------------|-------------------|
-| `html` | no | yes |
-| `react` | no | yes |
-| `svelte` | yes | **no** |
-| `ripple` | yes | **no** |
-
+The counter rides the **assets-only** deploy branch, and only that branch.
 `workers_deploy._write_deploy_files` gates on
-`not emits_worker and analytics_worker.counting_enabled(entitled=...)`. For `svelte`
-and `ripple` the config's `main` is already SvelteKit's own worker, and a second entry
-cannot be bolted in front of it from a config key. That is a later slice, not an
-oversight.
+`not emits_worker and analytics_worker.counting_enabled(entitled=...)`, where
+`emits_worker` comes from `engines.resolve_emits_server_worker(project_dir, engine)`.
 
-**The consequence to know about:** a `svelte` or `ripple` site on a paid tier is
-entitled to analytics and will report `never_counted` no matter how often it is
-republished. The entitlement says the plan buys the capability; it does not say the
-site's engine can deliver it yet. If that combination reaches customers before the
-server-worker slice lands, it needs a sentence on screen rather than a shrug.
+**That question is asked of the BUILD, not of the engine.**
+`resolve_emits_server_worker` looks for a `_worker.js` on disk in the build output and
+answers False when there is not one, even for an engine that usually emits one. So the
+row to read is the build shape, not the engine name:
+
+| Build | `_worker.js` in the output | Carries a counter |
+|-------|---------------------------|-------------------|
+| `html` | never | yes |
+| `react` | never | yes |
+| `svelte`, static | no | yes |
+| `svelte`, dynamic | yes | **no** |
+| `ripple` | always | **no** |
+
+`svelte` spans both rows because SL-1 split the track across two adapters, chosen by a
+property of the build rather than by the engine name. `engines.expects_server_worker`
+returns `None` for it for exactly that reason: either answer is legitimate, so only
+the artifact can say. Asking the engine name instead would point `main` at a
+`build/_worker.js` that does not exist and fail the deploy outright, which is the
+failure that predicate was introduced to prevent.
+
+For a dynamic build the config's `main` is already SvelteKit's own worker, and a
+second entry cannot be bolted in front of it from a config key. That is why those
+builds do not count here.
+
+**The consequence to know about, and its bounds:** a site whose build emits its own
+worker is entitled to analytics on a paid tier and still reports `never_counted`
+however often it is republished. The entitlement says the plan buys the capability; it
+does not say this build shape can deliver it.
+
+That gap is already being closed rather than left open. #2049 adds a wrapper shim that
+makes `ripple` and dynamic `svelte` count, and it is a **sibling** of this branch
+rather than an ancestor, which is why nothing here reflects it. What remains open
+after #2049 is narrower: a dynamic site provisioned through the durable provision job,
+which passes `analytics_entitled=False` unconditionally, since that function holds a
+site id and a directory and cannot resolve a plan. That case is tracked as SA-8.
 
 ## Retention: three months, and then it is gone
 

--- a/docs/design/2026-09-02-sites-visitor-analytics.md
+++ b/docs/design/2026-09-02-sites-visitor-analytics.md
@@ -1,0 +1,228 @@
+<!-- Engineering note for Paw Sites visitor analytics (SA-1 .. SA-7), written
+     2026-09-02 alongside ee/pocketpaw_ee/sites/analytics_worker.py and the read half
+     in sites/service.py. Records the three things a field list cannot show and that
+     the customer-facing API reference is the wrong place for: WHY counting is sold
+     rather than given away (the cost model, with its derivation, so nobody has to
+     re-derive it), which engines actually carry a counter today, and what the privacy
+     model is in enough detail to defend it.
+     The cost numbers are Cloudflare's published prices as of this date, with the URL
+     against each one. They move; re-check before quoting them at a customer. -->
+
+# Counting visitors on a Paw Site
+
+`GET /sites/{site_id}/analytics` and its wire shape are in
+[the API reference](../api-reference.md#sites--visitor-analytics). This note is the
+half that belongs to engineering: what counting costs, which sites can do it, and what
+a stored row actually holds.
+
+## Why counting is a paid grant
+
+**Serving a page costs nothing and counting it costs money.** The gap is entirely
+Cloudflare's billing model rather than ours.
+
+> "Requests to static assets are free and unlimited." … "Requests to the Worker
+> script (for example, in the case of SSR content) are billed according to Workers
+> pricing."
+> — [Workers static assets: billing and limitations](https://developers.cloudflare.com/workers/static-assets/billing-and-limitations/)
+
+A Paw Site built by the `html` or `react` generator is a static tree. Before SA-1 it
+deployed as an assets-only Worker with no `main` at all, so it shipped zero JavaScript
+and drew zero billable requests however much traffic it took. Putting a counter in
+front of it is what starts the meter. That is the whole reason the capability is
+attached to a plan instead of switched on for everyone.
+
+### The derivation
+
+Two line items move per pageview. Both are Workers Paid prices, both are the
+**overage** rate above a monthly allowance:
+
+| Line item | Cloudflare price | Included on Workers Paid | Per million pageviews |
+|-----------|------------------|--------------------------|-----------------------|
+| Worker request | $0.30 per additional million | 10 million / month | $0.30 |
+| Analytics Engine data point written | $0.25 per additional million | 10 million / month | $0.25 |
+| | | **Total** | **$0.55** |
+
+Sources: [Workers pricing](https://developers.cloudflare.com/workers/platform/pricing/),
+[Analytics Engine pricing](https://developers.cloudflare.com/analytics/analytics-engine/pricing/).
+
+CPU time is the third component and is left out of the figure deliberately rather
+than forgotten. The counter does one SHA-256 over a short string and one
+`writeDataPoint`; against 30 million CPU-milliseconds included per month and $0.02
+per additional million after that, it does not reach the second decimal place.
+
+Two caveats worth carrying:
+
+- **Analytics Engine is not actually billing yet.** Its pricing page still says
+  "Currently, you will not be billed for your use of Workers Analytics Engine." So
+  today's marginal cost is the $0.30 request half, and $0.55 is what it becomes when
+  that changes. Budget against $0.55; do not be surprised by an invoice that reads
+  $0.30.
+- **These are overage rates.** Under the included allowance the marginal cost of a
+  pageview is zero and the $5/month base fee is the whole bill. The per-million
+  figure is the number that matters at the scale where the answer stops being
+  obvious, which is the only scale where anyone asks.
+
+### What the allow-list is protecting
+
+A page carries something like twenty subresources — stylesheets, scripts, fonts,
+images. Routing every request through the Worker would multiply the per-pageview cost
+by roughly that factor, so `analytics_worker.run_worker_first_rules` emits an
+**allow-list** of page-shaped paths (`/`, `/*.html`, `/*.htm`, `/*/`) rather than a
+deny-list of asset extensions. A deny-list rots: every format nobody remembered to
+list — `.avif`, `.woff2`, `.webmanifest` — gets billed at page rates. The allow-list
+fails the other way, and an uncounted visit is the direction this is allowed to fail
+in.
+
+The allow-list does not buy everything, and the gap is real. Once the config carries
+a `main` at all, the asset router's final fallback sends any request for a path with
+**no matching asset** to the Worker. So 404 scans — the `/wp-login.php` traffic every
+public host receives — become billed invocations under any rule shape. They are not
+counted as pageviews (the entry only records a 200 or a 304), but they are billed.
+That is inherent to putting a server in front of a static site.
+
+## Which sites actually count today
+
+The counter rides the **assets-only** deploy branch, and only that branch:
+
+| Engine | Emits its own `_worker.js` | Carries a counter |
+|--------|---------------------------|-------------------|
+| `html` | no | yes |
+| `react` | no | yes |
+| `svelte` | yes | **no** |
+| `ripple` | yes | **no** |
+
+`workers_deploy._write_deploy_files` gates on
+`not emits_worker and analytics_worker.counting_enabled(entitled=...)`. For `svelte`
+and `ripple` the config's `main` is already SvelteKit's own worker, and a second entry
+cannot be bolted in front of it from a config key. That is a later slice, not an
+oversight.
+
+**The consequence to know about:** a `svelte` or `ripple` site on a paid tier is
+entitled to analytics and will report `never_counted` no matter how often it is
+republished. The entitlement says the plan buys the capability; it does not say the
+site's engine can deliver it yet. If that combination reaches customers before the
+server-worker slice lands, it needs a sentence on screen rather than a shrug.
+
+## Retention: three months, and then it is gone
+
+Cloudflare retains an Analytics Engine row for three months. There is **no rollup
+store** — nothing aggregates a day into a smaller row before the source row expires —
+so data older than the retention window is not archived anywhere. It is gone.
+
+That is why `90d` is the longest window the endpoint offers: a longer one could only
+return the same rows with more empty space in front of them.
+
+Read the retention figure off the response's `retention_days` rather than hard-coding
+90. A UI that copies the constant will keep displaying it after the day somebody adds
+a rollup store or Cloudflare changes the window, and the response is the only place
+that stays true through that change.
+
+`Site.analytics_since` interacts with this in a way worth stating: it is cleared by
+any publish that deploys no counter, so a site that lapsed to free and later
+re-upgraded loses its earlier era's start date. That looks lossy and is not. A stamp
+older than the retention window points at rows that no longer exist, so keeping it
+would only let the chart claim a history it cannot draw.
+
+## Privacy: no cookie, and nothing to reverse
+
+There is **no cookie, no `localStorage`, and no consent banner**, because there is no
+identifier that persists.
+
+A visitor is identified by `SHA-256(secret | UTC-day | ip | user-agent)`, truncated to
+16 bytes. What that construction buys:
+
+- **It cannot be reversed to a person.** The raw IP is never stored — only the digest
+  reaches the row.
+- **It rotates daily.** The UTC calendar day is part of the input, so today's hash
+  cannot be joined to yesterday's even by us. The visible consequence is that a
+  visitor who returns tomorrow counts twice, which is the honest cost of the design
+  rather than a rounding error.
+- **The salt is per-publish and unguessable.** `secrets.token_hex` at publish time,
+  not derived from the site id or anything else reconstructable. A salt an attacker
+  can rebuild turns the hash into a confirmation oracle: given a candidate IP and
+  user-agent, recompute and compare. Republishing rotates it early, which
+  over-splits a day's visitors and never over-links them.
+
+That last property is load-bearing on one config line. The salt lives inside the
+generated entry file, which sits at the project root — and for an assets-only site the
+project root **is** the asset directory. An entry that is not listed in
+`.assetsignore` gets uploaded and served, and the salt becomes a public download. The
+`.assetsignore` line is a privacy control, not housekeeping, and `_write_deploy_files`
+writes it whether counting is on or off for exactly that reason. It also deletes a
+leftover entry from an earlier paid publish, because a config with no `main` naming
+that file would otherwise upload it as an ordinary asset.
+
+### What the row holds
+
+Four blobs and one index, and that is the entire record of a visit:
+
+| Written as | Queried as | Contents |
+|------------|------------|----------|
+| `indexes[0]` | `index1` | the site id |
+| `blobs[0]` | `blob1` | request path, truncated to 256 characters |
+| `blobs[1]` | `blob2` | referrer **host** only, empty for a direct visit or a same-site link |
+| `blobs[2]` | `blob3` | `request.cf.country` |
+| `blobs[3]` | `blob4` | the visitor hash |
+| `doubles[0]` | `double1` | `1`, the pageview |
+
+The two columns are the same fields under two names, and mixing them up is the way
+this goes wrong quietly. The Worker writes a zero-indexed JavaScript array; Analytics
+Engine SQL addresses the same slots one-indexed, and its columns are **positional with
+no names at all**, so a query that reads the wrong slot reports referrers as countries
+and raises nothing. Reordering the write without changing the reader in the same PR
+does exactly that.
+
+**No user-agent string is retained.** The user-agent is read at the edge for two jobs
+and then discarded: rejecting bots, and salting the visitor hash. Nothing derived from
+it reaches the row.
+
+That is also why the read endpoint answers `devices: null` with `"devices"` in
+`unrecorded`. The dimension is not empty, it is unanswerable — no stored row carries
+device information, and because the hash is one-way it cannot be recovered from rows
+already written either. The reader already queries `blob5` for a device class so that
+a later slice can start writing one without a reader change; until such rows exist,
+every label is `unknown` and the dimension is reported as unrecorded rather than drawn
+as a chart of one bar. Analytics Engine has no schema, so a slot no row ever carried
+reads as an empty string instead of failing, which is what lets both row shapes arrive
+in one window without either crashing the read.
+
+## The read side, briefly
+
+Reads are billed too, on a different meter: $1.00 per million read queries, with one
+million included per month on Workers Paid and **10,000 per day on the free plan**.
+The free-plan number is the one that constrains, and it is account-wide.
+
+One cache miss costs **five queries** — one for the totals and one per dimension in
+`_ANALYTICS_DIMENSIONS`. A dashboard is reloaded by people, so the endpoint caches an
+assembled response for 60 seconds per `(workspace, site, window)`. The cache is
+in-process and deliberately not shared: a second API replica keeps its own, which puts
+the worst case at one query set per replica per minute rather than one per account,
+and costs no Redis dependency on a read whose entire value is being cheap. Only
+successes are cached, so a Cloudflare blip is not extended into a minute of errors.
+
+The read needs an **Account Analytics Read** token scope, which the deploy paths do
+not use. A token without it answers 403, surfaced as `sites.cloudflare_error` with
+Cloudflare's own message attached. A site that publishes and counts perfectly well
+while every read 403s is exactly the shape that failure takes.
+
+## The kill switch, and the failure it exists for
+
+`PAW_SITES_ANALYTICS_DISABLED` makes the next publish of every site — paid ones
+included — emit the pre-analytics config byte for byte: no `main`, no dataset binding,
+no `run_worker_first` rules, no entry file on disk.
+
+It is not a feature flag. It exists for one failure mode whose blast radius is larger
+than analytics: if this Cloudflare account turns out to be on the **Workers Free
+plan**, a config carrying a `main` starts drawing on a 100,000 request/day ceiling
+that is account-wide, and breaching that ceiling does not degrade analytics —
+Cloudflare stops serving the Workers behind it. Every published site goes dark
+together. A code change plus a release is minutes at best; an environment variable
+plus a republish is one publish long.
+
+The switch takes effect **at the next publish**, which is the part to plan around
+during an incident: already-deployed sites keep their counter until they are
+republished, so pulling the switch is the first step and republishing the affected
+sites is the second.
+
+Both variables are documented for operators in
+[the configuration reference](../api/configuration-reference.mdx#paw-sites--visitor-analytics).


### PR DESCRIPTION
## Merge this after #2049

These docs describe the state **once #2049 is in `dev`**: every engine counts, and the
row carries a device class. Merging them before #2049 publishes docs for a state that
does not exist yet. Intended order is 2042, 2043, 2049, 2051, 2054, then this.

### The conflict, and how to resolve it

`docs/api/configuration-reference.mdx` is the file where this branch and #2049 meet.
**The body merges clean.** The only conflict is one hunk at the top of the comment
block, where both branches add a changelog paragraph at the same anchor. Both sides are
purely additive.

**Resolution: keep both, with the SA-7 entry above the SA-3 entry**, which preserves the
file's newest-first ordering. No content decision required. Resolved, the top of the
block reads:

```
{/*
  docs/api/configuration-reference.mdx
  Updated 2026-09-02 (docs/sites-analytics, SA-7) — ...
  Updated 2026-09-02 (feat/sites-analytics-shim, SA-3) — ...
  Updated 2026-09-02 (feat/sites-analytics-gate, SA-2) — ...
```

This was left as a conflict on purpose. Reordering the SA-7 entry below SA-2's would
merge cleanly but leave the block as SA-3, SA-2, SA-7, PA-8a, breaking the convention
the file has kept. Two branches adding a changelog line to the same header will recur
between every pair of these SA branches.

### One block removed that belongs to another slice

`docs/api-reference.md` no longer shows `"devices": null` with `"unrecorded":
["devices"]` in the `200` example. That block came from SA-4 (#2051), so a reviewer
there may wonder where it went. It is still a legal response, but only for a site that
has not republished since #2049, and leading with it teaches clients the field is
always null. The example now shows a populated `devices` list, and the `unrecorded`
bullet explains the transitional case in words.

SA-7, the documentation slice. Every code slice for Paw Sites visitor analytics is
built and PR'd; this is the writing.

**Stacked.** This branch sits on `feat/sites-analytics-entitlement-field` (SA-5),
which sits on #2051, which sits on #2043 and #2042. It is targeted at SA-5's branch,
so the diff above is this slice alone rather than the whole stack. Four commits,
three files, nothing else:

    docs/design/2026-09-02-sites-visitor-analytics.md   (new, 283 lines)
    docs/api-reference.md                               (+121)
    docs/api/configuration-reference.mdx                (+23)

Merge each base with `--rebase`, not `--squash`. Squashing a base gives its stacked
dependents duplicate-content conflicts.

## What is in it

**The engineering note** carries the cost model so nobody re-derives it. Cloudflare
serves a static asset free and bills a Worker invocation, which is the whole reason
counting is sold rather than given away. The $0.55 per million pageviews is derived
in a table with the Cloudflare page against each half, plus the two things the figure
hides on its own: Analytics Engine is not billing yet, so today's marginal cost is
the $0.30 request half, and both prices are overage rates that only apply above the
monthly allowance. Also the privacy model in enough detail to defend rather than
assert, and the row layout with both its write-side and query-side names, because
Analytics Engine columns are positional and reading the wrong slot reports referrers
as countries without raising anything.

**The API reference** gains what the `analytics` grant buys. It needs an active
subscription and not only a tier, and upgrading does not backfill: a site's history
begins at the publish that first carried a counter. The `never_counted` row alone did
not say that, since it reads as a temporary state when the missing weeks are
permanent. It also documents `GET /sites/{site_id}/entitlements`, which was not in
this file at all, and says plainly that its `analytics` field is a pre-check rather
than the answer.

**The configuration reference** extends the section SA-2 already added rather than
opening a second one, with the token scope the read needs. `Account Analytics Read`
is a different permission from the Workers and SSL scopes the deploy paths use, so a
publish-only token deploys counters happily and then 403s every read.

## What the source said that the task brief did not

Worth reading before the diff, because each of these changed what got written.

**The counter gate is per BUILD, not per engine.** `workers_deploy` picks the counter
shape from `engines.resolve_emits_server_worker(project_dir, engine)`, which looks for
a `_worker.js` on disk rather than trusting the engine name. A *static* `svelte` build
emits none and deploys assets-only, exactly as `react` does. Anything keyed on the
engine name alone gets this wrong, which two drafts of these docs did.

**Every engine counts, in one of two shapes.** #2049 adds `build_shim_js`, which
imports the adapter's own worker, spreads it, overrides `fetch` and returns its
response untouched. So a `ripple` or dynamic `svelte` build counts through the shim
rather than not counting at all. The spread matters: it forwards handlers the adapter
may grow (`scheduled`, `queue`, `email`) instead of dropping them. The one case that
still does not count is the durable provision job, which passes
`analytics_entitled=False` because it cannot resolve a plan from a site id and a
directory. Tracked as SA-8.

**The row carries five blobs, not four.** #2049 appends a coarse device class at
`blobs[4]`. The user-agent itself is still never retained — only one of four derived
labels lands, and that ceiling is the privacy claim rather than a first pass.

These docs are written for the state **after #2049**, per the merge order at the top,
so all three statements describe what a reader will actually be looking at.

**Counting does not require Workers Paid.** It runs on the free plan, and that is
precisely the danger the kill switch exists for: a `main` in the request path there
draws on an account-wide 100,000 request/day ceiling whose breach takes every
published site dark rather than degrading analytics.

**The sites API reference is not under `docs/api/`.** That directory holds the
per-endpoint Mintlify pages for the OSS dashboard and carries no `/sites` routes. The
cloud sites API lives in `docs/api-reference.md`, where SA-4 had already documented
the read endpoint; that section was extended rather than duplicated. Only
`configuration-reference.mdx` lives under `docs/api/`.

**The $0.55 per million checks out.** Verified rather than repeated: $0.30 per million
Workers requests plus $0.25 per million Analytics Engine data points, both overage
rates above the monthly allowance.

## Checks

Docs only, no code touched. Cloudflare's pricing pages were read for the cost figures
rather than quoted from memory, and each number carries its URL. No test run: this
branch changes no Python, and running the suite here would sync a venv that sibling
worktrees share.





