### PR TITLE
fix(billing): stop dropping sub-credit spend, and stop crying wolf about the proxy's own traffic

### DIFF
--- a/docs/deployment/litellm-billing-cutover.md
+++ b/docs/deployment/litellm-billing-cutover.md
@@ -67,12 +67,45 @@ of it was lying. Every tick now also counts the window's spend rows that no swep
 workspace claims, and says so:
 
 ```
-spend_attribution_coverage: [...] 41 of 128 proxy spend row(s) belong to NO swept
-workspace — that spend is being served and not billed
+spend_attribution_coverage: [...] 41 of 128 proxy spend row(s) claimed by no tenant
+($1.284000) — 0 name a workspace the sweep did not visit (none), 41 are a real
+caller that named nobody ($1.284000), 0 are the proxy's own dashboard /
+health-check traffic and are nobody's to bill
 ```
 
-Treat a non-zero count as blocking. It is the number that tells you whether the
-meter you are about to trust alone can see what people are actually spending.
+**Watch `untagged`, not `unattributed`.** They are not the same number and the
+difference is the whole point. A LiteLLM proxy logs traffic of its own beside
+yours — a human trying a model in its admin dashboard, its periodic model health
+check — and none of it can name a workspace or be billed to one. `unattributed`
+counts that too, so on a live deployment it never reaches zero.
+
+This mattered in practice. On 2026-09-03 a sweep reported 8 of 19 rows served and
+not billed, which read as a serious under-bill and cost hours to chase. All 8 were
+the dashboard and the health check, worth $0.00014545 between them. Meanwhile the
+11 rows that WERE attributed cost exactly $0.00, because the models in use were
+free — so the `0 credits` beside them was correct too, and nothing was wrong at all.
+
+So the gate is: **`untagged` must be zero, and `unswept` must be zero.**
+`unattributed` is context. The dollar figures are there because a count cannot
+tell a hundredth of a cent of dashboard poking from a dollar of unbilled chat, and
+that is exactly the distinction this decision turns on.
+
+## Spend smaller than a credit
+
+A credit is one cent and the proxy prices a single API call, so most spend rows are
+worth a fraction of one. The sweep carries that fraction forward on the tenant's
+`pending_spend_usd` and debits a credit the moment the running total covers one.
+
+It used to convert each row on its own and drop anything that rounded to zero. With
+the default rate card that is `round(usd * 250)`, so every call under $0.002 billed
+nothing — and permanently, because the high-water mark advanced past the dropped row
+in the same pass and nothing accumulated it. Per-run metering shares the conversion
+and never showed this, because it priced a whole run at once; the cutover kept the
+arithmetic and made the unit about a hundred times smaller.
+
+Nothing to do about it operationally. It is here because `0 credits` on a sweep that
+read real dollars used to be the symptom, and that is worth recognising rather than
+re-diagnosing.
 
 ## The procedure
 
@@ -88,12 +121,15 @@ per-tenant `delta`, and `unattributed`.
 ```python
 from pocketpaw_ee.cloud.llm_provisioning.cutover_sweeper import run_cutover_sweep
 await run_cutover_sweep(mode="shadow")
-# {'tenants': 3, 'processed': 3, 'gaps': 0, 'credits': 0, 'unattributed': 0}
+# {'tenants': 3, 'processed': 3, 'gaps': 0, 'credits': 0,
+#  'unattributed': 8, 'unswept': 0, 'untagged': 0}
 ```
 
-`unattributed` must be zero, and a zero you got while a count was failing does not
-count — the log line says `INCOMPLETE` in that case rather than reporting a
-finding.
+`untagged` and `unswept` must be zero. A non-zero `unattributed` alongside them is
+the proxy's own traffic and is fine. A zero you got while a count was failing does
+not count — the log line says `INCOMPLETE` in that case rather than reporting a
+finding, and a split it could not read is flagged as coming from a truncated
+sample rather than passed off as a finding.
 
 **2. Drain the per-run sweep.** Let it run until no completed run is still
 unbilled. A run left unbilled at the moment you flip is billed by neither meter:

--- a/ee/pocketpaw_ee/catalog/admin_client.py
+++ b/ee/pocketpaw_ee/catalog/admin_client.py
@@ -62,6 +62,13 @@
 #   key was unreachable by any of them. This asks the PROXY who spent instead,
 #   which is the only source that includes those workspaces.
 
+# Updated 2026-09-04 (fix/litellm-spend-leaks): added ``spend_logs_window`` — the
+# unfiltered, row-returning sibling of ``spend_logs_by_end_user``. The coverage
+# check's counts can say how many rows no tenant claims but not WHAT they are, and
+# the proxy's own dashboard / health-check traffic needs the opposite response from
+# a caller that forgot to name a workspace. Hard-capped at ``max_rows``: a
+# diagnostic must not be able to cost more than the billing it observes.
+
 from __future__ import annotations
 
 import logging
@@ -380,6 +387,46 @@ class LiteLLMAdminClient:
                 max_pages,
             )
         return rows
