### PR TITLE
Bill the workspaces the spend sweep could not see

### DIFF
--- a/ee/pocketpaw_ee/catalog/admin_client.py
+++ b/ee/pocketpaw_ee/catalog/admin_client.py
@@ -55,6 +55,12 @@
 #   attribution a chat row has. ``spend_log_count`` exists for the sweep's coverage
 #   check: it asks for one row and reads the ``total``, which is how unattributed
 #   spend becomes visible rather than merely uncharged.
+# Updated 2026-09-02 (fix/bill-workspaces-the-sweep-cannot-see): added
+#   ``list_customers`` (GET /customer/list). The spend reads above can only be
+#   aimed at a customer id somebody already knows; every caller got that list from
+#   our OWN provisioning table, so a workspace that spends without a provisioned
+#   key was unreachable by any of them. This asks the PROXY who spent instead,
+#   which is the only source that includes those workspaces.
 
 from __future__ import annotations
 
@@ -398,6 +404,60 @@ class LiteLLMAdminClient:
             page_size=1,
         )
         return total
+
+    async def list_customers(self) -> list[str]:
+        """Every customer id the proxy has recorded spend against.
+
+        ``GET /customer/list``. A customer is what LiteLLM calls the ``user`` field
+        on a request body, which for us is the workspace that should pay — so this
+        is the proxy's own answer to "who has been spending", independent of
+        anything we provisioned.
+
+        That independence is the point. Every other spend read here takes a
+        customer id or a virtual key from the caller, and the only list of those we
+        kept was our provisioning table. A workspace that never minted a key is
+        absent from that table, so its spend was unreadable and therefore unbilled,
+        while the coverage check reported it as untagged. Both symptoms came from
+        asking ourselves who the tenants were instead of asking the proxy.
+
+        Ids only. The endpoint also returns a lifetime ``spend`` per customer, but
+        that is a running total the proxy never resets, so billing off it would
+        re-charge history on every sweep; the per-window row reads stay the source
+        of truth for money.
+        """
+        async with self._client() as client:
+            resp = await client.get(f"{self._base_url}/customer/list")
+
+        # This route answers with a bare JSON list, not the ``{"data": [...]}``
+        # envelope the /spend routes use.
+        if resp.status_code // 100 != 2:
+            raise LiteLLMAdminError(f"LiteLLM admin /customer/list returned {resp.status_code}")
+        try:
+            body = resp.json()
+        except Exception as exc:
+            raise LiteLLMAdminError(
+                "LiteLLM admin /customer/list returned a malformed body"
+            ) from exc
+
+        if isinstance(body, list):
+            rows: list[Any] = body
+        elif isinstance(body, dict) and isinstance(body.get("data"), list):
+            rows = body["data"]
+        else:
+            return []
+
+        customers: list[str] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            # ``user_id`` is LiteLLM's column name for the customer id. Blank ids
+            # are dropped rather than passed on: an empty string is a legal Mongo
+            # query that matches no workspace, so it would read as a tenant with
+            # no spend forever instead of as the malformed row it is.
+            cid = str(row.get("user_id") or "").strip()
+            if cid:
+                customers.append(cid)
+        return customers
 
     async def delete_keys(self, keys: list[str]) -> dict[str, Any]:
         """POST /key/delete — revoke the given virtual keys. Used by the live-check

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
@@ -38,6 +38,14 @@
 # tenant never wedges the whole sweep — the same isolation the BC-3 sweep uses.
 #
 # Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new entity.
+# Updated 2026-09-02 (fix/bill-workspaces-the-sweep-cannot-see): the sweep now
+#   iterates ``list_sweepable_workspaces`` — provisioned tenants UNION the
+#   workspaces the proxy has customer spend for. It iterated provisioned tenants
+#   alone, and on the deployment where this was caught those two sets did not
+#   overlap at all: three tenants with keys and no spend, three customers with
+#   spend and no keys. Every tick logged ``3/3 tenants -> 0 credits`` and every
+#   chat dollar was free. The coverage remainder is also split now, because it
+#   read as "nobody sent a ``user`` field" while the rows were tagged fine.
 # Updated 2026-09-02 (feat/proxy-spend-ingest-by-customer): added the
 #   attribution-coverage check to both the shadow and live branches, and put
 #   ``unattributed`` in the summary dict so a caller sees it without reading logs.
@@ -85,13 +93,22 @@ async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
         # Spend rows in the trailing window that no swept workspace claims. Zero is
         # the healthy value; anything else is served-and-unbilled compute.
         "unattributed": 0,
+        # The half of ``unattributed`` that names a workspace the sweep skipped —
+        # reported apart because it is a different bug with a different fix, and
+        # because the two were one number for the hours it took to tell them apart.
+        "unswept": 0,
     }
 
     if resolved == "off":
         # Nothing to do — BC-3 bills as today.
         return summary
 
-    workspaces = await provisioning_service.list_provisioned_workspaces()
+    # Every workspace with spend, not just every workspace with a KEY. Chat sends
+    # the deployment key and names its workspace in the request body, so a tenant
+    # can spend forever without ever appearing in the provisioning table — and did:
+    # the swept set and the spending set were completely disjoint in production
+    # while this read ``list_provisioned_workspaces``.
+    workspaces = await provisioning_service.list_sweepable_workspaces()
     summary["tenants"] = len(workspaces)
 
     # BEFORE the empty-tenant early return, deliberately. A deployment with no
@@ -99,11 +116,11 @@ async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
     # failure this check exists for, and returning first would be the one case
     # where it says nothing.
     coverage_until = datetime.now(UTC)
-    summary["unattributed"] = (
-        await provisioning_service.spend_attribution_coverage(
-            workspaces, since=coverage_until - _SHADOW_WINDOW, until=coverage_until
-        )
-    ).unattributed_rows
+    coverage = await provisioning_service.spend_attribution_coverage(
+        workspaces, since=coverage_until - _SHADOW_WINDOW, until=coverage_until
+    )
+    summary["unattributed"] = coverage.unattributed_rows
+    summary["unswept"] = coverage.unswept_rows
 
     if not workspaces:
         return summary
@@ -153,13 +170,15 @@ async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
                 )
         logger.info(
             "run_cutover_sweep[live]: ingested spend for %d/%d tenants -> %d credits, "
-            "%d failed, %d unattributed row(s) in the trailing window "
+            "%d failed, %d unattributed row(s) in the trailing window (%d of them "
+            "naming a workspace nobody swept) "
             "(LiteLLM is the sole meter; BC-3 gated off)",
             summary["processed"],
             summary["tenants"],
             summary["credits"],
             summary["failed"],
             summary["unattributed"],
+            summary["unswept"],
         )
         return summary
 

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
@@ -37,6 +37,10 @@
 # ``SpendReconciliation`` — the value object returned by the shadow-mode compare
 # (``service.reconcile_tenant_spend``). Distinct from the Beanie doc of the same
 # concept; this is the framework-free shape the sweep logs + the doc is built from.
+# Updated 2026-09-02 (fix/bill-workspaces-the-sweep-cannot-see): ``SpendCoverage``
+# now splits its remainder into rows that name an unswept workspace and rows that
+# name none, and carries the unswept ids. One number could not tell an operator
+# which of two unrelated bugs they had.
 # Updated 2026-09-02 (feat/proxy-spend-ingest-by-customer): added ``SpendCoverage``
 # — what ``service.spend_attribution_coverage`` returns. It exists because the bug
 # that motivated this branch was invisible: chat spend was attributed to nobody, the
@@ -155,8 +159,19 @@ class SpendCoverage:
 
     ``total_rows`` is every spend row the proxy recorded in the window;
     ``attributed_rows`` is the sum of the per-tenant counts over the workspaces
-    checked. ``unattributed_rows`` is the remainder — requests that reached the
-    proxy carrying no workspace, or one nobody is sweeping.
+    checked. ``unattributed_rows`` is the remainder, and it has two very different
+    halves that this object now reports apart:
+
+      * ``unswept_rows`` — rows that DO name a workspace, but one the sweep was
+        not iterating. The request was tagged correctly and the bug is on our
+        side of the wire.
+      * the rest — rows carrying no workspace at all, which is the failure the
+        request-tagging exists to prevent.
+
+    They were one number until 2026-09-02, and conflating them cost real
+    debugging time: the log line blamed missing ``user`` fields while a third of
+    the window was tagged and simply unswept. A fix for one does nothing for the
+    other, so an operator has to be able to tell which they are looking at.
 
     Any non-zero remainder is a billing hole, and reading it as a ROW count rather
     than a dollar amount is deliberate: a count needs one cheap request per tenant
@@ -174,8 +189,13 @@ class SpendCoverage:
     total_rows: int
     attributed_rows: int
     unattributed_rows: int
-    workspaces_checked: int
-    degraded: bool
+    # The half of ``unattributed_rows`` that names a workspace the sweep skipped.
+    # ``unswept_workspaces`` lists those ids so the log can name them; an operator
+    # who can see the id can go and ask why it is not being swept.
+    unswept_rows: int = 0
+    unswept_workspaces: tuple[str, ...] = ()
+    workspaces_checked: int = 0
+    degraded: bool = False
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -78,6 +78,34 @@
 #      is now strict ``<`` with the ``litellm:{request_id}`` ledger dedup as the
 #      exactly-once guard at the boundary. See the inline note at the loop.
 #
+# Updated 2026-09-02 (fix/bill-workspaces-the-sweep-cannot-see): the previous entry
+# made a chat run's spend READABLE. This one makes it reachable, because nothing
+# was asking for it.
+#
+# The sweep's tenant list was ``list_provisioned_workspaces`` — the workspaces we
+# minted a virtual key for. Chat needs no such key: it authenticates with the
+# deployment key and names its workspace in the request body. So the set of
+# workspaces that spend and the set we swept were free to drift apart, and on the
+# deployment where this surfaced they had drifted completely: three provisioned
+# tenants with no proxy spend, three spending customers with no provisioned key,
+# zero overlap. Every tick read three empty tenants, reported
+# ``3/3 tenants -> 0 credits``, and gave the chat away.
+#
+#   * ``list_sweepable_workspaces`` — the union of the provisioned tenants and the
+#     customers the PROXY reports. Asking the proxy who spent is the only way to
+#     learn about a workspace our own tables never recorded.
+#   * ``ingest_tenant_spend`` bills a keyless workspace instead of returning zero.
+#     ``_spend_bookkeeping_row`` gives it a row to hold the high-water mark, and
+#     ``ensure_tenant_key`` fills that same row in if a key is minted later rather
+#     than colliding with it on the UNIQUE index.
+#   * ``spend_attribution_coverage`` splits its remainder into rows naming an
+#     unswept workspace and rows naming nobody. It reported both as "no ``user``
+#     field", which is how this bug hid behind a diagnostic written to catch it.
+#
+# The discovery path checks every id against a real ``Workspace`` before billing
+# it: the value reaches us from a request body, and the cost of trusting it is a
+# ledger debit against a tenant that does not exist.
+#
 # Updated 2026-09-02 (feat/proxy-spend-ingest-by-customer): ``ingest_tenant_spend``
 # now reads a tenant's spend BY CUSTOMER as well as by virtual key.
 #
@@ -357,6 +385,98 @@ async def list_provisioned_workspaces() -> list[str]:
     return [d.workspace for d in docs if d.litellm_key]
 
 
+async def _existing_workspace_ids(candidates: list[str]) -> set[str]:
+    """Which of ``candidates`` are real workspaces. Bogus / deleted ids drop out.
+
+    The candidates come off the proxy's customer list, which is ultimately a
+    caller-supplied string: whatever a request put in its ``user`` field became a
+    customer. Everything ours puts there is a workspace id, but "ours" is an
+    assumption about a value that crossed the wire, and the consequence of
+    trusting it is a credit-ledger debit against a workspace that does not exist.
+    So it is checked rather than assumed.
+
+    Reaches into the ``Workspace`` doc, which belongs to the workspace entity, for
+    a single bulk existence read. The alternative — a public helper over there —
+    would be the tidier boundary, but this module is the only caller and the
+    import is lazy so the two services still load independently.
+    """
+    if not candidates:
+        return set()
+
+    from bson import ObjectId
+    from bson.errors import InvalidId
+
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    by_oid: dict[ObjectId, str] = {}
+    for raw in candidates:
+        try:
+            by_oid[ObjectId(raw)] = raw
+        except (InvalidId, TypeError):
+            # Not even shaped like a workspace id. Nothing to sweep, and saying so
+            # once at debug beats a warning per tick for a value we will never bill.
+            logger.debug(
+                "llm_provisioning: proxy customer %r is not a workspace id — skipping",
+                raw,
+            )
+    if not by_oid:
+        return set()
+
+    docs = await Workspace.find({"_id": {"$in": list(by_oid)}}).to_list()
+    return {by_oid[d.id] for d in docs if d.id in by_oid}
+
+
+async def list_sweepable_workspaces(*, admin_client: LiteLLMAdminClient | None = None) -> list[str]:
+    """Every workspace the spend sweep should visit this tick.
+
+    The union of two sources, because neither one alone is the set of tenants that
+    owe money:
+
+      * the workspaces we PROVISIONED a virtual key for — spend that arrives
+        attributed to that key, which is Studio and the media server; and
+      * the workspaces the PROXY has recorded a customer for — spend that arrives
+        attributed to the request's ``user`` field, which is chat.
+
+    Only the first was swept until 2026-09-02, and a workspace can spend its whole
+    life without appearing in it: chat authenticates with the deployment key and
+    never needs a tenant key at all. On the deployment where this was found, the
+    three provisioned tenants had no proxy spend and the three spending customers
+    had no provisioned key — the two sets were disjoint, every sweep reported
+    ``3/3 tenants -> 0 credits``, and every real dollar of chat was free.
+
+    The proxy half is best-effort: if that call fails we sweep the provisioned
+    tenants alone rather than skipping the tick, which is the same partial-outage
+    rule the two spend reads follow. It fails toward the old behaviour, which
+    under-bills — the safe direction for a mistake that moves money.
+    """
+    provisioned = await list_provisioned_workspaces()
+    client = admin_client if admin_client is not None else LiteLLMAdminClient()
+
+    try:
+        customers = await client.list_customers()
+    except Exception:
+        logger.exception(
+            "llm_provisioning.list_sweepable_workspaces: could not read the proxy's "
+            "customer list — sweeping the %d provisioned tenant(s) alone this tick. "
+            "Spend from any UNPROVISIONED workspace goes unbilled until this recovers",
+            len(provisioned),
+        )
+        return provisioned
+
+    known = set(provisioned)
+    discovered = await _existing_workspace_ids([c for c in customers if c not in known])
+    if discovered:
+        logger.info(
+            "llm_provisioning.list_sweepable_workspaces: %d workspace(s) have proxy "
+            "spend but no provisioned key — sweeping them too: %s",
+            len(discovered),
+            ", ".join(sorted(discovered)),
+        )
+    # Provisioned order first, then the discovered ids sorted, so the sweep's
+    # per-tenant logging is stable tick to tick.
+    return provisioned + sorted(discovered)
+
+
 async def prepare_spend_cutover(
     *,
     at: datetime | None = None,
@@ -478,6 +598,29 @@ async def ensure_tenant_key(
     if not isinstance(key, str) or not key:
         raise LiteLLMAdminError("LiteLLM /key/generate returned no key")
 
+    # A KEYLESS row already exists when the spend sweep discovered this workspace
+    # on the proxy before anything minted it a key. Fill that row in rather than
+    # inserting beside it: ``workspace`` is UNIQUE, so an insert would collide and
+    # be re-raised as a provisioning failure, and the row carries this tenant's
+    # ``last_spend_ingest_ts`` — replacing it would rewind the high-water mark and
+    # re-read spend the ledger has already been charged for.
+    if existing is not None:
+        existing.litellm_key = key
+        existing.key_alias = alias
+        existing.max_budget_usd = card.max_budget_usd
+        existing.budget_duration = card.budget_duration
+        existing.rpm_limit = card.rpm_limit
+        existing.tpm_limit = card.tpm_limit
+        existing.models = list(card.models)
+        await existing.save()
+        logger.info(
+            "llm_provisioning.ensure_tenant_key: workspace=%s minted a key onto the row "
+            "the spend sweep had already created (alias=%s)",
+            workspace,
+            alias,
+        )
+        return ProvisionResult(workspace_id=workspace, litellm_key=key, created=True)
+
     # Persist the mapping. Upsert-on-insert with the unique ``workspace`` index as
     # the concurrency guard: if a racing call minted + inserted first, our insert
     # collides — we swallow it and re-read the winner so we never store two rows
@@ -507,6 +650,14 @@ async def ensure_tenant_key(
             return ProvisionResult(
                 workspace_id=workspace, litellm_key=winner.litellm_key, created=False
             )
+        if winner is not None:
+            # The racer was the spend sweep creating a KEYLESS bookkeeping row, not
+            # another mint. Nobody has a key yet, so ours wins the row rather than
+            # being thrown away with a provisioning error.
+            winner.litellm_key = key
+            winner.key_alias = alias
+            await winner.save()
+            return ProvisionResult(workspace_id=workspace, litellm_key=key, created=True)
         # Not a duplicate-key collision — re-raise so the caller sees the real error.
         raise LiteLLMAdminError(f"persisting tenant key failed: {exc}") from exc
 
@@ -578,6 +729,54 @@ def _customer_read_window(doc: LiteLLMTenantKey, *, now: datetime) -> tuple[date
         return mark - _SPEND_READ_OVERLAP, now
     created = _as_aware(doc.createdAt)
     return (created if created is not None else now - _SPEND_READ_OVERLAP), now
+
+
+async def _spend_bookkeeping_row(workspace: str) -> LiteLLMTenantKey:
+    """This tenant's spend row, created keyless if provisioning never ran.
+
+    The row's job here is to hold ``last_spend_ingest_ts``. That mark is what
+    bounds the customer-scoped read and lets it advance, and a workspace with
+    nowhere to store it cannot be swept twice without re-reading its whole
+    history.
+
+    Creating one for an UNPROVISIONED workspace is the fix for a hole that made
+    real spend unbillable. Chat authenticates with the deployment key and names
+    its workspace in the request body, so a workspace can spend for its entire
+    life without ever minting a virtual key. ``ingest_tenant_spend`` used to
+    return a zero result for exactly those workspaces, and the sweep only ever
+    passed it workspaces that HAD a key, so their spend was read by nobody while
+    the coverage check reported it as untagged. Both readings were wrong in the
+    same direction: the spend was tagged, and free.
+
+    The new row carries no key, so ``list_provisioned_workspaces`` still excludes
+    it and ``ensure_tenant_key`` still mints on the same row later (it upserts on
+    ``workspace``). Its ``createdAt`` becomes the read window's start, which means
+    the first sweep after discovery bills forward from now and never reaches back
+    into spend some other meter already charged — the same guarantee
+    ``prepare_spend_cutover`` gives a provisioned tenant.
+    """
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+    if doc is not None:
+        return doc
+
+    doc = LiteLLMTenantKey(workspace=workspace, litellm_key=None)
+    try:
+        await doc.insert()
+    except Exception:
+        # The UNIQUE index on ``workspace`` is the arbiter: a concurrent sweep or
+        # a mint that landed between the read and this insert wins, and we re-read
+        # rather than raise. Losing this race is not an error — both racers wanted
+        # the same row to exist.
+        logger.debug(
+            "llm_provisioning: lost the create race for the spend row of workspace=%s "
+            "— re-reading the winner",
+            workspace,
+        )
+        existing = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+        if existing is None:
+            raise
+        return existing
+    return doc
 
 
 async def _read_tenant_spend_rows(
@@ -680,24 +879,14 @@ async def ingest_tenant_spend(
     NOTE: this is the GATED half (see the module header's double-bill boundary).
     The caller decides whether to run it — this function does NOT check the flag,
     so it stays reusable by an explicit admin trigger even when the periodic sweep
-    is off. A workspace with no provisioned key returns a zero result (nothing to
-    ingest) rather than raising.
+    is off. A workspace with no provisioned key is billed the same way as one with
+    a key: only the per-KEY half of the read is skipped, because the customer-
+    scoped half needs no key. It used to return a zero result instead, which is
+    how workspaces that spend on chat alone were served for free.
     """
     _require_workspace(workspace)
 
