### PR TITLE
fix(sites): a shim build is a counter, so stamp it like one

### DIFF
--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2921,9 +2921,24 @@ async def _deploy_site_doc(
         # where the delete legitimately fails — a directory sitting on the entry's name,
         # which ``_write_deploy_files`` swallows — reads as no counter, which is what
         # wrangler will actually deploy.
+        #
+        # BOTH names, and the reason is a bug this shipped with for one afternoon.
+        # ``_write_deploy_files`` emits ONE OF TWO artifacts: ``ENTRY_FILENAME`` for an
+        # assets-only build, whose counter IS the worker, and ``SHIM_FILENAME`` for a
+        # build that already has a worker of its own (ripple, dynamic svelte), whose
+        # counter wraps it. This check knew only the first, because when it was written
+        # only the first existed — the shim arrived on a SIBLING branch, so neither
+        # slice was wrong alone and the merge is what made this wrong. The result was
+        # the worst-shaped failure this feature has: a paid ripple site deployed a
+        # working counter, counted real visitors, and told its owner counting had never
+        # started, with a Publish button that could not fix it because the next publish
+        # failed the same check.
         from pocketpaw_ee.sites import analytics_worker
 
-        counter_deployed = Path(build.project_dir, analytics_worker.ENTRY_FILENAME).is_file()
+        counter_deployed = any(
+            Path(build.project_dir, name).is_file()
+            for name in (analytics_worker.ENTRY_FILENAME, analytics_worker.SHIM_FILENAME)
+        )
     else:  # "wfp"
         cf = cloudflare or _cf_client()
         bundle = bundle_reader(build.project_dir)

--- a/tests/ee/sites/test_sites_analytics_since.py
+++ b/tests/ee/sites/test_sites_analytics_since.py
@@ -91,25 +91,38 @@ class _FakeGenerator:
         return BuildResult(project_dir=str(self._project_dir), ripple_version="0.2.0")
 
 
-def _deployer(*, writes_counter: bool, seen: dict | None = None):
+def _deployer(*, writes_counter: bool, seen: dict | None = None, artifact: str | None = None):
     """A workers deployer that reproduces the ONE disk effect the real one has:
-    ``_write_deploy_files`` writes the generated entry when counting is on and deletes
-    it when counting is off.
+    ``_write_deploy_files`` writes the generated counter when counting is on and
+    deletes it when counting is off.
 
     ``writes_counter`` is deliberately INDEPENDENT of ``analytics_entitled``. The
     publish seam only knows the plan, and the deploy resolves two more things (the
     operator kill switch, and whether the engine already emits its own worker) — so a
     test has to be able to say "entitled, and yet no counter was deployed" or the claim
-    that the stamp follows the artifact cannot be tested at all."""
+    that the stamp follows the artifact cannot be tested at all.
+
+    ``artifact`` picks WHICH generated file is left behind, and it is not a detail.
+    ``_write_deploy_files`` emits one of two: ``ENTRY_FILENAME`` for an assets-only
+    build, where the counter IS the worker, and ``SHIM_FILENAME`` for a build that
+    already ships its own worker (ripple, dynamic svelte), where the counter wraps it.
+    Both mean counting is on, so both must stamp. Defaults to the entry so every test
+    written before the shim existed keeps testing what it always did.
+
+    The off case deletes BOTH names rather than the one it would have written. A
+    deploy that stops counting stops counting, and leaving the other name on disk would
+    let a previous publish's artifact answer for this one.
+    """
 
     async def _deploy(site_id: str, project_dir: str, *, analytics_entitled=False, **_: object):
         if seen is not None:
             seen["analytics_entitled"] = analytics_entitled
-        entry = Path(project_dir) / analytics_worker.ENTRY_FILENAME
         if writes_counter:
-            entry.write_text("// a counter", encoding="utf-8")
+            name = artifact or analytics_worker.ENTRY_FILENAME
+            (Path(project_dir) / name).write_text("// a counter", encoding="utf-8")
         else:
-            entry.unlink(missing_ok=True)
+            for name in (analytics_worker.ENTRY_FILENAME, analytics_worker.SHIM_FILENAME):
+                (Path(project_dir) / name).unlink(missing_ok=True)
         return f"https://paw-site-{site_id}.acct.workers.dev"
 
     return _deploy
@@ -328,4 +341,98 @@ async def test_a_local_deploy_never_stamps_even_with_a_stale_entry_on_disk(
     )
 
     assert (project / analytics_worker.ENTRY_FILENAME).is_file(), "the stale entry must survive"
+    assert await _stamp(site.id) is None
+
+
+# ---------------------------------------------------------------------------
+# The shim is a counter too (fix/sites-analytics-since-shim)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_shim_build_stamps_the_start_like_any_other_counter(
+    beanie_test_db, tmp_path, clock
+):
+    """The regression. A ripple or dynamic svelte build already ships its own worker, so
+    the counter cannot be put in front of it from a config key — the deploy writes a
+    SHIM that imports that worker and wraps it. The shim is a counter. It counts real
+    visitors into the same dataset from the same publish.
+
+    The stamp check knew only the assets-only filename, because when it was written that
+    was the only artifact; the shim landed on a sibling branch. Neither slice was wrong
+    alone and the merge is what made this wrong, which is why no test caught it.
+
+    The failure it produced is the worst shape this feature has. The site counts. The
+    panel says counting has never started. The panel offers a Publish button as the fix,
+    and the next publish fails the same check, so the button can never work.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+
+    site = await _publish("pk-since-shim", project, _deployer(writes_counter=False))
+    await _mark_paid(site.id)
+
+    moment = clock(datetime(2026, 6, 2, 9, 30, tzinfo=UTC))
+    await _publish(
+        "pk-since-shim",
+        project,
+        _deployer(writes_counter=True, artifact=analytics_worker.SHIM_FILENAME),
+    )
+
+    assert (project / analytics_worker.SHIM_FILENAME).is_file(), (
+        "the fixture must leave a shim on disk, or this asserts nothing"
+    )
+    assert not (project / analytics_worker.ENTRY_FILENAME).is_file(), (
+        "and it must NOT also leave the assets-only entry, or the old check would pass "
+        "for the wrong reason and the regression would be invisible"
+    )
+    assert await _stamp(site.id) == moment
+
+
+@pytest.mark.asyncio
+async def test_a_republish_that_keeps_the_shim_keeps_the_original_stamp(
+    beanie_test_db, tmp_path, clock
+):
+    """The stamp is when counting BEGAN, not when it was last confirmed. A ripple site
+    that republishes weekly must keep its first date, or the read would slide the start
+    of the series forward and quietly hide the history it does have."""
+    project = tmp_path / "project"
+    project.mkdir()
+    shim = _deployer(writes_counter=True, artifact=analytics_worker.SHIM_FILENAME)
+
+    site = await _publish("pk-since-shim-2", project, _deployer(writes_counter=False))
+    await _mark_paid(site.id)
+
+    first = clock(datetime(2026, 6, 2, 9, 30, tzinfo=UTC))
+    await _publish("pk-since-shim-2", project, shim)
+
+    clock(datetime(2026, 7, 14, 11, 0, tzinfo=UTC))
+    await _publish("pk-since-shim-2", project, shim)
+
+    assert await _stamp(site.id) == first
+
+
+@pytest.mark.asyncio
+async def test_a_shim_site_that_stops_counting_clears_the_stamp(beanie_test_db, tmp_path, clock):
+    """The clearing half, on the shim path. A lapsed ripple site republishes without a
+    counter, and the stamp has to go — otherwise the read answers "counting since June"
+    across months in which nothing was recording, which is the invented zero this whole
+    feature exists to avoid."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    site = await _publish("pk-since-shim-3", project, _deployer(writes_counter=False))
+    await _mark_paid(site.id)
+
+    clock(datetime(2026, 6, 2, 9, 30, tzinfo=UTC))
+    await _publish(
+        "pk-since-shim-3",
+        project,
+        _deployer(writes_counter=True, artifact=analytics_worker.SHIM_FILENAME),
+    )
+    assert await _stamp(site.id) is not None
+
+    clock(datetime(2026, 8, 1, 9, 0, tzinfo=UTC))
+    await _publish("pk-since-shim-3", project, _deployer(writes_counter=False))
+
     assert await _stamp(site.id) is None

--- a/tests/mutations/sites_analytics_read.json
+++ b/tests/mutations/sites_analytics_read.json
@@ -211,7 +211,7 @@
   {
     "label": "the stamp is derived from the plan rather than from what the deploy left on disk — a fourth copy of the counting rule, so the kill switch and the engine's own worker both stamp a site that is not counting",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "        counter_deployed = Path(build.project_dir, analytics_worker.ENTRY_FILENAME).is_file()",
+    "find": "        counter_deployed = any(\n            Path(build.project_dir, name).is_file()\n            for name in (analytics_worker.ENTRY_FILENAME, analytics_worker.SHIM_FILENAME)\n        )",
     "replace": "        counter_deployed = counts_pageviews",
     "tests": [
       "tests/ee/sites/test_sites_analytics_since.py"
@@ -251,6 +251,16 @@
     "replace": "        workspace_id=ctx.workspace_id, site_id=site_id\n    )",
     "tests": [
       "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the stamp sees only the assets-only counter, so a shim build counts and reports never_counted forever",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        counter_deployed = any(\n            Path(build.project_dir, name).is_file()\n            for name in (analytics_worker.ENTRY_FILENAME, analytics_worker.SHIM_FILENAME)\n        )",
+    "replace": "        counter_deployed = Path(build.project_dir, analytics_worker.ENTRY_FILENAME).is_file()",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_since.py::test_a_shim_build_stamps_the_start_like_any_other_counter",
+      "tests/ee/sites/test_sites_analytics_since.py::test_a_republish_that_keeps_the_shim_keeps_the_original_stamp"
     ]
   }
 ]


### PR DESCRIPTION
A paid ripple site counts its visitors correctly and tells its owner counting has never started. Found by looking at the panel after the analytics stack merged.

## What happens

The deploy writes one of two generated files. An assets-only build (`html`, `react`, static `svelte`) gets `_paw_analytics.js`, where the counter is the worker. A build that already ships its own worker (`ripple`, dynamic `svelte`) gets `_paw_analytics_shim.js` instead, which imports that worker and wraps it, because a counter cannot go in front of an existing `main` from a config key.

`_deploy_site_doc` decides whether to stamp `Site.analytics_since` by asking whether the deploy left a counter on disk. It looked for the first name only.

So for a ripple site: the shim deploys, the site counts real visitors into the dataset, `analytics_since` stays null, and the read answers `never_counted`. The panel then says counting has not started and offers Publish as the fix. Publishing runs the same check and fails it again, so that button can never work.

## Why no test caught it

The disk check was written when `_paw_analytics.js` was the only artifact that existed. The shim landed on a **sibling** branch, not an ancestor, so neither branch's tests could see the other's half. Each slice was correct on its own. The merge is what made this wrong, and per-slice review is structurally unable to find that.

Worth noting because the same shape is likely to recur across a stack of siblings.

## The fix

Ask for either artifact. The rule the check encodes is unchanged: read what the deploy actually left behind rather than re-deriving the counting rule from the plan, which already lives in three places.

## Tests

Three, and all three fail without the one-line change:

- a shim build stamps the start like any other counter
- a shim republish keeps the original date, rather than sliding the start of the series forward and hiding history the site does have
- a shim site that stops counting still clears the stamp, so a lapse cannot leave "counting since June" over months that recorded nothing

The fixture asserts the shim is on disk **and** that the assets-only entry is not, otherwise the old check would pass for the wrong reason and the regression would be invisible.

The off case in the shared fixture now deletes both names rather than the one it would have written, so a previous publish's artifact cannot answer for this one.

## Verification

```
uv run pytest tests/ee/sites tests/cloud/sites tests/cloud/entitlements -p no:cacheprovider -q
1876 passed, 4 skipped
```

Mutation sweep on the read plan: 29 of 29 caught, including a new mutation that reinstates this exact bug. One neighbouring anchor pointed at the line this PR rewrites and was repointed, so the plan does not silently abort. `mutate.py --validate` clean repo-wide at 949 anchors across 75 plans.

## Not fixed here

The durable provision lane still passes counting off unconditionally and clears the stamp on every provision, so a dynamic site that stands up through that job is the one paid site that still never counts. That is SA-8, tracked separately, and it is a different function with a different reason.
