### PR TITLE
Name the workspace that pays for a proxy search

### DIFF
--- a/src/pocketpaw/tools/builtin/web_search.py
+++ b/src/pocketpaw/tools/builtin/web_search.py
@@ -10,6 +10,16 @@
 # 2026-08-15 (HTN-1): declares a ``narration`` — the reference implementation
 #   for humanized tool narration, so a search reads as "Searching the web for
 #   quarterly filings" instead of the bare tool name.
+# 2026-09-02 (fix/attribute-proxy-search-spend): the 'litellm' provider now names
+#   the paying workspace on the request. It authenticates with the DEPLOYMENT's
+#   key, so every search the agent ran was spend the billing sweep could not
+#   attribute to any tenant — served and never charged, and counted as untagged in
+#   the attribution-coverage check. Completions solved this with the body's
+#   ``user`` field; a search cannot use it, because this body is forwarded to the
+#   search vendor and the vendor rejects unknown fields (measured: Parallel AI
+#   returns ``extra_forbidden`` and the call 500s). The id rides the
+#   ``x-litellm-end-user-id`` header instead, which the proxy consumes and does
+#   not forward.
 
 import logging
 from typing import Any
@@ -248,6 +258,13 @@ class WebSearchTool(BaseTool):
             )
         tool_name = str(getattr(settings, "litellm_search_tool_name", "") or "web_search")
 
+        # The workspace this run bills to, or None outside a cloud chat dispatch.
+        # ``end_user_id_for`` owns the "is this our proxy" decision, and this branch
+        # only runs when the search is going to it.
+        from pocketpaw.agents.spend_attribution import end_user_id_for
+
+        end_user = end_user_id_for("litellm")
+
         try:
             async with httpx.AsyncClient(timeout=30) as client:
                 resp = await client.post(
@@ -257,6 +274,23 @@ class WebSearchTool(BaseTool):
                         # was configured that way; sending an empty bearer is
                         # worse than sending none.
                         **({"Authorization": f"Bearer {key}"} if key else {}),
+                        # Name the workspace that pays for this search. Completions
+                        # do this with the request body's ``user`` field; a search
+                        # CANNOT, because the proxy forwards this body to the search
+                        # vendor and the vendor rejects fields it does not know —
+                        # Parallel AI answers a body-level ``user`` with
+                        # ``extra_forbidden`` and a 500, so the obvious version of
+                        # this fix breaks search outright. The header is read by the
+                        # proxy and stripped before the upstream call, which is why
+                        # it is the mechanism here.
+                        #
+                        # Without it every search the agent runs is spend no tenant
+                        # claims: the key on the request is the deployment's, shared
+                        # by everyone. Omitted entirely when there is no workspace
+                        # (a CLI turn, a background job) rather than sent blank —
+                        # the proxy treats an empty id as an id, which would pool
+                        # every untagged search under one nameless customer.
+                        **({"x-litellm-end-user-id": end_user} if end_user else {}),
                         "Content-Type": "application/json",
                     },
                     json={

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -309,6 +309,70 @@ class TestLiteLLMSearchProvider:
         assert "T" in result and "https://u" in result
 
     @patch("pocketpaw.tools.builtin.web_search.get_settings")
+    async def test_the_paying_workspace_rides_a_header_not_the_body(self, mock_settings, tool):
+        """A search names its tenant, and does it where the search vendor never sees.
+
+        This request authenticates with the DEPLOYMENT's key, so without an id the
+        spend belongs to nobody and is served free. The id CANNOT go in the body
+        beside ``query``: the proxy forwards that body to the search vendor, and
+        Parallel AI rejects an unknown ``user`` with ``extra_forbidden`` — measured,
+        not assumed, and it fails the whole search with a 500. The proxy reads the
+        header and strips it.
+        """
+        mock_settings.return_value = MagicMock(
+            web_search_provider="litellm",
+            litellm_api_base="https://gw.example.com",
+            litellm_search_api_base=None,
+            litellm_api_key="sk-proxy",
+            litellm_search_tool_name="web_search",
+        )
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"results": [{"title": "T", "url": "https://u", "snippet": "S"}]}
+
+        with (
+            patch("httpx.AsyncClient") as cls,
+            patch(
+                "pocketpaw.agents.spend_attribution.current_workspace_id",
+                return_value="ws_alpha",
+            ),
+        ):
+            client = self._client(resp)
+            cls.return_value = client
+            await tool.execute(query="q")
+
+        kwargs = client.post.call_args[1]
+        assert kwargs["headers"]["x-litellm-end-user-id"] == "ws_alpha"
+        assert "user" not in kwargs["json"], "a body-level user field 500s the search vendor"
+
+    @patch("pocketpaw.tools.builtin.web_search.get_settings")
+    async def test_a_run_with_no_workspace_sends_no_tenant_header(self, mock_settings, tool):
+        """A CLI turn has nobody to bill, and a blank id would pool them all as one."""
+        mock_settings.return_value = MagicMock(
+            web_search_provider="litellm",
+            litellm_api_base="https://gw.example.com",
+            litellm_search_api_base=None,
+            litellm_api_key="sk-proxy",
+            litellm_search_tool_name="web_search",
+        )
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"results": [{"title": "T", "url": "https://u", "snippet": "S"}]}
+
+        with (
+            patch("httpx.AsyncClient") as cls,
+            patch(
+                "pocketpaw.agents.spend_attribution.current_workspace_id",
+                return_value=None,
+            ),
+        ):
+            client = self._client(resp)
+            cls.return_value = client
+            await tool.execute(query="q")
+
+        assert "x-litellm-end-user-id" not in client.post.call_args[1]["headers"]
+
+    @patch("pocketpaw.tools.builtin.web_search.get_settings")
     async def test_snippet_is_normalised_into_the_shared_result_shape(self, mock_settings, tool):
         """The gateway returns ``snippet``; every other provider yields ``content``.
 


### PR DESCRIPTION
Web search through the LiteLLM proxy authenticates with the deployment's key, which every tenant shares, and it carried nothing to say whose search it was. So every search the agent ran was spend no workspace claimed. It was served, never charged, and counted against the attribution-coverage check as though the caller had forgotten to identify itself.

Completions solved this with the request body's `user` field. A search cannot use it.

I measured the three options against the gateway rather than picking one:

| Mechanism | Search call | `end_user` stamped |
|---|---|---|
| Body `user` field | 500, upstream rejects it | only on the failure row |
| `litellm_metadata.user` | 200 | yes |
| `x-litellm-end-user-id` header | 200 | yes |

The proxy forwards the search body to the vendor, and Parallel AI answers an unknown `user` with `extra_forbidden`. The obvious version of this fix breaks search outright, which is worth knowing before someone tries it again. The header never reaches the vendor, so it cannot collide with a search schema the way a body field can.

A run with no workspace sends no header rather than a blank one. The proxy treats an empty id as an id, which would pool every unattributed search under one nameless customer and make the coverage check read as clean.

This is the second of the two attribution holes behind the unbilled-spend warnings. The other one is #2055, which is independent of this and can merge in either order.

## Testing

`tests/test_web_search.py`: 23 passed. The new attribution test fails on `dev`.
