### PR TITLE
feat(sites): report the analytics entitlement on the wire

### DIFF
--- a/ee/pocketpaw_ee/cloud/entitlements/domain.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/domain.py
@@ -49,6 +49,12 @@
 #   Deliberately a separate frozen class rather than fields bolted onto
 #   ``Entitlements``: they resolve from different sources, on different cadences,
 #   and a caller that wants one almost never wants the other.
+# Updated 2026-09-02 (feat/sites-analytics-entitlement-field, SA-5): added
+#   ``SiteEntitlements.analytics`` (bool) — may this site's visitors be counted.
+#   A PAID grant, resolved by ``site_analytics_entitled`` rather than re-derived,
+#   because the publish seam and the read endpoint already share that predicate and
+#   a third copy is how the two drift. Exposing it lets the dashboard disable the
+#   panel and name the reason instead of rendering a refusal.
 
 from __future__ import annotations
 
@@ -134,6 +140,14 @@ class SiteEntitlements:
     the third on an org entity that does not exist. A field that always returns
     0/False reads as implemented, which is worse than its absence.
 
+    ``analytics`` is a PAID grant and deliberately not derived here: it is read
+    off ``site_analytics_entitled``, the one predicate the publish seam and the read
+    endpoint already share. A fourth expression of the same rule is how a site ends
+    up counting visitors it may not be shown, or being shown a blank chart it is
+    paying for. It has no default for the same reason nothing else here does —
+    every construction must state the answer, so a capability cannot be granted by
+    forgetting it.
+
     ``concierge_enabled`` and ``concierge_entitled`` are two different questions
     and are deliberately NOT folded into one boolean. The first is the owner's own
     kill switch, echoed unchanged; the second is whether the site's plan sells the
@@ -151,6 +165,7 @@ class SiteEntitlements:
     badge_required: bool
     custom_domain: bool
     max_domained_sites: int | None
+    analytics: bool
     concierge_enabled: bool
     concierge_entitled: bool
 

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -74,6 +74,15 @@
 #   and one of them (the deploy) holds two strings rather than a resolved
 #   entitlements object. Keeping it a function is what makes both seams able to
 #   share the single predicate instead of each re-deriving it.
+# Updated 2026-09-02 (feat/sites-analytics-entitlement-field, SA-5):
+#   ``resolve_site_entitlements`` now also reports that answer as
+#   ``SiteEntitlements.analytics``, so the dashboard can disable the analytics panel
+#   and say why rather than calling the endpoint to be refused. This does NOT
+#   supersede the entry above: the function stays THE predicate and the field CALLS
+#   it, exactly as ``max_domained_sites`` calls ``site_domain_allowance``. The
+#   function exists for the seams that hold two strings and no resolved object; the
+#   field exists for the one reader that already has the object. Neither re-derives
+#   the rule, which is the only property that matters.
 
 from __future__ import annotations
 
@@ -296,6 +305,19 @@ def resolve_site_entitlements(
         plan_tier=plan_tier, subscription_status=subscription_status
     )
 
+    # --- The analytics grant, borrowed rather than re-derived ---------------- #
+    # Not folded into the paid branch below as ``ANALYTICS_FEATURE in
+    # tier.cloudflare_features``, even though that is what it reduces to.
+    # ``site_analytics_entitled`` is already THE predicate for this capability: the
+    # publish seam asks it to decide whether the deployed config carries a counter,
+    # and the read endpoint asks it to decide whether numbers may be served. A
+    # third expression of the rule here would be a third thing to keep in step, and
+    # the two ways it can fall out of step are both bad — a site counting traffic it
+    # is never shown, or a customer paying for a chart that refuses to load.
+    analytics = site_analytics_entitled(
+        plan_tier=plan_tier, subscription_status=subscription_status
+    )
+
     # --- PAID grants: the tier AND an active subscription ------------------- #
     # Written as an explicit branch rather than ``paid and tier.x`` so the
     # None-narrowing is visible to the type checker instead of resting on
