### PR TITLE
Send one leading system message to strict OpenAI-compatible backends

### DIFF
--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -343,6 +343,23 @@ Per-RUN, beside ``usage_limits`` and ``max_tokens``, for the reason those are:
 run cannot live on it. The full chain, its two proxy-side preconditions, and why
 the id is the workspace rather than the session are in
 ``agents/spend_attribution.py``.
+
+Updated 2026-09-04 (fix/pydantic-ai-strict-system-messages) — **a self-hosted
+model group 400s on the second system message we send.** ``litellm:...`` against
+a vLLM-backed group returned ``System message must be at the beginning.`` on
+every turn. The cause is not history and not the retry: pydantic-ai holds
+instructions as a list of ``InstructionPart`` and the OpenAI chat mapper emits
+one ``system`` message per part, so a run with ``Planning`` plus the skills
+catalog puts two of them at the head of the FIRST request. Measured on the
+shipped stack: ``['system', 'system', 'user']``.
+
+The merge that collapses them lives in pydantic-ai
+(``_merge_leading_system_messages``) and is gated on
+``openai_chat_supports_multiple_system_messages``, which no profile sets for a
+name the provider does not recognise. ``_build_model`` now sets it for the
+providers that front a self-hosted server. Doing it in the profile rather than
+by joining our own instructions keeps capability- and toolset-contributed
+instructions working, which a single joined string would not.
 """
 
 from __future__ import annotations
@@ -367,6 +384,26 @@ logger = logging.getLogger(__name__)
 # served by ``OpenAIChatModel`` + ``OpenAIProvider(base_url=...)``; only the
 # base URL and key source differ.
 _OPENAI_COMPATIBLE = frozenset({"litellm", "openai", "openai_compatible", "openrouter", "ollama"})
+
+# Providers that reject a ``system`` message anywhere but index 0, with
+# ``System message must be at the beginning.`` — the chat template a
+# self-hosted vLLM/SGLang server applies, reached either directly
+# (``openai_compatible``, ``ollama``) or through a LiteLLM model group
+# (``litellm``, which surfaces it as ``Custom_openaiException``).
+#
+# We send more than one because pydantic-ai keeps instructions as a LIST of
+# ``InstructionPart`` — one for the joined literals, one per instruction
+# function, one per toolset that implements ``get_instructions`` (``Planning``
+# and the skills catalog both do, and so does any MCP server shipping an
+# ``instructions`` field) — and ``OpenAIChatModel._map_messages`` emits ONE
+# system message per part. So the wire is ``system, system, user`` on the very
+# first turn, and this fails deterministically rather than on the retry.
+#
+# pydantic-ai already ships the merge; it is gated on a profile flag no
+# provider sets for an unrecognised model name like ``hetzner/Qwen3.8-27B``.
+# Not applied to ``openai``/``openrouter``: both accept multiple system
+# messages, and a merge there would be a behaviour change for nothing.
+_STRICT_SYSTEM_MESSAGE_PROVIDERS = frozenset({"litellm", "openai_compatible", "ollama"})
 
 # Same gate as ``claude_sdk`` and ``deep_agents``: ``<pocket-scope>`` opens every
 # pocket/site prompt. Retained for the prompt-shape signal it carries into the
@@ -1066,7 +1103,17 @@ class PydanticAIBackend:
             base_url,
         )
         cls = _reasoning_echo_model_class(model) or OpenAIChatModel
-        return cls(model, provider=OpenAIProvider(**provider_kwargs))
+        model_kwargs: dict[str, Any] = {"provider": OpenAIProvider(**provider_kwargs)}
+        if provider in _STRICT_SYSTEM_MESSAGE_PROVIDERS:
+            from pydantic_ai.profiles.openai import OpenAIModelProfile
+
+            # A partial profile MERGES onto the provider-inferred one (see
+            # ``Model.profile``), so this keeps the json-schema transformer and
+            # tool support the model name would otherwise resolve to.
+            model_kwargs["profile"] = OpenAIModelProfile(
+                openai_chat_supports_multiple_system_messages=False,
+            )
+        return cls(model, **model_kwargs)
 
     def _get_http_client(self) -> Any:
         """The instance's shared HTTP client, built once.

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -193,6 +193,55 @@ def test_unsupported_provider_raises():
         backend._build_model()
 
 