-    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
-    if doc is None or not doc.litellm_key:
-        # Not provisioned — nothing to ingest. Return the current balance so the
-        # caller has a consistent shape.
-        return SpendIngestResult(
-            workspace_id=workspace,
-            rows_read=0,
-            rows_billed=0,
-            credits_debited=0,
-            cost_usd=0.0,
-            cached_tokens=0,
-            balance_after=await credits_service.balance(workspace),
-        )
+    doc = await _spend_bookkeeping_row(workspace)
 
     card = spend_card if spend_card is not None else load_spend_credits()
     client = admin_client if admin_client is not None else LiteLLMAdminClient()
@@ -1072,12 +1261,58 @@ async def spend_attribution_coverage(
     # one would train an operator to ignore the number.
     unattributed = max(0, total_rows - attributed_rows)
 
+    # Split the remainder. Rows that name a workspace nobody swept are a different
+    # bug from rows that name nobody, and until they were separated the log line
+    # blamed the wrong one: it advertised "no ``user`` field" while a third of the
+    # window was tagged and merely unswept. Asking the proxy for its customer list
+    # is what makes the distinction possible at all — a customer id is by
+    # definition one some request DID carry.
+    unswept_rows = 0
+    unswept: list[str] = []
+    swept = set(workspaces)
+    try:
+        customers = await client.list_customers()
+    except Exception:
+        degraded = True
+        customers = []
+        logger.exception(
+            "llm_provisioning.spend_attribution_coverage: could not list the proxy's "
+            "customers — the remainder cannot be split this tick, so all %d of it "
+            "reads as untagged whether or not it is",
+            unattributed,
+        )
+    for customer in customers:
+        if customer in swept:
+            continue
+        try:
+            rows = await client.spend_log_count(
+                start_date=start_date, end_date=end_date, end_user=customer
+            )
+        except Exception:
+            degraded = True
+            logger.exception(
+                "llm_provisioning.spend_attribution_coverage: could not count rows for "
+                "unswept customer=%s — coverage is unknown this tick, NOT clean",
+                customer,
+            )
+            continue
+        if rows:
+            unswept_rows += rows
+            unswept.append(customer)
+
+    # Bounded by the remainder for the same reason it is clamped at zero: the two
+    # sides are separate queries, and a split that claimed more unswept rows than
+    # there are unattributed ones would be reporting a race as a finding.
+    unswept_rows = min(unswept_rows, unattributed)
+
     coverage = SpendCoverage(
         window_start=start_date,
         window_end=end_date,
         total_rows=total_rows,
         attributed_rows=attributed_rows,
         unattributed_rows=unattributed,
+        unswept_rows=unswept_rows,
+        unswept_workspaces=tuple(unswept),
         workspaces_checked=len(workspaces),
         degraded=degraded,
     )
@@ -1097,13 +1332,17 @@ async def spend_attribution_coverage(
     elif unattributed:
         logger.warning(
             "llm_provisioning.spend_attribution_coverage: [%s,%s] %d of %d proxy spend "
-            "row(s) belong to NO swept workspace — that spend is being served and not "
-            "billed. Usual cause: requests reaching the proxy without a ``user`` field "
-            "naming the workspace",
+            "row(s) are being served and not billed — %d name a workspace the sweep "
+            "did not visit (%s), %d name no workspace at all. A tagged-but-unswept "
+            "row is OUR bug: the request said who pays and the sweep did not ask. An "
+            "untagged row is a caller reaching the proxy without a ``user`` field",
             start_date,
             end_date,
             unattributed,
             total_rows,
+            unswept_rows,
+            ", ".join(unswept) or "none",
+            unattributed - unswept_rows,
         )
     else:
         logger.info(
@@ -1123,6 +1362,7 @@ __all__ = [
     "get_tenant_key",
     "ingest_tenant_spend",
     "list_provisioned_workspaces",
+    "list_sweepable_workspaces",
     "load_key_budget",
     "load_spend_credits",
     "prepare_spend_cutover",

--- a/ee/pocketpaw_ee/cloud/models/litellm_key.py
+++ b/ee/pocketpaw_ee/cloud/models/litellm_key.py
@@ -59,7 +59,18 @@ class LiteLLMTenantKey(TimestampedDocument):
     # The proxy virtual key (the ``key`` from POST /key/generate). Sent as the
     # Bearer token on this tenant's proxy calls so the proxy attributes spend +
     # enforces the budget.
-    litellm_key: str
+    #
+    # OPTIONAL since 2026-09-02 (fix/bill-workspaces-the-sweep-cannot-see). A row
+    # is now also created for a workspace the SPEND sweep discovered on the proxy
+    # but that never minted a key — the row exists to hold that tenant's
+    # ``last_spend_ingest_ts``, which is what makes its spend billable exactly
+    # once. Every reader already coped with a missing key
+    # (``list_provisioned_workspaces`` filters on ``!= None``, the per-key spend
+    # read is guarded by ``if doc.litellm_key``), so this aligns the schema with
+    # code that was already written for it rather than loosening a guarantee.
+    # ``ensure_tenant_key`` upserts on ``workspace``, so a later mint fills this
+    # in on the same row instead of colliding with it.
+    litellm_key: str | None = None
     # The alias the proxy stamped on the key (``ws-<workspace>``) — for operator
     # legibility in the proxy admin UI / spend logs.
     key_alias: str | None = None

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -74,8 +74,15 @@ Beanie-writes-only-from-service contract.
 per-tenant LiteLLM key provisioning trigger — a BEST-EFFORT, NON-BLOCKING
 ensure_tenant_key(workspace) call. A proxy outage / mint failure is logged and
 swallowed (workspace creation NEVER fails on a provisioning error); the call is
-idempotent, so the billing-cutover sweep and any later workspace touch back-fill
-a key that didn't mint here. Mirrors the best-effort seed_default_agent step.
+idempotent, so a later workspace touch can mint a key that didn't mint here.
+Mirrors the best-effort seed_default_agent step.
+2026-09-02 (fix/bill-workspaces-the-sweep-cannot-see): the note above used to say
+the billing-cutover sweep back-filled a key that failed to mint here. It never
+did — the sweep started from the workspaces that ALREADY had one, so a swallowed
+mint failure meant a workspace nothing swept, and its chat spend was served free.
+The sweep now discovers such a workspace from the proxy's customer list and bills
+it without a key, so a failed mint costs the tenant their per-key budget ceiling
+rather than costing us the entire bill. Minting is still not retried here.
 2026-07-05 (fix/atlas-admin-security-hardening, FINDING A): privilege-escalation
 guard on ownership. ``update_member_role`` now refuses to GRANT the ``owner``
 role unless the ACTOR already holds owner (code ``owner_grant_requires_owner``),

--- a/tests/cloud/llm_provisioning/test_spend_by_customer.py
+++ b/tests/cloud/llm_provisioning/test_spend_by_customer.py
@@ -57,6 +57,10 @@ class FakeAdmin:
 
     ``counts`` drives the coverage check: ``None`` is the unfiltered total, a
     workspace id its own count.
+
+    ``customers`` is what ``/customer/list`` returns — every id the proxy has seen
+    spend for, whether or not we ever minted that workspace a key. It is the only
+    source that knows about a workspace which pays for chat and nothing else.
     """
 
     def __init__(
@@ -65,15 +69,19 @@ class FakeAdmin:
         key_rows: list[dict] | None = None,
         customer_rows: list[dict] | None = None,
         counts: dict[str | None, int] | None = None,
+        customers: list[str] | None = None,
         fail_customer_read: bool = False,
         fail_key_read: bool = False,
+        fail_customer_list: bool = False,
         fail_counts_for: set[str | None] | None = None,
     ) -> None:
         self.key_rows = key_rows or []
         self.customer_rows = customer_rows or []
         self.counts = counts or {}
+        self.customers = customers or []
         self.fail_customer_read = fail_customer_read
         self.fail_key_read = fail_key_read
+        self.fail_customer_list = fail_customer_list
         self.fail_counts_for = fail_counts_for or set()
         self.windows: list[tuple[str, str]] = []
         self.count_calls: list[str | None] = []
@@ -97,6 +105,11 @@ class FakeAdmin:
         if end_user in self.fail_counts_for:
             raise LiteLLMAdminError("count failed (simulated)")
         return self.counts.get(end_user, 0)
+
+    async def list_customers(self):
+        if self.fail_customer_list:
+            raise LiteLLMAdminError("customer list failed (simulated)")
+        return list(self.customers)
 
 
 async def _provision(workspace: str = WS) -> LiteLLMTenantKey:

--- a/tests/cloud/llm_provisioning/test_unswept_workspace_spend.py
+++ b/tests/cloud/llm_provisioning/test_unswept_workspace_spend.py
@@ -1,0 +1,286 @@
+# tests/cloud/llm_provisioning/test_unswept_workspace_spend.py — proves the sweep
+# bills a workspace that spends without ever having been provisioned a key.
+#
+# THE BUG. Chat authenticates to the proxy with the DEPLOYMENT's key and names the
+# paying workspace in the request body's ``user`` field, so a workspace never needs
+# a virtual key of its own to run up a bill. The cutover sweep, though, built its
+# tenant list from ``list_provisioned_workspaces`` — the workspaces that HAVE a
+# key. On the deployment where this was caught the two sets did not intersect at
+# all: three provisioned tenants with no proxy spend, and three spending customers
+# with no provisioned key. Every tick logged a confident
+# ``ingested spend for 3/3 tenants -> 0 credits`` and served every chat dollar
+# free, while the attribution-coverage check reported the tagged rows as though
+# nobody had sent a ``user`` field at all.
+#
+# Two independent failures, so these are written against both shapes:
+#
+#   * the sweep must VISIT a workspace the proxy has spend for, and
+#     ``ingest_tenant_spend`` must bill one that holds no key (it used to return a
+#     zero result and stop);
+#   * the coverage check must SEPARATE rows that name an unswept workspace from
+#     rows that name none, because a tagged-but-unswept row is our bug and an
+#     untagged row is the caller's, and the old single number sent the reader
+#     after the wrong one.
+#
+# Plus the guards that keep the discovery path from doing harm: an id the proxy
+# reports that is not a real workspace must never reach the credit ledger, and a
+# proxy that cannot answer must degrade to the OLD behaviour (under-bill) rather
+# than to a wrong one.
+#
+# Uses the shared ``mongo_db`` + autouse ``recording_bus`` fixtures from
+# tests/cloud/conftest.py, and the ``FakeAdmin`` proxy stand-in from
+# test_spend_by_customer.py.
+#
+# Created 2026-09-02 (fix/bill-workspaces-the-sweep-cannot-see): new test module.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.llm_provisioning import cutover_sweeper
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+from pocketpaw_ee.cloud.models.workspace import Workspace
+
+from tests.cloud.llm_provisioning.test_spend_by_customer import FakeAdmin, _row
+
+# Pinned so credits never depend on ambient settings: round(usd * 250).
+SPEND = SpendCredits(markup=2.5, credit_usd=0.01)
+
+
+async def _workspace(slug: str) -> str:
+    """A real workspace row, returning its id as the proxy would report it.
+
+    The id has to be a genuine Mongo id rather than a readable label, because the
+    discovery path deliberately refuses to bill an id that names no workspace —
+    which is exactly what a hand-written ``"ws_alpha"`` is.
+    """
+    doc = Workspace(name=slug, slug=slug, owner="u_owner")
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _credits(workspace: str) -> int:
+    """Credits actually debited to this wallet. ``amount_delta`` is signed."""
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == workspace).to_list()
+    return -sum(e.amount_delta for e in entries if e.amount_delta < 0)
+
+
+# ===========================================================================
+# The bug: a workspace that spends without a key.
+# ===========================================================================
+
+
+async def test_an_unprovisioned_workspace_with_proxy_spend_is_billed(mongo_db):
+    """The whole bug in one test: spend, no key, and the sweep must still bill it."""
+    ws = await _workspace("pays-for-chat-only")
+    admin = FakeAdmin(customer_rows=[_row("chat-1", usd=0.04)], customers=[ws])
+
+    result = await provisioning.ingest_tenant_spend(ws, spend_card=SPEND, admin_client=admin)
+
+    assert result.rows_billed == 1
+    assert result.credits_debited == 10
+    assert await _credits(ws) == 10
+
+
+async def test_the_sweep_visits_a_workspace_it_never_provisioned(mongo_db):
+    """``list_sweepable_workspaces`` is the union, not the provisioning table."""
+    spender = await _workspace("spender-no-key")
+    await provisioning.ensure_tenant_key(
+        "ws_with_a_key", budget=KeyBudget(), admin_client=FakeAdmin()
+    )
+    admin = FakeAdmin(customers=[spender])
+
+    sweepable = await provisioning.list_sweepable_workspaces(admin_client=admin)
+
+    assert "ws_with_a_key" in sweepable, "a provisioned tenant must still be swept"
+    assert spender in sweepable, "a spending workspace with no key must now be swept too"
+
+
+async def test_a_keyless_workspace_gets_a_row_to_hold_its_high_water_mark(mongo_db):
+    """The discovered tenant needs somewhere to record what it already paid for."""
+    ws = await _workspace("needs-bookkeeping")
+    admin = FakeAdmin(customer_rows=[_row("chat-1")], customers=[ws])
+
+    await provisioning.ingest_tenant_spend(ws, spend_card=SPEND, admin_client=admin)
+
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == ws)
+    assert doc is not None, "no row means the next sweep re-reads this tenant's history"
+    assert doc.litellm_key is None, "discovery must not fake a key it never minted"
+    assert doc.last_spend_ingest_ts is not None, "the mark is the point of the row"
+
+
+async def test_the_keyless_row_does_not_pretend_to_be_provisioned(mongo_db):
+    """A discovered tenant must not show up as one we minted a key for."""
+    ws = await _workspace("discovered-not-provisioned")
+    admin = FakeAdmin(customer_rows=[_row("chat-1")], customers=[ws])
+
+    await provisioning.ingest_tenant_spend(ws, spend_card=SPEND, admin_client=admin)
+
+    assert await provisioning.list_provisioned_workspaces() == []
+
+
+async def test_minting_a_key_later_reuses_the_discovered_row(mongo_db):
+    """``workspace`` is UNIQUE, so discovery must not block a later real mint."""
+    ws = await _workspace("discovered-then-minted")
+    admin = FakeAdmin(customer_rows=[_row("chat-1")], customers=[ws])
+    await provisioning.ingest_tenant_spend(ws, spend_card=SPEND, admin_client=admin)
+
+    await provisioning.ensure_tenant_key(ws, budget=KeyBudget(), admin_client=FakeAdmin())
+
+    docs = await LiteLLMTenantKey.find(LiteLLMTenantKey.workspace == ws).to_list()
+    assert len(docs) == 1, "a second row would split this tenant's high-water mark in two"
+    assert docs[0].litellm_key, "the mint has to land on the row discovery created"
+
+
+async def test_a_second_sweep_does_not_bill_the_same_row_twice(mongo_db):
+    """Discovery must not reset exactly-once billing for the tenant it found."""
+    ws = await _workspace("swept-twice")
+    admin = FakeAdmin(customer_rows=[_row("chat-1", usd=0.04)], customers=[ws])
+
+    await provisioning.ingest_tenant_spend(ws, spend_card=SPEND, admin_client=admin)
+    again = await provisioning.ingest_tenant_spend(ws, spend_card=SPEND, admin_client=admin)
+
+    assert again.credits_debited == 0
+    assert await _credits(ws) == 10
+
+
+# ===========================================================================
+# Guards: discovery must not bill things that are not tenants.
+# ===========================================================================
+
+
+async def test_a_customer_id_that_is_no_workspace_is_never_swept(mongo_db):
+    """The ``user`` field crossed the wire, so an id off it is checked, not trusted."""
+    real = await _workspace("a-real-one")
+    ghost = "6a1210f462bf55588dee1d4f"  # correctly shaped, and no such workspace
+    admin = FakeAdmin(customers=[real, ghost])
+
+    sweepable = await provisioning.list_sweepable_workspaces(admin_client=admin)
+
+    assert real in sweepable
+    assert ghost not in sweepable, "a debit here invents a wallet for a tenant that never existed"
+
+
+async def test_a_malformed_customer_id_is_skipped_not_raised(mongo_db):
+    """A junk id must not take the whole sweep down with it."""
+    real = await _workspace("survives-the-junk")
+    admin = FakeAdmin(customers=["not-an-object-id", "", real])
+
+    sweepable = await provisioning.list_sweepable_workspaces(admin_client=admin)
+
+    assert sweepable == [real]
+
+
+async def test_a_dead_customer_list_falls_back_to_the_provisioned_tenants(mongo_db):
+    """A proxy that cannot answer must degrade to under-billing, not to guessing."""
+    await provisioning.ensure_tenant_key(
+        "ws_provisioned", budget=KeyBudget(), admin_client=FakeAdmin()
+    )
+    admin = FakeAdmin(fail_customer_list=True)
+
+    sweepable = await provisioning.list_sweepable_workspaces(admin_client=admin)
+
+    assert sweepable == ["ws_provisioned"]
+
+
+# ===========================================================================
+# The second failure: the coverage check blamed the wrong thing.
+# ===========================================================================
+
+
+async def test_coverage_separates_an_unswept_workspace_from_an_untagged_row(mongo_db):
+    """10 rows: 2 attributed, 5 tagged to a workspace nobody sweeps, 3 tagged to nobody."""
+    unswept = "6a146169ad1f4c4decb828f4"
+    admin = FakeAdmin(
+        counts={None: 10, "ws_swept": 2, unswept: 5},
+        customers=["ws_swept", unswept],
+    )
+
+    coverage = await provisioning.spend_attribution_coverage(
+        ["ws_swept"],
+        since=_since(),
+        until=_until(),
+        admin_client=admin,
+    )
+
+    assert coverage.unattributed_rows == 8
+    assert coverage.unswept_rows == 5, "these rows named who pays and we did not look"
+    assert coverage.unswept_workspaces == (unswept,)
+    assert coverage.unattributed_rows - coverage.unswept_rows == 3
+    assert coverage.degraded is False
+
+
+async def test_coverage_reports_no_unswept_rows_when_every_customer_is_swept(mongo_db):
+    admin = FakeAdmin(counts={None: 10, "ws_swept": 7}, customers=["ws_swept"])
+
+    coverage = await provisioning.spend_attribution_coverage(
+        ["ws_swept"], since=_since(), until=_until(), admin_client=admin
+    )
+
+    assert coverage.unattributed_rows == 3
+    assert coverage.unswept_rows == 0
+    assert coverage.unswept_workspaces == ()
+
+
+async def test_an_unreadable_customer_list_is_degraded_not_a_clean_split(mongo_db):
+    """ "Could not split" and "nothing to split" must not look identical."""
+    admin = FakeAdmin(counts={None: 10, "ws_swept": 7}, fail_customer_list=True)
+
+    coverage = await provisioning.spend_attribution_coverage(
+        ["ws_swept"], since=_since(), until=_until(), admin_client=admin
+    )
+
+    assert coverage.unattributed_rows == 3
+    assert coverage.unswept_rows == 0
+    assert coverage.degraded is True
+
+
+async def test_the_split_never_exceeds_the_remainder(mongo_db):
+    """Separate queries against a table still being written can disagree."""
+    admin = FakeAdmin(
+        counts={None: 4, "ws_swept": 3, "6a146169ad1f4c4decb828f4": 9},
+        customers=["6a146169ad1f4c4decb828f4"],
+    )
+
+    coverage = await provisioning.spend_attribution_coverage(
+        ["ws_swept"], since=_since(), until=_until(), admin_client=admin
+    )
+
+    assert coverage.unattributed_rows == 1
+    assert coverage.unswept_rows == 1, "a split bigger than the remainder is a race, not a finding"
+
+
+# ===========================================================================
+# End to end through the sweep.
+# ===========================================================================
+
+
+async def test_the_live_sweep_bills_the_workspace_it_had_to_discover(mongo_db, monkeypatch):
+    """The production symptom, inverted: tenants swept, and credits actually move."""
+    ws = await _workspace("live-sweep-discovers-me")
+    admin = FakeAdmin(
+        customer_rows=[_row("chat-1", usd=0.04)],
+        counts={None: 1, ws: 1},
+        customers=[ws],
+    )
+    monkeypatch.setattr(provisioning, "LiteLLMAdminClient", lambda *a, **k: admin)
+
+    summary = await cutover_sweeper.run_cutover_sweep(mode="live")
+
+    assert summary["tenants"] == 1, "the discovered workspace is a tenant to sweep"
+    assert summary["processed"] == 1
+    assert summary["credits"] == 10, "the whole bug was that this stayed at zero"
+    assert summary["unattributed"] == 0
+
+
+def _since():
+    from datetime import UTC, datetime
+
+    return datetime(2026, 9, 2, tzinfo=UTC)
+
+
+def _until():
+    from datetime import UTC, datetime
+
+    return datetime(2026, 9, 3, tzinfo=UTC)


### PR DESCRIPTION
The cutover sweep built its tenant list from the workspaces we had minted a LiteLLM virtual key for. Chat never needs one. It authenticates with the deployment key and names the paying workspace in the request body, so a workspace can spend for its whole life without ever appearing in that table.

On the deployment where this surfaced, the two sets had drifted apart completely: three provisioned tenants with no proxy spend, three spending customers with no provisioned key, and no overlap between them. Every tick read three empty tenants, logged a confident `3/3 tenants -> 0 credits`, and gave the chat away.

## What the proxy actually said

Running the sweep's own query shape against the window it had just reported:

| Query over the sweep's window | Rows |
|---|---|
| Total in window | 33 |
| `end_user=6a146169ad1f4c4decb828f4` | 7 |
| `end_user=6a1210f462bf55588dee1d4f` | 3 |
| Counted as attributed by the sweep | 0 |

Ten of those rows named a workspace, and the same query that found them was already in the sweep. It just never asked about those two ids, because neither is in our provisioning table.

## What changed

- The sweep visits the union of the provisioned tenants and the customers the proxy reports. Asking the proxy who spent is the only way to learn about a workspace our own tables never recorded.
- `ingest_tenant_spend` bills a keyless workspace instead of returning zero. A keyless row holds its high-water mark, so exactly-once billing still holds, and `ensure_tenant_key` fills that same row in if a key is minted later rather than colliding with it on the unique index.
- Every discovered id is checked against a real `Workspace` before it can reach the credit ledger. The value arrives from a request body, and the cost of trusting it is a debit against a tenant that does not exist.
- The coverage check no longer conflates its two halves. It was reporting tagged-but-unswept rows as "requests reaching the proxy without a `user` field", which is a different bug with a different fix, and following that message is how the afternoon went.
- A comment in the workspace service said the sweep back-filled a key that failed to mint. The sweep never did that, so I rewrote the comment to say what actually happens.

## Testing

14 new tests, 12 of which fail on `dev`. One of them reproduces the production log line exactly.

`tests/cloud/llm_provisioning`, `tests/cloud/catalog`, `tests/cloud/credits`: 206 passed.

`tests/cloud/billing`, `entitlements`, `workspace`, `audit`, `growth`: 883 passed, 6 failed. Those same 6 fail on a clean `dev` checkout, so they are not from this branch.
