### PR TITLE
A pageview records which visit it belongs to

### DIFF
--- a/ee/pocketpaw_ee/sites/analytics_worker.py
+++ b/ee/pocketpaw_ee/sites/analytics_worker.py
@@ -24,6 +24,17 @@
 # it carry four blobs forever — the reader tolerates both. The full argument for why it
 # is this coarse, and why the append is not negotiable, is in the row contract below.
 #
+# Updated 2026-09-04 (feat/sites-analytics-visit-id, AD-1) — the row grew a SIXTH blob:
+# a VISIT ID at ``blobs[5]``, so a pageview can be attributed to the visit it belongs to
+# and visits become countable at all. It is ``SHA-256(secret | UTC-hour | visitor-hash)``
+# truncated to 16 bytes: the day-rotating visitor hash with an hourly rotation on top,
+# which is how Umami derives a visit from a session — a hash of the session id and a
+# salt that rotates on the hour. Appended, never inserted, for exactly the reason SA-3
+# appended the device class; rows written before this carry FIVE blobs forever and the
+# sixth reads as an empty string. A visit that crosses the top of the hour gets a new id
+# and counts as two, which is accepted rather than fixed — the argument is in the row
+# contract below.
+#
 # SHAPE MIRRORS ``badge.py`` / ``paw_bar/embed.py`` — a per-site injection into the
 # artifact between build and deploy, so what lands is already correct and there is no
 # second deploy and no post-publish patch. What differs is WHAT is injected: those two
@@ -148,15 +159,19 @@
 #   blobs[2]   — ``request.cf.country``.
 #   blobs[3]   — the visitor hash.
 #   blobs[4]   — the device class: ``desktop`` / ``mobile`` / ``tablet`` / ``unknown``.
+#   blobs[5]   — the visit id: which visit this pageview belongs to, rotating hourly.
 #   doubles[0] — 1, the pageview.
 #
 # Do not reorder these without changing the reader in the same PR: Analytics Engine
 # columns are positional and have no names. APPEND-ONLY for the same reason: SA-3 added
 # ``blobs[4]`` at the END rather than anywhere more logical, because inserting it
 # earlier would silently re-label every row already in the dataset, and the retention
-# window is three months. Rows written before SA-3 carry FOUR blobs and are not
-# backfilled — Analytics Engine has no update — so the reader must tolerate both
-# lengths and read a missing device as ``unknown``.
+# window is three months. AD-1 added ``blobs[5]`` under the same rule. A reordered write
+# against an unchanged reader raises nothing — it reports referrers as countries — which
+# is why this is a constraint and not a preference. Rows written before SA-3 carry FOUR
+# blobs and rows written before AD-1 carry FIVE; neither is backfilled, because Analytics
+# Engine has no update, so the reader must tolerate all three lengths, read a missing
+# device as ``unknown`` and a missing visit as empty.
 #
 # WHY A DEVICE CLASS IS THE ONE THING WORTH ADDING HERE, and why it is this coarse. The
 # user-agent is already parsed on this path (the bot filter reads it, and it is an
@@ -167,6 +182,27 @@
 # traced to a person, and every bit of user-agent entropy that reaches the row chips at
 # it. A browser name, a version, an OS build, a screen size — each is individually
 # reasonable and collectively a fingerprint. Two bits is not.
