### PR TITLE
Stop a gateway refusal from becoming a 500

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -73,6 +73,15 @@
 # secret and the API key are NEVER logged.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-2): new module.
+# Updated 2026-09-02 (fix/site-plan-change-gateway-conflict): every SDK call is
+#   now translated into a ``CloudError`` on failure. Nothing was, so the SDK's own
+#   exception escaped the provider, escaped the service, and reached the client as
+#   a 500 with a traceback. Changing a site's plan while the previous change was
+#   still awaiting payment is the case that surfaced it: Dodo answers ``409
+#   PENDING_PLAN_CHANGE_EXISTS``, which is a legible thing to tell a buyer, and
+#   ``POST /api/v1/sites/publish`` returned "Internal Server Error" instead. The
+#   mapping keeps the gateway's own message on the 4xx paths and refuses to
+#   dress an unclassifiable failure up as the caller's mistake.
 # Updated 2026-06-24 (security): warn (don't silently swallow) when a
 #   payment.succeeded event carries a non-int / missing ``total_amount`` — the
 #   safe-coerce-to-0 behavior is unchanged, but ops now get a log to triage.
@@ -121,7 +130,15 @@ import json
 import logging
 from typing import Any
 
-from pocketpaw_ee.cloud._core.errors import BadRequest, ValidationError
+from pocketpaw_ee.cloud._core.errors import (
+    BadRequest,
+    CloudError,
+    ConflictError,
+    Internal,
+    RateLimited,
+    ValidationError,
+    with_cause,
+)
 from pocketpaw_ee.cloud.billing.domain import (
     GatewayEvent,
     OneTimeCheckout,
@@ -267,6 +284,65 @@ class DodoProvider:
     # Checkout
     # ------------------------------------------------------------------ #
 
+    @staticmethod
+    def _gateway_failure(exc: Exception, *, operation: str) -> CloudError:
+        """Turn a Dodo SDK status error into the error contract this layer owes.
+
+        Every call in this class used to let the SDK's own exception escape. That
+        exception is not a ``CloudError``, so nothing mapped it, and a perfectly
+        legible gateway refusal reached the client as a 500 with a stack trace —
+        including the one that prompted this: changing a site's plan while the
+        previous change was still awaiting payment answered ``409
+        PENDING_PLAN_CHANGE_EXISTS``, and the publish endpoint returned "Internal
+        Server Error" for a condition the buyer could have acted on.
+
+        The gateway's own ``code`` decides the mapping wherever it is specific
+        enough to be worth naming, and the status decides the rest. Anything we
+        cannot classify becomes a 500 deliberately: an unrecognised gateway
+        failure is our problem to look at, not something to dress up as the
+        caller's mistake.
+        """
+        status = int(getattr(exc, "status_code", 0) or 0)
+        body = getattr(exc, "body", None)
+        gateway_code = ""
+        gateway_message = ""
+        if isinstance(body, dict):
+            gateway_code = str(body.get("code") or "")
+            gateway_message = str(body.get("message") or "")
+
+        if gateway_code == "PENDING_PLAN_CHANGE_EXISTS":
+            # The actionable one. A previous change_plan charged a proration that
+            # has not settled, and the gateway refuses to queue a second change
+            # behind it. Waiting genuinely fixes it, so say so rather than
+            # inviting a retry that will fail the same way.
+            return ConflictError(
+                "billing.plan_change_pending",
+                "This subscription already has a plan change waiting on payment. "
+                "The change will apply once that payment settles; try again after it does.",
+            )
+
+        # The gateway's message is passed through on the 4xx paths. It is written
+        # for the account holder, and replacing it with our own wording would drop
+        # the only specific thing we know about the refusal.
+        detail = gateway_message or f"the payment gateway refused the {operation}"
+        if status == 409:
+            return ConflictError("billing.gateway_conflict", detail)
+        if status == 429:
+            return RateLimited("billing.gateway_rate_limited", detail)
+        if status in (400, 404, 422):
+            return ValidationError("billing.gateway_rejected", detail)
+        if status in (401, 403):
+            # OUR credential is wrong, not the caller's request. A 403 here would
+            # tell the buyer they lack permission for something they are entitled
+            # to, and send whoever reads it to the wrong system.
+            return Internal(
+                "billing.gateway_unauthorized",
+                "Billing is misconfigured and the payment gateway rejected our credentials.",
+            )
+        return Internal(
+            "billing.gateway_unavailable", f"The payment gateway failed the {operation}."
+        )
+
     def _client(self):  # pragma: no cover - thin SDK wiring, mocked in tests
         """Construct the async DodoPayments client from settings.
 
@@ -314,19 +390,24 @@ class DodoProvider:
         meta["workspace_id"] = str(workspace_id)
 
         client = self._client()
-        response = await client.payments.create(
-            billing={"country": self._billing_country},
-            customer=_customer_param(customer_email),
-            product_cart=[
-                {
-                    "product_id": self._credit_product_id,
-                    "quantity": 1,
-                    "amount": cart_amount_cents,
-                }
-            ],
-            payment_link=True,
-            metadata=meta,
-        )
+        try:
+            response = await client.payments.create(
+                billing={"country": self._billing_country},
+                customer=_customer_param(customer_email),
+                product_cart=[
+                    {
+                        "product_id": self._credit_product_id,
+                        "quantity": 1,
+                        "amount": cart_amount_cents,
+                    }
+                ],
+                payment_link=True,
+                metadata=meta,
+            )
+        except CloudError:
+            raise
+        except Exception as exc:
+            raise with_cause(self._gateway_failure(exc, operation="payment"), exc) from exc
 
         checkout_url = getattr(response, "payment_link", None)
         gateway_ref = getattr(response, "payment_id", "") or ""
@@ -397,7 +478,12 @@ class DodoProvider:
             create_kwargs["cancel_url"] = cancel_url
 
         client = self._client()
-        response = await client.checkout_sessions.create(**create_kwargs)
+        try:
+            response = await client.checkout_sessions.create(**create_kwargs)
+        except CloudError:
+            raise
+        except Exception as exc:
+            raise with_cause(self._gateway_failure(exc, operation="checkout"), exc) from exc
 
         checkout_url = getattr(response, "checkout_url", None)
         # The session id is repurposed onto SubscriptionCheckout.subscription_id —
@@ -420,7 +506,12 @@ class DodoProvider:
         # ``subscriptions.update(<id>, status="cancelled")``. Dodo emits the
         # ``subscription.cancelled`` webhook that drives the entitlement revert.
         client = self._client()
-        await client.subscriptions.update(subscription_id, status="cancelled")
+        try:
+            await client.subscriptions.update(subscription_id, status="cancelled")
+        except CloudError:
+            raise
+        except Exception as exc:
+            raise with_cause(self._gateway_failure(exc, operation="cancellation"), exc) from exc
 
     async def change_plan(
         self,
@@ -452,14 +543,19 @@ class DodoProvider:
         # alone" at this gateway — it is "empty the cart". Passing the caller's
         # list through unconditionally means the destructive case only happens
         # when a caller actually asked for it.
-        await client.subscriptions.change_plan(
-            subscription_id,
-            product_id=product_id,
-            quantity=1,
-            proration_billing_mode="difference_immediately",
-            on_payment_failure="prevent_change",
-            addons=list(addons),
-        )
+        try:
+            await client.subscriptions.change_plan(
+                subscription_id,
+                product_id=product_id,
+                quantity=1,
+                proration_billing_mode="difference_immediately",
+                on_payment_failure="prevent_change",
+                addons=list(addons),
+            )
+        except CloudError:
+            raise
+        except Exception as exc:
+            raise with_cause(self._gateway_failure(exc, operation="plan change"), exc) from exc
 
     # ------------------------------------------------------------------ #
     # Webhook

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -501,10 +501,17 @@ async def sync_site_addons(
     one renewal date, one payment method, and a per-site charge that prorates
     against the term the workspace has already paid for.
 
-    Idempotent by construction. The cart is recomputed from the ``Site``
-    documents on every call and sent whole, so calling this twice with no change
-    between sends the same cart twice and the second is a no-op at the gateway.
-    Callers do not need to know whether a sync is "needed".
+    The cart is recomputed from the ``Site`` documents on every call and sent
+    whole, so callers do not need to know whether a sync is "needed" — the same
+    cart sent twice describes the same subscription.
+
+    That is NOT the same as being safe to call twice in quick succession, and
+    this docstring used to claim it was. A change that prorates has to be PAID
+    before it settles, and until it does, Dodo refuses a second one with
+    ``409 PENDING_PLAN_CHANGE_EXISTS``. So a second publish arriving before the
+    first proration clears raises ``ConflictError`` rather than no-opping. That
+    is the honest behaviour: the gateway is telling us the earlier change is
+    still in flight, and the caller has to leave it alone until it lands.
 
     RAISES ``NoActiveSubscription`` WHEN THE WORKSPACE HAS NO SUBSCRIPTION, and
     that refusal is the deliberate shape of the feature rather than a gap in it.

--- a/tests/cloud/billing/test_gateway_error_mapping.py
+++ b/tests/cloud/billing/test_gateway_error_mapping.py
@@ -1,0 +1,208 @@
+# tests/cloud/billing/test_gateway_error_mapping.py — proves a gateway refusal
+# reaches the client as the refusal it is, not as a 500.
+#
+# THE BUG. Not one call in the Dodo provider caught the SDK's exceptions. That
+# exception is not a ``CloudError``, so ``cloud_error_handler`` never saw it, the
+# router had no handler for it, and it fell all the way through to uvicorn.
+# Changing a site's plan while the previous change was still awaiting payment is
+# what surfaced it in production:
+#
+#     ConflictError: Error code: 409 - {'code': 'PENDING_PLAN_CHANGE_EXISTS',
+#     'message': 'A pending plan change already exists for this subscription.
+#     Please wait for the current payment to complete.'}
+#     POST /api/v1/sites/publish  ->  500 Internal Server Error
+#
+# The gateway had said exactly what was wrong and exactly what to do about it,
+# and the buyer got "Internal Server Error" and a stack trace in the logs.
+#
+# Two things are asserted, because fixing only the first leaves the same hole for
+# the next gateway code nobody anticipated:
+#
+#   * the pending-plan-change conflict maps to a 409 whose message tells the buyer
+#     to wait, rather than inviting a retry that fails identically; and
+#   * EVERY SDK failure becomes a CloudError, so no gateway response can reach the
+#     client as an unhandled exception again.
+#
+# An unclassifiable failure deliberately stays a 500. This is about the CONTRACT
+# being honoured, not about relabelling our own outages as the caller's fault.
+#
+# Created 2026-09-02 (fix/site-plan-change-gateway-conflict): new test module.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud._core.errors import (
+    CloudError,
+    ConflictError,
+    Internal,
+    RateLimited,
+    ValidationError,
+)
+from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+
+SUB_ID = "sub_0NmcG4qDOOs4hvA9Z5ssk"
+
+
+def _provider() -> DodoProvider:
+    return DodoProvider(
+        api_key="dodo_test_key",
+        environment="test_mode",
+        webhook_secret=None,
+        credit_product_id="prod_credits_sku",
+        plan_products={},
+    )
+
+
+def _status_error(status: int, *, code: str = "", message: str = ""):
+    """A real SDK status error, built the way the SDK builds one."""
+    from dodopayments import APIStatusError
+
+    body: dict = {}
+    if code:
+        body["code"] = code
+    if message:
+        body["message"] = message
+    request = httpx.Request("POST", f"https://test.dodopayments.com/subscriptions/{SUB_ID}")
+    response = httpx.Response(status, json=body, request=request)
+    return APIStatusError(f"Error code: {status}", response=response, body=body or None)
+
+
+def _sdk_raising(exc: Exception, monkeypatch) -> MagicMock:
+    client = MagicMock()
+    client.subscriptions.change_plan = AsyncMock(side_effect=exc)
+    client.subscriptions.update = AsyncMock(side_effect=exc)
+    client.checkout_sessions.create = AsyncMock(side_effect=exc)
+    client.payments.create = AsyncMock(side_effect=exc)
+
+    import pocketpaw_ee.cloud.billing.providers.dodo as dodo_mod
+
+    monkeypatch.setattr(dodo_mod, "AsyncDodoPayments", MagicMock(return_value=client))
+    return client
+
+
+async def _change_plan():
+    await _provider().change_plan(
+        subscription_id=SUB_ID, product_id="prod_site_business", plan_key="business", addons=[]
+    )
+
+
+# ===========================================================================
+# The production failure.
+# ===========================================================================
+
+
+async def test_a_pending_plan_change_is_a_conflict_not_a_server_error(monkeypatch):
+    """The exact 409 that made publish return 500."""
+    _sdk_raising(
+        _status_error(
+            409,
+            code="PENDING_PLAN_CHANGE_EXISTS",
+            message="A pending plan change already exists for this subscription. "
+            "Please wait for the current payment to complete.",
+        ),
+        monkeypatch,
+    )
+
+    with pytest.raises(ConflictError) as caught:
+        await _change_plan()
+
+    assert caught.value.status_code == 409
+    assert caught.value.code == "billing.plan_change_pending"
+
+
+async def test_the_pending_change_message_says_to_wait_not_to_retry(monkeypatch):
+    """Retrying fails identically, so the copy must not suggest it."""
+    _sdk_raising(
+        _status_error(409, code="PENDING_PLAN_CHANGE_EXISTS", message="whatever the gateway said"),
+        monkeypatch,
+    )
+
+    with pytest.raises(ConflictError) as caught:
+        await _change_plan()
+
+    assert "settle" in caught.value.message.lower()
+
+
+async def test_the_sdk_exception_is_kept_as_the_cause(monkeypatch):
+    """The gateway's own error stays in the logs even though the client sees ours."""
+    original = _status_error(409, code="PENDING_PLAN_CHANGE_EXISTS")
+    _sdk_raising(original, monkeypatch)
+
+    with pytest.raises(ConflictError) as caught:
+        await _change_plan()
+
+    assert caught.value.__cause__ is original
+
+
+# ===========================================================================
+# The general hole: no SDK failure may escape as an unhandled exception.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (400, ValidationError),
+        (404, ValidationError),
+        (422, ValidationError),
+        (409, ConflictError),
+        (429, RateLimited),
+        (401, Internal),
+        (403, Internal),
+        (500, Internal),
+        (502, Internal),
+    ],
+)
+async def test_every_gateway_status_becomes_a_cloud_error(status, expected, monkeypatch):
+    _sdk_raising(_status_error(status, message="gateway said no"), monkeypatch)
+
+    with pytest.raises(expected):
+        await _change_plan()
+
+
+async def test_a_credential_rejection_is_ours_not_the_buyers(monkeypatch):
+    """A 403 here would tell a paying customer they lack permission they have."""
+    _sdk_raising(_status_error(403, message="invalid api key"), monkeypatch)
+
+    with pytest.raises(Internal) as caught:
+        await _change_plan()
+
+    assert caught.value.status_code == 500
+    assert caught.value.code == "billing.gateway_unauthorized"
+    assert "invalid api key" not in caught.value.message, "our key material stays out of the body"
+
+
+async def test_a_transport_failure_is_still_a_cloud_error(monkeypatch):
+    """Not every SDK failure is a status error; a dropped connection is not."""
+    _sdk_raising(RuntimeError("connection reset"), monkeypatch)
+
+    with pytest.raises(CloudError):
+        await _change_plan()
+
+
+async def test_the_gateway_message_survives_on_the_caller_facing_statuses(monkeypatch):
+    """It is the only specific thing we know about the refusal."""
+    _sdk_raising(_status_error(422, message="product_id is not sellable"), monkeypatch)
+
+    with pytest.raises(ValidationError) as caught:
+        await _change_plan()
+
+    assert "product_id is not sellable" in caught.value.message
+
+
+async def test_cancellation_failures_are_mapped_too(monkeypatch):
+    _sdk_raising(_status_error(409, message="already cancelled"), monkeypatch)
+
+    with pytest.raises(ConflictError):
+        await _provider().cancel_subscription(SUB_ID)
+
+
+async def test_a_successful_change_plan_still_returns_none(monkeypatch):
+    """The wrapper must not change the happy path."""
+    client = _sdk_raising(_status_error(409), monkeypatch)
+    client.subscriptions.change_plan = AsyncMock(return_value=None)
+
+    assert await _change_plan() is None


