### PR TITLE
A model name may contain a colon

### DIFF
--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -360,6 +360,24 @@ name the provider does not recognise. ``_build_model`` now sets it for the
 providers that front a self-hosted server. Doing it in the profile rather than
 by joining our own instructions keeps capability- and toolset-contributed
 instructions working, which a single joined string would not.
+
+Updated 2026-09-04 (fix/model-ids-with-a-colon) — **a model whose NAME contains
+a colon was read as a provider.** Selecting the gateway's
+``minimax/minimax-m3:free`` failed with ``unsupported provider
+'minimax/minimax-m3'``. ``_parse_provider_model`` split on the first colon
+unconditionally, and OpenRouter spells its variants that way (``:free``,
+``:nitro``, ``:extended``) while Ollama spells its tags that way
+(``llama3.2:latest``). The split now happens only when the prefix names a
+provider we actually support; otherwise the whole string is the model and the
+provider settings decide, which is what a bare vendor-qualified name like
+``deepseek/deepseek-v4-flash`` already did.
+
+``supported_providers`` on the descriptor and the set the error message prints
+are now the same object the parser consults, so the three cannot drift.
+
+``deep_agents`` has the identical split and is deliberately NOT touched here.
+The claim in ``_parse_provider_model`` that the two mirror each other no longer
+holds, and fixing it there is its own change.
 """
 
 from __future__ import annotations
@@ -404,6 +422,20 @@ _OPENAI_COMPATIBLE = frozenset({"litellm", "openai", "openai_compatible", "openr
 # Not applied to ``openai``/``openrouter``: both accept multiple system
 # messages, and a merge there would be a behaviour change for nothing.
 _STRICT_SYSTEM_MESSAGE_PROVIDERS = frozenset({"litellm", "openai_compatible", "ollama"})
+
+# The providers a ``provider:model`` spec may name. The parser consults it
+# before it splits, because a model NAME can contain a colon too: OpenRouter
+# spells its variants that way (``minimax/minimax-m3:free``, ``:nitro``,
+# ``:extended``) and Ollama spells its tags that way (``llama3.2:latest``).
+# Splitting on the first colon unconditionally read the whole vendor-qualified
+# name as a provider and rejected the model with
+# ``unsupported provider 'minimax/minimax-m3'``.
+#
+# The trade: a genuine provider typo (``openrotuer:gpt-4o``) is no longer
+# caught here. It falls through as a model name and fails downstream, at the
+# gateway, as an unknown model. That is the cheaper mistake — a real model the
+# operator configured must work, and a typo still fails, just one hop later.
+_KNOWN_PROVIDERS = _OPENAI_COMPATIBLE | {"anthropic", "agentapi"}
 
 # Same gate as ``claude_sdk`` and ``deep_agents``: ``<pocket-scope>`` opens every
 # pocket/site prompt. Retained for the prompt-shape signal it carries into the
@@ -861,15 +893,7 @@ class PydanticAIBackend:
             builtin_tools=[],
             tool_policy_map={},
             required_keys=[],
-            supported_providers=[
-                "litellm",
-                "agentapi",
-                "anthropic",
-                "openai",
-                "openai_compatible",
-                "openrouter",
-                "ollama",
-            ],
+            supported_providers=sorted(_KNOWN_PROVIDERS),
             install_hint={
                 "pip_package": "pydantic-ai-slim",
                 "pip_spec": "pocketpaw[pydantic-ai]",
@@ -973,7 +997,10 @@ class PydanticAIBackend:
         ).strip()
         if ":" in model_str:
             provider, _, model = model_str.partition(":")
-            return provider.strip(), model.strip()
+            if provider.strip() in _KNOWN_PROVIDERS:
+                return provider.strip(), model.strip()
+            # Not a provider, so the colon belongs to the model name. Fall
+            # through and let the provider settings decide.
 
         provider = getattr(self.settings, "pydantic_ai_provider", "auto")
         if provider == "auto":
@@ -1085,7 +1112,7 @@ class PydanticAIBackend:
         if provider not in _OPENAI_COMPATIBLE:
             raise ValueError(
                 f"pydantic_ai backend: unsupported provider {provider!r}. "
-                f"Supported: {', '.join(sorted(_OPENAI_COMPATIBLE | {'anthropic', 'agentapi'}))}."
+                f"Supported: {', '.join(sorted(_KNOWN_PROVIDERS))}."
             )
 
         from pydantic_ai.models.openai import OpenAIChatModel

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -155,6 +155,18 @@ def test_model_routing_entry_exists():
         ("some-model", "auto", "auto", ("litellm", "some-model")),
         ("some-model", "auto", "ollama", ("ollama", "some-model")),
         ("some-model", "openrouter", "ollama", ("openrouter", "some-model")),
+        # A model NAME may contain a colon, so the prefix is only a provider
+        # when it names one. The first row is the gateway group that reported
+        # this: splitting it blind asked for a provider called
+        # minimax/minimax-m3.
+        ("minimax/minimax-m3:free", "auto", "auto", ("litellm", "minimax/minimax-m3:free")),
+        (
+            "openrouter:minimax/minimax-m3:free",
+            "auto",
+            "auto",
+            ("openrouter", "minimax/minimax-m3:free"),
+        ),
+        ("llama3.2:latest", "auto", "ollama", ("ollama", "llama3.2:latest")),
     ],
 )
 def test_parse_provider_model(model_setting, provider_setting, llm_provider, expected):
@@ -188,9 +200,24 @@ def test_litellm_base_url_not_double_suffixed():
 
 
 def test_unsupported_provider_raises():
-    backend = PydanticAIBackend(_settings(pydantic_ai_model="wat:some-model"))
+    """Reached through the provider SETTING, which can only be a provider."""
+    backend = PydanticAIBackend(
+        _settings(pydantic_ai_model="some-model", pydantic_ai_provider="wat")
+    )
     with pytest.raises(ValueError, match="unsupported provider"):
         backend._build_model()
+
+
+def test_an_unknown_prefix_stays_part_of_the_model_name():
+    """The cost of letting a model name carry a colon, stated as a test.
+
+    wat: used to raise here. It cannot any more, because the parser has no
+    way to tell a typo'd provider from a real vendor prefix, and a real model
+    the operator configured has to work. The typo still fails, one hop later,
+    as an unknown model at the gateway.
+    """
+    backend = PydanticAIBackend(_settings(pydantic_ai_model="wat:some-model", llm_provider="auto"))
+    assert backend._parse_provider_model() == ("litellm", "wat:some-model")
 
 
 async def _wire_roles(model) -> list[str]:


### PR DESCRIPTION
Replaces #2060, which GitHub auto-closed when its base branch was deleted on merge. Same commit, rebased onto `dev` now that #2059 has landed.

Picking the gateway's `minimax/minimax-m3:free` in the model picker fails before any request is made:

```
Error: Pydantic AI error: pydantic_ai backend: unsupported provider 'minimax/minimax-m3'.
Supported: agentapi, anthropic, litellm, ollama, openai, openai_compatible, openrouter.
```

## Why

`_parse_provider_model` splits on the first colon unconditionally, so a model whose own name carries one is read as `provider:model`. OpenRouter spells its variants that way (`:free`, `:nitro`, `:extended`) and Ollama spells its tags that way (`llama3.2:latest`).

The gateway lists 85 model groups and exactly one has a colon in it, which is why a new model surfaced a parser that has always been wrong:

```
with colon: ['minimax/minimax-m3:free']
```

## What changed

The split happens only when the prefix names a provider this backend supports. Otherwise the whole string is the model name and the provider settings decide, which is already how a bare `deepseek/deepseek-v4-flash` resolves today.

The descriptor's `supported_providers` and the set printed in the error now both come from the set the parser consults, so the three cannot drift.

## The trade

A typo'd provider is no longer caught at parse time. `openrotuer:gpt-4o` falls through as a model name and fails at the gateway as an unknown model instead. That is the cheaper of the two mistakes, since a real model the operator configured has to work and the typo still fails one hop later. `test_an_unknown_prefix_stays_part_of_the_model_name` states it so it is not rediscovered as a regression.

The existing `test_unsupported_provider_raises` moved to the path that can still reach that check, which is the provider setting itself.

## Scope

`deep_agents` has the identical split and is deliberately untouched. The mirror claim in the `pydantic_ai` docstring is corrected to say so.

## Tests

Three rows added to the existing parser table, pinning `llm_provider` on each as that table's own comment requires:

| spec | resolves to |
| --- | --- |
| `minimax/minimax-m3:free` | `("litellm", "minimax/minimax-m3:free")` |
| `openrouter:minimax/minimax-m3:free` | `("openrouter", "minimax/minimax-m3:free")` |
| `llama3.2:latest` | `("ollama", "llama3.2:latest")` |

```
205 passed
```

Covering `test_pydantic_ai_backend`, `test_deep_agents_backend` and `test_backend_registry`.