+#
+# WHY A VISIT IS AN HOUR, AND WHAT THE BOUNDARY COSTS. A pageview count answers "how
+# much traffic"; a visit count answers "how many times somebody came", and the gap
+# between them is the pages-per-visit ratio a bounce rate is read off. Nothing in the
+# row could recover that after the fact — the visitor hash is per DAY, so grouping by it
+# collapses a morning and an evening visit into one — which is why the id has to be
+# derived at write time.
+#
+# It is derived FROM the visitor hash rather than from the IP and user-agent again, so
+# it inherits the daily rotation: a visit id cannot outlive the identifier it is built
+# from, and the hour is a SECOND rotation on top of that rather than a longer-lived one.
+#
+# THE HOUR BOUNDARY IS A KNOWN, ACCEPTED ERROR AND NOT A BUG AWAITING A FIX. A visit
+# that starts at 10:58 and continues at 11:02 gets a new id and counts as TWO. There is
+# nowhere to carry an id across the boundary — no cookie, no storage, and a Worker holds
+# nothing between requests — so the choice is a fixed window or an identifier that
+# persists, and an identifier that persists is the one thing this feature exists to not
+# store. The error therefore runs in one direction only: it OVER-SPLITS and never
+# over-merges, the same direction the daily salt already accepts at midnight and a
+# republish already accepts mid-day. A visit count is an upper bound on sessions, never
+# an exact one, and whoever renders it should not imply otherwise.
 
 from __future__ import annotations
 
@@ -463,16 +499,39 @@ export function dayKey(nowMs) {{
   return new Date(nowMs).toISOString().slice(0, 10);
 }}
 