### PR DESCRIPTION
Changing a site's plan returns `500 Internal Server Error` when the previous plan change has not been paid for yet. Dodo answers the second attempt with:

```
409 - {'code': 'PENDING_PLAN_CHANGE_EXISTS',
       'message': 'A pending plan change already exists for this subscription.
                   Please wait for the current payment to complete.'}
```

The gateway said exactly what was wrong and exactly what to do about it. The buyer got "Internal Server Error" and the logs got a traceback.

## Why it reached the client at all

Not one call in the Dodo provider caught the SDK's exceptions. An SDK error is not a `CloudError`, so `cloud_error_handler` never saw it, no route had a handler for it, and it fell through to uvicorn. That is true of every call in the file, not just this one, so the same hole was waiting behind any gateway status nobody had hit yet.

## The mapping

| Gateway | Becomes | Why |
|---|---|---|
| 409 `PENDING_PLAN_CHANGE_EXISTS` | 409 `billing.plan_change_pending` | Waiting genuinely fixes it, so the copy says wait rather than retry |
| Other 409 | 409 `billing.gateway_conflict` | Keeps the gateway's own message |
| 400, 404, 422 | 422 `billing.gateway_rejected` | Keeps the gateway's own message |
| 429 | 429 `billing.gateway_rate_limited` | |
| 401, 403 | 500 `billing.gateway_unauthorized` | Our key is wrong. A 403 would tell a paying customer they lack permission they have, and send whoever reads it to the wrong system |
| Anything else | 500 `billing.gateway_unavailable` | An unrecognised gateway failure is ours to look at, not the caller's mistake |

The publish path already reverted the site's `plan_tier` on failure, so no state changes here. What changes is that the caller can now tell a refusal from an outage.

`sync_site_addons` claimed to be idempotent by construction. It is not, and I rewrote the docstring rather than the behaviour. The same cart sent twice does describe the same subscription, but a change that prorates has to be paid before it settles, and a second one arriving first gets refused. That refusal is correct.

## Testing

17 new tests, 16 of which fail on `dev`. The one that passes is the happy-path guard.

`tests/cloud/billing`, `credits`, `entitlements`: 374 passed, 2 failed. Both failures are in `test_plans.py` and fail identically on a clean `dev` checkout.

`tests/cloud/sites`: 184 passed.

## One thing this does not fix

Per an earlier finding, the frontend's `friendlyErrorMessage` reads `body.detail`, while cloud errors ship `{error: {code, message}}`. The 409 will reach the browser correctly but may still render as a generic message until that last hop is fixed. Worth a separate look.
