### PR TITLE
feat(billing): deduct exactly what was used, and bill it when the run ends

### DIFF
--- a/docs/deployment/litellm-billing-cutover.md
+++ b/docs/deployment/litellm-billing-cutover.md
@@ -107,6 +107,50 @@ Nothing to do about it operationally. It is here because `0 credits` on a sweep 
 read real dollars used to be the symptom, and that is worth recognising rather than
 re-diagnosing.
 
+## When a charge actually lands
+
+Two things bill proxy spend, and they bill the same rows through the same code.
+
+The **sweep** runs every five minutes on the API heartbeat and again at worker
+boot. It is the backstop and it is what guarantees nothing is missed.
+
+The **run-end trigger** fires about 20 seconds after any run reaches a terminal
+state, in `live` mode only. Without it a customer's balance lagged their usage by
+up to a full sweep interval, and the run-start balance gate could admit a run the
+previous one had already spent the credits for.
+
+The delay is measured, not guessed. LiteLLM writes its spend row from a background
+task after the response is already sent: on the production gateway the row
+appeared at about 15 seconds and was definitively absent at 6. A trigger that read
+immediately would find an empty window every time and bill nothing, which looks
+identical to working.
+
+The two race constantly and that is fine. Both debit under
+`litellm:{request_id}`, so whichever arrives first charges and the other is a
+no-op on the ledger's unique index.
+
+```
+POCKETPAW_SPEND_TRIGGER_ENABLED         default true; false leaves only the sweep
+POCKETPAW_SPEND_TRIGGER_DELAY_SECONDS   default 20
+```
+
+Turn it off if the extra proxy reads become expensive. They scale with run volume
+rather than with time, so a busy deployment pays more for them than a quiet one.
+
+### Why not read the cost off the response instead
+
+The proxy returns `x-litellm-response-cost` and `x-litellm-call-id` on every
+completion, which would need no delay at all. Two things rule it out.
+
+The call-id header is not the id the spend log records. Measured 2026-09-03: the
+header carried one uuid while the row's `request_id` was the response body's `id`.
+Billing on the header id would key the ledger on something the sweep can never
+match, so the sweep would charge the same call again under the real id.
+
+And the header only exists where our own code makes the HTTP call. The agent
+backends go through pydantic-ai and ChatLiteLLM, neither of which surfaces
+response headers, and that is where the spend actually is.
+
 ## The procedure
 
 **1. Run `shadow` for a while.** It reads proxy spend and the ledger over the same

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -515,8 +515,14 @@ class WorkspaceJobUpdated(Event):
 # Payload (carried under ``Event.data``):
 #   workspace_id      — tenancy.
 #   kind              — genesis | grant | spend | transfer.
-#   amount_delta      — signed credits this movement applied (+grant / -spend).
-#   balance_after     — the wallet balance once this movement landed.
+#   amount_delta      — signed WHOLE credits this movement applied (+grant /
+#                       -spend), truncated for display.
+#   balance_after     — the wallet balance in whole credits once it landed.
+#   amount_delta_micro / balance_after_micro — the same two exactly, in
+#                       micro-credits (1_000_000 == 1 credit). A metered spend is
+#                       routinely a fraction of a credit, so the whole-credit pair
+#                       above can both read 0 on a real charge; anything doing
+#                       arithmetic must use these.
 #   cause             — business reason (top_up | compute_spend | promo | ...).
 #   idempotency_key   — the caller's exactly-once key for this movement.
 @dataclass

--- a/ee/pocketpaw_ee/cloud/chat/runs/service.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/service.py
@@ -30,6 +30,7 @@ Changes:
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Any
@@ -40,6 +41,8 @@ from pymongo.errors import DuplicateKeyError
 from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.chat.runs.domain import RunActivityRow, RunSpec
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+logger = logging.getLogger(__name__)
 
 # A run is ACTIVE while it has been accepted but has not reached a terminal
 # state. One definition, one place: the scope lookup, the jail guard, and the
@@ -128,6 +131,27 @@ async def get_run(run_id: str) -> ChatRunDoc:
     return doc
 
 
+def _trigger_spend_ingest(doc: ChatRunDoc) -> None:
+    """Ask for this workspace's proxy spend to be billed shortly (live mode only).
+
+    Called from every terminal transition. In ``live`` the LiteLLM sweep is the
+    only meter and it runs every five minutes, so without this a customer's
+    balance lags their usage by up to that long — and the run-start balance gate
+    can admit a run the previous one had already spent the credits for.
+
+    Fire and forget, and deliberately last: it must never delay or fail a
+    transition that has already happened. The trigger schedules the SAME ingest
+    the sweep runs, keyed on the same ledger id, so the two racing is harmless
+    and the sweep remains the backstop for anything this misses.
+    """
+    try:
+        from pocketpaw_ee.cloud.llm_provisioning import run_end_trigger
+
+        run_end_trigger.schedule_spend_ingest(doc.workspace)
+    except Exception:  # noqa: BLE001 — a billing hint must not break the lifecycle
+        logger.debug("run spend-ingest trigger failed for %s", doc.run_id, exc_info=True)
+
+
 async def mark_running(run_id: str) -> None:
     doc = await get_run(run_id)
     doc.status = "running"