+
+    async def spend_logs_window(
+        self,
+        *,
+        start_date: str,
+        end_date: str,
+        page_size: int = 100,
+        max_rows: int = 1000,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Every spend row in a window, whoever it belongs to. Returns ``(rows, complete)``.
+
+        The unfiltered sibling of ``spend_logs_by_end_user``, and the only read that
+        can answer WHAT an unattributed row was. The counts the coverage check runs
+        every tick say how many rows no tenant claims; they cannot say whether those
+        are a caller that forgot to name a workspace or the proxy's own dashboard
+        poking at a model, and those need opposite responses.
+
+        ``max_rows`` is a hard ceiling, and ``complete`` is False when it was hit.
+        This is deliberately NOT the paging-to-exhaustion loop the per-customer read
+        uses: this one is unfiltered, so on a busy proxy the window is unbounded, and
+        a diagnostic must never be able to cost more than the billing it observes. A
+        truncated read still classifies a representative prefix (rows come back
+        oldest-first) and the caller reports it as partial rather than as a finding.
+        """
+        rows: list[dict[str, Any]] = []
+        page = 1
+        total = 0
+        while len(rows) < max_rows:
+            batch, total = await self._spend_logs_v2(
+                start_date=start_date,
+                end_date=end_date,
+                end_user=None,
+                page=page,
+                page_size=min(page_size, max_rows - len(rows)),
+            )
+            rows.extend(batch)
+            if not batch or len(rows) >= total:
+                break
+            page += 1
+        return rows[:max_rows], len(rows) >= total
 
     async def spend_log_count(
         self,

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -177,6 +177,14 @@
 # writes, no change to anything charged. The ``(workspace, createdAt)`` compound
 # index on ``CreditLedgerEntry`` already serves the ``$match``.
 
+# Updated 2026-09-04 (fix/litellm-spend-leaks): added ``record_no_movement`` — a
+# zero-value ledger entry that records a source event as accounted for without
+# touching the wallet. ``debit`` rightly refuses a non-positive amount, but an
+# ingest that accumulates fractional external spend still needs somewhere to say "I
+# have seen this row", and this ledger's unique (workspace, idempotency_key) index
+# is the only per-row store with an exactly-once guarantee. Without it the LiteLLM
+# sweep's overlapping re-read would fold the same fraction in on every tick.
+
 from __future__ import annotations
 
 import inspect
@@ -434,6 +442,58 @@ async def debit(
 
     await _emit_movement(entry)
     return new_balance
+
+
+async def record_no_movement(
+    workspace: str,
+    cause: str,
+    idempotency_key: str,
+    *,
+    ref: dict | None = None,
+    kind: str = "spend",
+) -> bool:
+    """Record that a source event was accounted for WITHOUT moving the wallet.
+
+    Writes one ledger entry with ``amount_delta = 0``. Returns True if this call
+    wrote it, False if the key was already present. Touches no balance, emits no
+    movement event — nothing moved.
+
+    WHY A ZERO ENTRY IS A REAL THING. ``debit`` requires a positive integer, and
+    rightly: a zero debit is not a debit. But an ingest that accumulates fractional
+    external spend needs somewhere to record "I have seen this row and folded it
+    into the remainder", and the only per-row store with an exactly-once guarantee
+    is this ledger's unique ``(workspace, idempotency_key)`` index. Without an
+    entry, ``is_recorded`` says no and the next overlapping read folds the same row
+    in a second time — turning an under-bill into an over-bill, which is worse.
+
+    So the entry is the marker, and ``amount_delta = 0`` is the honest amount. It
+    is written ``applied=True`` because there is no ``$inc`` to land and a phantom
+    is precisely what it must not look like to ``reconcile``; a zero contributes
+    nothing to any ``sum(amount_delta)``, so every existing read is unchanged by it.
+    """
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+    if not idempotency_key:
+        raise ValidationError("credits.invalid_key", "idempotency_key is required")
+
+    entry = CreditLedgerEntry(
+        workspace=workspace,
+        kind=kind,
+        amount_delta=0,
+        balance_after=await _current_balance(workspace),
+        # Nothing to land, so it is applied on arrival. An unapplied zero would
+        # read as a crash-window phantom to reconcile and be re-driven forever.
+        applied=True,
+        conditional=False,
+        cause=cause,
+        ref=dict(ref or {}),
+        idempotency_key=idempotency_key,
+    )
+    try:
+        await entry.insert()
+    except DuplicateKeyError:
+        return False
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1045,6 +1105,7 @@ __all__ = [
     "is_recorded",
     "month_to_date_spend",
     "reconcile",
+    "record_no_movement",
     "spend_by_model",
     "sum_debits_by_cause",
 ]

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/cutover_sweeper.py
@@ -38,6 +38,11 @@
 # tenant never wedges the whole sweep — the same isolation the BC-3 sweep uses.
 #
 # Created 2026-06-26 (feat/litellm-billing-cutover, WU-F): new entity.
+# Updated 2026-09-04 (fix/litellm-spend-leaks): the summary carries ``untagged``
+# beside ``unattributed``. A proxy logs traffic of its own (its admin dashboard, its
+# health check) that no workspace can claim, so ``unattributed`` never reaches zero
+# on a live deployment — a gate written against it can only ever be ignored, which
+# is what happened. ``untagged`` is the part that is genuinely ours and unbilled.
 # Updated 2026-09-02 (fix/bill-workspaces-the-sweep-cannot-see): the sweep now
 #   iterates ``list_sweepable_workspaces`` — provisioned tenants UNION the
 #   workspaces the proxy has customer spend for. It iterated provisioned tenants
@@ -97,6 +102,13 @@ async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
         # reported apart because it is a different bug with a different fix, and
         # because the two were one number for the hours it took to tell them apart.
         "unswept": 0,
+        # The part of ``unattributed`` that is genuinely OURS and unbilled: a real
+        # caller that reached the proxy without naming a workspace. This is the
+        # number to watch, not ``unattributed`` — a proxy always logs some traffic
+        # of its own (its admin dashboard, its health check) that no workspace can
+        # claim, so ``unattributed`` never reaches zero on a live deployment and a
+        # gate written against it can only ever be ignored.
+        "untagged": 0,
     }
 
     if resolved == "off":
@@ -121,6 +133,7 @@ async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
     )
     summary["unattributed"] = coverage.unattributed_rows
     summary["unswept"] = coverage.unswept_rows
+    summary["untagged"] = coverage.untagged_rows
 
     if not workspaces:
         return summary
@@ -170,14 +183,16 @@ async def run_cutover_sweep(*, mode: str | None = None) -> dict[str, int]:
                 )
         logger.info(
             "run_cutover_sweep[live]: ingested spend for %d/%d tenants -> %d credits, "
-            "%d failed, %d unattributed row(s) in the trailing window (%d of them "
-            "naming a workspace nobody swept) "
+            "%d failed, %d row(s) in the trailing window claimed by no tenant — %d of "
+            "them a real caller that named nobody and %d naming a workspace nobody "
+            "swept; the rest is the proxy's own traffic "
             "(LiteLLM is the sole meter; BC-3 gated off)",
             summary["processed"],
             summary["tenants"],
             summary["credits"],
             summary["failed"],
             summary["unattributed"],
+            summary["untagged"],
             summary["unswept"],
         )
         return summary

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
@@ -41,6 +41,14 @@
 # now splits its remainder into rows that name an unswept workspace and rows that
 # name none, and carries the unswept ids. One number could not tell an operator
 # which of two unrelated bugs they had.
+# Updated 2026-09-04 (fix/litellm-spend-leaks): ``SpendCredits`` gains
+# ``whole_credits`` + ``usd_for_credits`` (the remainder carry: floor what is fully
+# covered, hand the rest back) because ``to_credits`` rounds and was being applied
+# per spend row, so every call worth under half a credit billed nothing. And
+# ``SpendCoverage`` gains the classification fields — the remainder is now priced and
+# split into the proxy's own dashboard / health-check traffic versus a real caller
+# that named nobody, because only the second is a billing hole and reporting them as
+# one number made the check permanently red.
 # Updated 2026-09-02 (feat/proxy-spend-ingest-by-customer): added ``SpendCoverage``
 # — what ``service.spend_attribution_coverage`` returns. It exists because the bug
 # that motivated this branch was invisible: chat spend was attributed to nobody, the
@@ -51,6 +59,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from math import floor
 
 
 @dataclass(frozen=True)
@@ -105,10 +114,43 @@ class SpendCredits:
         ``round(cost_usd * markup / credit_usd)`` — identical to
         ``metering.domain.RateCard.to_credits``. A non-positive cost yields 0
         credits (no debit).
+
+        Correct for ONE total. Do NOT call it per spend row and add the results
+        up: the rounding is applied to each row separately, and a row worth less
+        than half a credit rounds to nothing. Summing the USD first and converting
+        once is what ``whole_credits`` + ``usd_for_credits`` are for.
         """
         if cost_usd <= 0:
             return 0
         return round(cost_usd * self.markup / self.credit_usd)
+
+    def whole_credits(self, cost_usd: float) -> int:
+        """How many WHOLE credits ``cost_usd`` covers. Never rounds up.
+
+        The billing half of the remainder carry. ``to_credits`` rounds, which is
+        right for a single total and wrong for a running one: rounding up would
+        bill money the tenant has not spent yet, and the next row would be billed
+        for it a second time. Flooring bills only what is fully covered and leaves
+        the rest in the remainder, where ``usd_for_credits`` can take it back out.
+
+        The ``round(..., 9)`` is not cosmetic. The remainder is accumulated by
+        repeated float addition, so a sum that is exactly three credits arrives as
+        2.9999999999999996 and a bare ``floor`` would bill two — re-creating the
+        under-bill this method exists to end, just further down the decimal.
+        """
+        if cost_usd <= 0:
+            return 0
+        return floor(round(cost_usd * self.markup / self.credit_usd, 9))
+
+    def usd_for_credits(self, credits: int) -> float:
+        """The USD that ``credits`` whole credits accounts for.
+
+        The inverse of ``whole_credits``, used to take the billed part back out of
+        the running remainder so what is left is exactly the unbilled fraction.
+        """
+        if credits <= 0:
+            return 0.0
+        return credits * self.credit_usd / self.markup
 
 
 @dataclass(frozen=True)
@@ -173,10 +215,27 @@ class SpendCoverage:
     the window was tagged and simply unswept. A fix for one does nothing for the
     other, so an operator has to be able to tell which they are looking at.
 
-    Any non-zero remainder is a billing hole, and reading it as a ROW count rather
-    than a dollar amount is deliberate: a count needs one cheap request per tenant
-    and answers the question that matters ("is anything falling through?") without
-    pretending to be an invoice. The reconciliation compare is where amounts belong.
+    NOT every unattributed row is a billing hole, and treating them all as one is
+    what made this check cry wolf. A LiteLLM proxy generates traffic of its own that
+    no workspace can ever claim and none of it should be billed to anyone:
+
+      * ``internal_rows`` — the proxy's OWN traffic. An operator trying a model in
+        the LiteLLM dashboard, and the proxy's periodic model health check. They
+        carry a ``team_id`` the proxy assigns itself (``litellm-dashboard``,
+        ``litellm-internal-health-check``) and they are almost always $0.
+      * ``untagged_rows`` — everything else with no workspace: a real caller that
+        reached the proxy without naming who pays. THIS is the billing hole.
+
+    Measured 2026-09-03 on the production proxy: all 8 of a window's "unattributed"
+    rows were the dashboard and the health check, worth $0.00014545 between them,
+    while the runbook told the operator to treat any non-zero count as blocking. A
+    guard that is permanently red is a guard nobody reads.
+
+    ``unattributed_usd`` and ``untagged_usd`` carry what the remainder actually
+    COSTS, because a row count cannot tell $0.0001 of dashboard poking from a dollar
+    of unbilled chat and the whole question is which one you have. They are only
+    populated when ``classified`` is True — the cheap count path runs every tick and
+    the row read that prices it runs only when there is a remainder to explain.
 
     ``degraded`` marks a check that could not complete — a proxy that failed one of
     the counts. The remainder is then unreliable and must not be read as a verdict,
@@ -196,6 +255,15 @@ class SpendCoverage:
     unswept_workspaces: tuple[str, ...] = ()
     workspaces_checked: int = 0
     degraded: bool = False
+    # Set once the remainder has been read back and priced (see ``classified``).
+    # ``internal_rows`` is the proxy's own dashboard / health-check traffic;
+    # ``untagged_rows`` is the real hole. They sum to the untagged half of the
+    # remainder — the unswept half is counted separately above.
+    internal_rows: int = 0
+    untagged_rows: int = 0
+    unattributed_usd: float = 0.0
+    untagged_usd: float = 0.0
+    classified: bool = False
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
@@ -173,6 +173,10 @@ class SpendIngestResult:
     cost_usd: float
     cached_tokens: int
     balance_after: int
+    # True when this call did no work because another ingest already held the
+    # tenant's lease. Distinct from a genuine zero: nothing was read, so the caller
+    # must not treat the zero as evidence the tenant has no spend.
+    lease_skipped: bool = False
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -165,6 +165,13 @@
 #      tenant's mark WOULD recover it and the request_id key still stops a double
 #      debit — but never rewind past the ``prepare_spend_cutover`` mark, where BC-3
 #      owns the billing under a key this ledger cannot dedup against.
+#      The carry also needs a LEASE, which the ledger cannot provide. It is a
+#      read-modify-write: two overlapping ingests read the same remainder, each folds
+#      in a row the other has not seen, each crosses the credit line, and both debit
+#      under different ``litellm:{request_id}`` keys — so the unique index never
+#      fires and the tenant quietly pays twice. ``ingest_tenant_spend`` is now a
+#      lease wrapper around ``_ingest_tenant_spend_locked``; a caller that cannot
+#      take the lease returns ``lease_skipped`` rather than waiting.
 #      The already-recorded check MOVED ABOVE the conversion as part of this: a row
 #      folded into the remainder carries a zero-value ledger entry rather than a
 #      debit, and the customer read re-offers 15 minutes of settled rows every tick,
@@ -781,6 +788,67 @@ def _customer_read_window(doc: LiteLLMTenantKey, *, now: datetime) -> tuple[date
     return (created if created is not None else now - _SPEND_READ_OVERLAP), now
 
 
+# How long a spend-ingest lease is held before anyone else may take it. Long enough
+# to cover a slow sweep (the per-key read walks a tenant's whole history), short
+# enough that a process killed mid-sweep does not wedge a tenant's billing for long.
+_SPEND_LEASE_TTL = timedelta(seconds=60)
+
+
+async def _acquire_spend_lease(workspace: str) -> bool:
+    """Take the exclusive right to ingest ``workspace``'s spend. True if we got it.
+
+    A single-document compare-and-swap: claim the row only if nobody holds it or the
+    holder's lease has expired. The same idiom ``credits.debit`` uses for the wallet,
+    and for the same reason — read-then-write cannot serialise two racers.
+
+    WHY A LEASE AT ALL, when every debit is already idempotent per row.
+    ``pending_spend_usd`` is the part the ledger cannot protect. Two ingests read the
+    same remainder, each folds in a row the OTHER has not seen, and each crosses the
+    credit line — so both debit, under different ``litellm:{request_id}`` keys, and
+    the unique index never fires. Nothing errors and nothing looks wrong; the tenant
+    is simply billed twice for one credit's worth of spend. The overlap is routine:
+    the sweep runs on the API process heartbeat AND at worker boot, and the per-run
+    trigger makes it happen on every run.
+
+    Mongo rather than an ``asyncio.Lock`` because the racers are in different
+    PROCESSES — runs execute in the arq worker, the sweep loop in the API.
+    """
+    now = datetime.now(UTC)
+    coll = LiteLLMTenantKey.get_pymongo_collection()
+    updated = await coll.find_one_and_update(
+        {
+            "workspace": workspace,
+            "$or": [
+                {"spend_ingest_lease_until": None},
+                {"spend_ingest_lease_until": {"$exists": False}},
+                {"spend_ingest_lease_until": {"$lt": now}},
+            ],
+        },
+        {"$set": {"spend_ingest_lease_until": now + _SPEND_LEASE_TTL}},
+    )
+    return updated is not None
+
+
+async def _release_spend_lease(workspace: str) -> None:
+    """Hand the lease back. Best effort — the expiry is the real guarantee.
+
+    Released in a ``finally`` so a failed sweep does not hold a tenant for the full
+    TTL, but a crash that skips this is survivable by design: the next caller past
+    the expiry takes the lease anyway.
+    """
+    try:
+        coll = LiteLLMTenantKey.get_pymongo_collection()
+        await coll.update_one(
+            {"workspace": workspace}, {"$set": {"spend_ingest_lease_until": None}}
+        )
+    except Exception:  # noqa: BLE001 — never fail a completed sweep on cleanup
+        logger.debug(
+            "llm_provisioning: could not release the spend lease for workspace=%s "
+            "— it expires on its own",
+            workspace,
+        )
+
+
 async def _spend_bookkeeping_row(workspace: str) -> LiteLLMTenantKey:
     """This tenant's spend row, created keyless if provisioning never ran.
 
@@ -901,6 +969,53 @@ async def _read_tenant_spend_rows(
 
 
 async def ingest_tenant_spend(
+    workspace: str,
+    *,
+    spend_card: SpendCredits | None = None,
+    admin_client: LiteLLMAdminClient | None = None,
+) -> SpendIngestResult:
+    """Bill ``workspace``'s proxy spend, under an exclusive per-tenant lease.
+
+    Thin wrapper over ``_ingest_tenant_spend_locked``, which holds the real logic
+    and its documentation. Everything here is the lease.
+
+    A tenant is ingested by one caller at a time because the sub-credit remainder is
+    a read-modify-write and the ledger's per-row idempotency key cannot protect it —
+    see ``_acquire_spend_lease``. A caller that cannot get the lease returns an empty
+    result with ``lease_skipped`` set rather than waiting: whoever holds it is
+    already reading the same rows, and the next sweep is at most five minutes out.
+    Skipping is therefore never a lost bill, only a later one.
+    """
+    _require_workspace(workspace)
+    # The lease is a CAS on this row, so the row has to exist before we can claim it.
+    await _spend_bookkeeping_row(workspace)
+
+    if not await _acquire_spend_lease(workspace):
+        logger.debug(
+            "llm_provisioning.ingest_tenant_spend: workspace=%s is already being "
+            "ingested — skipping this pass",
+            workspace,
+        )
+        return SpendIngestResult(
+            workspace_id=workspace,
+            rows_read=0,
+            rows_billed=0,
+            credits_debited=0,
+            cost_usd=0.0,
+            cached_tokens=0,
+            balance_after=await credits_service.balance(workspace),
+            lease_skipped=True,
+        )
+
+    try:
+        return await _ingest_tenant_spend_locked(
+            workspace, spend_card=spend_card, admin_client=admin_client
+        )
+    finally:
+        await _release_spend_lease(workspace)
+
+
+async def _ingest_tenant_spend_locked(
     workspace: str,
     *,
     spend_card: SpendCredits | None = None,

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -153,6 +153,18 @@
 #      dropped row in the same pass and nothing accumulated. Per-run metering shares
 #      the conversion and never showed this, because it priced a whole RUN at once;
 #      the cutover kept the arithmetic and made the unit ~100x smaller.
+#      SIZE, honestly: ``round`` is unbiased, so a row at $0.003 rounds UP to a credit
+#      it has not earned and offsets one at $0.0015 rounding down. Over a week of real
+#      traffic (2026-08-28..09-04) the two cancelled — one tenant over-billed by a
+#      credit, another under-billed by one. This is not a steady drain; it is being
+#      wrong per tenant in BOTH directions, and unboundedly wrong for a workload of
+#      uniformly cheap calls where nothing rounds up to offset anything. A thousand
+#      $0.0015 requests cost $1.50 and bill zero. The carry makes it exact instead.
+#      It does NOT bill what was already dropped: the reads start at the mark minus
+#      ``_SPEND_READ_OVERLAP``. A dropped row has no ledger entry, so rewinding a
+#      tenant's mark WOULD recover it and the request_id key still stops a double
+#      debit — but never rewind past the ``prepare_spend_cutover`` mark, where BC-3
+#      owns the billing under a key this ledger cannot dedup against.
 #      The already-recorded check MOVED ABOVE the conversion as part of this: a row
 #      folded into the remainder carries a zero-value ledger entry rather than a
 #      debit, and the customer read re-offers 15 minutes of settled rows every tick,

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -143,6 +143,32 @@
 #     the edge of the map — and the sweep's coverage check is what makes spend
 #     outside it visible.
 
+# Updated 2026-09-04 (fix/litellm-spend-leaks): three changes, one root cause —
+# money and noise were both being lost to arithmetic applied at the wrong grain.
+#
+#   1. ``ingest_tenant_spend`` CARRIES the sub-credit remainder instead of dropping
+#      it. It converted each row on its own and skipped anything that rounded to
+#      zero, so with the default card (round(usd * 250)) every call under $0.002
+#      billed nothing — permanently, because the high-water mark advanced past the
+#      dropped row in the same pass and nothing accumulated. Per-run metering shares
+#      the conversion and never showed this, because it priced a whole RUN at once;
+#      the cutover kept the arithmetic and made the unit ~100x smaller.
+#      The already-recorded check MOVED ABOVE the conversion as part of this: a row
+#      folded into the remainder carries a zero-value ledger entry rather than a
+#      debit, and the customer read re-offers 15 minutes of settled rows every tick,
+#      so without the check first the same fraction would be folded in once per
+#      sweep. That would turn an under-bill into an over-bill.
+#   2. ``reconcile_tenant_spend`` sums the window's USD and converts ONCE. Doing it
+#      per row understated the LiteLLM side of the shadow compare by exactly the
+#      rows the live ingest was dropping, which is how the cutover looked safe.
+#   3. ``spend_attribution_coverage`` PRICES its remainder and splits it three ways.
+#      A proxy logs traffic of its own — a human trying a model in its admin
+#      dashboard, its periodic health check — that can never name a workspace and is
+#      nobody's to bill. Counting it as "served and not billed" made the check
+#      permanently red while the runbook said to treat any non-zero count as
+#      blocking. Measured on the production proxy 2026-09-03: all 8 flagged rows
+#      were exactly that, worth $0.00014545 between them.
+
 from __future__ import annotations
 
 import logging
@@ -201,6 +227,18 @@ _KEY_ALIAS_PREFIX = "ws-"
 # sweep — they cost one ``is_recorded`` lookup apiece and debit nothing — to buy
 # back rows that would otherwise be lost silently and permanently.
 _SPEND_READ_OVERLAP = timedelta(minutes=15)
+
+# Team ids LiteLLM stamps on its OWN traffic. Rows carrying one of these are the
+# proxy talking to itself and can never name a workspace: ``litellm-dashboard`` is
+# a human trying a model in the proxy's admin UI, ``litellm-internal-health-check``
+# is its periodic model probe. Neither is ours to bill, so counting them as spend
+# "being served and not billed" is what made the coverage check permanently red.
+#
+# Matched on ``team_id`` rather than on a zero cost: the dashboard's test chats DO
+# cost money (a real model answers them), just nobody's money. A cost filter would
+# also swallow a genuinely untagged production call that happened to be free, which
+# is the case worth keeping visible — free models do not stay free.
+_PROXY_INTERNAL_TEAMS = frozenset({"litellm-dashboard", "litellm-internal-health-check"})
 
 # The timestamp format /spend/logs/v2 parses. It also accepts a bare date; second
 # precision keeps the window tight enough that the overlap above is the only
@@ -911,6 +949,11 @@ async def ingest_tenant_spend(
     credits_debited = 0
     cost_usd_total = 0.0
     cached_total = 0
+    # Spend carried from earlier sweeps that was not yet worth a whole credit. It
+    # is real money the tenant owes; it just could not be expressed in the ledger's
+    # integer unit yet.
+    pending_usd = float(doc.pending_spend_usd or 0.0)
+    pending_at_start = pending_usd
 
     # Oldest first so the high-water mark advances monotonically.
     for row, honour_mark in sorted(rows, key=lambda pair: _row_start_time(pair[0]) or ""):
@@ -952,10 +995,6 @@ async def ingest_tenant_spend(
         cached_total += _cached_tokens(row)
         cost_usd_total += cost_usd
 
-        credits = card.to_credits(cost_usd)
-        if credits <= 0:
-            continue  # sub-credit / zero-cost row — nothing to debit
-
         rid = _row_id(row)
         if rid is None:
             # No stable id — we can't dedup it, so skip rather than risk a
@@ -969,12 +1008,44 @@ async def ingest_tenant_spend(
             continue
 
         ledger_key = f"litellm:{rid}"
-        # Skip a row already recorded (the high-water mark normally prevents this,
-        # but a reset / a row predating the mark could re-surface). The debit would
-        # no-op on the unique index anyway — this keeps ``rows_billed`` honest and
-        # avoids the wasted insert-then-rollback. NOT the exactly-once guard (that
-        # is BC-1's unique index); just accurate bookkeeping.
+        # Skip a row already accounted for. This gate now guards the REMAINDER as
+        # well as the debit, and that is why it moved above the conversion. A row
+        # folded into ``pending_usd`` on an earlier sweep has a zero-value ledger
+        # entry rather than a debit, and the customer read deliberately re-offers
+        # the last ``_SPEND_READ_OVERLAP`` of settled rows every tick — so without
+        # this check first, a cheap row would be added to the remainder once per
+        # sweep for fifteen minutes and the tenant would be billed several times
+        # over for it. Under-billing became over-billing, which is worse.
         if await credits_service.is_recorded(workspace, ledger_key):
+            continue
+
+        # Carry the fraction instead of discarding it. Credits are integers (1 ==
+        # $0.01) and the proxy prices ONE API call, so a single row is routinely
+        # worth less than a whole credit. Converting each row on its own and
+        # dropping anything that rounded to zero served every cheap call for free,
+        # permanently: nothing accumulated, and the high-water mark moved past the
+        # dropped row in the same pass. Per-run metering had the same arithmetic and
+        # never showed it, because it priced a whole run at once — the cutover kept
+        # the conversion and made the unit ~100x smaller.
+        pending_usd += cost_usd
+        credits = card.whole_credits(pending_usd)
+
+        if credits <= 0:
+            # Not yet worth a credit. Record it so the overlap cannot re-fold it,
+            # and leave the money in ``pending_usd`` for the row that tips it over.
+            await credits_service.record_no_movement(
+                workspace=workspace,
+                cause=_LITELLM_SPEND_CAUSE,
+                idempotency_key=ledger_key,
+                ref={
+                    "request_id": rid,
+                    "cost_usd": cost_usd,
+                    "model": row.get("model"),
+                    "cached_tokens": _cached_tokens(row),
+                    "source": "litellm_spend_log",
+                    "pending_usd": pending_usd,
+                },
+            )
             continue
 
         balance_after = await credits_service.debit(
@@ -988,9 +1059,15 @@ async def ingest_tenant_spend(
                 "model": row.get("model"),
                 "cached_tokens": _cached_tokens(row),
                 "source": "litellm_spend_log",
+                # What this debit actually settles: its own row plus every
+                # sub-credit row folded in ahead of it. Without this the ledger
+                # looks like a $0.0015 call was billed 3 credits.
+                "settles_usd": card.usd_for_credits(credits),
             },
             allow_negative=True,
         )
+        # Take the billed part back out; what is left is the unbilled fraction.
+        pending_usd -= card.usd_for_credits(credits)
         credits_debited += credits
         rows_billed += 1
         logger.debug(
@@ -1003,10 +1080,20 @@ async def ingest_tenant_spend(
             balance_after,
         )
 
-    # Advance the high-water mark so a re-sweep doesn't re-read settled rows. Only
-    # write when it actually moved (avoid a no-op save).
-    if newest_ts is not None and newest_ts != doc.last_spend_ingest_ts:
-        doc.last_spend_ingest_ts = newest_ts
+    # Advance the high-water mark so a re-sweep doesn't re-read settled rows, and
+    # persist the sub-credit remainder alongside it. Only write when something
+    # actually moved (avoid a no-op save).
+    #
+    # The two MUST be saved together. The mark says "these rows are settled" and the
+    # remainder says "and this much of them is still owed"; writing the mark without
+    # the remainder is exactly the old bug, since the rows behind the mark are the
+    # ones whose fractions are sitting in it.
+    mark_moved = newest_ts is not None and newest_ts != doc.last_spend_ingest_ts
+    pending_moved = pending_usd != pending_at_start
+    if mark_moved or pending_moved:
+        if newest_ts is not None:
+            doc.last_spend_ingest_ts = newest_ts
+        doc.pending_spend_usd = pending_usd
         doc.updatedAt = datetime.now(UTC)
         await doc.save()
 
@@ -1133,12 +1220,20 @@ async def reconcile_tenant_spend(
     if doc is not None and doc.litellm_key:
         client = admin_client if admin_client is not None else LiteLLMAdminClient()
         rows = await client.spend_logs(api_key=doc.litellm_key)
+        # Sum the USD and convert ONCE. Converting per row and adding the results
+        # up rounds each row separately, so every call worth less than half a credit
+        # contributes nothing — and this is the compare an operator reads to decide
+        # whether LiteLLM can be trusted as the only meter. It understated the
+        # LiteLLM side against BC-3's per-run figure by exactly the rows the live
+        # ingest was also dropping, which made the cutover look safer than it was.
+        litellm_usd = 0.0
         for row in rows:
             row_dt = _parse_iso(_row_start_time(row))
             if not _in_window(row_dt, since, until):
                 continue
             litellm_rows += 1
-            litellm_credits += card.to_credits(_num(row.get("spend")))
+            litellm_usd += _num(row.get("spend"))
+        litellm_credits = card.to_credits(litellm_usd)
 
     # --- BC-3 side: the metered compute_spend debits over the SAME window. ---
     # Read through the credits service (entity-isolation: it owns its ledger doc).
@@ -1305,6 +1400,48 @@ async def spend_attribution_coverage(
     # there are unattributed ones would be reporting a race as a finding.
     unswept_rows = min(unswept_rows, unattributed)
 
+    # Price and classify the untagged half, but only when there IS one. The counts
+    # above are O(1) in spend volume and run every tick; this reads rows, so it is
+    # gated on there being something to explain.
+    #
+    # It exists because the bare count cries wolf. A LiteLLM proxy logs its own
+    # traffic next to ours — an operator trying a model in the dashboard, the
+    # periodic model health check — and none of it can ever name a workspace or be
+    # billed to one. Measured on the production proxy 2026-09-03: all 8 "served and
+    # not billed" rows were exactly that, worth $0.00014545 between them, while the
+    # runbook told the operator to treat any non-zero count as blocking. The number
+    # was right and the conclusion it invited was wrong.
+    internal_rows = 0
+    untagged_rows = 0
+    unattributed_usd = 0.0
+    untagged_usd = 0.0
+    classified = False
+    if unattributed - unswept_rows > 0:
+        try:
+            window_rows, complete = await client.spend_logs_window(
+                start_date=start_date, end_date=end_date
+            )
+        except Exception:
+            logger.exception(
+                "llm_provisioning.spend_attribution_coverage: could not read the "
+                "window's rows to classify %d unattributed row(s) — reporting the "
+                "count alone, which cannot tell the proxy's own traffic from a real "
+                "billing hole",
+                unattributed,
+            )
+        else:
+            classified = complete
+            for row in window_rows:
+                if (row.get("end_user") or "").strip():
+                    continue
+                cost = _num(row.get("spend"))
+                unattributed_usd += cost
+                if (row.get("team_id") or "") in _PROXY_INTERNAL_TEAMS:
+                    internal_rows += 1
+                else:
+                    untagged_rows += 1
+                    untagged_usd += cost
+
     coverage = SpendCoverage(
         window_start=start_date,
         window_end=end_date,
@@ -1315,6 +1452,11 @@ async def spend_attribution_coverage(
         unswept_workspaces=tuple(unswept),
         workspaces_checked=len(workspaces),
         degraded=degraded,
+        internal_rows=internal_rows,
+        untagged_rows=untagged_rows,
+        unattributed_usd=unattributed_usd,
+        untagged_usd=untagged_usd,
+        classified=classified,
     )
 
     if degraded:
@@ -1329,20 +1471,40 @@ async def spend_attribution_coverage(
             len(workspaces),
             unattributed,
         )
-    elif unattributed:
+    elif unswept_rows or untagged_rows or (unattributed and not classified):
+        # Loud only for the halves that are actually ours. The proxy's own dashboard
+        # and health-check rows are reported, because an operator who sees a
+        # remainder wants to know where it went, but they do not raise the alarm.
         logger.warning(
             "llm_provisioning.spend_attribution_coverage: [%s,%s] %d of %d proxy spend "
-            "row(s) are being served and not billed — %d name a workspace the sweep "
-            "did not visit (%s), %d name no workspace at all. A tagged-but-unswept "
-            "row is OUR bug: the request said who pays and the sweep did not ask. An "
-            "untagged row is a caller reaching the proxy without a ``user`` field",
+            "row(s) claimed by no tenant ($%.6f) — %d name a workspace the sweep did "
+            "not visit (%s), %d are a real caller that named nobody ($%.6f), %d are the "
+            "proxy's own dashboard / health-check traffic and are nobody's to bill. A "
+            "tagged-but-unswept row is OUR bug: the request said who pays and the sweep "
+            "did not ask. An untagged row is a caller reaching the proxy without a "
+            "``user`` field%s",
             start_date,
             end_date,
             unattributed,
             total_rows,
+            unattributed_usd,
             unswept_rows,
             ", ".join(unswept) or "none",
-            unattributed - unswept_rows,
+            untagged_rows,
+            untagged_usd,
+            internal_rows,
+            "" if classified else " (the split is from a TRUNCATED read — treat it as a sample)",
+        )
+    elif unattributed:
+        logger.info(
+            "llm_provisioning.spend_attribution_coverage: [%s,%s] %d of %d proxy spend "
+            "row(s) claimed by no tenant ($%.6f), and every one is the proxy's own "
+            "dashboard / health-check traffic — nothing of ours is unbilled",
+            start_date,
+            end_date,
+            unattributed,
+            total_rows,
+            unattributed_usd,
         )
     else:
         logger.info(

--- a/ee/pocketpaw_ee/cloud/models/litellm_key.py
+++ b/ee/pocketpaw_ee/cloud/models/litellm_key.py
@@ -32,6 +32,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from beanie import Indexed
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
@@ -106,6 +108,17 @@ class LiteLLMTenantKey(TimestampedDocument):
     # one credit's worth of USD — the moment it covers a whole credit, that credit
     # is debited and this drops back below the line.
     pending_spend_usd: float = 0.0
+    # Lease held by whoever is currently ingesting this tenant's spend, as the UTC
+    # instant it expires. ``pending_spend_usd`` is a read-modify-write and the
+    # ledger's per-row key cannot protect it: two overlapping sweeps read the same
+    # remainder, each fold in a DIFFERENT row, and each cross the credit line, so
+    # both debit under distinct idempotency keys and the tenant pays twice. The
+    # overlap is not hypothetical — the 5-minute sweep runs in the API process and
+    # again at worker boot, and the per-run trigger makes it routine.
+    #
+    # An expiry rather than a boolean so a holder that crashes mid-sweep cannot
+    # wedge a tenant's billing forever; the next sweep past the expiry takes it.
+    spend_ingest_lease_until: datetime | None = None
 
     class Settings:
         name = "litellm_tenant_keys"

--- a/ee/pocketpaw_ee/cloud/models/litellm_key.py
+++ b/ee/pocketpaw_ee/cloud/models/litellm_key.py
@@ -25,6 +25,11 @@
 # in ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
 # ``init_beanie`` wires the ``litellm_tenant_keys`` collection.
 
+# Updated 2026-09-04 (fix/litellm-spend-leaks): added ``pending_spend_usd``, the
+# per-tenant sub-credit remainder. Credits are integers and the proxy prices one API
+# call, so most rows are worth a fraction of one; the sweep used to discard every
+# such row. This is where the fraction waits for the row that tips it over.
+
 from __future__ import annotations
 
 from beanie import Indexed
@@ -92,6 +97,15 @@ class LiteLLMTenantKey(TimestampedDocument):
     # /spend/logs row already debited to the ledger. The sweep reads rows AFTER
     # this and advances it; None means nothing has been ingested yet.
     last_spend_ingest_ts: str | None = None
+    # Spend this tenant has incurred that is not yet worth a whole credit, carried
+    # forward to the next sweep. Credits are integers (1 == $0.01) and the proxy
+    # prices a single API call, so most rows are worth a fraction of one; the sweep
+    # used to convert each row on its own and discard anything that rounded to
+    # zero, which served every cheap call for free and permanently, because the
+    # high-water mark moved past the dropped row in the same pass. Always less than
+    # one credit's worth of USD — the moment it covers a whole credit, that credit
+    # is debited and this drops back below the line.
+    pending_spend_usd: float = 0.0
 
     class Settings:
         name = "litellm_tenant_keys"

--- a/tests/cloud/llm_provisioning/test_coverage_false_alarm.py
+++ b/tests/cloud/llm_provisioning/test_coverage_false_alarm.py
@@ -1,0 +1,207 @@
+# tests/cloud/llm_provisioning/test_coverage_false_alarm.py — proves the
+# attribution-coverage check can tell the proxy's own traffic from a billing hole.
+#
+# THE BUG. The check counted every spend row no tenant claimed and the runbook told
+# the operator to treat any non-zero count as blocking. But a LiteLLM proxy logs
+# traffic of its own beside ours — a human trying a model in its admin dashboard,
+# its periodic model health check — and none of it can ever carry a workspace or be
+# billed to one. So the count could never reach zero on a live deployment, and the
+# one guard protecting the billing cutover was permanently red.
+#
+# The shape is taken from the production proxy on 2026-09-03. A sweep reported
+# "8 of 19 proxy spend row(s) are being served and not billed", which read as a
+# serious under-bill. Reading the rows back showed all 8 were the dashboard and the
+# health check, worth $0.00014545 between them, and the 11 rows that WERE tagged
+# cost exactly $0.00 because the models in use were free. Nothing was wrong. Several
+# hours went into finding that out, which is the cost this test exists to stop
+# paying again.
+#
+# So the check now prices the remainder and splits it three ways: rows naming an
+# unswept workspace, rows from a real caller that named nobody, and the proxy's own.
+# Only the first two are ours.
+#
+# Uses the shared ``mongo_db`` fixture from tests/cloud/conftest.py and a FAKE admin
+# client, mirroring test_spend_by_customer.py.
+#
+# Created 2026-09-04 (fix/litellm-spend-leaks): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.catalog.admin_client import LiteLLMAdminError
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+
+UNTIL = datetime(2026, 9, 3, 21, 44, 22, tzinfo=UTC)
+SINCE = UNTIL - timedelta(hours=24)
+
+WS_A = "6a1210f462bf55588dee1d4f"
+WS_B = "6a146169ad1f4c4decb828f4"
+
+
+def _tagged(rid: str, workspace: str, usd: float = 0.0) -> dict:
+    return {
+        "request_id": rid,
+        "end_user": workspace,
+        "spend": usd,
+        "startTime": "2026-09-03T20:11:29+00:00",
+        "model": "deepseek/deepseek-v4-pro-0813-free",
+    }
+
+
+def _dashboard(rid: str, usd: float = 0.0) -> dict:
+    """A human clicking "test model" in the LiteLLM admin UI."""
+    return {
+        "request_id": rid,
+        "end_user": "",
+        "team_id": "litellm-dashboard",
+        "spend": usd,
+        "startTime": "2026-09-03T20:14:42+00:00",
+        "model": "Qwen3.8-27B",
+    }
+
+
+def _health_check(rid: str) -> dict:
+    """The proxy probing its own models."""
+    return {
+        "request_id": rid,
+        "end_user": "",
+        "team_id": "litellm-internal-health-check",
+        "spend": 0.0,
+        "startTime": "2026-09-03T20:40:48+00:00",
+        "model": "minimax/minimax-m3:free",
+    }
+
+
+def _real_untagged(rid: str, usd: float) -> dict:
+    """Our own deployment reaching the proxy without naming who pays."""
+    return {
+        "request_id": rid,
+        "end_user": "",
+        "team_id": None,
+        "spend": usd,
+        "startTime": "2026-09-02T06:07:56+00:00",
+        "model": "deepseek/deepseek-v4-flash",
+    }
+
+
+class FakeAdmin:
+    """Serves the window's rows, and derives the counts from them.
+
+    Deriving rather than hardcoding matters: the check reads counts on one path and
+    rows on another, and a fake that let the two disagree would pass a version of
+    the code where they do.
+    """
+
+    def __init__(self, rows: list[dict], *, customers=None, fail_window=False):
+        self.rows = rows
+        self.customers = customers or []
+        self.fail_window = fail_window
+        self.window_calls = 0
+
+    async def spend_log_count(self, *, start_date, end_date, end_user=None):
+        if end_user is None:
+            return len(self.rows)
+        return sum(1 for r in self.rows if (r.get("end_user") or "") == end_user)
+
+    async def spend_logs_window(self, *, start_date, end_date, page_size=100, max_rows=1000):
+        self.window_calls += 1
+        if self.fail_window:
+            raise LiteLLMAdminError("window read failed (simulated)")
+        return list(self.rows), True
+
+    async def list_customers(self):
+        return list(self.customers)
+
+
+async def test_the_proxys_own_traffic_is_not_a_billing_hole(mongo_db):
+    """The production shape. Twelve tagged rows, eight unattributed, and every one
+    of the eight is the proxy talking to itself. Nothing of ours is unbilled."""
+    rows = (
+        [_tagged(f"a{i}", WS_A) for i in range(6)]
+        + [_tagged(f"b{i}", WS_B) for i in range(6)]
+        + [_dashboard(f"d{i}") for i in range(7)]
+        + [_health_check("h0")]
+    )
+    admin = FakeAdmin(rows)
+
+    coverage = await provisioning.spend_attribution_coverage(
+        [WS_A, WS_B], since=SINCE, until=UNTIL, admin_client=admin
+    )
+
+    assert coverage.unattributed_rows == 8
+    assert coverage.internal_rows == 8
+    assert coverage.untagged_rows == 0, "the proxy's own traffic was read as our hole"
+    assert coverage.untagged_usd == 0.0
+    assert coverage.classified is True
+    assert not coverage.degraded
+
+
+async def test_a_real_untagged_caller_is_still_reported(mongo_db):
+    """The check must not go quiet. Our own deployment reaching the proxy without
+    a workspace is the failure the whole seam exists to catch, and it has to
+    survive the noise filter that let the dashboard through."""
+    rows = [
+        _tagged("a0", WS_A),
+        _dashboard("d0"),
+        _health_check("h0"),
+        _real_untagged("r0", 0.02039758),
+        _real_untagged("r1", 0.00692236),
+    ]
+    admin = FakeAdmin(rows)
+
+    coverage = await provisioning.spend_attribution_coverage(
+        [WS_A], since=SINCE, until=UNTIL, admin_client=admin
+    )
+
+    assert coverage.unattributed_rows == 4
+    assert coverage.internal_rows == 2
+    assert coverage.untagged_rows == 2
+    assert coverage.untagged_usd == pytest.approx(0.02731994)
+
+
+async def test_the_remainder_is_priced_not_just_counted(mongo_db):
+    """A count cannot tell a hundredth of a cent of dashboard poking from a dollar
+    of unbilled chat, and deciding whether to block a billing cutover is exactly
+    the question that needs the difference."""
+    rows = [_tagged("a0", WS_A), _dashboard("d0", usd=0.00014545)]
+    admin = FakeAdmin(rows)
+
+    coverage = await provisioning.spend_attribution_coverage(
+        [WS_A], since=SINCE, until=UNTIL, admin_client=admin
+    )
+
+    assert coverage.unattributed_usd == pytest.approx(0.00014545)
+    assert coverage.untagged_usd == 0.0
+
+
+async def test_a_clean_window_never_reads_the_rows(mongo_db):
+    """The classification is a diagnostic, and a diagnostic that runs when there is
+    nothing to diagnose is just cost. Every tick pays for the counts; only a tick
+    with a remainder pays to explain it."""
+    admin = FakeAdmin([_tagged("a0", WS_A)])
+
+    coverage = await provisioning.spend_attribution_coverage(
+        [WS_A], since=SINCE, until=UNTIL, admin_client=admin
+    )
+
+    assert coverage.unattributed_rows == 0
+    assert admin.window_calls == 0
+
+
+async def test_a_failed_row_read_leaves_the_count_alone(mongo_db):
+    """The classification is an observation of the check, not part of it. If the
+    proxy will not serve the rows, the operator still gets the remainder — flagged
+    as unclassified, so a zero in the split reads as "could not tell" rather than
+    as "nothing of ours"."""
+    rows = [_tagged("a0", WS_A), _real_untagged("r0", 0.5)]
+    admin = FakeAdmin(rows, fail_window=True)
+
+    coverage = await provisioning.spend_attribution_coverage(
+        [WS_A], since=SINCE, until=UNTIL, admin_client=admin
+    )
+
+    assert coverage.unattributed_rows == 1
+    assert coverage.classified is False
+    assert coverage.untagged_rows == 0

--- a/tests/cloud/llm_provisioning/test_sub_credit_spend_drop.py
+++ b/tests/cloud/llm_provisioning/test_sub_credit_spend_drop.py
@@ -1,0 +1,196 @@
+# tests/cloud/llm_provisioning/test_sub_credit_spend_drop.py — proves that proxy
+# spend below one credit is served for free, permanently.
+#
+# THE BUG. ``ingest_tenant_spend`` converts each spend row to credits on its own
+# and drops the row when the result rounds to zero:
+#
+#     credits = card.to_credits(cost_usd)
+#     if credits <= 0:
+#         continue  # sub-credit / zero-cost row — nothing to debit
+#
+# With the default rate card (markup 2.5, credit_usd 0.01) that is
+# ``round(cost_usd * 250)``, so every row under $0.002 bills nothing. The row is
+# not deferred and nothing accumulates: the high-water mark advances past it in
+# the same pass, and the ledger never sees it. Ten thousand such rows are ten
+# thousand separate zeros.
+#
+# This matters more after the billing cutover than before it, and that is the
+# regression. BC-3 priced a whole RUN, so the rounding applied once to the sum of
+# everything a run spent. LiteLLM prices one API CALL, so the same rounding now
+# applies to each call separately — a much smaller unit, far more often under the
+# threshold. The conversion did not change; the grain it is applied at did.
+#
+# The failure is silent by construction. ``cost_usd`` on the result still carries
+# the real dollars that were read, so the sweep logs a confident
+# ``ingested spend for 5/5 tenants -> 0 credits`` over money the proxy has
+# already priced and served.
+#
+# Uses the shared ``mongo_db`` fixture from tests/cloud/conftest.py and a FAKE
+# admin client, mirroring test_spend_by_customer.py.
+#
+# Created 2026-09-04 (fix/sub-credit-spend-drop): new test module.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
+from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+
+WS = "ws_sub_credit"
+
+# Pinned so credits never depend on ambient settings: round(usd * 250).
+SPEND = SpendCredits(markup=2.5, credit_usd=0.01)
+
+# One cheap call. $0.0015 * 250 = 0.375 credits, which rounds to zero.
+CHEAP_USD = 0.0015
+CHEAP_ROWS = 8
+# What the same money is worth billed as a sum instead of row by row.
+EXPECTED_CREDITS = round(CHEAP_USD * CHEAP_ROWS * 250)  # 3
+
+
+class FakeAdmin:
+    """In-memory stand-in for LiteLLMAdminClient.
+
+    Carries BOTH spend reads so this module runs unchanged against the pre- and
+    post-customer-read shapes of ``ingest_tenant_spend``.
+    """
+
+    def __init__(self, *, key_rows=None, customer_rows=None):
+        self.key_rows = key_rows or []
+        self.customer_rows = customer_rows or []
+
+    async def generate_key(self, **kwargs):
+        return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **kwargs}
+
+    async def spend_logs(self, *, api_key: str):
+        return list(self.key_rows)
+
+    async def spend_logs_by_end_user(self, *, end_user, start_date, end_date, page_size=100):
+        return list(self.customer_rows)
+
+    async def spend_log_count(self, *, start_date, end_date, end_user=None):
+        return 0
+
+    async def list_customers(self):
+        return []
+
+
+async def _provision(workspace: str = WS) -> LiteLLMTenantKey:
+    await provisioning.ensure_tenant_key(workspace, budget=KeyBudget(), admin_client=FakeAdmin())
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
+    assert doc is not None
+    return doc
+
+
+def _cheap_rows() -> list[dict]:
+    """Eight real calls, each priced under half a cent."""
+    return [
+        {
+            "request_id": f"req-cheap-{i}",
+            "spend": CHEAP_USD,
+            "startTime": f"2026-09-02T10:0{i}:00",
+            "model": "gpt-5.2-mini",
+        }
+        for i in range(CHEAP_ROWS)
+    ]
+
+
+async def test_sub_credit_rows_are_not_served_for_free(mongo_db):
+    """Twelve tenths of a cent of real, already-served compute must reach the
+    ledger. Today each row rounds to zero on its own and the whole sum is
+    discarded, so the wallet is untouched and the sweep reports zero credits over
+    money the proxy has already priced."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(key_rows=_cheap_rows())
+
+    result = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    # The read itself is fine — the money is seen.
+    assert result.rows_read == CHEAP_ROWS
+    assert result.cost_usd == pytest.approx(CHEAP_USD * CHEAP_ROWS)
+
+    # And then it is thrown away.
+    assert result.credits_debited == EXPECTED_CREDITS, (
+        f"read ${result.cost_usd:.4f} of served compute and debited "
+        f"{result.credits_debited} credits"
+    )
+    assert await credits.balance(WS) == 1000 - EXPECTED_CREDITS
+
+
+async def test_a_dropped_sub_credit_row_never_comes_back(mongo_db):
+    """The drop is permanent, not deferred. The high-water mark advances past a
+    dropped row in the same pass, so a later sweep cannot re-examine it — and even
+    inside the customer read's window it rounds to zero again. Nothing accumulates
+    a remainder, so this money has no path to the ledger at all."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(key_rows=_cheap_rows())
+
+    await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+    second = await provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin)
+
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
+    assert doc is not None
+    assert doc.last_spend_ingest_ts is not None, "the mark advanced past the dropped rows"
+
+    total_charged = 1000 - await credits.balance(WS)
+    assert total_charged == EXPECTED_CREDITS, (
+        f"${CHEAP_USD * CHEAP_ROWS:.4f} of served compute billed {total_charged} "
+        f"credits across two sweeps (second sweep read {second.rows_read} row(s))"
+    )
+
+
+async def test_the_remainder_survives_between_sweeps(mongo_db):
+    """The carry is only worth having if it persists. Four cheap rows arrive, then
+    four more on a later sweep; the tenant owes the same three credits as if all
+    eight had arrived at once. A remainder held only in memory would restart at
+    zero and lose the first four rows' fractions."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    first, second = _cheap_rows()[:4], _cheap_rows()[4:]
+
+    await provisioning.ingest_tenant_spend(
+        WS, spend_card=SPEND, admin_client=FakeAdmin(key_rows=first)
+    )
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
+    assert doc is not None
+    assert doc.pending_spend_usd > 0, "the unbilled fraction was not carried"
+
+    await provisioning.ingest_tenant_spend(
+        WS, spend_card=SPEND, admin_client=FakeAdmin(key_rows=first + second)
+    )
+
+    assert 1000 - await credits.balance(WS) == EXPECTED_CREDITS
+
+
+async def test_a_re_read_cheap_row_is_not_charged_twice(mongo_db):
+    """The failure mode the fix could have introduced, and the reason the
+    already-recorded check moved ABOVE the conversion.
+
+    The customer read deliberately re-offers the last fifteen minutes of settled
+    rows every sweep, to catch rows the proxy wrote late. A cheap row folded into
+    the remainder has no debit against it, so if "already recorded" only covered
+    debited rows, the overlap would fold the same row in on every tick and the
+    tenant would be billed several times over. Under-billing would have become
+    over-billing.
+    """
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    rows = _cheap_rows()
+    for _ in range(5):  # five sweeps, the same window re-offered each time
+        await provisioning.ingest_tenant_spend(
+            WS, spend_card=SPEND, admin_client=FakeAdmin(customer_rows=rows)
+        )
+
+    charged = 1000 - await credits.balance(WS)
+    assert charged == EXPECTED_CREDITS, (
+        f"${CHEAP_USD * CHEAP_ROWS:.4f} of compute billed {charged} credits after "
+        f"five overlapping sweeps"
+    )

--- a/tests/cloud/llm_provisioning/test_sub_credit_spend_drop.py
+++ b/tests/cloud/llm_provisioning/test_sub_credit_spend_drop.py
@@ -194,3 +194,88 @@ async def test_a_re_read_cheap_row_is_not_charged_twice(mongo_db):
         f"${CHEAP_USD * CHEAP_ROWS:.4f} of compute billed {charged} credits after "
         f"five overlapping sweeps"
     )
+
+
+async def test_two_concurrent_sweeps_do_not_double_bill_the_remainder(mongo_db):
+    """The remainder is a read-modify-write, so it needs a lease.
+
+    Two ingests for one workspace can overlap: the 5-minute sweep runs in the API
+    process and again at worker boot, and a per-run trigger makes the overlap
+    routine. Both load the same ``pending_spend_usd``, both add their own row to it,
+    both cross the credit line, and both debit — on DIFFERENT rows, so the ledger's
+    unique key never fires and nothing looks wrong afterwards.
+
+    The overlap is forced rather than hoped for. ``ingest_tenant_spend`` loads the
+    bookkeeping row BEFORE it reads spend, so a barrier inside the spend read holds
+    both callers until each is holding the same stale remainder. Left to chance the
+    two coroutines simply run to completion in turn and the race never appears,
+    which is exactly why it survived review.
+
+    Here: $0.003 already carried, plus one $0.0015 row on each side. Six tenths of a
+    cent is worth one credit with $0.002 left over. Without a lease it bills two.
+    """
+    import asyncio
+
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    doc = await _provision()
+    doc.pending_spend_usd = 0.003
+    await doc.save()
+
+    both_loaded = asyncio.Event()
+    arrived = 0
+
+    class BarrierAdmin(FakeAdmin):
+        """Blocks inside the spend read until BOTH ingests hold the same doc."""
+
+        async def spend_logs(self, *, api_key: str):
+            nonlocal arrived
+            arrived += 1
+            if arrived >= 2:
+                both_loaded.set()
+            # A short timeout, not a hard barrier. When the lease works the second
+            # caller never reaches here at all, so waiting for it would deadlock the
+            # first — the test has to survive the fix as well as catch the bug.
+            try:
+                await asyncio.wait_for(both_loaded.wait(), timeout=0.5)
+            except TimeoutError:
+                pass
+            return list(self.key_rows)
+
+    left = [
+        {
+            "request_id": "req-left",
+            "spend": CHEAP_USD,
+            "startTime": "2026-09-02T10:00:00",
+            "model": "gpt-5.2-mini",
+        }
+    ]
+    right = [
+        {
+            "request_id": "req-right",
+            "spend": CHEAP_USD,
+            "startTime": "2026-09-02T10:00:01",
+            "model": "gpt-5.2-mini",
+        }
+    ]
+
+    await asyncio.gather(
+        provisioning.ingest_tenant_spend(
+            WS, spend_card=SPEND, admin_client=BarrierAdmin(key_rows=left)
+        ),
+        provisioning.ingest_tenant_spend(
+            WS, spend_card=SPEND, admin_client=BarrierAdmin(key_rows=right)
+        ),
+    )
+
+    charged = 1000 - await credits.balance(WS)
+    assert charged == 1, f"$0.006 of spend billed {charged} credits across two overlapping sweeps"
+
+    # And the row the skipped caller was holding is not lost — it carries no ledger
+    # entry, so a later sweep picks it up and folds it into the remainder.
+    await provisioning.ingest_tenant_spend(
+        WS, spend_card=SPEND, admin_client=FakeAdmin(key_rows=left + right)
+    )
+    assert 1000 - await credits.balance(WS) == 1
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
+    assert doc is not None
+    assert doc.pending_spend_usd == pytest.approx(0.002)


### PR DESCRIPTION
## What this is

A sweep in production logged this, and it reads like money going out the door:

```
llm_provisioning.spend_attribution_coverage: 8 of 19 proxy spend row(s) are being
served and not billed
run_cutover_sweep: ingested spend for 5/5 tenants -> 0 credits
```

It was not. I pulled the rows off the proxy for that exact window. All 8 were the
LiteLLM admin dashboard and the proxy's own health check, worth $0.00014545
between them. The 12 rows that *were* attributed cost exactly $0.00, because
every model in use that day was free or self-hosted, so the `0 credits` was right
too.

Nothing was broken. Finding that out took hours, and the reason it took hours is
worth fixing. Along the way I found something that was broken.

## The alarm could never go quiet

A LiteLLM proxy logs traffic of its own next to ours. Someone tries a model in the
admin UI; the proxy probes its own models on a timer. Those rows carry a `team_id`
the proxy assigns itself and they can never name a workspace, because there isn't
one. The coverage check counted them as spend "being served and not billed", and
`docs/deployment/litellm-billing-cutover.md` said to treat any non-zero count as
blocking.

So the one guard protecting the billing cutover was permanently red. A guard like
that gets ignored, and then it is not a guard.

The check now reads the remainder back and splits it three ways: rows naming an
unswept workspace, rows from a real caller that named nobody, and the proxy's own.
Only the first two warn. It also reports what the remainder **cost**, because a
row count cannot tell a hundredth of a cent of dashboard poking from a dollar of
unbilled chat, which is what you actually need to know before flipping a meter.

The row read is gated on there being a remainder to explain, and hard-capped, so a
diagnostic can never cost more than the billing it observes.

## Spend under $0.002 was billed to nobody

This one is real, and it is why I kept going after the alarm turned out to be
noise.

The ingest converted each spend row to credits on its own:

```python
credits = card.to_credits(cost_usd)
if credits <= 0:
    continue  # sub-credit / zero-cost row — nothing to debit
```

A credit is one cent. With the default card that is `round(usd * 250)`, so any row
under $0.002 rounds to zero and is dropped. Not deferred: the high-water mark
advances past it in the same pass and nothing accumulates it, so it never comes
back.

Per-run metering shares that conversion and never showed the problem, because it
priced a whole **run** at once. LiteLLM prices one API **call**. The cutover kept
the arithmetic and made the unit about a hundred times smaller, which is the
regression.

I want to be accurate about the size of this, because I overstated it to myself at
first. `round` is not biased. A row at $0.003 rounds *up* to a credit it has not
earned, and that offsets a row at $0.0015 rounding down to nothing. Over the last
week of real traffic the two roughly cancelled: one workspace was over-billed by a
credit, the other under-billed by one. So this is not a revenue leak that has been
quietly draining, and I do not want the PR read that way.

What it is: wrong per tenant, in both directions, and unboundedly wrong for a
workload of uniformly cheap calls, where nothing rounds up to offset anything. A
thousand $0.0015 requests cost $1.50 and bill zero. That is a plausible shape for
an agent doing many small tool-model calls, which is where this is heading.

The fraction is now carried on the tenant document and debited the moment it covers
a credit, so the ledger tracks the dollars exactly instead of approximately.

## Does this bill what was already missed?

No, and it is worth being explicit. The reads start at `last_spend_ingest_ts` minus
fifteen minutes, so only the trailing overlap gets re-examined. Anything dropped
before that stays unbilled.

It is recoverable if you want it. A dropped row got no ledger entry at all, so
rewinding a tenant's `last_spend_ingest_ts` makes the next sweep re-read it and
bill it, while every row that *was* billed is skipped on its `litellm:{request_id}`
key. The exactly-once guarantee holds through a rewind.

The one rule: do not rewind earlier than the cutover mark
`prepare_spend_cutover` stamped. Before that instant BC-3 owns the billing, and
those rows carry a different idempotency key, so the ledger cannot recognise them
as already charged. That is the double-bill the runbook warns about.

Given the numbers above I would not bother for this week's traffic. Say the word if
you want the rewind as a follow-up and I will write it as a bounded operation with
a dry run.

### The part that could have gone wrong

The already-recorded check had to move above the conversion, and that ordering is
load-bearing. A row folded into the remainder gets a zero-value ledger entry
instead of a debit, and the customer read deliberately re-offers fifteen minutes of
settled rows on every sweep to catch rows the proxy wrote late. Without the check
first, the same fraction gets folded in once per tick and the tenant is billed
several times over. Under-billing would have become over-billing, which is worse.

`test_a_re_read_cheap_row_is_not_charged_twice` runs five overlapping sweeps and
asserts the tenant is charged once.

The zero-value entry needed a new writer, `credits.record_no_movement`. `debit`
rightly refuses a non-positive amount, but the ledger's unique
`(workspace, idempotency_key)` index is the only per-row store with an
exactly-once guarantee, so that is where "I have seen this row" has to live. It
moves no money, emits nothing, and contributes zero to every existing sum. Ledger
growth is unchanged: one entry per proxy row either way.

## The shadow compare had the same bug

`reconcile_tenant_spend` also rounded per row, so it understated the LiteLLM side
against BC-3 by exactly the rows the live ingest was dropping. That is part of why
the cutover looked safe when it was read. It sums the window and converts once now.

## Verification

Against the production proxy, same window as the original log:

```
before: WARNING ... 8 of 19 proxy spend row(s) are being served and not billed
after:  INFO ... 8 of 20 proxy spend row(s) claimed by no tenant ($0.000145), and
        every one is the proxy's own dashboard / health-check traffic — nothing of
        ours is unbilled
```

`untagged=0`, `unswept=0`, `classified=True`, `degraded=False`.

Tests: 158 pass across `tests/cloud/llm_provisioning/` and `tests/cloud/credits/`,
including 9 new ones. The two in `test_sub_credit_spend_drop.py` were written
first and failed against `dev` with `read $0.0120 of served compute and debited 0
credits`.

## Worth knowing

`POCKETPAW_LITELLM_API_KEY` is both the runtime LLM bearer and the proxy admin
bearer. That is why chat rows are stamped with the deployment key, and why the
billing diagnostics only work from an environment holding the master key. Not
changed here, but it is a single credential doing two jobs with very different
blast radii.

The gate in the runbook changed. It was "`unattributed` must be zero". It is now
"`untagged` and `unswept` must be zero". `unattributed` is context, and on a live
deployment it never reaches zero.