-// SHA-256 over the secret, the day, the IP and the user-agent, truncated to 16 bytes.
-// Truncation is a storage decision, not a security one: 128 bits is far past the
-// collision budget of one site-day, and the row is smaller for it.
-export async function visitorHash(ip, ua, secret, day) {{
-  const data = new TextEncoder().encode(`${{secret}}|${{day}}|${{ip}}|${{ua}}`);
-  const digest = await crypto.subtle.digest("SHA-256", data);
+// The VISIT's rotating half: the UTC calendar hour, `YYYY-MM-DDTHH`. An hour is the
+// whole session model — see the row contract in analytics_worker.py for why there is
+// nowhere to carry a visit across the boundary, and why the resulting over-split is
+// accepted rather than fixed.
+export function hourKey(nowMs) {{
+  return new Date(nowMs).toISOString().slice(0, 13);
+}}
+
+// SHA-256, truncated to 16 bytes, rendered hex. ONE copy of the construction, because
+// the visitor hash and the visit id are the same digest over different components and a
+// second transcription is how the two stop agreeing about what they mean. Truncation is
+// a storage decision, not a security one: 128 bits is far past the collision budget of
+// one site-day, and the row is smaller for it.
+async function sha256Hex16(input) {{
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
   const bytes = new Uint8Array(digest).subarray(0, 16);
   let hex = "";
   for (const byte of bytes) hex += byte.toString(16).padStart(2, "0");
   return hex;
+}}
+
+// SHA-256 over the secret, the day, the IP and the user-agent: WHO, for one UTC day.
+export async function visitorHash(ip, ua, secret, day) {{
+  return sha256Hex16(`${{secret}}|${{day}}|${{ip}}|${{ua}}`);
+}}
+
+// SHA-256 over the secret, the hour and the day's visitor hash: WHICH VISIT, stored at
+// blobs[5]. Built FROM the visitor hash rather than from the IP and user-agent a second
+// time, so it inherits the daily rotation and can never outlive the identifier it is
+// derived from; the hour is a second rotation on top. This mirrors how Umami derives a
+// visit from a session — a hash of the session id plus a salt that rotates hourly.
+export async function visitId(visitor, secret, hour) {{
+  return sha256Hex16(`${{secret}}|${{hour}}|${{visitor}}`);
 }}
 
 // A same-site referrer is not a referrer — it is internal navigation, and reporting it
@@ -499,8 +558,12 @@ export async function count(request, env, nowMs) {{
     if (isBot(ua)) return;
     const url = new URL(request.url);
     const ip = request.headers.get("cf-connecting-ip") || "";
-    const day = dayKey(typeof nowMs === "number" ? nowMs : Date.now());
+    // ONE reading of the clock feeds both rotations. Two calls to Date.now() could
+    // straddle a boundary and pair a day with an hour that is not inside it.
+    const now = typeof nowMs === "number" ? nowMs : Date.now();
+    const day = dayKey(now);
     const visitor = await visitorHash(ip, ua, SALT, day);
+    const visit = await visitId(visitor, SALT, hourKey(now));
     dataset.writeDataPoint({{
       indexes: [SITE_ID],
       blobs: [
@@ -509,6 +572,7 @@ export async function count(request, env, nowMs) {{
         (request.cf && request.cf.country) || "",
         visitor,
         deviceClass(ua),
+        visit,
       ],
       doubles: [1],
     }});

--- a/tests/ee/sites/test_sites_analytics_counter.py
+++ b/tests/ee/sites/test_sites_analytics_counter.py
@@ -12,6 +12,16 @@
 # did before there was one — since a shifted column silently re-labels three months of
 # history and nothing else in the suite would notice.
 #
+# Updated 2026-09-04 (feat/sites-analytics-visit-id, AD-1) — the row grew ``blobs[5]``,
+# the VISIT id, and its tests live here for the same reason: the subject is the row the
+# shared counting core writes. ``test_the_device_class_is_appended_and_shifts_nothing``
+# now expects SIX blobs rather than five; that number is the append-check itself, not a
+# claim about the device class, and the device stays asserted at position 4 beside it.
+# The visit section at the foot pins three things a passing hex pattern alone would not:
+# the id is STABLE inside a UTC hour, it ROTATES across the boundary, and it DISTINGUISHES
+# two visitors in the same hour — the last of those fails for a visit id that hashed the
+# hour and dropped the visitor, which every other assertion here would accept.
+#
 # THE CENTRE OF THIS FILE IS THE COST MODEL, not the config keys. Cloudflare bills a
 # Worker invocation and serves a static asset free, so a ``run_worker_first`` rule that
 # matches a page's subresources multiplies the per-pageview cost by roughly twenty.
@@ -571,7 +581,8 @@ def test_a_free_server_worker_publish_gets_no_counter(tmp_path):
 # ── driving the generated Worker under node ──────────────────────────────────
 
 _DRIVER_PRELUDE = """
-import worker, { isBot, dayKey, visitorHash, count, deviceClass } from "./entry.mjs";
+import worker, { isBot, dayKey, hourKey, visitorHash, visitId, count, deviceClass }
+  from "./entry.mjs";
 
 const request = (url, headers = {}, cf = {}) => ({
   url,
@@ -921,7 +932,12 @@ def test_the_device_class_is_appended_and_shifts_nothing(tmp_path):
 
     Asserted on the row that CARRIES the device, so it cannot pass by reading a
     pre-SA-3 row: path, referrer host, country and visitor hash must still be at 0, 1,
-    2 and 3 with the fifth blob present beside them."""
+    2 and 3 with the fifth blob present beside them.
+
+    The length moved to SIX with AD-1's visit id. The length is the append-check — it
+    catches a slot inserted anywhere but the end — and it has to track the contract as
+    the contract grows. What it must never do is stop naming the position each field is
+    read at, which is why every one of them is still asserted individually."""
     out = _run_node(
         tmp_path,
         """
@@ -945,7 +961,8 @@ emit({ rows: rec.rows });
     assert blobs[2] == "DE"
     assert re.fullmatch(r"[0-9a-f]{32}", blobs[3])
     assert blobs[4] == "desktop"
-    assert len(blobs) == 5
+    assert re.fullmatch(r"[0-9a-f]{32}", blobs[5])
+    assert len(blobs) == 6
     assert out["rows"][0]["doubles"] == [1]
 
 
@@ -1010,3 +1027,151 @@ def test_the_device_class_never_carries_the_user_agent(tmp_path):
     # Nothing version-shaped, platform-shaped or otherwise narrowing rides along.
     for device in out["devices"]:
         assert re.fullmatch(r"desktop|mobile|tablet|unknown", device)
+
+
+# ── AD-1: the visit id at blobs[5] ───────────────────────────────────────────
+
+
+def test_the_row_carries_a_visit_id_at_blob_five(tmp_path):
+    """AD-1's half of the row contract, driven end to end through the default handler.
+    A derivation that is right and a ``count`` that never calls it would pass a unit
+    check on the helper and store nothing, which is the failure this catches.
+
+    The other five fields are asserted beside it because the id was APPENDED: a slot
+    inserted anywhere earlier re-labels three months of stored rows, silently, and
+    Analytics Engine has no update to fix them with."""
+    out = _run_node(
+        tmp_path,
+        """
+const rec = recorder();
+const pending = [];
+const res = await worker.fetch(
+  request(
+    "https://site.example.dev/docs/guide.html",
+    { "user-agent": HUMAN, "cf-connecting-ip": "203.0.113.9",
+      referer: "https://news.example.com/story" },
+    { country: "DE" },
+  ),
+  { ASSETS: page(200), PAW_ANALYTICS: rec },
+  { waitUntil: (p) => pending.push(p) },
+);
+await Promise.all(pending);
+emit({ status: res.status, rows: rec.rows });
+""",
+    )
+
+    assert out["status"] == 200
+    assert len(out["rows"]) == 1
+    blobs = out["rows"][0]["blobs"]
+    assert blobs[0] == "/docs/guide.html"
+    assert blobs[1] == "news.example.com"
+    assert blobs[2] == "DE"
+    assert re.fullmatch(r"[0-9a-f]{32}", blobs[3])
+    assert blobs[4] == "desktop"
+    assert re.fullmatch(r"[0-9a-f]{32}", blobs[5])
+    assert len(blobs) == 6
+    assert out["rows"][0]["doubles"] == [1]
+
+
+def test_the_visit_id_is_stable_within_the_hour_and_rotates_across_it(tmp_path):
+    """What makes a visit countable: every pageview of one visit carries one id, and
+    the id does not survive the hour.
+
+    Asserted on the ROW rather than on the helper, so a derivation that rotates
+    correctly and a ``count`` that writes something else would still fail. The visitor
+    hash is read off the same three rows and must NOT move — it rotates daily, the visit
+    rotates hourly, and a change that collapsed the two into one clock would pass every
+    other assertion in this section.
+
+    The 10:58 → 11:02 pair is the accepted over-split named in the module's row
+    contract: one real visit, two ids, counted twice. There is nowhere to carry an id
+    across the boundary, so the error is designed to run in this direction."""
+    out = _run_node(
+        tmp_path,
+        """
+const rec = recorder();
+const env = { PAW_ANALYTICS: rec };
+const req = request(
+  "https://site.example.dev/",
+  { "user-agent": HUMAN, "cf-connecting-ip": "203.0.113.9" },
+  { country: "US" },
+);
+const early = Date.UTC(2026, 8, 2, 10, 5, 0);
+const late = Date.UTC(2026, 8, 2, 10, 58, 0);
+const nextHour = Date.UTC(2026, 8, 2, 11, 2, 0);
+await count(req, env, early);
+await count(req, env, late);
+await count(req, env, nextHour);
+emit({
+  visits: rec.rows.map((row) => row.blobs[5]),
+  visitors: rec.rows.map((row) => row.blobs[3]),
+  hours: [hourKey(early), hourKey(late), hourKey(nextHour)],
+});
+""",
+    )
+
+    assert out["hours"] == ["2026-09-02T10", "2026-09-02T10", "2026-09-02T11"]
+    early, late, next_hour = out["visits"]
+    assert early == late
+    assert next_hour != early
+    # One visitor across all three: the day did not turn, so only the visit rotated.
+    assert len(set(out["visitors"])) == 1
+
+
+def test_two_visitors_in_the_same_hour_get_different_visit_ids(tmp_path):
+    """The assertion a visit id of ``hash(salt | hour)`` alone would fail, and which
+    every other check in this section would let through: the id has to identify a
+    VISIT, so two people browsing at the same moment cannot share one.
+
+    Driven through ``count`` with a single fixed clock, so the only thing that differs
+    between the two rows is who sent the request."""
+    out = _run_node(
+        tmp_path,
+        """
+const rec = recorder();
+const env = { PAW_ANALYTICS: rec };
+const when = Date.UTC(2026, 8, 2, 10, 5, 0);
+for (const ip of ["203.0.113.9", "198.51.100.4"]) {
+  await count(
+    request("https://site.example.dev/", { "user-agent": HUMAN, "cf-connecting-ip": ip }),
+    env,
+    when,
+  );
+}
+emit({
+  visits: rec.rows.map((row) => row.blobs[5]),
+  visitors: rec.rows.map((row) => row.blobs[3]),
+});
+""",
+    )
+
+    assert out["visits"][0] != out["visits"][1]
+    assert out["visitors"][0] != out["visitors"][1]
+    # And the visit is a DERIVED value, not the visitor hash copied into a second slot —
+    # a duplicate column would count visits as visitors and read as working.
+    assert out["visits"][0] != out["visitors"][0]
+
+
+def test_the_visit_id_rotates_with_the_per_publish_salt(tmp_path):
+    """The visit inherits every privacy property the visitor hash has, because it is
+    derived from it and salted by the same secret. A republish mints a fresh salt, so
+    ids from before and after it cannot be joined — the same over-split the hour
+    boundary accepts, for the same reason."""
+    out = _run_node(
+        tmp_path,
+        """
+const SECRET = "0123456789abcdef0123456789abcdef";
+const when = Date.UTC(2026, 8, 2, 10, 5, 0);
+const visitor = await visitorHash("203.0.113.9", HUMAN, SECRET, dayKey(when));
+emit({
+  visitor,
+  visit: await visitId(visitor, SECRET, hourKey(when)),
+  otherSalt: await visitId(visitor, "a-different-secret", hourKey(when)),
+});
+""",
+    )
+
+    assert re.fullmatch(r"[0-9a-f]{32}", out["visit"])
+    assert out["otherSalt"] != out["visit"]
+    assert out["visit"] != out["visitor"]
+    assert "203.0.113.9" not in json.dumps(out)

--- a/tests/ee/sites/test_sites_analytics_shim.py
+++ b/tests/ee/sites/test_sites_analytics_shim.py
@@ -5,6 +5,14 @@
 #
 # Created 2026-09-02 (feat/sites-analytics-shim).
 #
+# Updated 2026-09-04 (feat/sites-analytics-visit-id, AD-1) — the row grew ``blobs[5]``,
+# the visit id. The derivation and its rotation are pinned beside the counter, where the
+# row contract lives; what belongs HERE is that the shim branch writes the same six
+# columns as the assets-only one. The two entries share one counting core precisely so
+# they cannot drift, and this file is where that stops being an assumption: a dataset
+# holding two positional shapes with no column names to tell them apart is unreadable,
+# and nothing would raise.
+#
 # THE TWO CLAIMS THIS FILE EXISTS TO KEEP HONEST, because both fail silently:
 #
 #   1. THE SITE STILL WORKS. The shim sits in front of the module that RENDERS a
@@ -665,6 +673,8 @@ emit({ rows: rec.rows });
     assert row["blobs"][2] == "DE"
     assert re.fullmatch(r"[0-9a-f]{32}", row["blobs"][3])
     assert row["blobs"][4] == "desktop"
+    assert re.fullmatch(r"[0-9a-f]{32}", row["blobs"][5])
+    assert len(row["blobs"]) == 6
     assert row["doubles"] == [1]
 
 

--- a/tests/mutations/sites_analytics_counter.json
+++ b/tests/mutations/sites_analytics_counter.json
@@ -89,5 +89,33 @@
     "tests": [
       "tests/ee/sites/test_sites_analytics_counter.py"
     ]
+  },
+  {
+    "label": "the visit id drops the visitor (every visitor browsing in the same hour shares one id, so the visit count becomes an hour count and still reads as a plausible number)",
+    "file": "ee/pocketpaw_ee/sites/analytics_worker.py",
+    "find": "  return sha256Hex16(`${{secret}}|${{hour}}|${{visitor}}`);",
+    "replace": "  return sha256Hex16(`${{secret}}|${{hour}}`);",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_counter.py"
+    ]
+  },
+  {
+    "label": "the visit id stops rotating hourly (a visit becomes a whole UTC day, so pages-per-visit collapses and a returning visitor is never a second visit)",
+    "file": "ee/pocketpaw_ee/sites/analytics_worker.py",
+    "find": "  return new Date(nowMs).toISOString().slice(0, 13);",
+    "replace": "  return \"static\";",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_counter.py"
+    ]
+  },
+  {
+    "label": "the visit id is written first instead of last (Analytics Engine columns are positional, so every row already stored is silently re-labelled and there is no update to fix them with)",
+    "file": "ee/pocketpaw_ee/sites/analytics_worker.py",
+    "find": "        visitor,\n        deviceClass(ua),\n        visit,",
+    "replace": "        visit,\n        visitor,\n        deviceClass(ua),",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_counter.py",
+      "tests/ee/sites/test_sites_analytics_shim.py"
+    ]
   }
 ]


### PR DESCRIPTION
A pageview now records which visit it belongs to, which is what makes visits, bounce
rate and visit duration countable at all. Nothing reads the new field yet; that is the
next slice.

## Why a visit needs its own id

The row already carries a visitor hash, but that hash rotates daily. Grouping by it
collapses somebody's morning visit and their evening visit into one, so pages-per-visit
is unrecoverable after the fact and a bounce rate cannot be derived from it. The id has
to be computed at write time.

It is `SHA-256(secret | UTC-hour | visitor-hash)`, truncated to 16 bytes. Deriving it
from the visitor hash rather than hashing the address and user agent a second time means
it inherits the daily rotation: a visit id can never outlive the identifier it is built
from, and the hour is a second rotation on top rather than a longer-lived one. This is
how Umami derives a visit from a session.

## The hour boundary splits a visit, and that is accepted

A visit that starts at 10:58 and continues at 11:02 gets a new id and counts as two.
There is nowhere to carry an id across the boundary, since there is no cookie, no
storage, and a Worker holds nothing between requests. So the choice is a fixed window or
an identifier that persists, and an identifier that persists is the one thing this
feature exists to not store.

The error runs in one direction only. It over-splits and never over-merges, the same
direction the daily salt already accepts at midnight. A visit count is an upper bound on
sessions, and whoever renders it should not imply otherwise.

## Appended, never inserted

`blobs[5]`, after the device class. Analytics Engine columns are positional and have no
names, so a reordered write against an unchanged reader reports referrers as countries
and raises nothing. Rows written before this carry five blobs forever, and the sixth
reads as an empty string. The mutation plan now includes that reorder as a mutation, so
a future change that makes it stops being silent.

## Verification

143 tests pass across the analytics files and their direct consumers, `test_workers_deploy`
and `test_preview_deploy_engine_aware` included:

```
143 passed in 10.72s
```

The mutation plan proves the new tests catch what they claim to:

```
all 7 mutations caught
```

Anchors validate repo-wide, so this edit rotted nothing in another plan:

```
OK: 952 anchors across 75 plans each resolve exactly once.
```

## Query cost

Unchanged. This PR only writes; no read path touches the new field yet.

## Design

`docs/design/2026-09-02-sites-visitor-analytics.md` carries the row contract and the
cost model. The dashboard slices that consume this land separately.