@@ -152,6 +176,7 @@ async def mark_completed(
         doc.usage = usage
     doc.ended_at = _utcnow()
     await doc.save()
+    _trigger_spend_ingest(doc)
 
 
 async def mark_terminal(
@@ -175,6 +200,10 @@ async def mark_terminal(
         doc.usage = usage
     doc.ended_at = _utcnow()
     await doc.save()
+    # A cancelled or failed run consumed tokens before it stopped, and the proxy
+    # priced them. Billing only completed runs would serve every interrupted one
+    # free — which is why the metering sweeper bills all four terminal states too.
+    _trigger_spend_ingest(doc)
 
 
 async def mark_billed(run_id: str) -> None:

--- a/ee/pocketpaw_ee/cloud/credits/domain.py
+++ b/ee/pocketpaw_ee/cloud/credits/domain.py
@@ -81,7 +81,12 @@ class LedgerEntry:
 
     Mirrors ``models.credit.CreditLedgerEntry`` with framework-free types.
     ``amount_delta`` is signed; ``balance_after`` is the wallet balance once
-    this movement landed.
+    this movement landed. Both are WHOLE credits, for display — the exact figures
+    are the ``_micro`` pair beside them, and the two can differ by up to a credit
+    on a sub-credit movement (a $0.0015 proxy call is 375_000 micro, which is 0
+    whole credits). Anything reasoning about money must read the micro fields;
+    ``amount_delta`` exists so the HTTP layer and the audit UI keep rendering the
+    unit a customer understands.
     """
 
     id: str
@@ -91,6 +96,54 @@ class LedgerEntry:
     balance_after: int
     member_id: str | None
     cause: str | None
+    amount_delta_micro: int = 0
+    balance_after_micro: int = 0
     ref: dict = field(default_factory=dict)
     idempotency_key: str = ""
     created_at: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# The wallet's storage unit (2026-09-04, feat/exact-credit-deduction).
+# ---------------------------------------------------------------------------
+#
+# Balances and ledger amounts are stored in MICRO-CREDITS: millionths of a
+# credit, so 1 credit == 1_000_000 micro == $0.01.
+#
+# WHY. The wallet used to store whole credits, and a credit is a cent, while the
+# proxy prices a single API call — routinely a tenth of a cent or less. Every
+# debit therefore had to round to a unit far coarser than the thing it was
+# charging for. Rounding down served cheap calls free; rounding to the nearest
+# credit was unbiased in aggregate but wrong on every individual charge, and
+# unboundedly wrong for a workload of uniformly cheap calls where nothing rounds
+# up to offset anything. A thousand $0.0015 requests cost $1.50 and billed zero.
+#
+# A micro-credit is $0.00000001 of pre-markup compute. The smallest spend row
+# observed on the production proxy ($0.00014545) is 36,362 of them, so per-row
+# rounding error is about eight orders of magnitude below the amount charged.
+# Summed over real proxy rows the drift is 2e-9 USD. That is exact for money.
+#
+# INTEGER, still. This is a finer integer unit, NOT a float: floats cannot hold a
+# ledger invariant, and ``balance == sum(amount_delta)`` is checked by
+# ``reconcile``. Every atomic ``$inc`` and every CAS comparison keeps working
+# unchanged because they are all integer operations either way.
+#
+# WHAT THE CUSTOMER SEES IS UNCHANGED. The HTTP surface still speaks whole
+# credits — ``dto`` converts at the boundary — so no balance, plan, top-up or
+# price changes meaning. This is a storage precision change, not a repricing.
+MICRO_PER_CREDIT = 1_000_000
+
+
+def credits_to_micro(credits: int | float) -> int:
+    """Whole credits -> micro-credits. For callers that speak the public unit."""
+    return round(credits * MICRO_PER_CREDIT)
+
+
+def micro_to_credits(micro: int) -> int:
+    """Micro-credits -> whole credits for DISPLAY, rounded toward zero.
+
+    Truncating rather than rounding is deliberate on the balance: showing a
+    customer a credit they cannot spend is worse than showing them one fewer than
+    they hold. The exact figure is always in the stored value.
+    """
+    return int(micro / MICRO_PER_CREDIT)

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -203,7 +203,13 @@ from pocketpaw_ee.cloud._core.errors import (
 )
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import CreditMovement
-from pocketpaw_ee.cloud.credits.domain import GrantResult, LedgerEntry, ModelSpendRow
+from pocketpaw_ee.cloud.credits.domain import (
+    GrantResult,
+    LedgerEntry,
+    ModelSpendRow,
+    credits_to_micro,
+    micro_to_credits,
+)
 from pocketpaw_ee.cloud.models.credit import CreditBalance, CreditLedgerEntry
 
 logger = logging.getLogger(__name__)
@@ -219,8 +225,12 @@ def _entry_to_domain(doc: CreditLedgerEntry) -> LedgerEntry:
         id=str(doc.id),
         workspace_id=doc.workspace,
         kind=doc.kind,
-        amount_delta=doc.amount_delta,
-        balance_after=doc.balance_after,
+        # The domain object speaks WHOLE credits — it is what the HTTP layer
+        # renders. The exact micro figures stay on the document.
+        amount_delta=micro_to_credits(doc.amount_delta_micro),
+        balance_after=micro_to_credits(doc.balance_after_micro),
+        amount_delta_micro=doc.amount_delta_micro,
+        balance_after_micro=doc.balance_after_micro,
         member_id=doc.member_id,
         cause=doc.cause,
         ref=dict(doc.ref or {}),
@@ -230,9 +240,14 @@ def _entry_to_domain(doc: CreditLedgerEntry) -> LedgerEntry:
 
 
 async def _current_balance(workspace: str) -> int:
-    """Read the workspace's current balance, or 0 when no row exists yet."""
+    """The workspace's current balance in MICRO-credits, or 0 when no row exists.
+
+    Internal and exact. The public ``balance`` truncates this to whole credits;
+    every arithmetic path inside this module uses the micro figure, so rounding
+    happens once, at the surface, and never compounds.
+    """
     doc = await CreditBalance.find_one(CreditBalance.workspace == workspace)
-    return int(doc.balance_credits) if doc is not None else 0
+    return int(doc.balance_micro) if doc is not None else 0
 
 
 async def _emit_movement(entry: CreditLedgerEntry) -> None:
@@ -242,8 +257,15 @@ async def _emit_movement(entry: CreditLedgerEntry) -> None:
             data={
                 "workspace_id": entry.workspace,
                 "kind": entry.kind,
-                "amount_delta": entry.amount_delta,
-                "balance_after": entry.balance_after,
+                # The event is a published contract, so its credit-denominated
+                # keys keep their names and meaning. The exact figures ride
+                # alongside for any consumer that needs sub-credit precision —
+                # a metered spend is routinely a fraction of a credit, so both
+                # whole-credit values can read 0 on a real charge.
+                "amount_delta": micro_to_credits(entry.amount_delta_micro),
+                "balance_after": micro_to_credits(entry.balance_after_micro),
+                "amount_delta_micro": entry.amount_delta_micro,
+                "balance_after_micro": entry.balance_after_micro,
                 "cause": entry.cause,
                 "idempotency_key": entry.idempotency_key,
             }
@@ -277,11 +299,18 @@ async def grant(
 
     ``kind`` defaults to ``"grant"``; pass ``"genesis"`` to seed a fresh
     wallet's first credits (the ledger origin row).
+
+    ``amount`` is WHOLE credits and the returned balance is whole credits, both
+    unchanged. Grants are top-ups and plan allowances, which are priced in whole
+    credits by definition — nobody buys a millionth of one. The storage unit
+    underneath is micro-credits; the conversion happens here so no caller of this
+    function had to change.
     """
     # Rule 6 — validate at entry. Money-handling: an amount must be a positive
     # integer (1 credit == $0.01) and the idempotency key must be present.
     if not isinstance(amount, int) or isinstance(amount, bool) or amount <= 0:
         raise ValidationError("credits.invalid_amount", "Grant amount must be a positive integer")
+    amount_micro = credits_to_micro(amount)
     if not workspace:
         raise ValidationError("credits.invalid_workspace", "workspace is required")
     if not idempotency_key:
@@ -293,8 +322,8 @@ async def grant(
     entry = CreditLedgerEntry(
         workspace=workspace,
         kind=kind,
-        amount_delta=amount,
-        balance_after=0,  # stamped after the $inc returns the new balance
+        amount_delta_micro=amount_micro,
+        balance_after_micro=0,  # stamped after the $inc returns the new balance
         applied=False,
         conditional=False,
         member_id=member_id,
@@ -308,7 +337,9 @@ async def grant(
         # This movement was already applied — return the current balance and
         # signal a replay (created=False) so the caller suppresses any
         # money-moved side effect (e.g. a capture-event emit).
-        return GrantResult(balance=await _current_balance(workspace), created=False)
+        return GrantResult(
+            balance=micro_to_credits(await _current_balance(workspace)), created=False
+        )
 
     # Step 2 — apply the effect: unconditional $inc with upsert (creates the
     # balance row at 0 then increments in one atomic call).
@@ -316,37 +347,51 @@ async def grant(
     updated = await coll.find_one_and_update(
         {"workspace": workspace},
         {
-            "$inc": {"balance_credits": amount},
+            "$inc": {"balance_micro": amount_micro},
             "$setOnInsert": {"createdAt": datetime.now(UTC)},
             "$currentDate": {"updatedAt": True},
         },
         upsert=True,
         return_document=ReturnDocument.AFTER,
     )
-    new_balance = int(updated["balance_credits"])
+    new_balance_micro = int(updated["balance_micro"])
 
     # Step 3 — the $inc landed: stamp balance_after and mark the entry applied so
     # reconcile counts it (and never re-drives it as a phantom).
-    entry.balance_after = new_balance
+    entry.balance_after_micro = new_balance_micro
     entry.applied = True
     await entry.save()
 
     await _emit_movement(entry)
-    return GrantResult(balance=new_balance, created=True)
+    return GrantResult(balance=micro_to_credits(new_balance_micro), created=True)
 
 
 async def debit(
     workspace: str,
-    amount: int,
-    cause: str,
-    idempotency_key: str,
+    amount: int | None = None,
+    cause: str = "",
+    idempotency_key: str = "",
     *,
+    amount_micro: int | None = None,
     member_id: str | None = None,
     ref: dict | None = None,
     kind: str = "spend",
     allow_negative: bool = False,
 ) -> int:
-    """Remove ``amount`` credits from the workspace wallet. Atomic + idempotent.
+    """Remove credits from the workspace wallet. Atomic + idempotent.
+
+    Takes EITHER ``amount`` (whole credits, the original signature) or
+    ``amount_micro`` (micro-credits, 1_000_000 == 1 credit). Exactly one.
+
+    ``amount_micro`` exists because metered compute cannot be expressed in whole
+    credits. A credit is a cent and the proxy prices a single API call, so a
+    $0.0015 call is 0.375 of a credit — a real charge with no whole-credit
+    representation. Rounding it down served it free; rounding to nearest billed a
+    number that was simply not what the customer used. The finer unit is how the
+    deduction becomes exactly what was consumed.
+
+    The return value stays WHOLE credits so existing callers are unaffected. Use
+    ``balance_micro`` when you need the exact figure.
 
     Returns the new balance. A retried call with the same
     ``(workspace, idempotency_key)`` is a no-op that returns the current balance.
@@ -367,11 +412,27 @@ async def debit(
       negative balance. The no-overdraft guarantee is enforced at run-start, not
       here. The entry is tagged ``conditional=False``.
     """
-    # Rule 6 — validate at entry.
-    if not isinstance(amount, int) or isinstance(amount, bool) or amount <= 0:
-        raise ValidationError("credits.invalid_amount", "Debit amount must be a positive integer")
+    # Rule 6 — validate at entry. Exactly one unit, never both: a caller passing
+    # each would otherwise silently get whichever the code happened to prefer, and
+    # the two differ by a factor of a million.
+    if (amount is None) == (amount_micro is None):
+        raise ValidationError(
+            "credits.invalid_amount", "Pass exactly one of amount or amount_micro"
+        )
+    if amount is not None:
+        if not isinstance(amount, int) or isinstance(amount, bool) or amount <= 0:
+            raise ValidationError(
+                "credits.invalid_amount", "Debit amount must be a positive integer"
+            )
+        amount_micro = credits_to_micro(amount)
+    if not isinstance(amount_micro, int) or isinstance(amount_micro, bool) or amount_micro <= 0:
+        raise ValidationError(
+            "credits.invalid_amount", "Debit amount_micro must be a positive integer"
+        )
     if not workspace:
         raise ValidationError("credits.invalid_workspace", "workspace is required")
+    if not cause:
+        raise ValidationError("credits.invalid_cause", "cause is required")
     if not idempotency_key:
         raise ValidationError("credits.invalid_key", "idempotency_key is required")
 
@@ -383,8 +444,8 @@ async def debit(
     entry = CreditLedgerEntry(
         workspace=workspace,
         kind=kind,
-        amount_delta=-amount,
-        balance_after=0,  # stamped after the $inc returns the new balance
+        amount_delta_micro=-amount_micro,
+        balance_after_micro=0,  # stamped after the $inc returns the new balance
         applied=False,
         conditional=not allow_negative,
         member_id=member_id,
@@ -396,7 +457,7 @@ async def debit(
         await entry.insert()
     except DuplicateKeyError:
         # This movement was already applied — return the current balance.
-        return await _current_balance(workspace)
+        return micro_to_credits(await _current_balance(workspace))
 
     coll = CreditBalance.get_pymongo_collection()
     if allow_negative:
@@ -406,7 +467,7 @@ async def debit(
         updated = await coll.find_one_and_update(
             {"workspace": workspace},
             {
-                "$inc": {"balance_credits": -amount},
+                "$inc": {"balance_micro": -amount_micro},
                 "$setOnInsert": {"createdAt": datetime.now(UTC)},
                 "$currentDate": {"updatedAt": True},
             },
@@ -420,8 +481,8 @@ async def debit(
         # wallet that doesn't exist yet has zero credits and cannot satisfy the
         # filter.
         updated = await coll.find_one_and_update(
-            {"workspace": workspace, "balance_credits": {"$gte": amount}},
-            {"$inc": {"balance_credits": -amount}, "$currentDate": {"updatedAt": True}},
+            {"workspace": workspace, "balance_micro": {"$gte": amount_micro}},
+            {"$inc": {"balance_micro": -amount_micro}, "$currentDate": {"updatedAt": True}},
             return_document=ReturnDocument.AFTER,
         )
         if updated is None:
@@ -429,19 +490,19 @@ async def debit(
             # 1 so the rejected debit leaves NO trace (invariant b) and a retry
             # with the same key can re-evaluate cleanly (the key is free again).
             await entry.delete()
-            available = await _current_balance(workspace)
-            raise InsufficientCredits(amount, available)
+            available = micro_to_credits(await _current_balance(workspace))
+            raise InsufficientCredits(micro_to_credits(amount_micro), available)
 
-    new_balance = int(updated["balance_credits"])
+    new_balance_micro = int(updated["balance_micro"])
 
     # Step 3 — the $inc landed: stamp balance_after and mark the entry applied so
     # reconcile counts it (and never re-drives it as a phantom).
-    entry.balance_after = new_balance
+    entry.balance_after_micro = new_balance_micro
     entry.applied = True
     await entry.save()
 
     await _emit_movement(entry)
-    return new_balance
+    return micro_to_credits(new_balance_micro)
 
 
 async def record_no_movement(
@@ -479,8 +540,8 @@ async def record_no_movement(
     entry = CreditLedgerEntry(
         workspace=workspace,
         kind=kind,
-        amount_delta=0,
-        balance_after=await _current_balance(workspace),
+        amount_delta_micro=0,
+        balance_after_micro=await _current_balance(workspace),
         # Nothing to land, so it is applied on arrival. An unapplied zero would
         # read as a crash-window phantom to reconcile and be re-driven forever.
         applied=True,
@@ -502,7 +563,23 @@ async def record_no_movement(
 
 
 async def balance(workspace: str) -> int:
-    """Return the workspace's current spendable balance (0 when no wallet)."""
+    """The workspace's spendable balance in WHOLE credits (0 when no wallet).
+
+    Truncated toward zero, so a wallet holding 4.7 credits reads as 4: showing a
+    customer a credit they cannot spend is the worse error. ``balance_micro`` is
+    the exact figure, and it is what every guard here compares against.
+    """
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+    return micro_to_credits(await _current_balance(workspace))
+
+
+async def balance_micro(workspace: str) -> int:
+    """The workspace's exact balance in micro-credits (1_000_000 == 1 credit).
+
+    For callers that must not lose the fraction — the spend ingest's reporting,
+    and any future pre-flight estimate that reasons about sub-credit amounts.
+    """
     if not workspace:
         raise ValidationError("credits.invalid_workspace", "workspace is required")
     return await _current_balance(workspace)
@@ -521,9 +598,13 @@ async def check_balance(workspace: str) -> None:
     ``available`` is the clamped non-negative balance so the message reads
     sensibly even on a metered-overage negative wallet.
     """
-    bal = await balance(workspace)
-    if bal <= 0:
-        raise InsufficientCredits(1, max(bal, 0))
+    # Compare the EXACT balance, not the displayed one. ``balance`` truncates, so
+    # a wallet holding half a credit reads as 0 there — and this gate would lock a
+    # customer out of a run they can genuinely pay for. Sub-credit balances were
+    # impossible when the wallet stored whole credits; they are routine now.
+    bal_micro = await _current_balance(workspace)
+    if bal_micro <= 0:
+        raise InsufficientCredits(1, max(micro_to_credits(bal_micro), 0))
 
 
 # The grant cause that EXTENDS the monthly ceiling — a PURCHASED one-time top-up
@@ -557,8 +638,10 @@ async def _period_topup_credits(workspace: str) -> int:
         "applied": True,
         "createdAt": {"$gte": month_start},
     }
-    net = await _sum_amount_delta(query)
-    return max(net, 0)
+    # ``_sum_amount_delta`` sums the stored MICRO field; the ceiling this feeds is
+    # expressed in whole credits, so convert before returning.
+    net_micro = await _sum_amount_delta(query)
+    return micro_to_credits(max(net_micro, 0))
 
 
 async def check_quota(workspace: str) -> None:
@@ -672,8 +755,10 @@ async def sum_debits_by_cause(
     # "credits debited" figure. A stray positive delta under this cause (there
     # should be none — compute_spend is debit-only) is clamped out so a bad row
     # can't make the spend total read as a refund.
-    total = sum(-int(e.amount_delta) for e in entries if int(e.amount_delta) < 0)
-    return total, len(entries)
+    total_micro = sum(-int(e.amount_delta_micro) for e in entries if int(e.amount_delta_micro) < 0)
+    # Whole credits: the shadow compare puts this beside a LiteLLM-side figure that
+    # is also whole credits, and a delta between two units would be meaningless.
+    return micro_to_credits(total_micro), len(entries)
 
 
 # The spend causes that count toward the monthly quota — the SAME two the usage
@@ -692,7 +777,9 @@ def _utc_month_start(now: datetime) -> datetime:
 
 
 async def _sum_amount_delta(query: dict[str, Any]) -> int:
-    """Server-side ``$sum`` of ``amount_delta`` over the entries matching ``query``.
+    """Server-side ``$sum`` of ``amount_delta_micro`` over entries matching ``query``.
+
+    Returns MICRO-credits. Callers that surface a whole-credit figure convert.
 
     Runs a Mongo ``$match`` + ``$group`` aggregation in the DB (NOT a
     pull-all-then-sum in Python) and returns the summed ``amount_delta`` (signed),
@@ -707,7 +794,7 @@ async def _sum_amount_delta(query: dict[str, Any]) -> int:
     cursor = CreditLedgerEntry.get_pymongo_collection().aggregate(
         [
             {"$match": query},
-            {"$group": {"_id": None, "total": {"$sum": "$amount_delta"}}},
+            {"$group": {"_id": None, "total": {"$sum": "$amount_delta_micro"}}},
         ]
     )
     if inspect.isawaitable(cursor):
@@ -747,10 +834,13 @@ async def month_to_date_spend(workspace: str) -> int:
         "applied": True,
         "createdAt": {"$gte": month_start},
     }
-    # ``amount_delta`` is negative for a debit, so the grouped sum is <= 0. Flip to
-    # positive credits spent; clamp a stray net-positive to 0 (spend is debit-only).
-    net = await _sum_amount_delta(query)
-    return max(-net, 0)
+    # ``amount_delta_micro`` is negative for a debit, so the grouped sum is <= 0.
+    # Flip to positive spend; clamp a stray net-positive to 0 (spend is debit-only).
+    # Converted to whole credits because the quota ceiling is denominated that way —
+    # this is the one place the fine unit is deliberately coarsened, and it rounds
+    # DOWN, so the gate never fires early on a fraction the customer has not spent.
+    net_micro = await _sum_amount_delta(query)
+    return micro_to_credits(max(-net_micro, 0))
 
 
 def _spend_by_model_pipeline(query: dict[str, Any]) -> list[dict[str, Any]]:
@@ -803,7 +893,7 @@ def _spend_by_model_pipeline(query: dict[str, Any]) -> list[dict[str, Any]]:
         ]
     }
     return [
-        {"$match": {**query, "amount_delta": {"$lt": 0}}},
+        {"$match": {**query, "amount_delta_micro": {"$lt": 0}}},
         {
             "$group": {
                 "_id": {
@@ -811,7 +901,7 @@ def _spend_by_model_pipeline(query: dict[str, Any]) -> list[dict[str, Any]]:
                     "model": model_or_unknown,
                 },
                 # A debit's delta is negative; flip it to positive credits spent.
-                "credits": {"$sum": {"$subtract": [0, "$amount_delta"]}},
+                "credits": {"$sum": {"$subtract": [0, "$amount_delta_micro"]}},
                 "requests": {"$sum": 1},
                 "tokens": {"$sum": tokens_or_zero},
             }
@@ -886,7 +976,8 @@ async def spend_by_model(
             ModelSpendRow(
                 day=str(key.get("day") or ""),
                 model=str(key.get("model") or "unknown"),
-                credits=int(doc.get("credits") or 0),
+                # The pipeline sums the micro field; the graph plots whole credits.
+                credits=micro_to_credits(int(doc.get("credits") or 0)),
                 requests=int(doc.get("requests") or 0),
                 tokens=int(doc.get("tokens") or 0),
             )
@@ -991,11 +1082,11 @@ async def reconcile(workspace: str) -> int:
         if entry.conditional:
             # Strict debit: re-apply only if the funds are there. ``amount_delta``
             # is negative, so the required balance is ``-amount_delta``.
-            required = -int(entry.amount_delta)
+            required = -int(entry.amount_delta_micro)
             updated = await coll.find_one_and_update(
-                {"workspace": workspace, "balance_credits": {"$gte": required}},
+                {"workspace": workspace, "balance_micro": {"$gte": required}},
                 {
-                    "$inc": {"balance_credits": int(entry.amount_delta)},
+                    "$inc": {"balance_micro": int(entry.amount_delta_micro)},
                     "$currentDate": {"updatedAt": True},
                 },
                 return_document=ReturnDocument.AFTER,
@@ -1007,7 +1098,7 @@ async def reconcile(workspace: str) -> int:
                     "(key=%s, delta=%d) — insufficient funds, never authorized",
                     workspace,
                     entry.idempotency_key,
-                    int(entry.amount_delta),
+                    int(entry.amount_delta_micro),
                 )
                 await entry.delete()
                 continue
@@ -1017,7 +1108,7 @@ async def reconcile(workspace: str) -> int:
             updated = await coll.find_one_and_update(
                 {"workspace": workspace},
                 {
-                    "$inc": {"balance_credits": int(entry.amount_delta)},
+                    "$inc": {"balance_micro": int(entry.amount_delta_micro)},
                     "$setOnInsert": {"createdAt": datetime.now(UTC)},
                     "$currentDate": {"updatedAt": True},
                 },
@@ -1026,16 +1117,16 @@ async def reconcile(workspace: str) -> int:
             )
 
         # The re-drive landed: stamp and mark applied.
-        entry.balance_after = int(updated["balance_credits"])
+        entry.balance_after_micro = int(updated["balance_micro"])
         entry.applied = True
         await entry.save()
         logger.warning(
             "credits.reconcile: workspace=%s re-drove unapplied entry (key=%s, delta=%d) "
-            "→ balance_after=%d",
+            "→ balance_after_micro=%d",
             workspace,
             entry.idempotency_key,
-            int(entry.amount_delta),
-            entry.balance_after,
+            int(entry.amount_delta_micro),
+            entry.balance_after_micro,
         )
 
     # Phase 2 — the canonical balance is the sum over the APPLIED entries.
@@ -1043,7 +1134,7 @@ async def reconcile(workspace: str) -> int:
         CreditLedgerEntry.workspace == workspace,
         CreditLedgerEntry.applied == True,  # noqa: E712 — Beanie field equality, not `is`
     ).to_list()
-    computed = sum(int(e.amount_delta) for e in applied_entries)
+    computed = sum(int(e.amount_delta_micro) for e in applied_entries)
 
     if computed < 0:
         # Not an error — a metered allow_negative overage legitimately drives the
@@ -1064,7 +1155,7 @@ async def reconcile(workspace: str) -> int:
         await coll.update_one(
             {"workspace": workspace},
             {
-                "$set": {"balance_credits": computed},
+                "$set": {"balance_micro": computed},
                 "$setOnInsert": {"createdAt": datetime.now(UTC)},
                 "$currentDate": {"updatedAt": True},
             },
@@ -1076,27 +1167,30 @@ async def reconcile(workspace: str) -> int:
             workspace,
             computed,
         )
-        return computed
+        return micro_to_credits(computed)
 
-    if int(bal_doc.balance_credits) != computed:
+    if int(bal_doc.balance_micro) != computed:
         logger.warning(
             "credits.reconcile: workspace=%s balance drifted (stored=%d, applied-ledger=%d); "
             "repaired",
             workspace,
-            int(bal_doc.balance_credits),
+            int(bal_doc.balance_micro),
             computed,
         )
         await coll.update_one(
             {"workspace": workspace},
-            {"$set": {"balance_credits": computed}, "$currentDate": {"updatedAt": True}},
+            {"$set": {"balance_micro": computed}, "$currentDate": {"updatedAt": True}},
         )
-    return computed
+    # The repair above works in micro end to end — that is what keeps the ledger
+    # invariant exact. Only the reported figure is coarsened, for the caller.
+    return micro_to_credits(computed)
 
 
 __all__ = [
     "GrantResult",
     "ModelSpendRow",
     "balance",
+    "balance_micro",
     "check_balance",
     "check_quota",
     "debit",

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/domain.py
@@ -59,7 +59,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from math import floor
+
+from pocketpaw_ee.cloud.credits.domain import MICRO_PER_CREDIT
 
 
 @dataclass(frozen=True)
@@ -115,42 +116,31 @@ class SpendCredits:
         ``metering.domain.RateCard.to_credits``. A non-positive cost yields 0
         credits (no debit).
 
-        Correct for ONE total. Do NOT call it per spend row and add the results
-        up: the rounding is applied to each row separately, and a row worth less
-        than half a credit rounds to nothing. Summing the USD first and converting
-        once is what ``whole_credits`` + ``usd_for_credits`` are for.
+        Correct for ONE total, which is what the shadow compare wants. Do NOT call
+        it per spend row and add the results up: the rounding applies to each row
+        separately, so a row worth less than half a credit contributes nothing.
+        Per-row billing uses ``to_micro_credits``, which needs no rounding at all.
         """
         if cost_usd <= 0:
             return 0
         return round(cost_usd * self.markup / self.credit_usd)
 
-    def whole_credits(self, cost_usd: float) -> int:
-        """How many WHOLE credits ``cost_usd`` covers. Never rounds up.
+    def to_micro_credits(self, cost_usd: float) -> int:
+        """Convert a USD spend amount into MICRO-credits (1_000_000 == 1 credit).
 
-        The billing half of the remainder carry. ``to_credits`` rounds, which is
-        right for a single total and wrong for a running one: rounding up would
-        bill money the tenant has not spent yet, and the next row would be billed
-        for it a second time. Flooring bills only what is fully covered and leaves
-        the rest in the remainder, where ``usd_for_credits`` can take it back out.
+        The conversion the spend ingest actually bills on, and the reason the
+        wallet's storage unit had to get finer. ``to_credits`` cannot express one
+        API call: a $0.0015 row is 0.375 of a credit, so rounding it down serves it
+        free and rounding it up charges for money nobody spent. In micro-credits
+        that row is exactly 375_000 — an integer, with nothing left over to carry.
 
-        The ``round(..., 9)`` is not cosmetic. The remainder is accumulated by
-        repeated float addition, so a sum that is exactly three credits arrives as
-        2.9999999999999996 and a bare ``floor`` would bill two — re-creating the
-        under-bill this method exists to end, just further down the decimal.
+        Per-row error is at most half a micro-credit, or $0.000000002 of pre-markup
+        compute. Summed over real proxy rows the drift is 2e-9 USD, which is exact
+        as far as any ledger is concerned.
         """
         if cost_usd <= 0:
             return 0
-        return floor(round(cost_usd * self.markup / self.credit_usd, 9))
-
-    def usd_for_credits(self, credits: int) -> float:
-        """The USD that ``credits`` whole credits accounts for.
-
-        The inverse of ``whole_credits``, used to take the billed part back out of
-        the running remainder so what is left is exactly the unbilled fraction.
-        """
-        if credits <= 0:
-            return 0.0
-        return credits * self.credit_usd / self.markup
+        return round(cost_usd * self.markup / self.credit_usd * MICRO_PER_CREDIT)
 
 
 @dataclass(frozen=True)
@@ -173,10 +163,10 @@ class SpendIngestResult:
     cost_usd: float
     cached_tokens: int
     balance_after: int
-    # True when this call did no work because another ingest already held the
-    # tenant's lease. Distinct from a genuine zero: nothing was read, so the caller
-    # must not treat the zero as evidence the tenant has no spend.
-    lease_skipped: bool = False
+    # The exact figure ``credits_debited`` rounds. A sweep of cheap calls can debit
+    # real money and still show 0 whole credits, so anything reconciling this
+    # against the ledger has to read the micro value.
+    micro_debited: int = 0
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/run_end_trigger.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/run_end_trigger.py
@@ -1,0 +1,201 @@
+# ee/pocketpaw_ee/cloud/llm_provisioning/run_end_trigger.py — bill a workspace's
+# proxy spend when its run ends, instead of waiting for the next sweep tick.
+#
+# WHAT THIS IS FOR. In ``live`` mode the credit ledger only moves when the
+# five-minute cutover sweep runs, so a customer's balance can be up to five
+# minutes stale. That is a problem in two directions: someone watching their
+# balance sees nothing happen after a run, and the run-start hard-block
+# (``credits.check_balance``) can wave through a run that a not-yet-ingested
+# charge would have paid for the last of.
+#
+# THE TIMING CONSTRAINT, measured rather than assumed. On 2026-09-03 against the
+# production gateway a completion's spend row appeared in ``/spend/logs/v2``
+# about 15 seconds after the response returned; it was NOT there at 6 seconds.
+# LiteLLM writes spend rows from a background task after the response is sent, so
+# reading immediately at run end reliably finds nothing. Hence the delay before
+# the ingest, and hence this being a scheduled task rather than an inline await.
+#
+# WHY NOT READ THE COST OFF THE RESPONSE. The proxy returns
+# ``x-litellm-response-cost`` and ``x-litellm-call-id`` on every completion, and
+# billing straight from those would need no delay at all. Two things rule it out:
+#
+#   * ``x-litellm-call-id`` is NOT the id the spend log records. Measured the same
+#     day: the header carried ``846f51b6-...`` while the row's ``request_id`` was
+#     the response BODY's ``id`` (``chatcmpl-c4bf1015-...``). Billing on the header
+#     id would key the ledger on something the sweep can never match, so the sweep
+#     would bill the same call again under the row's real id. A double charge.
+#   * The header only exists where OUR code makes the HTTP call. The agent
+#     backends go through pydantic-ai and ChatLiteLLM, which do not surface
+#     response headers, and that is where the spend actually is.
+#
+# So this triggers the SAME ingest the sweep runs, against the same rows, keyed on
+# the same ``litellm:{request_id}``. It races the sweep by design and the race is
+# safe: whichever gets there first debits, the other no-ops on the ledger's unique
+# index. This changes WHEN a charge lands, never whether or how much.
+#
+# FIRE AND FORGET, deliberately. A billing read must never delay a user's response
+# or fail their run — the compute is already served and the sweep is the backstop
+# for anything this misses. Every failure path here logs and returns.
+#
+# Created 2026-09-04 (feat/bill-spend-at-run-end): new entity.
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# How long to wait after a run ends before reading the tenant's spend.
+#
+# Measured, not guessed: the proxy wrote the row at ~15s in the 2026-09-03 probe
+# and had not written it at 6s. 20 seconds buys margin on that without making the
+# balance feel stale. Too short is the expensive mistake — the read finds nothing,
+# the trigger is wasted, and the charge waits for the sweep anyway.
+_DEFAULT_DELAY_SECONDS = 20.0
+
+# Background tasks are held here for the lifetime of their run. ``asyncio`` keeps
+# only a weak reference to a task, so a fire-and-forget task with no strong
+# reference can be garbage-collected mid-await and simply never finish — silently,
+# which for a billing path means a charge that quietly never lands.
+_pending: set[asyncio.Task] = set()
+
+
+def _delay_seconds() -> float:
+    """The post-run delay, overridable for tests and slow proxies.
+
+    ``POCKETPAW_SPEND_TRIGGER_DELAY_SECONDS``. A bad value falls back to the
+    default rather than raising — this is a billing timer, and a malformed env var
+    must not take the trigger out.
+    """
+    raw = os.environ.get("POCKETPAW_SPEND_TRIGGER_DELAY_SECONDS", "").strip()
+    if not raw:
+        return _DEFAULT_DELAY_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "run_end_trigger: POCKETPAW_SPEND_TRIGGER_DELAY_SECONDS=%r is not a number "
+            "— using the %.0fs default",
+            raw,
+            _DEFAULT_DELAY_SECONDS,
+        )
+        return _DEFAULT_DELAY_SECONDS
+    return value if value >= 0 else _DEFAULT_DELAY_SECONDS
+
+
+def is_enabled() -> bool:
+    """Whether run-end billing is on. Default ON, and only meaningful in ``live``.
+
+    ``POCKETPAW_SPEND_TRIGGER_ENABLED=false`` turns it off, leaving the sweep as
+    the sole path. The kill switch exists because this adds proxy reads
+    proportional to run volume rather than to time, and an operator who finds that
+    expensive needs a way to stop it that is not a deploy.
+    """
+    raw = os.environ.get("POCKETPAW_SPEND_TRIGGER_ENABLED", "").strip().lower()
+    return raw not in {"false", "0", "no", "off"}
+
+
+async def _ingest_after_delay(workspace: str, delay: float) -> None:
+    """Wait for the proxy to write the row, then run the tenant's normal ingest."""
+    try:
+        await asyncio.sleep(delay)
+    except asyncio.CancelledError:
+        # Shutdown, or the loop going away mid-wait. The sweep will bill this
+        # tenant on its next tick, so there is nothing to recover here.
+        raise
+
+    try:
+        from pocketpaw_ee.cloud.llm_provisioning import service as provisioning_service
+
+        result = await provisioning_service.ingest_tenant_spend(workspace)
+    except Exception:
+        # Never propagates. The run is finished, the customer has their answer, and
+        # the five-minute sweep re-reads the same window.
+        logger.exception(
+            "run_end_trigger: spend ingest failed for workspace=%s — the sweep will "
+            "retry on its next tick",
+            workspace,
+        )
+        return
+
+    if result.rows_billed:
+        logger.info(
+            "run_end_trigger: workspace=%s billed %d row(s) -> %d micro-credits "
+            "(%.6f USD) %.0fs after the run ended",
+            workspace,
+            result.rows_billed,
+            result.micro_debited,
+            result.cost_usd,
+            delay,
+        )
+    else:
+        # Not a failure. The sweep's overlapping read may have got there first, or
+        # the proxy is slower than the delay today, in which case the sweep bills it.
+        logger.debug(
+            "run_end_trigger: workspace=%s had no new spend rows %.0fs after the run "
+            "ended (read %d row(s))",
+            workspace,
+            delay,
+            result.rows_read,
+        )
+
+
+def schedule_spend_ingest(workspace: str, *, delay: float | None = None) -> asyncio.Task | None:
+    """Schedule ``workspace``'s proxy spend to be billed shortly after a run ends.
+
+    Returns the task (tests await it) or None when nothing was scheduled. NEVER
+    raises: called from the run lifecycle, where an exception would fail a run that
+    has already produced its answer.
+
+    Only fires in ``live`` mode. In ``off`` and ``shadow`` the per-run meter is
+    still charging, and running the proxy ingest alongside it would bill the same
+    compute twice under two different idempotency keys — the double-bill boundary
+    the cutover exists to keep closed.
+    """
+    if not workspace:
+        return None
+    if not is_enabled():
+        return None
+
+    try:
+        from pocketpaw_ee.cloud.llm_provisioning import service as provisioning_service
+
+        if provisioning_service.spend_mode() != "live":
+            return None
+    except Exception:
+        logger.debug("run_end_trigger: could not resolve the spend mode", exc_info=True)
+        return None
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop (a sync caller, a teardown). Nothing to schedule onto.
+        return None
+
+    task = loop.create_task(
+        _ingest_after_delay(workspace, _delay_seconds() if delay is None else delay),
+        name=f"spend-ingest:{workspace}",
+    )
+    # Hold a strong reference until it finishes — see ``_pending``.
+    _pending.add(task)
+    task.add_done_callback(_pending.discard)
+    return task
+
+
+async def drain_pending(timeout: float = 30.0) -> None:
+    """Wait for scheduled ingests to finish. For shutdown and for tests.
+
+    A task still sleeping out its delay when the process stops is simply dropped;
+    the sweep bills that tenant on its next tick, which is what makes it safe to
+    cancel these at any point.
+    """
+    if not _pending:
+        return
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.gather(*_pending, return_exceptions=True), timeout)
+
+
+__all__ = ["drain_pending", "is_enabled", "schedule_spend_ingest"]

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -165,13 +165,13 @@
 #      tenant's mark WOULD recover it and the request_id key still stops a double
 #      debit — but never rewind past the ``prepare_spend_cutover`` mark, where BC-3
 #      owns the billing under a key this ledger cannot dedup against.
-#      The carry also needs a LEASE, which the ledger cannot provide. It is a
-#      read-modify-write: two overlapping ingests read the same remainder, each folds
-#      in a row the other has not seen, each crosses the credit line, and both debit
-#      under different ``litellm:{request_id}`` keys — so the unique index never
-#      fires and the tenant quietly pays twice. ``ingest_tenant_spend`` is now a
-#      lease wrapper around ``_ingest_tenant_spend_locked``; a caller that cannot
-#      take the lease returns ``lease_skipped`` rather than waiting.
+#      SUPERSEDED 2026-09-04 by the micro-credit wallet. The carry existed only
+#      because a credit (one cent) could not express one API call; with the wallet
+#      storing micro-credits, ``to_micro_credits`` bills each row exactly and there
+#      is no remainder to hold. The carry needed a per-tenant lease too — it was a
+#      read-modify-write two overlapping sweeps could both win — and that went with
+#      it: rows are independent again, so the ledger's per-row key is the whole
+#      guard, as it was before. Two mechanisms deleted by fixing the unit instead.
 #      The already-recorded check MOVED ABOVE the conversion as part of this: a row
 #      folded into the remainder carries a zero-value ledger entry rather than a
 #      debit, and the customer read re-offers 15 minutes of settled rows every tick,
@@ -197,6 +197,7 @@ from typing import Any
 from pocketpaw_ee.catalog.admin_client import LiteLLMAdminClient, LiteLLMAdminError
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.credits import service as credits_service
+from pocketpaw_ee.cloud.credits.domain import micro_to_credits
 from pocketpaw_ee.cloud.llm_provisioning.domain import (
     CutoverPreparation,
     KeyBudget,
@@ -788,67 +789,6 @@ def _customer_read_window(doc: LiteLLMTenantKey, *, now: datetime) -> tuple[date
     return (created if created is not None else now - _SPEND_READ_OVERLAP), now
 
 
-# How long a spend-ingest lease is held before anyone else may take it. Long enough
-# to cover a slow sweep (the per-key read walks a tenant's whole history), short
-# enough that a process killed mid-sweep does not wedge a tenant's billing for long.
-_SPEND_LEASE_TTL = timedelta(seconds=60)
-
-
-async def _acquire_spend_lease(workspace: str) -> bool:
-    """Take the exclusive right to ingest ``workspace``'s spend. True if we got it.
-
-    A single-document compare-and-swap: claim the row only if nobody holds it or the
-    holder's lease has expired. The same idiom ``credits.debit`` uses for the wallet,
-    and for the same reason — read-then-write cannot serialise two racers.
-
-    WHY A LEASE AT ALL, when every debit is already idempotent per row.
-    ``pending_spend_usd`` is the part the ledger cannot protect. Two ingests read the
-    same remainder, each folds in a row the OTHER has not seen, and each crosses the
-    credit line — so both debit, under different ``litellm:{request_id}`` keys, and
-    the unique index never fires. Nothing errors and nothing looks wrong; the tenant
-    is simply billed twice for one credit's worth of spend. The overlap is routine:
-    the sweep runs on the API process heartbeat AND at worker boot, and the per-run
-    trigger makes it happen on every run.
-
-    Mongo rather than an ``asyncio.Lock`` because the racers are in different
-    PROCESSES — runs execute in the arq worker, the sweep loop in the API.
-    """
-    now = datetime.now(UTC)
-    coll = LiteLLMTenantKey.get_pymongo_collection()
-    updated = await coll.find_one_and_update(
-        {
-            "workspace": workspace,
-            "$or": [
-                {"spend_ingest_lease_until": None},
-                {"spend_ingest_lease_until": {"$exists": False}},
-                {"spend_ingest_lease_until": {"$lt": now}},
-            ],
-        },
-        {"$set": {"spend_ingest_lease_until": now + _SPEND_LEASE_TTL}},
-    )
-    return updated is not None
-
-
-async def _release_spend_lease(workspace: str) -> None:
-    """Hand the lease back. Best effort — the expiry is the real guarantee.
-
-    Released in a ``finally`` so a failed sweep does not hold a tenant for the full
-    TTL, but a crash that skips this is survivable by design: the next caller past
-    the expiry takes the lease anyway.
-    """
-    try:
-        coll = LiteLLMTenantKey.get_pymongo_collection()
-        await coll.update_one(
-            {"workspace": workspace}, {"$set": {"spend_ingest_lease_until": None}}
-        )
-    except Exception:  # noqa: BLE001 — never fail a completed sweep on cleanup
-        logger.debug(
-            "llm_provisioning: could not release the spend lease for workspace=%s "
-            "— it expires on its own",
-            workspace,
-        )
-
-
 async def _spend_bookkeeping_row(workspace: str) -> LiteLLMTenantKey:
     """This tenant's spend row, created keyless if provisioning never ran.
 
@@ -974,53 +914,6 @@ async def ingest_tenant_spend(
     spend_card: SpendCredits | None = None,
     admin_client: LiteLLMAdminClient | None = None,
 ) -> SpendIngestResult:
-    """Bill ``workspace``'s proxy spend, under an exclusive per-tenant lease.
-
-    Thin wrapper over ``_ingest_tenant_spend_locked``, which holds the real logic
-    and its documentation. Everything here is the lease.
-
-    A tenant is ingested by one caller at a time because the sub-credit remainder is
-    a read-modify-write and the ledger's per-row idempotency key cannot protect it —
-    see ``_acquire_spend_lease``. A caller that cannot get the lease returns an empty
-    result with ``lease_skipped`` set rather than waiting: whoever holds it is
-    already reading the same rows, and the next sweep is at most five minutes out.
-    Skipping is therefore never a lost bill, only a later one.
-    """
-    _require_workspace(workspace)
-    # The lease is a CAS on this row, so the row has to exist before we can claim it.
-    await _spend_bookkeeping_row(workspace)
-
-    if not await _acquire_spend_lease(workspace):
-        logger.debug(
-            "llm_provisioning.ingest_tenant_spend: workspace=%s is already being "
-            "ingested — skipping this pass",
-            workspace,
-        )
-        return SpendIngestResult(
-            workspace_id=workspace,
-            rows_read=0,
-            rows_billed=0,
-            credits_debited=0,
-            cost_usd=0.0,
-            cached_tokens=0,
-            balance_after=await credits_service.balance(workspace),
-            lease_skipped=True,
-        )
-
-    try:
-        return await _ingest_tenant_spend_locked(
-            workspace, spend_card=spend_card, admin_client=admin_client
-        )
-    finally:
-        await _release_spend_lease(workspace)
-
-
-async def _ingest_tenant_spend_locked(
-    workspace: str,
-    *,
-    spend_card: SpendCredits | None = None,
-    admin_client: LiteLLMAdminClient | None = None,
-) -> SpendIngestResult:
     """Read ``workspace``'s LiteLLM proxy spend and debit it to the EXISTING credit
     ledger, exactly once per spend row.
 
@@ -1073,14 +966,12 @@ async def _ingest_tenant_spend_locked(
 
     rows_read = 0
     rows_billed = 0
-    credits_debited = 0
+    # Accumulated in MICRO-credits and converted once at the end. Summing per-row
+    # whole-credit figures would round every row separately and under-report the
+    # sweep by exactly the sub-credit spend this path exists to capture.
+    micro_debited = 0
     cost_usd_total = 0.0
     cached_total = 0
-    # Spend carried from earlier sweeps that was not yet worth a whole credit. It
-    # is real money the tenant owes; it just could not be expressed in the ledger's
-    # integer unit yet.
-    pending_usd = float(doc.pending_spend_usd or 0.0)
-    pending_at_start = pending_usd
 
     # Oldest first so the high-water mark advances monotonically.
     for row, honour_mark in sorted(rows, key=lambda pair: _row_start_time(pair[0]) or ""):
@@ -1135,31 +1026,25 @@ async def _ingest_tenant_spend_locked(
             continue
 
         ledger_key = f"litellm:{rid}"
-        # Skip a row already accounted for. This gate now guards the REMAINDER as
-        # well as the debit, and that is why it moved above the conversion. A row
-        # folded into ``pending_usd`` on an earlier sweep has a zero-value ledger
-        # entry rather than a debit, and the customer read deliberately re-offers
-        # the last ``_SPEND_READ_OVERLAP`` of settled rows every tick — so without
-        # this check first, a cheap row would be added to the remainder once per
-        # sweep for fifteen minutes and the tenant would be billed several times
-        # over for it. Under-billing became over-billing, which is worse.
+        # Skip a row already accounted for. The customer read deliberately re-offers
+        # the last ``_SPEND_READ_OVERLAP`` of settled rows every tick to catch rows
+        # the proxy wrote late, so a row reaching here twice is routine; the ledger
+        # key is what makes it bill once. Checked before the debit to keep
+        # ``rows_billed`` honest and skip a wasted insert-then-rollback.
         if await credits_service.is_recorded(workspace, ledger_key):
             continue
 
-        # Carry the fraction instead of discarding it. Credits are integers (1 ==
-        # $0.01) and the proxy prices ONE API call, so a single row is routinely
-        # worth less than a whole credit. Converting each row on its own and
-        # dropping anything that rounded to zero served every cheap call for free,
-        # permanently: nothing accumulated, and the high-water mark moved past the
-        # dropped row in the same pass. Per-run metering had the same arithmetic and
-        # never showed it, because it priced a whole run at once — the cutover kept
-        # the conversion and made the unit ~100x smaller.
-        pending_usd += cost_usd
-        credits = card.whole_credits(pending_usd)
+        # Bill the row for exactly what it cost. The wallet stores micro-credits
+        # (1_000_000 == 1 credit), so a $0.0015 call is 375_000 — an integer, with
+        # no rounding decision to make and nothing left over. This used to convert
+        # to WHOLE credits and skip anything that rounded to zero, which served
+        # every call under $0.002 free and permanently, because the high-water mark
+        # advanced past the dropped row in the same pass.
+        micro = card.to_micro_credits(cost_usd)
 
-        if credits <= 0:
-            # Not yet worth a credit. Record it so the overlap cannot re-fold it,
-            # and leave the money in ``pending_usd`` for the row that tips it over.
+        if micro <= 0:
+            # A genuinely free row (a $0 model, a cached hit). Record it so the
+            # customer read's overlap does not re-examine it every sweep.
             await credits_service.record_no_movement(
                 workspace=workspace,
                 cause=_LITELLM_SPEND_CAUSE,
@@ -1170,14 +1055,13 @@ async def _ingest_tenant_spend_locked(
                     "model": row.get("model"),
                     "cached_tokens": _cached_tokens(row),
                     "source": "litellm_spend_log",
-                    "pending_usd": pending_usd,
                 },
             )
             continue
 
         balance_after = await credits_service.debit(
             workspace=workspace,
-            amount=credits,
+            amount_micro=micro,
             cause=_LITELLM_SPEND_CAUSE,
             idempotency_key=ledger_key,
             ref={
@@ -1186,22 +1070,16 @@ async def _ingest_tenant_spend_locked(
                 "model": row.get("model"),
                 "cached_tokens": _cached_tokens(row),
                 "source": "litellm_spend_log",
-                # What this debit actually settles: its own row plus every
-                # sub-credit row folded in ahead of it. Without this the ledger
-                # looks like a $0.0015 call was billed 3 credits.
-                "settles_usd": card.usd_for_credits(credits),
             },
             allow_negative=True,
         )
-        # Take the billed part back out; what is left is the unbilled fraction.
-        pending_usd -= card.usd_for_credits(credits)
-        credits_debited += credits
+        micro_debited += micro
         rows_billed += 1
         logger.debug(
-            "llm_provisioning.ingest_tenant_spend: workspace=%s billed %d credits "
+            "llm_provisioning.ingest_tenant_spend: workspace=%s billed %d micro-credits "
             "(request_id=%s, cost_usd=%.6f) -> balance=%d",
             workspace,
-            credits,
+            micro,
             rid,
             cost_usd,
             balance_after,
@@ -1215,12 +1093,8 @@ async def _ingest_tenant_spend_locked(
     # remainder says "and this much of them is still owed"; writing the mark without
     # the remainder is exactly the old bug, since the rows behind the mark are the
     # ones whose fractions are sitting in it.
-    mark_moved = newest_ts is not None and newest_ts != doc.last_spend_ingest_ts
-    pending_moved = pending_usd != pending_at_start
-    if mark_moved or pending_moved:
-        if newest_ts is not None:
-            doc.last_spend_ingest_ts = newest_ts
-        doc.pending_spend_usd = pending_usd
+    if newest_ts is not None and newest_ts != doc.last_spend_ingest_ts:
+        doc.last_spend_ingest_ts = newest_ts
         doc.updatedAt = datetime.now(UTC)
         await doc.save()
 
@@ -1232,7 +1106,7 @@ async def _ingest_tenant_spend_locked(
             workspace,
             rows_billed,
             rows_read,
-            credits_debited,
+            micro_to_credits(micro_debited),
             cost_usd_total,
             cached_total,
             balance_after,
@@ -1241,7 +1115,8 @@ async def _ingest_tenant_spend_locked(
         workspace_id=workspace,
         rows_read=rows_read,
         rows_billed=rows_billed,
-        credits_debited=credits_debited,
+        credits_debited=micro_to_credits(micro_debited),
+        micro_debited=micro_debited,
         cost_usd=cost_usd_total,
         cached_tokens=cached_total,
         balance_after=balance_after,

--- a/ee/pocketpaw_ee/cloud/metering/domain.py
+++ b/ee/pocketpaw_ee/cloud/metering/domain.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 from decimal import ROUND_HALF_EVEN, Decimal
 from typing import Literal
 
+from pocketpaw_ee.cloud.credits.domain import MICRO_PER_CREDIT
+
 # Where a run's resolved cost came from — for the bill ref + debug logging.
 #
 # ``unpriced`` was split out of ``none`` on 2026-09-02. They used to be the same
@@ -75,6 +77,31 @@ class RateCard:
         exact = cost_usd if isinstance(cost_usd, Decimal) else Decimal(str(cost_usd))
         credits = exact * Decimal(str(self.markup)) / Decimal(str(self.credit_usd))
         return int(credits.quantize(Decimal("1"), rounding=ROUND_HALF_EVEN))
+
+    def to_micro_credits(self, cost_usd: Decimal | float) -> int:
+        """Convert a USD compute cost into MICRO-credits (1_000_000 == 1 credit).
+
+        The conversion the per-run debit uses. ``to_credits`` rounds a whole run to
+        the nearest cent, which was defensible when a run was the billing unit and
+        cost several cents — but the same run priced at $0.0015 rounds to nothing,
+        and a workload of cheap runs is billed zero however many of them there are.
+        The finer unit removes the rounding decision rather than choosing a
+        direction for it.
+
+        Kept in ``Decimal`` end to end for the same reason ``to_credits`` is: the
+        price arrives exact from ``usage_tracker.price_run`` and converting through
+        a float would round it on the way into a rounding function.
+        """
+        if cost_usd <= 0:
+            return 0
+        exact = cost_usd if isinstance(cost_usd, Decimal) else Decimal(str(cost_usd))
+        micro = (
+            exact
+            * Decimal(str(self.markup))
+            / Decimal(str(self.credit_usd))
+            * Decimal(MICRO_PER_CREDIT)
+        )
+        return int(micro.quantize(Decimal("1"), rounding=ROUND_HALF_EVEN))
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/metering/dto.py
+++ b/ee/pocketpaw_ee/cloud/metering/dto.py
@@ -18,18 +18,22 @@ from pydantic import BaseModel, Field
 class BillResult(BaseModel):
     """The outcome of billing one run's compute cost.
 
-    ``credits_charged`` is the integer credits debited (0 when the cost rounded
-    to nothing or usage was empty — the run is still marked billed).
+    ``credits_charged`` is the WHOLE credits debited, truncated for display, so a
+    run costing 3.125 credits reports 3. ``micro_charged`` is the exact figure
+    (1_000_000 == 1 credit) and is what the wallet actually moved — read that one
+    to reconcile against the ledger. A cheap run can charge real money and still
+    show ``credits_charged == 0``; only ``debited`` says whether money moved.
     ``balance_after`` is the workspace wallet balance once the debit landed (may
     be negative: a completed run is always billed, so an overage is recorded as a
-    legitimate negative). ``debited`` is False when ``credits_charged == 0`` and
-    no ledger movement was written.
+    legitimate negative). ``debited`` is False only when the run was genuinely free
+    and no ledger movement was written.
     """
 
     run_id: str
     workspace_id: str
     cost_usd: float
     credits_charged: int
+    micro_charged: int = 0
     balance_after: int
     debited: bool
     cost_source: str = Field(

--- a/ee/pocketpaw_ee/cloud/metering/service.py
+++ b/ee/pocketpaw_ee/cloud/metering/service.py
@@ -93,6 +93,7 @@ from typing import Any
 
 from pocketpaw_ee.cloud.chat.runs import service as chat_runs_service
 from pocketpaw_ee.cloud.credits import service as credits_service
+from pocketpaw_ee.cloud.credits.domain import micro_to_credits
 from pocketpaw_ee.cloud.metering.domain import ComputeCost, RateCard
 from pocketpaw_ee.cloud.metering.dto import BillResult
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
@@ -376,7 +377,10 @@ async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) ->
     cost = resolve_cost(run_doc.usage, at=run_moment(run_doc))
     # The Decimal when there is one: the price came back exact and rounding it to
     # a float on the way into a rounding function is two roundings for one bill.
-    credits = card.to_credits(
+    # Micro-credits: a run priced at $0.0015 is 375_000 of them, where rounding to
+    # whole credits made it 0 and served the run free. Same rate card, same money,
+    # a unit fine enough to express it.
+    micro = card.to_micro_credits(
         cost.cost_usd_exact if cost.cost_usd_exact is not None else cost.cost_usd
     )
     # Real per-run token volume (see ``_total_tokens``) — stamped on the debit ref
@@ -387,10 +391,10 @@ async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) ->
     workspace = run_doc.workspace
     run_id = run_doc.run_id
 
-    if credits > 0:
+    if micro > 0:
         balance_after = await credits_service.debit(
             workspace=workspace,
-            amount=credits,
+            amount_micro=micro,
             cause=_COMPUTE_SPEND_CAUSE,
             idempotency_key=f"run:{run_id}",
             ref={
@@ -404,11 +408,11 @@ async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) ->
         )
         debited = True
         logger.info(
-            "metering.bill_run: run=%s workspace=%s billed %d credits "
+            "metering.bill_run: run=%s workspace=%s billed %d micro-credits "
             "(cost_usd=%.6f, source=%s, model=%r) -> balance=%d",
             run_id,
             workspace,
-            credits,
+            micro,
             cost.cost_usd,
             cost.source,
             cost.model,
@@ -419,7 +423,7 @@ async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) ->
         balance_after = await credits_service.balance(workspace)
         debited = False
         logger.debug(
-            "metering.bill_run: run=%s workspace=%s cost rounds to 0 credits "
+            "metering.bill_run: run=%s workspace=%s is genuinely free "
             "(cost_usd=%.6f, source=%s) — marking billed, no debit",
             run_id,
             workspace,
@@ -437,7 +441,8 @@ async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) ->
         run_id=run_id,
         workspace_id=workspace,
         cost_usd=cost.cost_usd,
-        credits_charged=credits,
+        credits_charged=micro_to_credits(micro),
+        micro_charged=micro,
         balance_after=balance_after,
         debited=debited,
         cost_source=cost.source,

--- a/ee/pocketpaw_ee/cloud/models/credit.py
+++ b/ee/pocketpaw_ee/cloud/models/credit.py
@@ -37,6 +37,16 @@
 # invariant: the balance MAY go slightly negative from metered compute overage
 # (BC-3) — the no-overdraft guarantee is enforced at run-start, not by clamping
 # the balance to >= 0 here.
+# Changed 2026-09-04 (feat/exact-credit-deduction): the wallet's storage unit is
+# now MICRO-CREDITS (1_000_000 == 1 credit == $0.01), and the three amount fields
+# are renamed to say so — ``balance_credits`` -> ``balance_micro``,
+# ``amount_delta`` -> ``amount_delta_micro``, ``balance_after`` ->
+# ``balance_after_micro``. A whole-credit wallet could not charge for an API call
+# worth a tenth of a cent without rounding it away, which is how sub-credit proxy
+# spend was served free. The rename is the migration's safety net: a reader left
+# on the old name gets an AttributeError instead of a number a million times too
+# large. Requires ``scripts/migrations/2026_09_04_micro_credits.py``; see
+# ``credits.domain.MICRO_PER_CREDIT``.
 # Changed 2026-06-30 (feat/billing-quota-enforcement, chunk 2): added a second
 # ``CreditLedgerEntry`` index ``ix_workspace_created_at`` on
 # ``(workspace, createdAt)``. The monthly-quota read (``month_to_date_spend``)
@@ -57,7 +67,7 @@ class CreditBalance(TimestampedDocument):
 
     Exactly one row per workspace (the ``workspace`` index is UNIQUE). The
     balance is mutated only by the atomic conditional ``$inc`` in
-    ``credits.service`` — a debit uses a ``{balance_credits: {$gte: amount}}``
+    ``credits.service`` — a debit uses a ``{balance_micro: {$gte: amount}}``
     filter so two racing debits can never both pass the funds check
     (compare-and-swap, not read-then-write).
     """
@@ -65,14 +75,25 @@ class CreditBalance(TimestampedDocument):
     # UNIQUE — one balance row per workspace. The grant path upserts on this
     # key; the debit path CAS-updates the matching row.
     workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
-    # Integer credits; 1 credit == $0.01. Usually >= 0 — a STRICT debit CAS only
-    # decrements a row that already holds >= the debit amount. It MAY go slightly
-    # negative from a metered ``allow_negative`` compute-spend debit (BC-3): a
-    # completed run is always billed, the spend already happened, so the overage
-    # is recorded as a legitimate negative balance rather than dropped. The
-    # no-overdraft guarantee is enforced at run-start (a later task) — NOT by
-    # clamping this field to >= 0. Always integer; never a float.
-    balance_credits: int = 0
+    # Integer MICRO-CREDITS; 1_000_000 micro == 1 credit == $0.01. See
+    # ``credits.domain.MICRO_PER_CREDIT`` for why the unit is this fine: a credit
+    # is a cent and the proxy prices one API call, so a whole-credit wallet could
+    # not charge for a call worth a tenth of a cent without rounding it away.
+    #
+    # RENAMED from ``balance_credits`` 2026-09-04 deliberately. Reading a micro
+    # value as though it were credits over-reports a balance by a factor of a
+    # million, and every such read is a plain attribute access that no type
+    # checker would catch. The rename turns a silent wrong answer into an
+    # AttributeError at the one moment anyone can act on it.
+    #
+    # Usually >= 0 — a STRICT debit CAS only decrements a row that already holds
+    # >= the debit amount. It MAY go slightly negative from a metered
+    # ``allow_negative`` compute-spend debit (BC-3): a completed run is always
+    # billed, the spend already happened, so the overage is recorded as a
+    # legitimate negative balance rather than dropped. The no-overdraft guarantee
+    # is enforced at run-start — NOT by clamping this field to >= 0. Always
+    # integer; never a float (a ledger invariant cannot survive float drift).
+    balance_micro: int = 0
 
     class Settings:
         name = "credit_balances"
@@ -87,10 +108,10 @@ class CreditLedgerEntry(TimestampedDocument):
     movement collide on insert (``DuplicateKeyError`` / Mongo code 11000) so
     the service returns the current balance without re-applying.
 
-    ``amount_delta`` is signed (positive for grant/genesis, negative for
-    spend). ``balance_after`` is the wallet balance once this entry's effect
+    ``amount_delta_micro`` is signed (positive for grant/genesis, negative
+    for spend). ``balance_after`` is the wallet balance once this entry's effect
     landed — stamped after the atomic ``$inc`` returns the new balance.
-    ``reconcile`` recomputes ``balance == sum(amount_delta)`` over the rows whose
+    ``reconcile`` recomputes ``balance == sum(amount_delta_micro)`` over the rows whose
     effect actually landed (``applied is True``).
 
     ``applied`` closes the crash window. An entry is inserted FIRST (the
@@ -110,10 +131,15 @@ class CreditLedgerEntry(TimestampedDocument):
     workspace: Indexed(str)  # type: ignore[valid-type]
     # One of: ``genesis`` | ``grant`` | ``spend`` | ``transfer``.
     kind: str
-    # Signed delta this entry applied (e.g. +500 on a grant, -120 on a spend).
-    amount_delta: int
-    # Wallet balance once this entry's effect landed. Stamped after the $inc.
-    balance_after: int = 0
+    # Signed delta this entry applied, in MICRO-CREDITS (1_000_000 == 1 credit ==
+    # $0.01). A 500-credit grant is +500_000_000; a $0.0015 proxy call after the
+    # 2.5x markup is -375_000. RENAMED from ``amount_delta`` alongside the balance
+    # field, for the same reason: a stale reader that finds the attribute still
+    # there would report a million-fold wrong amount and never raise.
+    amount_delta_micro: int
+    # Wallet balance in micro-credits once this entry's effect landed. Stamped
+    # after the $inc returns the new balance.
+    balance_after_micro: int = 0
     # The balance $inc for this entry has LANDED. False is the crash-window
     # state: the entry committed but its effect never reached the balance.
     # ``reconcile`` re-drives every ``applied is False`` entry, then sums only the

--- a/ee/pocketpaw_ee/cloud/models/litellm_key.py
+++ b/ee/pocketpaw_ee/cloud/models/litellm_key.py
@@ -32,8 +32,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-
 from beanie import Indexed
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
@@ -99,26 +97,12 @@ class LiteLLMTenantKey(TimestampedDocument):
     # /spend/logs row already debited to the ledger. The sweep reads rows AFTER
     # this and advances it; None means nothing has been ingested yet.
     last_spend_ingest_ts: str | None = None
-    # Spend this tenant has incurred that is not yet worth a whole credit, carried
-    # forward to the next sweep. Credits are integers (1 == $0.01) and the proxy
-    # prices a single API call, so most rows are worth a fraction of one; the sweep
-    # used to convert each row on its own and discard anything that rounded to
-    # zero, which served every cheap call for free and permanently, because the
-    # high-water mark moved past the dropped row in the same pass. Always less than
-    # one credit's worth of USD — the moment it covers a whole credit, that credit
-    # is debited and this drops back below the line.
-    pending_spend_usd: float = 0.0
-    # Lease held by whoever is currently ingesting this tenant's spend, as the UTC
-    # instant it expires. ``pending_spend_usd`` is a read-modify-write and the
-    # ledger's per-row key cannot protect it: two overlapping sweeps read the same
-    # remainder, each fold in a DIFFERENT row, and each cross the credit line, so
-    # both debit under distinct idempotency keys and the tenant pays twice. The
-    # overlap is not hypothetical — the 5-minute sweep runs in the API process and
-    # again at worker boot, and the per-run trigger makes it routine.
-    #
-    # An expiry rather than a boolean so a holder that crashes mid-sweep cannot
-    # wedge a tenant's billing forever; the next sweep past the expiry takes it.
-    spend_ingest_lease_until: datetime | None = None
+    # NOTE 2026-09-04: ``pending_spend_usd`` and ``spend_ingest_lease_until`` were
+    # added and removed the same day. They held the sub-credit remainder the sweep
+    # could not bill, and the lock that stopped two sweeps double-spending it. The
+    # micro-credit wallet made both unnecessary — a row now bills exactly, so there
+    # is no shared remainder to carry or to race on. Recorded here because the
+    # fields exist in deployed documents and the migration drops them.
 
     class Settings:
         name = "litellm_tenant_keys"

--- a/scripts/migrations/2026_09_04_micro_credits.py
+++ b/scripts/migrations/2026_09_04_micro_credits.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+"""Convert the credit wallet from whole credits to micro-credits.
+
+WHAT THIS DOES. Multiplies every stored amount by 1_000_000 and renames the three
+fields that carry one:
+
+    credit_balances.balance_credits   -> balance_micro        (x 1_000_000)
+    credit_ledger.amount_delta        -> amount_delta_micro   (x 1_000_000)
+    credit_ledger.balance_after       -> balance_after_micro  (x 1_000_000)
+
+It also drops two fields from ``litellm_tenant_keys`` that the finer unit made
+unnecessary: ``pending_spend_usd`` (the sub-credit remainder) and
+``spend_ingest_lease_until`` (the lock that protected it).
+
+WHY THE RENAME IS PART OF THE MIGRATION, not a separate tidy-up. If the values
+were scaled while the names stayed, any code still reading ``balance_credits``
+would find the field present and report a balance a million times too large. That
+is a silent wrong answer in a money path. Renaming makes such a reader raise
+AttributeError instead, at the one moment someone can act on it. The two halves
+must land together or not at all.
+
+IDEMPOTENT. Documents are selected by the OLD field's existence, so a re-run
+matches nothing and reports zero. Safe to run twice, and safe to resume after an
+interruption — a partial run leaves each document either fully converted or fully
+untouched, never half.
+
+ORDER MATTERS. Run this while the API and worker are STOPPED. A process on the
+old code writing ``balance_credits`` mid-migration creates a document with both
+fields, and the new code would then read a zero balance beside a real one. There
+is no lock here that can prevent that; stopping the writers is the control.
+
+USAGE:
+    python scripts/migrations/2026_09_04_micro_credits.py --dry-run
+    python scripts/migrations/2026_09_04_micro_credits.py
+
+Reads the same ``POCKETPAW_MONGO_URL`` / ``POCKETPAW_MONGO_DB`` the app uses.
+
+Created 2026-09-04 (feat/exact-credit-deduction).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("micro_credits_migration")
+
+MICRO_PER_CREDIT = 1_000_000
+
+# (collection, old field, new field). Order is irrelevant — each is independent.
+_RENAMES: tuple[tuple[str, str, str], ...] = (
+    ("credit_balances", "balance_credits", "balance_micro"),
+    ("credit_ledger", "amount_delta", "amount_delta_micro"),
+    ("credit_ledger", "balance_after", "balance_after_micro"),
+)
+
+# Fields the micro unit made obsolete. Dropped, not renamed — see the module
+# docstring. A document that never had them is unaffected.
+_DROPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("litellm_tenant_keys", ("pending_spend_usd", "spend_ingest_lease_until")),
+)
+
+
+async def _scale_and_rename(db, collection: str, old: str, new: str, *, dry_run: bool) -> int:
+    """Multiply ``old`` by a million into ``new``, then remove ``old``.
+
+    One ``update_many`` with an aggregation pipeline, so the read and the write are
+    a single server-side operation per document. Doing it as read-then-write from
+    here would leave a window where a crash strands a document with neither field.
+    """
+    coll = db[collection]
+    matched = await coll.count_documents({old: {"$exists": True}})
+    if dry_run or matched == 0:
+        return matched
+
+    await coll.update_many(
+        {old: {"$exists": True}},
+        [
+            # ``$toLong`` keeps this an integer type in Mongo. A stored double
+            # would round at 2^53 and, worse, make the ledger's exact-sum
+            # invariant a float comparison.
+            {"$set": {new: {"$toLong": {"$multiply": [f"${old}", MICRO_PER_CREDIT]}}}},
+        ],
+    )
+    # The unset is a SECOND pass, not a stage in the pipeline above, because
+    # pipeline ``$unset`` is unsupported by mongomock and the migration's tests run
+    # on it. Splitting costs one extra pass over a small collection and buys the
+    # tests. It is also safe to interrupt between the two: a document left with
+    # both fields is picked up by a re-run, which re-scales into ``new`` from the
+    # untouched ``old`` and gets the same answer.
+    await coll.update_many({old: {"$exists": True}}, {"$unset": {old: ""}})
+    return matched
+
+
+async def _drop_fields(db, collection: str, fields: tuple[str, ...], *, dry_run: bool) -> int:
+    coll = db[collection]
+    query = {"$or": [{f: {"$exists": True}} for f in fields]}
+    matched = await coll.count_documents(query)
+    if dry_run or matched == 0:
+        return matched
+    await coll.update_many(query, {"$unset": {f: "" for f in fields}})
+    return matched
+
+
+async def _verify(db) -> bool:
+    """Re-check that no document still carries an old field. Cheap; always runs."""
+    ok = True
+    for collection, old, _new in _RENAMES:
+        left = await db[collection].count_documents({old: {"$exists": True}})
+        if left:
+            ok = False
+            logger.error("verify: %s still has %d document(s) with %s", collection, left, old)
+    return ok
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="report what would change, write nothing"
+    )
+    args = parser.parse_args()
+
+    url = os.environ.get("POCKETPAW_MONGO_URL", "").strip()
+    if not url:
+        logger.error("POCKETPAW_MONGO_URL is not set")
+        return 2
+    db_name = os.environ.get("POCKETPAW_MONGO_DB", "").strip() or "pocketpaw"
+
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+    client = AsyncIOMotorClient(url)
+    db = client[db_name]
+
+    mode = "DRY RUN — nothing will be written" if args.dry_run else "WRITING"
+    logger.info("micro-credit migration on %s/%s — %s", url.split("@")[-1], db_name, mode)
+
+    total = 0
+    for collection, old, new in _RENAMES:
+        n = await _scale_and_rename(db, collection, old, new, dry_run=args.dry_run)
+        total += n
+        logger.info(
+            "%s: %d document(s) %s %s -> %s (x%d)",
+            collection,
+            n,
+            "would convert" if args.dry_run else "converted",
+            old,
+            new,
+            MICRO_PER_CREDIT,
+        )
+
+    for collection, fields in _DROPS:
+        n = await _drop_fields(db, collection, fields, dry_run=args.dry_run)
+        logger.info(
+            "%s: %d document(s) %s obsolete field(s) %s",
+            collection,
+            n,
+            "would drop" if args.dry_run else "dropped",
+            ", ".join(fields),
+        )
+
+    if args.dry_run:
+        logger.info("dry run complete — %d credit document(s) would be converted", total)
+        return 0
+
+    if not await _verify(db):
+        logger.error("MIGRATION INCOMPLETE — old fields remain; do NOT start the app")
+        return 1
+
+    logger.info("migration complete and verified — %d credit document(s) converted", total)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/cloud/billing/test_usage.py
+++ b/tests/cloud/billing/test_usage.py
@@ -42,6 +42,7 @@ from datetime import UTC, date, datetime, timedelta
 import pytest
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.billing import usage
+from pocketpaw_ee.cloud.credits.domain import credits_to_micro
 from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
 
 WS = "ws_usage_test"
@@ -70,8 +71,8 @@ async def _seed_spend(
     entry = CreditLedgerEntry(
         workspace=ws,
         kind="spend",
-        amount_delta=-credits,
-        balance_after=0,
+        amount_delta_micro=credits_to_micro(-credits),
+        balance_after_micro=credits_to_micro(0),
         applied=True,
         conditional=False,
         cause=cause,

--- a/tests/cloud/billing/test_usage_ledger_source.py
+++ b/tests/cloud/billing/test_usage_ledger_source.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from pocketpaw_ee.cloud.billing import usage
+from pocketpaw_ee.cloud.credits.domain import credits_to_micro
 from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
 from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
 
@@ -59,8 +60,8 @@ async def _seed_spend(
     entry = CreditLedgerEntry(
         workspace=ws,
         kind="spend",
-        amount_delta=-credits,
-        balance_after=0,
+        amount_delta_micro=credits_to_micro(-credits),
+        balance_after_micro=credits_to_micro(0),
         applied=True,
         conditional=False,
         cause=cause,
@@ -156,8 +157,8 @@ async def test_usage_excludes_non_spend_causes(mongo_db):
     grant = CreditLedgerEntry(
         workspace=WS,
         kind="grant",
-        amount_delta=5000,
-        balance_after=0,
+        amount_delta_micro=credits_to_micro(5000),
+        balance_after_micro=credits_to_micro(0),
         applied=True,
         conditional=False,
         cause="top_up",

--- a/tests/cloud/credits/test_guards.py
+++ b/tests/cloud/credits/test_guards.py
@@ -30,6 +30,7 @@ import pytest
 from pocketpaw_ee.cloud._core.errors import InsufficientCredits, QuotaExceeded
 from pocketpaw_ee.cloud.credits import guards
 from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.credits.domain import credits_to_micro
 from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
 from pocketpaw_ee.cloud.models.workspace import Workspace
 
@@ -62,8 +63,8 @@ async def _seed_spend(ws: str, amount: int, *, idem: str) -> None:
     entry = CreditLedgerEntry(
         workspace=ws,
         kind="spend",
-        amount_delta=-amount,
-        balance_after=0,
+        amount_delta_micro=credits_to_micro(-amount),
+        balance_after_micro=0,
         applied=True,
         conditional=False,
         cause="compute_spend",

--- a/tests/cloud/credits/test_ledger.py
+++ b/tests/cloud/credits/test_ledger.py
@@ -24,6 +24,7 @@ import asyncio
 import pytest
 from pocketpaw_ee.cloud._core.errors import InsufficientCredits, ValidationError
 from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.credits.domain import credits_to_micro
 from pocketpaw_ee.cloud.models.credit import CreditBalance, CreditLedgerEntry
 
 WS = "ws_credit_test"
@@ -59,8 +60,8 @@ async def test_debit_lowers_balance(mongo_db):
     # The spend is recorded as a signed-negative ledger movement.
     entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
     spend = [e for e in entries if e.idempotency_key == "d1"][0]
-    assert spend.amount_delta == -300
-    assert spend.balance_after == 700
+    assert spend.amount_delta_micro == credits_to_micro(-300)
+    assert spend.balance_after_micro == credits_to_micro(700)
     assert spend.kind == "spend"
 
 
@@ -172,7 +173,7 @@ async def test_reconcile_repairs_drift(mongo_db):
     # Simulate a crash that left the balance doc stale (e.g. a $inc that landed
     # but a later mutation corrupted the cached balance).
     coll = CreditBalance.get_pymongo_collection()
-    await coll.update_one({"workspace": WS}, {"$set": {"balance_credits": 999999}})
+    await coll.update_one({"workspace": WS}, {"$set": {"balance_micro": credits_to_micro(999999)}})
     assert await credits.balance(WS) == 999999  # corrupted
 
     repaired = await credits.reconcile(WS)
@@ -305,8 +306,8 @@ async def test_allow_negative_debit_can_go_below_zero(mongo_db):
     # conditional (so reconcile re-drives it unconditionally).
     entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
     spend = [e for e in entries if e.idempotency_key == "meter"][0]
-    assert spend.amount_delta == -300
-    assert spend.balance_after == -200
+    assert spend.amount_delta_micro == credits_to_micro(-300)
+    assert spend.balance_after_micro == credits_to_micro(-200)
     assert spend.applied is True
     assert spend.conditional is False
     assert spend.kind == "spend"
@@ -330,8 +331,8 @@ async def test_reconcile_redrives_unapplied_grant(mongo_db):
     phantom = CreditLedgerEntry(
         workspace=WS,
         kind="grant",
-        amount_delta=250,
-        balance_after=0,
+        amount_delta_micro=credits_to_micro(250),
+        balance_after_micro=0,
         applied=False,
         conditional=False,
         cause="promo",
@@ -347,7 +348,7 @@ async def test_reconcile_redrives_unapplied_grant(mongo_db):
 
     reloaded = await CreditLedgerEntry.get(phantom.id)
     assert reloaded.applied is True
-    assert reloaded.balance_after == 750
+    assert reloaded.balance_after_micro == credits_to_micro(750)
 
 
 async def test_reconcile_redrives_or_voids_unapplied_strict_debit(mongo_db):
@@ -359,8 +360,8 @@ async def test_reconcile_redrives_or_voids_unapplied_strict_debit(mongo_db):
     over = CreditLedgerEntry(
         workspace=WS,
         kind="spend",
-        amount_delta=-1000,
-        balance_after=0,
+        amount_delta_micro=-credits_to_micro(1000),
+        balance_after_micro=0,
         applied=False,
         conditional=True,
         cause="compute_spend",
@@ -379,8 +380,8 @@ async def test_reconcile_redrives_or_voids_unapplied_strict_debit(mongo_db):
     within = CreditLedgerEntry(
         workspace=WS,
         kind="spend",
-        amount_delta=-40,
-        balance_after=0,
+        amount_delta_micro=-credits_to_micro(40),
+        balance_after_micro=0,
         applied=False,
         conditional=True,
         cause="compute_spend",
@@ -394,7 +395,7 @@ async def test_reconcile_redrives_or_voids_unapplied_strict_debit(mongo_db):
     assert await credits.balance(WS) == 60
     reloaded = await CreditLedgerEntry.get(within.id)
     assert reloaded.applied is True
-    assert reloaded.balance_after == 60
+    assert reloaded.balance_after_micro == credits_to_micro(60)
 
 
 async def test_reconcile_never_invents_balance_from_phantom(mongo_db):
@@ -408,8 +409,8 @@ async def test_reconcile_never_invents_balance_from_phantom(mongo_db):
     phantom = CreditLedgerEntry(
         workspace=WS,
         kind="spend",
-        amount_delta=-1000,
-        balance_after=0,
+        amount_delta_micro=-credits_to_micro(1000),
+        balance_after_micro=0,
         applied=False,
         conditional=True,
         cause="compute_spend",

--- a/tests/cloud/credits/test_micro_credit_migration.py
+++ b/tests/cloud/credits/test_micro_credit_migration.py
@@ -1,0 +1,199 @@
+# tests/cloud/credits/test_micro_credit_migration.py — proves the wallet survives
+# the move from whole credits to micro-credits.
+#
+# THE MIGRATION. ``scripts/migrations/2026_09_04_micro_credits.py`` multiplies every
+# stored amount by 1_000_000 and renames the three fields that carry one, so the
+# ledger can express what a single API call costs. A credit is a cent; the proxy
+# prices one call; a $0.0015 call is 0.375 of a credit and had no honest integer
+# representation until the unit got finer.
+#
+# WHAT THESE TESTS ARE FOR. A migration that runs once against real money gets no
+# second attempt, and its failure modes are quiet ones:
+#
+#   * a document converted twice (a re-run, or a resumed interrupted run) would be
+#     a million times too large and nothing would flag it;
+#   * a value stored as a double instead of a long would break the ledger's
+#     exact-sum invariant at the point where floats stop being exact;
+#   * a negative balance — legitimate, from metered overage — must scale like any
+#     other, not get clamped;
+#   * and the ledger invariant ``balance == sum(amount_delta)`` has to still hold
+#     afterwards, because that is the only thing that says the wallet is intact.
+#
+# The migration logic is duplicated here rather than imported: the script is a
+# standalone operator tool with a ``__main__`` and an argparse front door, and
+# importing it would drag its CLI into the suite. What is under test is the
+# aggregation pipeline, which is copied verbatim.
+#
+# Created 2026-09-04 (feat/exact-credit-deduction): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.credits.domain import MICRO_PER_CREDIT, credits_to_micro
+from pocketpaw_ee.cloud.models.credit import CreditBalance, CreditLedgerEntry
+
+WS = "ws_micro_migration"
+_NOW = datetime(2026, 9, 4, 12, 0, tzinfo=UTC)
+
+# Copied verbatim from scripts/migrations/2026_09_04_micro_credits.py.
+_RENAMES = (
+    ("credit_balances", "balance_credits", "balance_micro"),
+    ("credit_ledger", "amount_delta", "amount_delta_micro"),
+    ("credit_ledger", "balance_after", "balance_after_micro"),
+)
+
+
+async def _run_migration(db) -> dict[str, int]:
+    """The script's core, against the test database. Returns per-field counts."""
+    counts: dict[str, int] = {}
+    for collection, old, new in _RENAMES:
+        coll = db[collection]
+        matched = await coll.count_documents({old: {"$exists": True}})
+        counts[old] = matched
+        if matched:
+            await coll.update_many(
+                {old: {"$exists": True}},
+                [{"$set": {new: {"$toLong": {"$multiply": [f"${old}", MICRO_PER_CREDIT]}}}}],
+            )
+            await coll.update_many({old: {"$exists": True}}, {"$unset": {old: ""}})
+    return counts
+
+
+async def _seed_old_shape(db, *, balance: int, movements: list[tuple[str, int]]) -> None:
+    """Write documents in the PRE-migration shape, bypassing the models.
+
+    The Beanie classes now describe the new field names, so the old shape has to be
+    written through the raw collection — which is also exactly how it exists in a
+    deployed database on the morning of the migration.
+    """
+    await db["credit_balances"].insert_one(
+        {"workspace": WS, "balance_credits": balance, "createdAt": _NOW, "updatedAt": _NOW}
+    )
+    running = 0
+    for idem, delta in movements:
+        running += delta
+        await db["credit_ledger"].insert_one(
+            {
+                "workspace": WS,
+                "kind": "grant" if delta > 0 else "spend",
+                "amount_delta": delta,
+                "balance_after": running,
+                "applied": True,
+                "conditional": False,
+                "cause": "top_up" if delta > 0 else "compute_spend",
+                "ref": {},
+                "idempotency_key": idem,
+                "createdAt": _NOW,
+                "updatedAt": _NOW,
+            }
+        )
+
+
+async def test_a_migrated_wallet_reads_back_the_same_balance(mongo_db):
+    """The headline guarantee. A customer holding 700 credits before the migration
+    holds 700 credits after it — the number they see must not move."""
+    await _seed_old_shape(mongo_db, balance=700, movements=[("g1", 1000), ("d1", -300)])
+
+    await _run_migration(mongo_db)
+
+    assert await credits.balance(WS) == 700
+    assert await credits.balance_micro(WS) == credits_to_micro(700)
+
+
+async def test_the_ledger_invariant_survives(mongo_db):
+    """``balance == sum(amount_delta)`` is what says the wallet is intact, and
+    ``reconcile`` is what checks it. If the migration scaled the balance and the
+    entries by different factors — or missed one collection — this is where it
+    shows, and it would otherwise show as a silent repair on the next reconcile."""
+    await _seed_old_shape(
+        mongo_db, balance=660, movements=[("g1", 1000), ("d1", -300), ("d2", -40)]
+    )
+
+    await _run_migration(mongo_db)
+
+    assert await credits.reconcile(WS) == 660
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
+    assert sum(e.amount_delta_micro for e in entries) == credits_to_micro(660)
+
+
+async def test_running_it_twice_changes_nothing(mongo_db):
+    """The failure that would be hardest to notice and worst to suffer: a re-run
+    scaling an already-migrated wallet by another million. Selecting on the OLD
+    field's existence is what prevents it, so a second pass must match zero."""
+    await _seed_old_shape(mongo_db, balance=700, movements=[("g1", 1000), ("d1", -300)])
+
+    first = await _run_migration(mongo_db)
+    assert first["balance_credits"] == 1
+
+    second = await _run_migration(mongo_db)
+    assert second == {"balance_credits": 0, "amount_delta": 0, "balance_after": 0}
+    assert await credits.balance(WS) == 700
+
+
+async def test_a_negative_balance_scales_like_any_other(mongo_db):
+    """A metered overage legitimately drives a wallet below zero, and the ledger
+    preserves that rather than clamping it. The migration must not quietly repair
+    a negative into a zero — it is a debt someone owes."""
+    await _seed_old_shape(mongo_db, balance=-200, movements=[("g1", 100), ("d1", -300)])
+
+    await _run_migration(mongo_db)
+
+    assert await credits.balance(WS) == -200
+    assert await credits.balance_micro(WS) == credits_to_micro(-200)
+
+
+async def test_amounts_stay_integers(mongo_db):
+    """Stored as a long, not a double. Mongo's ``$multiply`` yields a double for a
+    double input, and a float ledger cannot hold an exact-sum invariant — that is
+    the whole reason credits are integers. ``$toLong`` in the pipeline is what
+    pins this, and nothing else in the system would notice if it were dropped."""
+    await _seed_old_shape(mongo_db, balance=700, movements=[("g1", 1000), ("d1", -300)])
+
+    await _run_migration(mongo_db)
+
+    bal = await mongo_db["credit_balances"].find_one({"workspace": WS})
+    assert isinstance(bal["balance_micro"], int)
+    assert not isinstance(bal["balance_micro"], float)
+    async for row in mongo_db["credit_ledger"].find({"workspace": WS}):
+        assert isinstance(row["amount_delta_micro"], int)
+        assert isinstance(row["balance_after_micro"], int)
+
+
+async def test_the_old_field_names_are_gone(mongo_db):
+    """The rename is the safety net, so it has to actually happen. A document left
+    carrying ``balance_credits`` beside ``balance_micro`` would let stale code read
+    a plausible-looking number that is a million times wrong, silently."""
+    await _seed_old_shape(mongo_db, balance=700, movements=[("g1", 1000), ("d1", -300)])
+
+    await _run_migration(mongo_db)
+
+    assert (
+        await mongo_db["credit_balances"].count_documents({"balance_credits": {"$exists": True}})
+        == 0
+    )
+    assert await mongo_db["credit_ledger"].count_documents({"amount_delta": {"$exists": True}}) == 0
+
+    bal_doc = await CreditBalance.find_one(CreditBalance.workspace == WS)
+    assert bal_doc is not None
+    with pytest.raises(AttributeError):
+        _ = bal_doc.balance_credits
+
+
+async def test_spending_continues_from_the_migrated_balance(mongo_db):
+    """End to end. The wallet is migrated, then a real sub-credit proxy charge
+    lands on it — the charge the old unit could not express at all. It has to be
+    deducted exactly, from the balance the customer already had."""
+    await _seed_old_shape(mongo_db, balance=700, movements=[("g1", 1000), ("d1", -300)])
+    await _run_migration(mongo_db)
+
+    # A $0.0015 call at the 2.5x markup: 0.375 credits, 375_000 micro.
+    await credits.debit(
+        WS, amount_micro=375_000, cause="litellm_spend", idempotency_key="litellm:req-1"
+    )
+
+    assert await credits.balance_micro(WS) == credits_to_micro(700) - 375_000
+    # Still 699 whole credits to the customer, because they have spent under one.
+    assert await credits.balance(WS) == 699

--- a/tests/cloud/credits/test_quota.py
+++ b/tests/cloud/credits/test_quota.py
@@ -36,6 +36,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from pocketpaw_ee.cloud._core.errors import QuotaExceeded
 from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.credits.domain import credits_to_micro
 from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
 from pocketpaw_ee.cloud.models.workspace import Workspace
 
@@ -63,8 +64,11 @@ async def _seed(
     entry = CreditLedgerEntry(
         workspace=ws,
         kind="grant" if amount_delta > 0 else "spend",
-        amount_delta=amount_delta,
-        balance_after=0,
+        # Callers seed in WHOLE credits (what the quota ceiling speaks); the
+        # ledger stores micro-credits. Converting here keeps every call site
+        # readable as the amount the test is actually reasoning about.
+        amount_delta_micro=credits_to_micro(amount_delta),
+        balance_after_micro=0,
         applied=applied,
         conditional=False,
         cause=cause,

--- a/tests/cloud/credits/test_spend_by_model.py
+++ b/tests/cloud/credits/test_spend_by_model.py
@@ -50,7 +50,7 @@ from datetime import UTC, datetime
 
 import pytest
 from pocketpaw_ee.cloud.credits import service as credits
-from pocketpaw_ee.cloud.credits.domain import ModelSpendRow
+from pocketpaw_ee.cloud.credits.domain import ModelSpendRow, credits_to_micro
 from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
 
 WS = "ws_spend_by_model"
@@ -86,8 +86,9 @@ async def _seed(
     entry = CreditLedgerEntry(
         workspace=ws,
         kind="spend",
-        amount_delta=amount_delta,
-        balance_after=0,
+        # Seeded in WHOLE credits; stored as micro. See the note in test_quota.
+        amount_delta_micro=credits_to_micro(amount_delta),
+        balance_after_micro=0,
         applied=applied,
         conditional=False,
         cause=cause,
@@ -470,7 +471,7 @@ def test_pipeline_groups_server_side():
     # query rather than by a post-hoc clamp.
     assert match_stage["$match"]["workspace"] == WS
     assert match_stage["$match"]["applied"] is True
-    assert match_stage["$match"]["amount_delta"] == {"$lt": 0}
+    assert match_stage["$match"]["amount_delta_micro"] == {"$lt": 0}
     assert query == {"workspace": WS, "applied": True}  # caller's dict untouched
 
     group = group_stage["$group"]
@@ -478,7 +479,7 @@ def test_pipeline_groups_server_side():
     assert group["_id"]["day"] == {"$dateToString": {"format": "%Y-%m-%d", "date": "$createdAt"}}
     assert "timezone" not in group["_id"]["day"]["$dateToString"]
     # All three measures accumulate in the ``$group``, not in a Python loop.
-    assert group["credits"] == {"$sum": {"$subtract": [0, "$amount_delta"]}}
+    assert group["credits"] == {"$sum": {"$subtract": [0, "$amount_delta_micro"]}}
     assert group["requests"] == {"$sum": 1}
     assert set(group["tokens"]) == {"$sum"}
 

--- a/tests/cloud/llm_provisioning/test_billing_cutover.py
+++ b/tests/cloud/llm_provisioning/test_billing_cutover.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.credits.domain import credits_to_micro
 from pocketpaw_ee.cloud.llm_provisioning import cutover_sweeper
 from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
 from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
@@ -307,7 +308,7 @@ async def test_live_cutover_sweep_debits_proxy_spend_once(mongo_db):
         CreditLedgerEntry.idempotency_key == "litellm:req-1",
     ).to_list()
     assert len(entries) == 1
-    assert entries[0].amount_delta == -10
+    assert entries[0].amount_delta_micro == credits_to_micro(-10)
 
 
 async def test_no_double_charge_same_usage_live(mongo_db):
@@ -568,7 +569,7 @@ async def test_high_water_boundary_same_second_rows_both_billed_once(mongo_db):
             CreditLedgerEntry.idempotency_key == f"litellm:{rid}",
         ).to_list()
         assert len(entries) == 1, f"{rid} must have exactly one ledger row"
-        assert entries[0].amount_delta == delta
+        assert entries[0].amount_delta_micro == credits_to_micro(delta)
 
 
 # ===========================================================================

--- a/tests/cloud/llm_provisioning/test_provisioning.py
+++ b/tests/cloud/llm_provisioning/test_provisioning.py
@@ -30,6 +30,7 @@
 from __future__ import annotations
 
 from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.credits.domain import credits_to_micro
 from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
 from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
 from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
@@ -170,9 +171,9 @@ async def test_ingest_spend_debits_existing_credit_ledger(mongo_db):
     ).to_list()
     assert {e.idempotency_key for e in spend_entries} == {"litellm:req-1", "litellm:req-2"}
     by_key = {e.idempotency_key: e for e in spend_entries}
-    assert by_key["litellm:req-1"].amount_delta == -10
+    assert by_key["litellm:req-1"].amount_delta_micro == credits_to_micro(-10)
     assert by_key["litellm:req-1"].ref.get("cached_tokens") == 128
-    assert by_key["litellm:req-2"].amount_delta == -5
+    assert by_key["litellm:req-2"].amount_delta_micro == credits_to_micro(-5)
 
 
 async def test_reingest_is_idempotent_even_if_high_water_reset(mongo_db):

--- a/tests/cloud/llm_provisioning/test_run_end_trigger.py
+++ b/tests/cloud/llm_provisioning/test_run_end_trigger.py
@@ -1,0 +1,189 @@
+# tests/cloud/llm_provisioning/test_run_end_trigger.py — proves a run's cost is
+# billed shortly after it ends, not up to five minutes later.
+#
+# THE GAP. In ``live`` mode the LiteLLM cutover sweep is the only meter, and it
+# runs on a five-minute heartbeat. So a customer's balance lagged their usage by
+# up to that long, and the run-start balance gate could admit a run the previous
+# one had already spent the credits for.
+#
+# WHAT THESE TESTS PIN. Not the ingest itself (that is covered next door) but the
+# properties that make triggering it from the run lifecycle safe:
+#
+#   * it only fires in ``live`` — in ``off`` / ``shadow`` the per-run meter is
+#     still charging, and running both would bill the same compute twice under two
+#     different idempotency keys;
+#   * it waits before reading, because the proxy writes its spend row from a
+#     background task AFTER the response returns (measured at ~15s on the
+#     production gateway, absent at 6s) so an immediate read finds nothing;
+#   * it can never fail or delay the run that triggered it;
+#   * and racing the sweep is harmless — both bill the same row and the ledger's
+#     unique key means the second is a no-op.
+#
+# Created 2026-09-04 (feat/bill-spend-at-run-end): new test module.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.credits.domain import credits_to_micro
+from pocketpaw_ee.cloud.llm_provisioning import run_end_trigger
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
+from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+
+WS = "ws_run_end_trigger"
+SPEND = SpendCredits(markup=2.5, credit_usd=0.01)
+
+# One real-shaped proxy row: $0.0015, which is 375_000 micro-credits.
+ROW = {
+    "request_id": "req-run-end",
+    "spend": 0.0015,
+    "startTime": "2026-09-04T10:00:00",
+    "model": "gpt-5.2-mini",
+}
+ROW_MICRO = 375_000
+
+
+class FakeAdmin:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.reads = 0
+
+    async def generate_key(self, **kwargs):
+        return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **kwargs}
+
+    async def spend_logs(self, *, api_key: str):
+        self.reads += 1
+        return list(self.rows)
+
+    async def spend_logs_by_end_user(self, *, end_user, start_date, end_date, page_size=100):
+        return []
+
+    async def spend_log_count(self, *, start_date, end_date, end_user=None):
+        return 0
+
+    async def list_customers(self):
+        return []
+
+
+@pytest.fixture(autouse=True)
+def _fast_and_enabled(monkeypatch):
+    """No real waiting, and the trigger explicitly on."""
+    monkeypatch.setenv("POCKETPAW_SPEND_TRIGGER_ENABLED", "true")
+    monkeypatch.setenv("POCKETPAW_SPEND_TRIGGER_DELAY_SECONDS", "0")
+
+
+async def _provision() -> LiteLLMTenantKey:
+    await provisioning.ensure_tenant_key(WS, budget=KeyBudget(), admin_client=FakeAdmin())
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
+    assert doc is not None
+    return doc
+
+
+async def test_a_finished_run_bills_without_waiting_for_the_sweep(monkeypatch, mongo_db):
+    """The point of the whole thing. The run ends; the charge lands seconds later
+    rather than on the next five-minute tick."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(rows=[ROW])
+    monkeypatch.setattr(provisioning, "spend_mode", lambda: "live")
+    monkeypatch.setattr(provisioning, "LiteLLMAdminClient", lambda: admin)
+
+    task = run_end_trigger.schedule_spend_ingest(WS)
+    assert task is not None
+    await task
+
+    assert await credits.balance_micro(WS) == credits_to_micro(1000) - ROW_MICRO
+
+
+async def test_it_does_not_fire_outside_live_mode(monkeypatch, mongo_db):
+    """The double-bill boundary. In ``off`` and ``shadow`` the per-run meter is
+    still charging; billing proxy spend alongside it would charge the same compute
+    twice, under two idempotency keys the ledger cannot recognise as one."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    for mode in ("off", "shadow"):
+        monkeypatch.setattr(provisioning, "spend_mode", lambda mode=mode: mode)
+        assert run_end_trigger.schedule_spend_ingest(WS) is None
+
+    assert await credits.balance(WS) == 1000
+
+
+async def test_it_waits_before_reading(monkeypatch, mongo_db):
+    """The proxy writes its spend row from a background task after the response is
+    sent — measured at ~15s on the production gateway and NOT present at 6s. A
+    trigger that read immediately would find an empty window every time and bill
+    nothing, which looks exactly like working correctly."""
+    monkeypatch.setenv("POCKETPAW_SPEND_TRIGGER_DELAY_SECONDS", "0.05")
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(rows=[ROW])
+    monkeypatch.setattr(provisioning, "spend_mode", lambda: "live")
+    monkeypatch.setattr(provisioning, "LiteLLMAdminClient", lambda: admin)
+
+    task = run_end_trigger.schedule_spend_ingest(WS)
+    assert task is not None
+    # Nothing has been read yet — the task is still waiting out its delay.
+    assert admin.reads == 0
+    await task
+    assert admin.reads == 1
+
+
+async def test_a_failing_ingest_never_escapes(monkeypatch, mongo_db):
+    """The run is over and the customer has their answer. A proxy outage must
+    reduce this to a missed optimisation, never a failed run — the sweep re-reads
+    the same window five minutes later."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("proxy is down")
+
+    monkeypatch.setattr(provisioning, "spend_mode", lambda: "live")
+    monkeypatch.setattr(provisioning, "ingest_tenant_spend", _boom)
+
+    task = run_end_trigger.schedule_spend_ingest(WS)
+    assert task is not None
+    await task  # must not raise
+    assert task.exception() is None
+
+
+async def test_the_trigger_and_the_sweep_do_not_double_bill(monkeypatch, mongo_db):
+    """They race by design: the trigger fires at ~20s and the sweep every five
+    minutes, so both read the same row routinely. Whichever lands first debits and
+    the other no-ops on the ledger's unique ``litellm:{request_id}`` key."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(rows=[ROW])
+    monkeypatch.setattr(provisioning, "spend_mode", lambda: "live")
+    monkeypatch.setattr(provisioning, "LiteLLMAdminClient", lambda: admin)
+
+    await asyncio.gather(
+        run_end_trigger.schedule_spend_ingest(WS),
+        provisioning.ingest_tenant_spend(WS, spend_card=SPEND, admin_client=admin),
+    )
+
+    assert await credits.balance_micro(WS) == credits_to_micro(1000) - ROW_MICRO
+
+
+async def test_the_kill_switch_works(monkeypatch, mongo_db):
+    """This adds proxy reads proportional to run volume rather than to time. An
+    operator who finds that expensive needs to stop it without a deploy."""
+    monkeypatch.setenv("POCKETPAW_SPEND_TRIGGER_ENABLED", "false")
+    monkeypatch.setattr(provisioning, "spend_mode", lambda: "live")
+
+    assert run_end_trigger.is_enabled() is False
+    assert run_end_trigger.schedule_spend_ingest(WS) is None
+
+
+async def test_a_workspaceless_run_schedules_nothing(monkeypatch, mongo_db):
+    """A run outside a cloud dispatch has no workspace to bill, and an empty id
+    would be a read for a tenant that does not exist."""
+    monkeypatch.setattr(provisioning, "spend_mode", lambda: "live")
+    assert run_end_trigger.schedule_spend_ingest("") is None

--- a/tests/cloud/llm_provisioning/test_sub_credit_spend_drop.py
+++ b/tests/cloud/llm_provisioning/test_sub_credit_spend_drop.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import pytest
 from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.credits.domain import credits_to_micro
 from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
 from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
 from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
@@ -48,6 +49,9 @@ CHEAP_USD = 0.0015
 CHEAP_ROWS = 8
 # What the same money is worth billed as a sum instead of row by row.
 EXPECTED_CREDITS = round(CHEAP_USD * CHEAP_ROWS * 250)  # 3
+# And what each row is worth on its own, exactly, in the wallet's storage unit.
+EXPECTED_MICRO_PER_ROW = round(CHEAP_USD * 250 * 1_000_000)  # 375_000
+EXPECTED_MICRO_TOTAL = EXPECTED_MICRO_PER_ROW * CHEAP_ROWS
 
 
 class FakeAdmin:
@@ -145,137 +149,42 @@ async def test_a_dropped_sub_credit_row_never_comes_back(mongo_db):
     )
 
 
-async def test_the_remainder_survives_between_sweeps(mongo_db):
-    """The carry is only worth having if it persists. Four cheap rows arrive, then
-    four more on a later sweep; the tenant owes the same three credits as if all
-    eight had arrived at once. A remainder held only in memory would restart at
-    zero and lose the first four rows' fractions."""
+async def test_each_row_bills_its_own_exact_cost(mongo_db):
+    """The point of the finer unit: no row waits on another to become billable.
+
+    Eight $0.0015 calls used to bill nothing at all, then briefly billed 3 credits
+    only once the eighth arrived to push the carried total over the line. Now each
+    one is 375_000 micro-credits the moment it is read."""
     await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
     await _provision()
 
-    first, second = _cheap_rows()[:4], _cheap_rows()[4:]
-
-    await provisioning.ingest_tenant_spend(
-        WS, spend_card=SPEND, admin_client=FakeAdmin(key_rows=first)
-    )
-    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
-    assert doc is not None
-    assert doc.pending_spend_usd > 0, "the unbilled fraction was not carried"
-
-    await provisioning.ingest_tenant_spend(
-        WS, spend_card=SPEND, admin_client=FakeAdmin(key_rows=first + second)
-    )
-
-    assert 1000 - await credits.balance(WS) == EXPECTED_CREDITS
-
-
-async def test_a_re_read_cheap_row_is_not_charged_twice(mongo_db):
-    """The failure mode the fix could have introduced, and the reason the
-    already-recorded check moved ABOVE the conversion.
-
-    The customer read deliberately re-offers the last fifteen minutes of settled
-    rows every sweep, to catch rows the proxy wrote late. A cheap row folded into
-    the remainder has no debit against it, so if "already recorded" only covered
-    debited rows, the overlap would fold the same row in on every tick and the
-    tenant would be billed several times over. Under-billing would have become
-    over-billing.
-    """
-    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
-    await _provision()
-
-    rows = _cheap_rows()
-    for _ in range(5):  # five sweeps, the same window re-offered each time
+    for i, row in enumerate(_cheap_rows(), start=1):
         await provisioning.ingest_tenant_spend(
-            WS, spend_card=SPEND, admin_client=FakeAdmin(customer_rows=rows)
+            WS, spend_card=SPEND, admin_client=FakeAdmin(key_rows=[row])
+        )
+        assert (
+            await credits.balance_micro(WS) == credits_to_micro(1000) - i * EXPECTED_MICRO_PER_ROW
         )
 
-    charged = 1000 - await credits.balance(WS)
-    assert charged == EXPECTED_CREDITS, (
-        f"${CHEAP_USD * CHEAP_ROWS:.4f} of compute billed {charged} credits after "
-        f"five overlapping sweeps"
-    )
 
+async def test_the_wallet_never_owes_a_fraction(mongo_db):
+    """Balance plus billings equals the grant, exactly, with nothing held back.
 
-async def test_two_concurrent_sweeps_do_not_double_bill_the_remainder(mongo_db):
-    """The remainder is a read-modify-write, so it needs a lease.
-
-    Two ingests for one workspace can overlap: the 5-minute sweep runs in the API
-    process and again at worker boot, and a per-run trigger makes the overlap
-    routine. Both load the same ``pending_spend_usd``, both add their own row to it,
-    both cross the credit line, and both debit — on DIFFERENT rows, so the ledger's
-    unique key never fires and nothing looks wrong afterwards.
-
-    The overlap is forced rather than hoped for. ``ingest_tenant_spend`` loads the
-    bookkeeping row BEFORE it reads spend, so a barrier inside the spend read holds
-    both callers until each is holding the same stale remainder. Left to chance the
-    two coroutines simply run to completion in turn and the race never appears,
-    which is exactly why it survived review.
-
-    Here: $0.003 already carried, plus one $0.0015 row on each side. Six tenths of a
-    cent is worth one credit with $0.002 left over. Without a lease it bills two.
+    The carry this file was written against could only be correct in aggregate —
+    it always had money parked outside the ledger between sweeps. There is no
+    outside now: the wallet holds the exact figure after every single row.
     """
-    import asyncio
-
     await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
-    doc = await _provision()
-    doc.pending_spend_usd = 0.003
-    await doc.save()
+    await _provision()
 
-    both_loaded = asyncio.Event()
-    arrived = 0
-
-    class BarrierAdmin(FakeAdmin):
-        """Blocks inside the spend read until BOTH ingests hold the same doc."""
-
-        async def spend_logs(self, *, api_key: str):
-            nonlocal arrived
-            arrived += 1
-            if arrived >= 2:
-                both_loaded.set()
-            # A short timeout, not a hard barrier. When the lease works the second
-            # caller never reaches here at all, so waiting for it would deadlock the
-            # first — the test has to survive the fix as well as catch the bug.
-            try:
-                await asyncio.wait_for(both_loaded.wait(), timeout=0.5)
-            except TimeoutError:
-                pass
-            return list(self.key_rows)
-
-    left = [
-        {
-            "request_id": "req-left",
-            "spend": CHEAP_USD,
-            "startTime": "2026-09-02T10:00:00",
-            "model": "gpt-5.2-mini",
-        }
-    ]
-    right = [
-        {
-            "request_id": "req-right",
-            "spend": CHEAP_USD,
-            "startTime": "2026-09-02T10:00:01",
-            "model": "gpt-5.2-mini",
-        }
-    ]
-
-    await asyncio.gather(
-        provisioning.ingest_tenant_spend(
-            WS, spend_card=SPEND, admin_client=BarrierAdmin(key_rows=left)
-        ),
-        provisioning.ingest_tenant_spend(
-            WS, spend_card=SPEND, admin_client=BarrierAdmin(key_rows=right)
-        ),
-    )
-
-    charged = 1000 - await credits.balance(WS)
-    assert charged == 1, f"$0.006 of spend billed {charged} credits across two overlapping sweeps"
-
-    # And the row the skipped caller was holding is not lost — it carries no ledger
-    # entry, so a later sweep picks it up and folds it into the remainder.
     await provisioning.ingest_tenant_spend(
-        WS, spend_card=SPEND, admin_client=FakeAdmin(key_rows=left + right)
+        WS, spend_card=SPEND, admin_client=FakeAdmin(key_rows=_cheap_rows())
     )
-    assert 1000 - await credits.balance(WS) == 1
-    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
-    assert doc is not None
-    assert doc.pending_spend_usd == pytest.approx(0.002)
+
+    spent_micro = credits_to_micro(1000) - await credits.balance_micro(WS)
+    assert spent_micro == EXPECTED_MICRO_TOTAL
+    # And the exact dollars, back out through the rate card, are what the proxy
+    # charged us — no rounding in either direction.
+    assert spent_micro / 1_000_000 * SPEND.credit_usd / SPEND.markup == pytest.approx(
+        CHEAP_USD * CHEAP_ROWS
+    )

--- a/tests/cloud/llm_provisioning/test_unswept_workspace_spend.py
+++ b/tests/cloud/llm_provisioning/test_unswept_workspace_spend.py
@@ -35,6 +35,7 @@
 
 from __future__ import annotations
 
+from pocketpaw_ee.cloud.credits.domain import micro_to_credits
 from pocketpaw_ee.cloud.llm_provisioning import cutover_sweeper
 from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
 from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
@@ -61,9 +62,15 @@ async def _workspace(slug: str) -> str:
 
 
 async def _credits(workspace: str) -> int:
-    """Credits actually debited to this wallet. ``amount_delta`` is signed."""
+    """Whole credits actually debited to this wallet.
+
+    The ledger stores micro-credits (1_000_000 == 1 credit), so the sum is taken
+    in that unit and converted once — summing per-entry conversions would round
+    each row separately and lose exactly the sub-credit spend this suite is about.
+    """
     entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == workspace).to_list()
-    return -sum(e.amount_delta for e in entries if e.amount_delta < 0)
+    micro = -sum(e.amount_delta_micro for e in entries if e.amount_delta_micro < 0)
+    return micro_to_credits(micro)
 
 
 # ===========================================================================

--- a/tests/cloud/metering/test_compute_meter.py
+++ b/tests/cloud/metering/test_compute_meter.py
@@ -44,6 +44,7 @@ from datetime import UTC, datetime
 
 import pytest
 from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.credits.domain import credits_to_micro
 from pocketpaw_ee.cloud.metering import service as metering
 from pocketpaw_ee.cloud.metering.domain import RateCard
 from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
@@ -115,7 +116,7 @@ async def test_reported_cost_debits_expected_credits(mongo_db):
     entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
     spend = [e for e in entries if e.idempotency_key == "run:run-1"]
     assert len(spend) == 1
-    assert spend[0].amount_delta == -10
+    assert spend[0].amount_delta_micro == credits_to_micro(-10)
     assert spend[0].cause == "compute_spend"
     assert spend[0].ref.get("run_id") == "run-1"
 
@@ -150,7 +151,11 @@ async def test_estimate_fallback_when_no_reported_cost(mongo_db, reported):
     assert result.cost_source == "estimated"
     assert result.credits_charged > 0
     assert result.credits_charged == 3
-    assert await credits.balance(WS) == before - result.credits_charged
+    # The wallet moved by the EXACT charge, which is 3.125 credits here — not the
+    # 3 that ``credits_charged`` shows after truncation. Asserting against the
+    # displayed figure would pass only while every cost happened to land on a whole
+    # credit, which is exactly the assumption the micro unit removed.
+    assert await credits.balance_micro(WS) == credits_to_micro(before) - result.micro_charged
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Stacked on #2062. Merge that one first.

## The problem

In `live` mode the LiteLLM sweep is the only meter and it runs every five
minutes. So a customer's balance lagged their real usage by up to that long, and
the run-start balance gate reads that stale number — meaning it could admit a run
the previous one had already spent the credits for.

## Two changes, and the second is why the first was needed

### Deductions are now exact

A credit is one cent. The proxy prices a single API call. Those cannot both hold
in a whole-credit wallet:

| Real proxy row | True cost in credits | What an integer credit field can store |
|---|---|---|
| $0.0015 | 0.375 | 0 or 1 |
| $0.00014545 | 0.036 | 0 or 1 |

Rounding down served the call free. That is the bug #2062 fixes. Rounding to the
nearest charged nearly three times what was used. The carry I built in #2062 was
an attempt to be right in aggregate while every individual charge stayed wrong.

So the unit changes instead. Balances and ledger amounts are stored in millionths
of a credit — the same reasoning as storing money in cents rather than whole
dollars. That $0.0015 call is exactly 375,000 micro-credits. No rounding, no
remainder.

**Two mechanisms delete themselves.** The sub-credit carry existed only to hold
the fraction that would not fit. The per-tenant lease existed only to stop two
sweeps racing on that shared carry. With every row independently exact, the
ledger's per-row idempotency key is the whole guard again, exactly as it was
before I touched it. Deleting both is the strongest evidence the unit was the
real problem and the carry was a workaround.

Per-run metering had the same rounding and gets the same treatment. It hurt less
because it priced a whole run, but a workload of cheap runs billed zero however
many there were.

**Nothing changes for customers.** Balances, top-ups, plans and prices stay in
whole credits, converted at the HTTP boundary. One credit is still one cent.

One real behaviour change fell out: `check_balance` now compares the exact
figure. A wallet holding half a credit used to read as zero and would have locked
someone out of a run they could pay for. Sub-credit balances were impossible
before; they are routine now.

### Charges land seconds after a run, not minutes

Every terminal run transition schedules the same ingest the sweep runs, for the
same tenant, against the same rows, under the same `litellm:{request_id}`. The
two race constantly and that is the design: whichever arrives first debits, the
other no-ops on the unique index. This changes *when* a charge lands, never
whether or how much.

The 20 second delay is measured. LiteLLM writes its spend row from a background
task after the response has already been sent — on the production gateway the row
appeared at about 15 seconds and was definitively absent at 6. A trigger that read
immediately would find an empty window every time and bill nothing, which looks
identical to working.

Fires only in `live`, because in `off` and `shadow` the per-run meter is still
charging and running both would double-bill under two keys the ledger cannot
reconcile. Fire and forget, so a proxy outage is a missed optimisation rather than
a failed run. `POCKETPAW_SPEND_TRIGGER_ENABLED=false` stops it without a deploy,
since these reads scale with run volume rather than with time.

Cancelled and failed runs trigger it too. They consumed tokens before stopping and
the proxy priced them, which is the same reason the metering sweeper bills all
four terminal states.

## The faster route I tried first, and why it does not work

The proxy returns `x-litellm-response-cost` and `x-litellm-call-id` on every
completion. Billing straight from those needs no delay at all. Two things kill it,
written down so nobody retries them:

**The call-id header is not the id the spend log records.** Measured 2026-09-03:
the header carried `846f51b6-...` while the row's `request_id` was the response
*body's* `id`, `chatcmpl-c4bf1015-...`. Billing on the header id keys the ledger
on something the sweep can never match, so the sweep charges the same call again
under the real id. A double charge.

**The header only exists where our own code makes the HTTP call.** The agent
backends go through pydantic-ai and ChatLiteLLM, neither of which surfaces
response headers, and that is where the spend actually is.

## Migration

`scripts/migrations/2026_09_04_micro_credits.py` multiplies stored amounts by a
million and renames three fields. It has a dry run, a verify pass, and
instructions to stop the writers first.

**The rename is not tidying, it is the safety net.** Scaling values while keeping
the names would let any stale reader report a balance a million times too large,
silently, in a money path. Renaming turns that into an `AttributeError` at the one
moment someone can act on it. The two halves land together or not at all.

Its tests cover the failures that would otherwise be quiet: a double run, a value
stored as a float instead of a long, a negative balance from metered overage, and
the ledger invariant still holding afterwards.

## Verification

537 tests pass across credits, metering, llm_provisioning, billing, runs and chat.
16 are new.

Both new gates were mutation-checked rather than assumed: stubbing out the
live-mode check fails `test_it_does_not_fire_outside_live_mode`, and the
concurrency test in #2062 fails with its lease removed.

Two failures in `tests/cloud/runs/test_run_core.py` are pre-existing. I confirmed
that by stashing this branch and re-running them on the base commit. They are
about tool deny-lists and have nothing to do with billing.

## Deploy order

1. Stop the API and worker. A process on the old code writing `balance_credits`
   mid-migration leaves a document with both fields.
2. `python scripts/migrations/2026_09_04_micro_credits.py --dry-run`
3. Run it for real. It verifies itself and exits non-zero if any old field
   survives.
4. Deploy and start.

Rolling back after step 3 means reversing the migration, since the old code cannot
read the new field names. That is deliberate, for the reason in the migration
section.