@@ -325,6 +347,7 @@ def resolve_site_entitlements(
         # at the attach seam in ``sites.service``.
         custom_domain=max_domained_sites != 0,
         max_domained_sites=max_domained_sites,
+        analytics=analytics,
         # Echoed unchanged — the owner's switch is not a billing question. The
         # AND of the two is ``concierge_available``, which is what seams ask.
         concierge_enabled=bool(concierge_enabled),

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -12,6 +12,12 @@
 # not a status value at all — it is an error response, so an outage can never arrive
 # looking like a quiet week.
 #
+# Updated 2026-09-02 (SA-5 — the entitlement on the wire): added
+# ``SiteEntitlementsResponse.analytics``, resolved by the same predicate the publish
+# seam and the read endpoint use. Without it the dashboard's only way to learn that
+# a site's plan excludes analytics was to request the numbers and read the refusal,
+# which is the exact shape this response type was created to stop.
+#
 # Updated 2026-08-24 (SP-2 — draft preview joins the ephemeral build lane):
 # ``NativeArtifactResponse`` gained ``build_status`` / ``build_reason`` /
 # ``build_job_id`` and defaulted ``body_html`` / ``css`` to empty strings. A cold
@@ -735,6 +741,14 @@ class SiteEntitlementsResponse(BaseModel):
     catalog. ``subscription_active`` distinguishes a lapsed paid site from a site
     that never had the capability — the tier stays recorded, only the payment
     stopped, and the UI should say so.
+
+    ``analytics`` says whether this site's plan buys visitor counting. It is what
+    lets the panel disable itself with a reason BEFORE the call, and it is
+    deliberately not the last word: the analytics endpoint's own ``status`` is
+    authoritative, because entitlement alone cannot distinguish "your plan does not
+    include this" from "it does, and you have not republished since you upgraded".
+    Those need different sentences and different buttons. This field is the cheap
+    pre-check; the endpoint is the answer.
     """
 
     site_id: str
@@ -745,6 +759,7 @@ class SiteEntitlementsResponse(BaseModel):
     max_domained_sites: int | None = 0
     domained_sites_used: int = 0
     domain_slots_available: bool = False
+    analytics: bool = False
     concierge_entitled: bool = False
     concierge_enabled: bool = False
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,13 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-09-02 (SA-5 — the entitlement on the wire): ``site_entitlements`` now
+# reports ``analytics``, echoed off the resolver. It is the cheap pre-check that lets
+# the dashboard disable the panel with a reason instead of calling the endpoint to be
+# refused. It does not replace that endpoint's ``status``, which stays authoritative:
+# entitlement alone cannot tell "your plan does not include this" from "it does, and
+# you have not republished since you upgraded", and those need different sentences.
+#
 # Updated 2026-09-02 (SA-4 — the visitor-analytics read): the read half of the feature
 # SA-1/SA-2 built. Two things landed here.
 #
@@ -4044,6 +4051,10 @@ async def site_entitlements(*, workspace_id: str, site_id: str) -> SiteEntitleme
         # tier that cannot hold a domain and hand back
         # ``billing.custom_domain_not_entitled``.
         domain_slots_available=resolved.custom_domain and not exceeded,
+        # Echoed straight off the resolver. There is no second condition to AND in
+        # here — unlike the domain slot, whose plan grant and workspace room are two
+        # different questions, analytics has no per-workspace count to exhaust.
+        analytics=resolved.analytics,
         concierge_entitled=resolved.concierge_entitled,
         concierge_enabled=resolved.concierge_enabled,
     )

--- a/tests/cloud/sites/test_billing_state_on_the_wire.py
+++ b/tests/cloud/sites/test_billing_state_on_the_wire.py
@@ -25,6 +25,15 @@
 # place that question can be answered.
 #
 # Created 2026-08-22 (feat/site-entitlement-ui-state): new test module.
+#
+# Updated 2026-09-02 (feat/sites-analytics-entitlement-field, SA-5): covers
+# ``SiteEntitlementsResponse.analytics``. The headline case is the same shape as the
+# original defect above — a capability the UI branches on that the wire never sent —
+# so it is asserted on the DTO the router returns rather than on the resolver. The
+# load-bearing test is the agreement one: three seams now answer "may this site's
+# visitors be counted", and it asserts the wire EQUALS the shared predicate rather
+# than restating the expected booleans, so a second copy of the rule fails here even
+# while it still happens to agree with the catalog.
 
 from __future__ import annotations
 
@@ -315,6 +324,7 @@ async def test_no_capability_means_no_slot_however_empty_the_workspace(mongo_db,
             badge_required=True,
             custom_domain=False,
             max_domained_sites=0,
+            analytics=False,
             concierge_enabled=False,
             concierge_entitled=False,
         ),
@@ -327,3 +337,143 @@ async def test_no_capability_means_no_slot_however_empty_the_workspace(mongo_db,
         "an empty workspace made a slot look available on a tier that cannot hold "
         "a domain — the button would enable and then 402"
     )
+
+
+# ---------------------------------------------------------------------------
+# The analytics grant (SA-5) — the pre-check that keeps the panel from
+# discovering a refusal by rendering it
+# ---------------------------------------------------------------------------
+
+
+async def test_a_paid_site_reports_that_its_visitors_may_be_counted(mongo_db, monkeypatch):
+    """The whole point of the field: the panel can enable itself without calling
+    the analytics endpoint first."""
+    _enforce(monkeypatch)
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await _seed_site(
+        workspace_id=ws, pocket_id=pocket_id, plan_tier="site", subscription_status="active"
+    )
+
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert ent.analytics is True
+
+
+async def test_a_free_site_reports_no_analytics(mongo_db, monkeypatch):
+    """A free site's traffic is never counted — a Worker invocation is billed and
+    a static asset is not, so the grant has to track the plan."""
+    _enforce(monkeypatch)
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await _seed_site(
+        workspace_id=ws, pocket_id=pocket_id, plan_tier="free", subscription_status="none"
+    )
+
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert ent.analytics is False
+
+
+async def test_a_lapsed_paid_site_loses_analytics_though_it_keeps_the_tier(mongo_db, monkeypatch):
+    """The bug this whole module exists to prevent, on the newest field. Cancelling
+    leaves ``plan_tier`` on the paid key — nothing resets it — so a field that read
+    the tier alone would grant analytics to a cancelled site forever."""
+    _enforce(monkeypatch)
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await _seed_site(
+        workspace_id=ws, pocket_id=pocket_id, plan_tier="site", subscription_status="cancelled"
+    )
+
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert ent.plan_tier == "site", "the tier is still recorded; only the payment stopped"
+    assert ent.analytics is False
+
+
+async def test_the_wire_field_agrees_with_the_predicate_the_publish_seam_reads(
+    mongo_db, monkeypatch
+):
+    """The anti-drift assertion, and the reason this field calls
+    ``site_analytics_entitled`` instead of re-deriving the rule.
+
+    Three seams now answer "may this site's visitors be counted": the publish path
+    (which decides whether the deployed config carries a counter at all), the read
+    endpoint (which decides whether numbers may be served), and this field (which
+    decides what the dashboard offers). They must never disagree. A site whose
+    publish counted but whose panel is greyed out is a customer paying for a chart
+    they cannot open; the reverse offers a chart that 402s.
+
+    So this drives the endpoint across the states that separate them and asserts the
+    wire value EQUALS the predicate, rather than restating the expected booleans. A
+    future edit that reintroduces a second copy of the rule fails here even if it
+    happens to agree with the catalog today.
+    """
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    _enforce(monkeypatch)
+    ws = await _make_workspace()
+
+    cases = [
+        ("site", "active"),
+        ("staff", "active"),
+        ("free", "none"),
+        ("free", "active"),
+        ("site", "cancelled"),
+        ("site", "pending"),
+        (None, "active"),
+        ("not-a-tier", "active"),
+    ]
+
+    for plan_tier, subscription_status in cases:
+        pocket_id = await _make_pocket(workspace_id=ws)
+        doc = await _seed_site(
+            workspace_id=ws,
+            pocket_id=pocket_id,
+            plan_tier=plan_tier,
+            subscription_status=subscription_status,
+        )
+
+        ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+        expected = entitlements_service.site_analytics_entitled(
+            plan_tier=plan_tier, subscription_status=subscription_status
+        )
+
+        assert ent.analytics is expected, (
+            f"the wire disagreed with the predicate for {plan_tier!r}/"
+            f"{subscription_status!r}: wire={ent.analytics}, predicate={expected}"
+        )
+
+
+async def test_the_cases_are_not_all_the_same_answer(mongo_db, monkeypatch):
+    """Guards the test above from decaying into a tautology. If the catalog ever
+    stopped granting analytics to any tier, every case would agree at False and the
+    agreement test would still pass while proving nothing."""
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    assert (
+        entitlements_service.site_analytics_entitled(plan_tier="site", subscription_status="active")
+        is True
+    )
+    assert (
+        entitlements_service.site_analytics_entitled(plan_tier="free", subscription_status="active")
+        is False
+    )
+
+
+def test_the_response_defaults_refuse_rather_than_grant():
+    """Every capability on ``SiteEntitlementsResponse`` defaults to the REFUSING
+    direction, so a partially-populated response can never hand out a capability by
+    omission. This is the only thing standing behind ``analytics``'s default: the
+    single construction site sets it explicitly, so a flipped default would ship
+    unnoticed until the second caller appeared."""
+    from pocketpaw_ee.sites.dto import SiteEntitlementsResponse
+
+    bare = SiteEntitlementsResponse(site_id="s1")
+
+    assert bare.analytics is False
+    assert bare.custom_domain is False
+    assert bare.concierge_entitled is False
+    assert bare.subscription_active is False
+    assert bare.badge_required is True, "the badge default is a requirement, not a grant"

--- a/tests/mutations/sites_analytics_entitlement_field.json
+++ b/tests/mutations/sites_analytics_entitlement_field.json
@@ -1,0 +1,60 @@
+[
+  {
+    "label": "the field stops asking the predicate and grants analytics to everyone",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    analytics = site_analytics_entitled(\n        plan_tier=plan_tier, subscription_status=subscription_status\n    )",
+    "replace": "    analytics = True",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_a_free_site_reports_no_analytics",
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_wire_field_agrees_with_the_predicate_the_publish_seam_reads"
+    ]
+  },
+  {
+    "label": "the field refuses everyone — a paying site sees a greyed-out panel",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    analytics = site_analytics_entitled(\n        plan_tier=plan_tier, subscription_status=subscription_status\n    )",
+    "replace": "    analytics = False",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_a_paid_site_reports_that_its_visitors_may_be_counted",
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_wire_field_agrees_with_the_predicate_the_publish_seam_reads"
+    ]
+  },
+  {
+    "label": "a second copy of the rule appears and reads the tier alone",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    analytics = site_analytics_entitled(\n        plan_tier=plan_tier, subscription_status=subscription_status\n    )",
+    "replace": "    analytics = site_plan_catalog.site_scoped_tier(plan_tier) is not None",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_a_lapsed_paid_site_loses_analytics_though_it_keeps_the_tier",
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_wire_field_agrees_with_the_predicate_the_publish_seam_reads"
+    ]
+  },
+  {
+    "label": "the wire stops echoing the resolver and hardcodes the grant",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        analytics=resolved.analytics,",
+    "replace": "        analytics=True,",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_a_free_site_reports_no_analytics",
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_wire_field_agrees_with_the_predicate_the_publish_seam_reads"
+    ]
+  },
+  {
+    "label": "the response default flips to granting, so an omitted field enables the panel",
+    "file": "ee/pocketpaw_ee/sites/dto.py",
+    "find": "    analytics: bool = False\n    concierge_entitled: bool = False",
+    "replace": "    analytics: bool = True\n    concierge_entitled: bool = False",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_response_defaults_refuse_rather_than_grant"
+    ]
+  },
+  {
+    "label": "the agreement test decays into a tautology — the catalog grants nobody analytics",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    \"site\": frozenset({\"custom_domain\", \"analytics\"}),",
+    "replace": "    \"site\": frozenset({\"custom_domain\"}),",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_cases_are_not_all_the_same_answer"
+    ]
+  }
+]


### PR DESCRIPTION
Fifth slice of visitor analytics for Paw Sites. The dashboard can now find out that a site's plan excludes analytics without asking for the numbers and reading the refusal. **Stacked on #2051.** Merge the base with `--rebase`, not `--squash`.

Plan and design: qbtrix/paw-workspace#184.

## The field

`GET /sites/{site_id}/entitlements` gains `analytics: bool`, resolved off `SiteEntitlements.analytics`, which is new too.

That response type exists for exactly this job: the UI disables a control and says why, instead of offering it and rendering the 402 that comes back. Analytics was the one capability shipping without it, so the panel's only way to learn that a free site cannot have numbers was to request them.

## It calls the predicate rather than restating it

Three seams now answer "may this site's visitors be counted". The publish path decides whether the deployed config carries a counter at all (#2043). The read endpoint decides whether numbers may be served (#2051). This field decides what the dashboard offers.

They must not disagree, and both ways of disagreeing are bad. A site whose publish counted but whose panel is greyed out is a customer paying for a chart they cannot open. The reverse offers a chart that 402s.

So the resolver calls `site_analytics_entitled`, the same function the other two read, rather than the `ANALYTICS_FEATURE in tier.cloudflare_features` it reduces to. That mirrors `max_domained_sites`, which calls `site_domain_allowance` for the same reason. The function stays the predicate. The field is an echo for the one reader that already holds a resolved object.

The test that carries this is the agreement one. It drives the endpoint across eight tier and subscription combinations and asserts the wire value equals the predicate, rather than restating expected booleans. A future edit that reintroduces a second copy of the rule fails there even while it still happens to agree with the catalog.

A second test guards that one from decaying into a tautology. If the catalog ever stopped granting analytics to any tier, all eight cases would agree at `False`, and the agreement test would keep passing while proving nothing.

## It is not the last word, deliberately

The analytics endpoint's own `status` stays authoritative. Entitlement alone cannot separate "your plan does not include this" from "it does, and you have not republished since you upgraded". Those need different sentences and different buttons, and only `Site.analytics_since` separates them. This field is the cheap pre-check that avoids a call. The endpoint is the answer.

## Two smaller things

`SiteEntitlements.analytics` has no default, like every other field on that dataclass. A capability that can be granted by forgetting to mention it is a capability that will eventually be granted by forgetting to mention it. The one existing test that hand-builds that object now states it.

`SiteEntitlementsResponse` fields do have defaults, so a test pins that every one of them refuses rather than grants. That test is the only thing standing behind the new default: the single construction site sets the field explicitly, so a flipped default would ship unnoticed until a second caller appeared.

## Verification

```
uv run pytest tests/ee/sites tests/cloud/sites tests/cloud/entitlements -p no:cacheprovider -q
1846 passed, 4 skipped in 123.04s
```

Mutation sweep: 6 of 6 caught on the new plan. `mutate.py --validate` clean repo-wide at 902 anchors across 72 plans. `ruff check` and `ruff format --check` clean on the changed modules.