+async def _wire_roles(model) -> list[str]:
+    """The ``role`` of every message this model would put on the wire.
+
+    Asserting on the ROLES rather than on the profile flag on purpose: the flag
+    is what we set, and the roles are what the server rejects. A profile that
+    stopped being merged would still carry the flag we passed.
+    """
+    from pydantic_ai.messages import InstructionPart, ModelRequest, UserPromptPart
+    from pydantic_ai.models import ModelRequestParameters
+
+    mapped = await model._map_messages(
+        [ModelRequest(parts=[UserPromptPart(content="hi")])],
+        ModelRequestParameters(
+            # Two parts is the shipped shape, not a contrivance: the joined
+            # literals are one, and every toolset with ``get_instructions``
+            # (``Planning``, the skills catalog, an MCP server that ships an
+            # ``instructions`` field) contributes another.
+            instruction_parts=[
+                InstructionPart(content="persona"),
+                InstructionPart(content="skills catalog", dynamic=True),
+            ]
+        ),
+    )
+    return [m["role"] for m in mapped]
+
+
+async def test_litellm_sends_one_leading_system_message():
+    """A vLLM-backed model group 400s on the second one.
+
+    ``System message must be at the beginning.`` — surfaced through LiteLLM as
+    ``Custom_openaiException``, and it fires on the FIRST turn, so a retry
+    reproduces it rather than recovering from it.
+    """
+    backend = PydanticAIBackend(_settings(pydantic_ai_model="litellm:hetzner/Qwen3.8-27B"))
+    assert await _wire_roles(backend._build_model()) == ["system", "user"]
+
+
+async def test_openrouter_keeps_its_system_messages_separate():
+    """The merge is scoped to providers that front a self-hosted server.
+
+    OpenRouter and OpenAI accept several leading system messages, so collapsing
+    them there would be a behaviour change bought for nothing.
+    """
+    backend = PydanticAIBackend(
+        _settings(pydantic_ai_model="openrouter:some/model", openrouter_api_key="sk-test")
+    )
+    assert await _wire_roles(backend._build_model()) == ["system", "system", "user"]
+
+
 # --------------------------------------------------------------------------
 # streaming + event mapping
 # --------------------------------------------------------------------------


### PR DESCRIPTION
`litellm:hetzner/Qwen3.8-27B` fails every turn with `System message must be at the beginning.`, which LiteLLM wraps as `Custom_openaiException`. The retry fails identically because the first request already has the wrong shape.

## Why

pydantic-ai keeps instructions as a list of `InstructionPart`: one for the joined literals, one per instruction function, one per toolset that implements `get_instructions`. `OpenAIChatModel._map_messages` emits one `system` message per part. A run carrying `Planning` and the skills catalog puts two at the head of the request, and the chat template a self-hosted vLLM server applies rejects the one at index 1.

Measured against the installed pydantic-ai, with the model name from the failing run:

```
stock wire roles : ['system', 'system', 'user']
fixed wire roles : ['system', 'user']
```

History is not involved. `_build_history` maps every non-assistant row to a user part, and a retained transcript carries instructions on `ModelRequest.instructions`, which the mapper never turns into a message.

## What changed

pydantic-ai already ships the merge, in `_merge_leading_system_messages`. It is gated on `openai_chat_supports_multiple_system_messages`, and no profile sets it for a model name the provider does not recognise. `_build_model` now sets it for the three providers that front a self-hosted server: litellm, openai_compatible, ollama. openai and openrouter accept several leading system messages, so merging there would change behaviour for nothing.

A partial profile merges onto the provider-inferred one, so the json-schema transformer and tool support survive. Verified in the same run.

Setting the flag rather than joining our own instructions matters: capabilities and toolsets contribute instructions at run time, and a single joined string cannot carry the ones that do not exist before the run starts.

## Tests

Two tests assert the roles that go on the wire rather than the flag that was passed, since the flag is what we set and the roles are what the server rejects. The openrouter case is the negative control and still expects two.

```
tests/test_pydantic_ai_backend.py  146 passed
```

Neighbouring model-build suites also run clean: `test_agent_max_output_tokens`, `test_prompt_backend_digest`, `test_proxy_spend_attribution`, `test_pydantic_ai_agentapi_model`, `test_openai_agents_backend`.
