### PR TITLE
The analytics read answers visits, bounces and duration

### DIFF
--- a/ee/pocketpaw_ee/sites/analytics_worker.py
+++ b/ee/pocketpaw_ee/sites/analytics_worker.py
@@ -24,6 +24,17 @@
 # it carry four blobs forever — the reader tolerates both. The full argument for why it
 # is this coarse, and why the append is not negotiable, is in the row contract below.
 #
+# Updated 2026-09-04 (feat/sites-analytics-visit-id, AD-1) — the row grew a SIXTH blob:
+# a VISIT ID at ``blobs[5]``, so a pageview can be attributed to the visit it belongs to
+# and visits become countable at all. It is ``SHA-256(secret | UTC-hour | visitor-hash)``
+# truncated to 16 bytes: the day-rotating visitor hash with an hourly rotation on top,
+# which is how Umami derives a visit from a session — a hash of the session id and a
+# salt that rotates on the hour. Appended, never inserted, for exactly the reason SA-3
+# appended the device class; rows written before this carry FIVE blobs forever and the
+# sixth reads as an empty string. A visit that crosses the top of the hour gets a new id
+# and counts as two, which is accepted rather than fixed — the argument is in the row
+# contract below.
+#
 # SHAPE MIRRORS ``badge.py`` / ``paw_bar/embed.py`` — a per-site injection into the
 # artifact between build and deploy, so what lands is already correct and there is no
 # second deploy and no post-publish patch. What differs is WHAT is injected: those two
@@ -148,15 +159,19 @@
 #   blobs[2]   — ``request.cf.country``.
 #   blobs[3]   — the visitor hash.
 #   blobs[4]   — the device class: ``desktop`` / ``mobile`` / ``tablet`` / ``unknown``.
+#   blobs[5]   — the visit id: which visit this pageview belongs to, rotating hourly.
 #   doubles[0] — 1, the pageview.
 #
 # Do not reorder these without changing the reader in the same PR: Analytics Engine
 # columns are positional and have no names. APPEND-ONLY for the same reason: SA-3 added
 # ``blobs[4]`` at the END rather than anywhere more logical, because inserting it
 # earlier would silently re-label every row already in the dataset, and the retention
-# window is three months. Rows written before SA-3 carry FOUR blobs and are not
-# backfilled — Analytics Engine has no update — so the reader must tolerate both
-# lengths and read a missing device as ``unknown``.
+# window is three months. AD-1 added ``blobs[5]`` under the same rule. A reordered write
+# against an unchanged reader raises nothing — it reports referrers as countries — which
+# is why this is a constraint and not a preference. Rows written before SA-3 carry FOUR
+# blobs and rows written before AD-1 carry FIVE; neither is backfilled, because Analytics
+# Engine has no update, so the reader must tolerate all three lengths, read a missing
+# device as ``unknown`` and a missing visit as empty.
 #
 # WHY A DEVICE CLASS IS THE ONE THING WORTH ADDING HERE, and why it is this coarse. The
 # user-agent is already parsed on this path (the bot filter reads it, and it is an
@@ -167,6 +182,27 @@
 # traced to a person, and every bit of user-agent entropy that reaches the row chips at
 # it. A browser name, a version, an OS build, a screen size — each is individually
 # reasonable and collectively a fingerprint. Two bits is not.
+#
+# WHY A VISIT IS AN HOUR, AND WHAT THE BOUNDARY COSTS. A pageview count answers "how
+# much traffic"; a visit count answers "how many times somebody came", and the gap
+# between them is the pages-per-visit ratio a bounce rate is read off. Nothing in the
+# row could recover that after the fact — the visitor hash is per DAY, so grouping by it
+# collapses a morning and an evening visit into one — which is why the id has to be
+# derived at write time.
+#
+# It is derived FROM the visitor hash rather than from the IP and user-agent again, so
+# it inherits the daily rotation: a visit id cannot outlive the identifier it is built
+# from, and the hour is a SECOND rotation on top of that rather than a longer-lived one.
+#
+# THE HOUR BOUNDARY IS A KNOWN, ACCEPTED ERROR AND NOT A BUG AWAITING A FIX. A visit
+# that starts at 10:58 and continues at 11:02 gets a new id and counts as TWO. There is
+# nowhere to carry an id across the boundary — no cookie, no storage, and a Worker holds
+# nothing between requests — so the choice is a fixed window or an identifier that
+# persists, and an identifier that persists is the one thing this feature exists to not
+# store. The error therefore runs in one direction only: it OVER-SPLITS and never
+# over-merges, the same direction the daily salt already accepts at midnight and a
+# republish already accepts mid-day. A visit count is an upper bound on sessions, never
+# an exact one, and whoever renders it should not imply otherwise.
 
 from __future__ import annotations
 
@@ -463,16 +499,39 @@ export function dayKey(nowMs) {{
   return new Date(nowMs).toISOString().slice(0, 10);
 }}
 
-// SHA-256 over the secret, the day, the IP and the user-agent, truncated to 16 bytes.
-// Truncation is a storage decision, not a security one: 128 bits is far past the
-// collision budget of one site-day, and the row is smaller for it.
-export async function visitorHash(ip, ua, secret, day) {{
-  const data = new TextEncoder().encode(`${{secret}}|${{day}}|${{ip}}|${{ua}}`);
-  const digest = await crypto.subtle.digest("SHA-256", data);
+// The VISIT's rotating half: the UTC calendar hour, `YYYY-MM-DDTHH`. An hour is the
+// whole session model — see the row contract in analytics_worker.py for why there is
+// nowhere to carry a visit across the boundary, and why the resulting over-split is
+// accepted rather than fixed.
+export function hourKey(nowMs) {{
+  return new Date(nowMs).toISOString().slice(0, 13);
+}}
+
+// SHA-256, truncated to 16 bytes, rendered hex. ONE copy of the construction, because
+// the visitor hash and the visit id are the same digest over different components and a
+// second transcription is how the two stop agreeing about what they mean. Truncation is
+// a storage decision, not a security one: 128 bits is far past the collision budget of
+// one site-day, and the row is smaller for it.
+async function sha256Hex16(input) {{
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
   const bytes = new Uint8Array(digest).subarray(0, 16);
   let hex = "";
   for (const byte of bytes) hex += byte.toString(16).padStart(2, "0");
   return hex;
+}}
+
+// SHA-256 over the secret, the day, the IP and the user-agent: WHO, for one UTC day.
+export async function visitorHash(ip, ua, secret, day) {{
+  return sha256Hex16(`${{secret}}|${{day}}|${{ip}}|${{ua}}`);
+}}
+
+// SHA-256 over the secret, the hour and the day's visitor hash: WHICH VISIT, stored at
+// blobs[5]. Built FROM the visitor hash rather than from the IP and user-agent a second
+// time, so it inherits the daily rotation and can never outlive the identifier it is
+// derived from; the hour is a second rotation on top. This mirrors how Umami derives a
+// visit from a session — a hash of the session id plus a salt that rotates hourly.
+export async function visitId(visitor, secret, hour) {{
+  return sha256Hex16(`${{secret}}|${{hour}}|${{visitor}}`);
 }}
 
 // A same-site referrer is not a referrer — it is internal navigation, and reporting it
@@ -499,8 +558,12 @@ export async function count(request, env, nowMs) {{
     if (isBot(ua)) return;
     const url = new URL(request.url);
     const ip = request.headers.get("cf-connecting-ip") || "";
-    const day = dayKey(typeof nowMs === "number" ? nowMs : Date.now());
+    // ONE reading of the clock feeds both rotations. Two calls to Date.now() could
+    // straddle a boundary and pair a day with an hour that is not inside it.
+    const now = typeof nowMs === "number" ? nowMs : Date.now();
+    const day = dayKey(now);
     const visitor = await visitorHash(ip, ua, SALT, day);
+    const visit = await visitId(visitor, SALT, hourKey(now));
     dataset.writeDataPoint({{
       indexes: [SITE_ID],
       blobs: [
@@ -509,6 +572,7 @@ export async function count(request, env, nowMs) {{
         (request.cf && request.cf.country) || "",
         visitor,
         deviceClass(ua),
+        visit,
       ],
       doubles: [1],
     }});

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -2,6 +2,16 @@
 # plane. Distinct request and response shapes per the cloud 4-file rules.
 # Created: 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.5).
 #
+# Updated 2026-09-04 (AD-2 — the visit metrics on the wire): added
+# ``SiteAnalyticsVisits`` and ``SiteAnalyticsResponse.visits``, the visits / bounce rate /
+# visit duration block the overview leads with. It carries this model's absence rule
+# further than the metrics above it needed to: a bounce rate over zero visits and a mean
+# duration over zero measurable visits are both None rather than 0.0, because a ratio of
+# nothing is not a result of nothing. And the block ITSELF is None, with ``"visits"`` named
+# in ``unrecorded``, when every row in the window was written before the counter learned to
+# stamp a visit id — the FOURTH empty state, which is the device class's problem one metric
+# over.
+#
 # Updated 2026-09-02 (SA-4 — the visitor-analytics read): added
 # ``SiteAnalyticsResponse`` / ``SiteAnalyticsBreakdown`` and the three
 # ``ANALYTICS_STATUS_*`` constants, backing GET /sites/{site_id}/analytics. The
@@ -954,6 +964,32 @@ class SiteAnalyticsBreakdown(BaseModel):
     visitors: int
 
 
+class SiteAnalyticsVisits(BaseModel):
+    """Visits, bounce rate and visit duration for one site over one window.
+
+    A VISIT is the run of pageviews sharing the visit id the counting Worker stamps on
+    every row, under a salt that rotates on the hour. So a visit that crosses the top of
+    an hour is counted as TWO. That is accepted rather than fixed, and it is stated here
+    because it is part of what these numbers mean: the error over-splits and never
+    over-merges, the direction the daily visitor salt already accepts, and it leaves
+    visits slightly generous and duration slightly pessimistic.
+
+    ``bounce_rate`` is a FRACTION and not a percentage — bounces over visits, where a
+    bounce is a visit of exactly one pageview. None when there were no visits at all,
+    because a rate over zero is undefined and 0.0 would say nobody bounced.
+
+    ``visit_duration_seconds`` is the mean over visits of MORE THAN ONE pageview. A
+    single-pageview visit has no measurable duration — its one row carries one timestamp
+    — so averaging it in as a zero would drag the mean down in proportion to how well the
+    landing page holds people, which is backwards. None when every visit was a bounce,
+    for the same reason the rate is None when there were no visits.
+    """
+
+    visits: int
+    bounce_rate: float | None = None
+    visit_duration_seconds: float | None = None
+
+
 class SiteAnalyticsResponse(BaseModel):
     """Visitor analytics for one site over one window (GET
     /sites/{site_id}/analytics).
@@ -969,15 +1005,14 @@ class SiteAnalyticsResponse(BaseModel):
     site's creation, it begins here, and a window that reaches further back is
     reaching into time nobody recorded. None when nothing has ever counted.
 
-    ``unrecorded`` names the dimensions the stored row cannot answer AT ALL, as
-    opposed to answered-and-empty. It is empty today for pages, referrers and
-    countries, and carries ``"devices"``: the row a published site writes holds the
-    path, the referrer host, the country and a per-day visitor hash, and nothing
-    about the device. The user-agent is read at the edge only to reject bots and to
-    salt that hash, and the hash is one-way, so no device breakdown can be recovered
-    from data already stored either. Naming it beats returning an empty list that a
-    chart would render as "no devices", and beats omitting the field, which a client
-    cannot tell from a version skew.
+    ``unrecorded`` names the parts of this response the stored rows cannot answer AT
+    ALL, as opposed to answered-and-empty. WHICH parts is not fixed, because the row has
+    grown twice since this model was written and a window ninety days long can span the
+    change: it carries ``"devices"`` while every row in the window predates the device
+    class, and ``"visits"`` while every row predates the visit id, and it empties on its
+    own once real rows exist. Naming a part beats returning an empty list, which a chart
+    renders as "no devices", and beats omitting the field, which a client cannot tell
+    from a version skew.
     """
 
     site_id: str
@@ -990,6 +1025,11 @@ class SiteAnalyticsResponse(BaseModel):
     retention_days: int = 90
     pageviews: int | None = None
     visitors: int | None = None
+    # None with ``"visits"`` in ``unrecorded`` when no row in the window carries a
+    # visit id, which means the site has not republished since the counter learned to
+    # stamp one. Never a zeroed block: a 0% bounce rate is not an empty panel, it is a
+    # spectacular result, and this site has not measured a single visit.
+    visits: SiteAnalyticsVisits | None = None
     top_pages: list[SiteAnalyticsBreakdown] | None = None
     referrers: list[SiteAnalyticsBreakdown] | None = None
     countries: list[SiteAnalyticsBreakdown] | None = None

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -978,16 +978,16 @@ class SiteAnalyticsVisits(BaseModel):
     bounce is a visit of exactly one pageview. None when there were no visits at all,
     because a rate over zero is undefined and 0.0 would say nobody bounced.
 
-    ``visit_duration_seconds`` is the mean over visits of MORE THAN ONE pageview. A
+    ``duration_seconds`` is the mean over visits of MORE THAN ONE pageview. A
     single-pageview visit has no measurable duration — its one row carries one timestamp
     — so averaging it in as a zero would drag the mean down in proportion to how well the
     landing page holds people, which is backwards. None when every visit was a bounce,
     for the same reason the rate is None when there were no visits.
     """
 
-    visits: int
+    count: int
     bounce_rate: float | None = None
-    visit_duration_seconds: float | None = None
+    duration_seconds: float | None = None
 
 
 class SiteAnalyticsResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,20 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-09-04 (AD-2 — visits, bounce rate and visit duration): ``site_analytics``
+# answers a VISIT block beside the pageview totals, read off the visit id AD-1 stamps on
+# every row. It costs one more query — SIX per uncached read, up from five — and it is the
+# only statement in this module with a subquery, which is why ``_analytics_sql`` grew an
+# ``outer`` parameter. That shape is not a preference: the SQL API documents a subquery in
+# FROM but neither JOIN, UNION nor a CTE, so grouping by a visit id STORED at write time is
+# the only way these three numbers are reachable at all.
+#
+# It brings a FOURTH empty state, governed by the same rule as the other three. A window
+# whose rows all predate the visit id is not a site with a zero bounce rate; it is a site
+# that has not republished since the counter learned to record visits. It reads as
+# ``visits: null`` with ``"visits"`` named in ``unrecorded``, exactly as the device class
+# already reports a row shape that cannot answer it.
+#
 # Updated 2026-09-02 (SA-5 — the entitlement on the wire): ``site_entitlements`` now
 # reports ``analytics``, echoed off the resolver. It is the cheap pre-check that lets
 # the dashboard disable the panel with a reason instead of calling the endpoint to be
@@ -1041,6 +1055,7 @@ from pocketpaw_ee.sites.dto import (
     DomainStatusResponse,
     SiteAnalyticsBreakdown,
     SiteAnalyticsResponse,
+    SiteAnalyticsVisits,
     SiteClientResponse,
     SiteClientUpdate,
     SiteDataRowsResponse,
@@ -5260,7 +5275,16 @@ def _analytics_breakdown(
     ]
 
 
-def _analytics_sql(*, select: str, site_id: str, days: int, group: str = "", limit: int = 0) -> str:
+def _analytics_sql(
+    *,
+    select: str,
+    site_id: str,
+    days: int,
+    group: str = "",
+    limit: int = 0,
+    where: str = "",
+    outer: str = "",
+) -> str:
     """Build ONE Analytics Engine statement over this site's pageview rows.
 
     EVERY value interpolated here is one this module controls: ``site_id`` is
@@ -5276,6 +5300,15 @@ def _analytics_sql(*, select: str, site_id: str, days: int, group: str = "", lim
     counted the way they are stored, on the per-day hash in ``blob4``, so a visitor who
     returns tomorrow counts twice. That is the privacy design rather than a defect: the
     salt rotates at UTC midnight, so no join across days is possible even in principle.
+
+    ``where`` ANDs one more condition onto the window filter, and ``outer`` wraps the
+    whole statement in a second SELECT reading its rows — the SUBQUERY FORM the visit
+    metrics need, and the only shape in which they are reachable, since the SQL API
+    documents a subquery in FROM but neither JOIN, UNION nor a CTE. Both are literals
+    written in this file exactly as ``select`` and ``group`` are, for the same reason.
+    The dataset, the site filter and the window all stay on the INNER half — the only
+    half that touches a table — so a subquery form is scoped by the same two conditions
+    every other statement here is.
     """
     if not re.fullmatch(r"[0-9a-f]{24}", site_id):
         # Belt and braces behind ``_load``'s ObjectId round-trip. This is the last
@@ -5289,11 +5322,19 @@ def _analytics_sql(*, select: str, site_id: str, days: int, group: str = "", lim
         f"FROM {analytics_worker.dataset_name()}",
         f"WHERE index1 = '{site_id}' AND timestamp > NOW() - INTERVAL '{int(days)}' DAY",
     ]
+    if where:
+        parts.append(f"AND {where}")
     if group:
         parts.append(f"GROUP BY {group}")
-        parts.append("ORDER BY pageviews DESC")
+        if not outer:
+            # The sort is what makes a breakdown's LIMIT a top-N. An aggregate reading a
+            # subquery does not care what order its rows arrive in, so the outer form does
+            # not pay Cloudflare to sort a site's whole visit table and then discard it.
+            parts.append("ORDER BY pageviews DESC")
     if limit:
         parts.append(f"LIMIT {int(limit)}")
+    if outer:
+        parts = [f"SELECT {outer}", "FROM (", *parts, ")"]
     parts.append("FORMAT JSON")
     return "\n".join(parts)
 
@@ -5312,6 +5353,56 @@ _ANALYTICS_DIMENSIONS: tuple[tuple[str, str, str], ...] = (
     ("referrers", "blob2", "(direct)"),
     ("countries", "blob3", "(unknown)"),
     ("devices", "blob5", "unknown"),
+)
+
+
+# ── AD-2: the visit statement ────────────────────────────────────────────────
+#
+# A VISIT is a run of pageviews sharing ``blob6``, the id the counting Worker stamps on
+# every row under a salt that rotates on the HOUR — ``analytics_worker``'s row contract
+# holds the construction and the hour-boundary caveat. Grouping by an id STORED at write
+# time is the whole reason these numbers are reachable: the SQL API documents a subquery
+# in FROM but neither JOIN, UNION nor a CTE, so RECONSTRUCTING a visit at read time —
+# ordering one visitor's timestamps and cutting them on an inactivity gap — is not
+# expressible here at all, and the fallback is pulling raw rows and clustering them in
+# Python on a read path whose entire value is being cheap.
+#
+# The inner statement answers ONE ROW PER VISIT: how many pages it viewed, how long it
+# lasted, and the sampling interval its rows carry. The outer collapses those into three
+# integers. Bounce rate and mean duration are deliberately NOT computed in SQL — they are
+# ratios whose denominators go to zero in two ordinary situations (a window with no
+# visits, and a window of nothing but bounces), and both have to be answered as "not
+# measurable" rather than as a zero. That belongs where it can be said.
+#
+# WHY THE OUTER SUMS AN INTERVAL RATHER THAN COUNTING ROWS. Analytics Engine downsamples
+# a hot index: it keeps a fraction of the rows and sets ``_sample_interval`` on each
+# survivor to the number of rows it stands for. Counting the subquery's rows would
+# under-report visits by exactly that factor on the busiest sites — the failure
+# ``SUM(_sample_interval)`` exists to prevent, one level up — and it would leave visits on
+# a different scale from the pageviews they are divided into. Each visit is therefore
+# weighted by the interval its own rows carry, ``MAX`` of them so a sampling rate that
+# changed mid-visit cannot round the estimate down. The weight is exact for a
+# single-pageview visit, which is every bounce, and generous for a long visit that
+# survived sampling on several rows. Unsampled traffic weighs 1 and the question does not
+# arise.
+_ANALYTICS_VISIT_SELECT = (
+    "blob6 AS visit, "
+    "SUM(_sample_interval) AS pageviews, "
+    "MAX(_sample_interval) AS sample_interval, "
+    "toUnixTimestamp(MAX(timestamp)) - toUnixTimestamp(MIN(timestamp)) AS seconds"
+)
+
+# Rows written before AD-1 carry no visit id, and Analytics Engine answers an empty string
+# for a blob a row never held. Left in, every one of them would group TOGETHER into a
+# single fabricated visit spanning the window: one visit, thousands of pageviews, a
+# duration measured in days, and not one number on the panel true. Dropped instead — and
+# their absence is what the fourth empty state is read from.
+_ANALYTICS_VISIT_RECORDED = "blob6 != ''"
+
+_ANALYTICS_VISIT_TOTALS = (
+    "SUM(sample_interval) AS visits, "
+    "sumIf(sample_interval, pageviews = 1) AS bounces, "
+    "sumIf(seconds * sample_interval, pageviews > 1) AS total_seconds"
 )
 
 
@@ -5348,8 +5439,11 @@ async def site_analytics(
       and its ValidationError travels out of here untouched, because a failed read is
       not a report about the site's traffic and must not arrive shaped like one.
 
-    ``devices`` may come back None with ``"devices"`` in ``unrecorded`` — see
-    ``_analytics_devices``.
+    ``devices`` and ``visits`` may each come back None with their own name in
+    ``unrecorded``. That is not a fifth status: the stored row has GROWN twice since
+    the oldest rows in a window were written, so one part of an otherwise healthy
+    response can be unanswerable while the rest of it is real. See
+    ``_analytics_devices`` and ``_analytics_visits``.
     """
     doc = await _load(workspace_id, site_id)
 
@@ -5396,6 +5490,25 @@ async def site_analytics(
     # window held no data — a real answer, and the ``ok``-with-zeros state rather than a
     # failure. A failure would already have raised out of the client.
     totals = totals_rows[0] if totals_rows else {}
+    pageviews = _analytics_int(totals, "pageviews")
+
+    # THE VISIT QUERY, read here rather than beside the breakdowns because its empty
+    # state is decided against the totals above: no visits AND no pageviews is a quiet
+    # week, while no visits AND real pageviews is a window written before the visit id
+    # existed. Those are different sentences — see ``_analytics_visits``.
+    visit_rows = await cf.query_analytics_sql(
+        _analytics_sql(
+            select=_ANALYTICS_VISIT_SELECT,
+            site_id=site_id,
+            days=days,
+            group="visit",
+            where=_ANALYTICS_VISIT_RECORDED,
+            outer=_ANALYTICS_VISIT_TOTALS,
+        )
+    )
+    visits, visits_unrecorded = _analytics_visits(
+        visit_rows[0] if visit_rows else {}, pageviews=pageviews
+    )
 
     breakdowns: dict[str, list[SiteAnalyticsBreakdown]] = {}
     for field, blob, empty in _ANALYTICS_DIMENSIONS:
@@ -5420,13 +5533,14 @@ async def site_analytics(
         status=ANALYTICS_STATUS_OK,
         counting_since=_analytics_iso(since),
         retention_days=_ANALYTICS_RETENTION_DAYS,
-        pageviews=_analytics_int(totals, "pageviews"),
+        pageviews=pageviews,
         visitors=_analytics_int(totals, "visitors"),
+        visits=visits,
         top_pages=breakdowns["top_pages"],
         referrers=breakdowns["referrers"],
         countries=breakdowns["countries"],
         devices=devices,
-        unrecorded=unrecorded,
+        unrecorded=unrecorded + visits_unrecorded,
     )
     _analytics_cache_put(cache_key, response)
     return response
@@ -5458,6 +5572,52 @@ def _analytics_devices(
     if not rows or all(row.label == "unknown" for row in rows):
         return None, ["devices"]
     return rows, []
+
+
+def _analytics_visits(row: dict, *, pageviews: int) -> tuple[SiteAnalyticsVisits | None, list[str]]:
+    """The visit block for one window, or None plus ``"visits"`` in ``unrecorded``.
+
+    THE FOURTH EMPTY STATE IS DECIDED HERE, and it is the device class's problem one
+    metric over. A site published before AD-1 is counting pageviews perfectly well and
+    stamping a visit id on none of them, so the visit query answers nothing while the
+    totals answer real traffic. Rendering that as 0 visits and a 0% bounce rate would be
+    the invented zero this whole endpoint is built against — and a worse one than the
+    others, because 0% bounce does not look like an empty panel, it looks like a
+    spectacular result. Real pageviews with no visits therefore returns None and names
+    ``"visits"`` unrecorded, which a client shows as "republish to start measuring
+    visits", the way it already shows a device class it cannot answer.
+
+    NO pageviews and no visits is a different sentence and keeps its numbers: the site is
+    counting, the window is genuinely quiet, and that zero is honest. The two ratios stay
+    None even then, because a bounce rate over zero visits is undefined rather than zero.
+
+    A MIXED WINDOW — some rows before the republish, some after — reports the visits it
+    can measure and under-states them until the window has rolled past that publish. It
+    is the shape ``counting_since`` already has, and it is transient by the length of the
+    window; refusing the whole block instead would black the panel out for up to ninety
+    days after an upgrade."""
+    visits = _analytics_int(row, "visits")
+    if visits <= 0:
+        if pageviews > 0:
+            return None, ["visits"]
+        return SiteAnalyticsVisits(visits=0), []
+    # Clamped because the remainder is a denominator below. More bounces than visits is
+    # impossible out of the statement above, and a negative mean duration reaching a
+    # customer's screen is not worth the one call it costs to make it unreachable.
+    bounces = min(_analytics_int(row, "bounces"), visits)
+    measured = visits - bounces
+    total_seconds = _analytics_int(row, "total_seconds")
+    return (
+        SiteAnalyticsVisits(
+            visits=visits,
+            # Rounded because a ratio of two sampled estimates means nothing in its
+            # fifteenth decimal place, and the wire should not carry float noise that a
+            # UI then has to hide.
+            bounce_rate=round(bounces / visits, 4),
+            visit_duration_seconds=round(total_seconds / measured, 1) if measured else None,
+        ),
+        [],
+    )
 
 
 def _analytics_iso(moment: datetime) -> str:

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -5600,7 +5600,7 @@ def _analytics_visits(row: dict, *, pageviews: int) -> tuple[SiteAnalyticsVisits
     if visits <= 0:
         if pageviews > 0:
             return None, ["visits"]
-        return SiteAnalyticsVisits(visits=0), []
+        return SiteAnalyticsVisits(count=0), []
     # Clamped because the remainder is a denominator below. More bounces than visits is
     # impossible out of the statement above, and a negative mean duration reaching a
     # customer's screen is not worth the one call it costs to make it unreachable.
@@ -5609,12 +5609,12 @@ def _analytics_visits(row: dict, *, pageviews: int) -> tuple[SiteAnalyticsVisits
     total_seconds = _analytics_int(row, "total_seconds")
     return (
         SiteAnalyticsVisits(
-            visits=visits,
+            count=visits,
             # Rounded because a ratio of two sampled estimates means nothing in its
             # fifteenth decimal place, and the wire should not carry float noise that a
             # UI then has to hide.
             bounce_rate=round(bounces / visits, 4),
-            visit_duration_seconds=round(total_seconds / measured, 1) if measured else None,
+            duration_seconds=round(total_seconds / measured, 1) if measured else None,
         ),
         [],
     )

--- a/tests/ee/sites/test_sites_analytics_counter.py
+++ b/tests/ee/sites/test_sites_analytics_counter.py
@@ -12,6 +12,16 @@
 # did before there was one — since a shifted column silently re-labels three months of
 # history and nothing else in the suite would notice.
 #
+# Updated 2026-09-04 (feat/sites-analytics-visit-id, AD-1) — the row grew ``blobs[5]``,
+# the VISIT id, and its tests live here for the same reason: the subject is the row the
+# shared counting core writes. ``test_the_device_class_is_appended_and_shifts_nothing``
+# now expects SIX blobs rather than five; that number is the append-check itself, not a
+# claim about the device class, and the device stays asserted at position 4 beside it.
+# The visit section at the foot pins three things a passing hex pattern alone would not:
+# the id is STABLE inside a UTC hour, it ROTATES across the boundary, and it DISTINGUISHES
+# two visitors in the same hour — the last of those fails for a visit id that hashed the
+# hour and dropped the visitor, which every other assertion here would accept.
+#
 # THE CENTRE OF THIS FILE IS THE COST MODEL, not the config keys. Cloudflare bills a
 # Worker invocation and serves a static asset free, so a ``run_worker_first`` rule that
 # matches a page's subresources multiplies the per-pageview cost by roughly twenty.
@@ -571,7 +581,8 @@ def test_a_free_server_worker_publish_gets_no_counter(tmp_path):
 # ── driving the generated Worker under node ──────────────────────────────────
 
 _DRIVER_PRELUDE = """
-import worker, { isBot, dayKey, visitorHash, count, deviceClass } from "./entry.mjs";
+import worker, { isBot, dayKey, hourKey, visitorHash, visitId, count, deviceClass }
+  from "./entry.mjs";
 
 const request = (url, headers = {}, cf = {}) => ({
   url,
@@ -921,7 +932,12 @@ def test_the_device_class_is_appended_and_shifts_nothing(tmp_path):
 
     Asserted on the row that CARRIES the device, so it cannot pass by reading a
     pre-SA-3 row: path, referrer host, country and visitor hash must still be at 0, 1,
-    2 and 3 with the fifth blob present beside them."""
+    2 and 3 with the fifth blob present beside them.
+
+    The length moved to SIX with AD-1's visit id. The length is the append-check — it
+    catches a slot inserted anywhere but the end — and it has to track the contract as
+    the contract grows. What it must never do is stop naming the position each field is
+    read at, which is why every one of them is still asserted individually."""
     out = _run_node(
         tmp_path,
         """
@@ -945,7 +961,8 @@ emit({ rows: rec.rows });
     assert blobs[2] == "DE"
     assert re.fullmatch(r"[0-9a-f]{32}", blobs[3])
     assert blobs[4] == "desktop"
-    assert len(blobs) == 5
+    assert re.fullmatch(r"[0-9a-f]{32}", blobs[5])
+    assert len(blobs) == 6
     assert out["rows"][0]["doubles"] == [1]
 
 
@@ -1010,3 +1027,151 @@ def test_the_device_class_never_carries_the_user_agent(tmp_path):
     # Nothing version-shaped, platform-shaped or otherwise narrowing rides along.
     for device in out["devices"]:
         assert re.fullmatch(r"desktop|mobile|tablet|unknown", device)
+
+
+# ── AD-1: the visit id at blobs[5] ───────────────────────────────────────────
+
+
+def test_the_row_carries_a_visit_id_at_blob_five(tmp_path):
+    """AD-1's half of the row contract, driven end to end through the default handler.
+    A derivation that is right and a ``count`` that never calls it would pass a unit
+    check on the helper and store nothing, which is the failure this catches.
+
+    The other five fields are asserted beside it because the id was APPENDED: a slot
+    inserted anywhere earlier re-labels three months of stored rows, silently, and
+    Analytics Engine has no update to fix them with."""
+    out = _run_node(
+        tmp_path,
+        """
+const rec = recorder();
+const pending = [];
+const res = await worker.fetch(
+  request(
+    "https://site.example.dev/docs/guide.html",
+    { "user-agent": HUMAN, "cf-connecting-ip": "203.0.113.9",
+      referer: "https://news.example.com/story" },
+    { country: "DE" },
+  ),
+  { ASSETS: page(200), PAW_ANALYTICS: rec },
+  { waitUntil: (p) => pending.push(p) },
+);
+await Promise.all(pending);
+emit({ status: res.status, rows: rec.rows });
+""",
+    )
+
+    assert out["status"] == 200
+    assert len(out["rows"]) == 1
+    blobs = out["rows"][0]["blobs"]
+    assert blobs[0] == "/docs/guide.html"
+    assert blobs[1] == "news.example.com"
+    assert blobs[2] == "DE"
+    assert re.fullmatch(r"[0-9a-f]{32}", blobs[3])
+    assert blobs[4] == "desktop"
+    assert re.fullmatch(r"[0-9a-f]{32}", blobs[5])
+    assert len(blobs) == 6
+    assert out["rows"][0]["doubles"] == [1]
+
+
+def test_the_visit_id_is_stable_within_the_hour_and_rotates_across_it(tmp_path):
+    """What makes a visit countable: every pageview of one visit carries one id, and
+    the id does not survive the hour.
+
+    Asserted on the ROW rather than on the helper, so a derivation that rotates
+    correctly and a ``count`` that writes something else would still fail. The visitor
+    hash is read off the same three rows and must NOT move — it rotates daily, the visit
+    rotates hourly, and a change that collapsed the two into one clock would pass every
+    other assertion in this section.
+
+    The 10:58 → 11:02 pair is the accepted over-split named in the module's row
+    contract: one real visit, two ids, counted twice. There is nowhere to carry an id
+    across the boundary, so the error is designed to run in this direction."""
+    out = _run_node(
+        tmp_path,
+        """
+const rec = recorder();
+const env = { PAW_ANALYTICS: rec };
+const req = request(
+  "https://site.example.dev/",
+  { "user-agent": HUMAN, "cf-connecting-ip": "203.0.113.9" },
+  { country: "US" },
+);
+const early = Date.UTC(2026, 8, 2, 10, 5, 0);
+const late = Date.UTC(2026, 8, 2, 10, 58, 0);
+const nextHour = Date.UTC(2026, 8, 2, 11, 2, 0);
+await count(req, env, early);
+await count(req, env, late);
+await count(req, env, nextHour);
+emit({
+  visits: rec.rows.map((row) => row.blobs[5]),
+  visitors: rec.rows.map((row) => row.blobs[3]),
+  hours: [hourKey(early), hourKey(late), hourKey(nextHour)],
+});
+""",
+    )
+
+    assert out["hours"] == ["2026-09-02T10", "2026-09-02T10", "2026-09-02T11"]
+    early, late, next_hour = out["visits"]
+    assert early == late
+    assert next_hour != early
+    # One visitor across all three: the day did not turn, so only the visit rotated.
+    assert len(set(out["visitors"])) == 1
+
+
+def test_two_visitors_in_the_same_hour_get_different_visit_ids(tmp_path):
+    """The assertion a visit id of ``hash(salt | hour)`` alone would fail, and which
+    every other check in this section would let through: the id has to identify a
+    VISIT, so two people browsing at the same moment cannot share one.
+
+    Driven through ``count`` with a single fixed clock, so the only thing that differs
+    between the two rows is who sent the request."""
+    out = _run_node(
+        tmp_path,
+        """
+const rec = recorder();
+const env = { PAW_ANALYTICS: rec };
+const when = Date.UTC(2026, 8, 2, 10, 5, 0);
+for (const ip of ["203.0.113.9", "198.51.100.4"]) {
+  await count(
+    request("https://site.example.dev/", { "user-agent": HUMAN, "cf-connecting-ip": ip }),
+    env,
+    when,
+  );
+}
+emit({
+  visits: rec.rows.map((row) => row.blobs[5]),
+  visitors: rec.rows.map((row) => row.blobs[3]),
+});
+""",
+    )
+
+    assert out["visits"][0] != out["visits"][1]
+    assert out["visitors"][0] != out["visitors"][1]
+    # And the visit is a DERIVED value, not the visitor hash copied into a second slot —
+    # a duplicate column would count visits as visitors and read as working.
+    assert out["visits"][0] != out["visitors"][0]
+
+
+def test_the_visit_id_rotates_with_the_per_publish_salt(tmp_path):
+    """The visit inherits every privacy property the visitor hash has, because it is
+    derived from it and salted by the same secret. A republish mints a fresh salt, so
+    ids from before and after it cannot be joined — the same over-split the hour
+    boundary accepts, for the same reason."""
+    out = _run_node(
+        tmp_path,
+        """
+const SECRET = "0123456789abcdef0123456789abcdef";
+const when = Date.UTC(2026, 8, 2, 10, 5, 0);
+const visitor = await visitorHash("203.0.113.9", HUMAN, SECRET, dayKey(when));
+emit({
+  visitor,
+  visit: await visitId(visitor, SECRET, hourKey(when)),
+  otherSalt: await visitId(visitor, "a-different-secret", hourKey(when)),
+});
+""",
+    )
+
+    assert re.fullmatch(r"[0-9a-f]{32}", out["visit"])
+    assert out["otherSalt"] != out["visit"]
+    assert out["visit"] != out["visitor"]
+    assert "203.0.113.9" not in json.dumps(out)

--- a/tests/ee/sites/test_sites_analytics_read.py
+++ b/tests/ee/sites/test_sites_analytics_read.py
@@ -3,6 +3,13 @@
 #
 # Created 2026-09-02 (feat/sites-analytics-read).
 #
+# Updated 2026-09-04 (AD-2 — visits, bounce rate and visit duration): section 8 covers
+# the visit block and the FOURTH empty state, a window whose rows all predate the visit
+# id and which has to read as "republish to start measuring visits" rather than as a zero
+# bounce rate. Its fixtures are RAW PAGEVIEWS rather than scripted aggregates, so the
+# hour-boundary split is present in the data instead of being asserted into existence —
+# the section's own note says why that distinction is the point.
+#
 # THE REQUIREMENT THIS WHOLE FILE EXISTS FOR: never invent a zero. Four situations can
 # leave a dashboard looking empty and they are four different sentences to a customer:
 #
@@ -57,19 +64,42 @@ class _FakeAnalyticsCF:
     what was actually sent rather than on what the caller meant to send.
     """
 
-    def __init__(self, rows_by_blob: dict[str, list[dict]] | None = None, totals=None) -> None:
+    def __init__(
+        self,
+        rows_by_blob: dict[str, list[dict]] | None = None,
+        totals=None,
+        visits: dict | None = None,
+    ) -> None:
         self.rows_by_blob = rows_by_blob or {}
         self.totals = totals
+        self.visits = visits
         self.queries: list[str] = []
 
     async def query_analytics_sql(self, sql: str) -> list[dict]:
         self.queries.append(sql)
+        if "blob6 AS visit" in sql:
+            return [self.visits if self.visits is not None else self._default_visits()]
         if "GROUP BY" not in sql:
             return [] if self.totals is None else [self.totals]
         for blob, rows in self.rows_by_blob.items():
             if f"{blob} AS label" in sql:
                 return rows
         return []
+
+    def _default_visits(self) -> dict:
+        """The smallest visit answer COHERENT with this fake's scripted totals.
+
+        Every test written before AD-2 needs one. Defaulting to nothing would drop all of
+        them into the fourth empty state — "no row here has ever carried a visit id" —
+        which is a real answer to a question they are not asking, and they would then be
+        asserting it by accident. So a fixture that scripts pageviews gets one visit that
+        bounced, and a fixture that scripts none gets none. Section 8 does not use this
+        path: its fake aggregates raw rows."""
+        raw = (self.totals or {}).get("pageviews", 0)
+        counted = int(raw) if str(raw).isdigit() else 0
+        if counted <= 0:
+            return {"visits": 0, "bounces": 0, "total_seconds": 0}
+        return {"visits": 1, "bounces": 1, "total_seconds": 0}
 
 
 class _ExplodingCF:
@@ -863,3 +893,336 @@ async def test_the_endpoint_honours_a_window_other_than_the_default(client, monk
     assert resp.status_code == 200, resp.text
     assert resp.json()["window"] == "90d"
     assert cf.queries and all("INTERVAL '90' DAY" in sql for sql in cf.queries)
+
+
+# ── 8. AD-2: visits, bounce rate and visit duration ──────────────────────────
+#
+# THE FIXTURES HERE ARE RAW PAGEVIEWS, NOT SCRIPTED AGGREGATES, and that is the whole
+# design of the section. A fake that answers ``{"visits": 3, "bounces": 1}`` can only
+# contain the cases whoever wrote the query already had in mind, and the case this
+# feature is most likely to get wrong is one nobody types in by hand: a person reading
+# two pages either side of the top of an hour, whom the hourly visit salt splits into TWO
+# visits. A fixture built to match the query leaves that out and then certifies the split
+# as absent — the same trap as a contract test whose one payload is the shape where a
+# wrong expression gives the right answer.
+#
+# So ``_RawRowsCF`` models what ANALYTICS ENGINE does with the statement: group the rows
+# by the stored visit id, sum the sampling intervals, take the span from a visit's first
+# pageview to its last. The visit id itself comes from ``_pv``, which derives it from the
+# HOUR the pageview happened in the way the generated Worker does, so the split is a
+# property of the data rather than of the assertion. Bounce rate and mean duration are
+# the service's own arithmetic and every test below asserts them against numbers worked
+# out by hand.
+
+
+def _pv(when: datetime, visitor: str, *, sample: int = 1, visit: str | None = None) -> dict:
+    """One stored pageview, as the counting Worker would have written it.
+
+    ``visit`` defaults to the id AD-1 stamps: the visitor under a salt that rotates on the
+    hour, so two pageviews by one person inside one hour share it and two either side of
+    the hour do not. Pass ``""`` for a row written BEFORE AD-1, which is the only way a
+    stored row carries no visit id at all."""
+    return {
+        "when": when,
+        "visitor": visitor,
+        "sample": sample,
+        "visit": f"{visitor}@{when:%Y-%m-%dT%H}" if visit is None else visit,
+    }
+
+
+class _RawRowsCF:
+    """An Analytics Engine that AGGREGATES a fixture of raw pageviews.
+
+    It reads the two parts of the statement that change the answer — which blob the
+    visits are grouped by, and whether rows carrying no visit id are filtered out — so a
+    query that grouped by the device class, or that stopped excluding the unrecorded
+    rows, gets a different answer here instead of the same one. What the statement does
+    that no fake can check on the reader's behalf (the sampling sum, the bounce
+    condition, the duration's own filter) is asserted as TEXT in
+    ``test_the_visit_statement_is_the_one_cloudflare_will_run``, because Cloudflare is the
+    only thing that can execute this SQL and the statement is therefore the artifact."""
+
+    def __init__(self, rows: list[dict]) -> None:
+        self.rows = rows
+        self.queries: list[str] = []
+
+    async def query_analytics_sql(self, sql: str) -> list[dict]:
+        self.queries.append(sql)
+        if "blob6 AS visit" in sql:
+            return [self._visits(drop_unrecorded="blob6 != ''" in sql)]
+        if "GROUP BY" in sql:
+            return []
+        return [
+            {
+                "pageviews": sum(row["sample"] for row in self.rows),
+                "visitors": len({row["visitor"] for row in self.rows}),
+            }
+        ]
+
+    def _visits(self, *, drop_unrecorded: bool) -> dict:
+        """The outer aggregate, computed the way the two-level statement computes it."""
+        grouped: dict[str, list[dict]] = {}
+        for row in self.rows:
+            if drop_unrecorded and row["visit"] == "":
+                continue
+            grouped.setdefault(row["visit"], []).append(row)
+        visits = bounces = total_seconds = 0
+        for group in grouped.values():
+            weight = max(row["sample"] for row in group)
+            pageviews = sum(row["sample"] for row in group)
+            visits += weight
+            if pageviews == 1:
+                bounces += weight
+            else:
+                span = max(row["when"] for row in group) - min(row["when"] for row in group)
+                total_seconds += int(span.total_seconds()) * weight
+        return {"visits": visits, "bounces": bounces, "total_seconds": total_seconds}
+
+
+@pytest.mark.asyncio
+async def test_a_visit_that_crosses_the_top_of_the_hour_counts_as_two(beanie_test_db):
+    """THE ACCEPTED ERROR, asserted so that it stays accepted rather than becoming a
+    surprise. One person, three pageviews, never more than eight minutes apart — one
+    reading session to any human looking at the log. The visit id rotates on the hour, so
+    the two before 11:00 are one visit and the one after is another, and the endpoint
+    answers two. It over-splits and never over-merges, the direction the daily visitor
+    salt already accepts.
+
+    Driven from raw pageviews for exactly this reason: a fixture that scripted the
+    aggregate would say two because its author typed two."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _RawRowsCF(
+        [
+            _pv(datetime(2026, 9, 3, 10, 50, tzinfo=UTC), "reader"),
+            _pv(datetime(2026, 9, 3, 10, 58, tzinfo=UTC), "reader"),
+            _pv(datetime(2026, 9, 3, 11, 3, tzinfo=UTC), "reader"),
+        ]
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.pageviews == 3
+    assert out.visitors == 1, "one person, whatever the visit id was split into"
+    assert out.visits.visits == 2, "the hourly salt cut one reading session in two"
+    # The first visit ran 10:50 to 10:58. The second is a single pageview and therefore a
+    # bounce, which is what the tail of a split visit always looks like.
+    assert out.visits.bounce_rate == 0.5
+    assert out.visits.visit_duration_seconds == 480.0
+
+
+@pytest.mark.asyncio
+async def test_a_one_page_visit_is_a_bounce_and_never_dilutes_the_duration(beanie_test_db):
+    """A visit of one pageview has no measurable duration — its single row carries a
+    single timestamp — so it counts as a bounce and stays OUT of the duration's
+    denominator. The mean here is 300 over the one visit that has a duration, not 300 over
+    both visits: dividing by visits would make a site's average time on page fall every
+    time somebody read one page and left, which is backwards."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _RawRowsCF(
+        [
+            _pv(datetime(2026, 9, 3, 10, 0, tzinfo=UTC), "deep"),
+            _pv(datetime(2026, 9, 3, 10, 2, tzinfo=UTC), "deep"),
+            _pv(datetime(2026, 9, 3, 10, 5, tzinfo=UTC), "deep"),
+            _pv(datetime(2026, 9, 3, 10, 1, tzinfo=UTC), "quick"),
+        ]
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert (out.pageviews, out.visitors) == (4, 2)
+    assert out.visits.visits == 2
+    assert out.visits.bounce_rate == 0.5
+    assert out.visits.visit_duration_seconds == 300.0, "300 / 1 measurable visit, not 300 / 2"
+
+
+@pytest.mark.asyncio
+async def test_every_visit_a_bounce_leaves_the_duration_unmeasurable(beanie_test_db):
+    """Three people, one page each. The bounce rate is a real 100% and the duration is
+    genuinely unknown — every visit carries one timestamp, so there is nothing to measure.
+    Reporting 0 seconds would claim everyone left instantly, which is a statement about
+    the site that the stored rows cannot support."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _RawRowsCF(
+        [
+            _pv(datetime(2026, 9, 3, 10, 0, tzinfo=UTC), "a"),
+            _pv(datetime(2026, 9, 3, 10, 10, tzinfo=UTC), "b"),
+            _pv(datetime(2026, 9, 3, 10, 20, tzinfo=UTC), "c"),
+        ]
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.visits.visits == 3
+    assert out.visits.bounce_rate == 1.0
+    assert out.visits.visit_duration_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_a_window_written_before_the_visit_id_says_republish_not_zero(beanie_test_db):
+    """THE FOURTH EMPTY STATE, and the reason this slice needed one. The site is counting
+    and the pageviews are real; every row was written by a publish that predates the visit
+    id, so not one of them can be attributed to a visit.
+
+    A zero bounce rate here would be the worst invented zero on this endpoint. The other
+    three empty states look empty; 0% bounce looks like a triumph — and it would be
+    printed for every site that has not republished since the day this shipped."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _RawRowsCF(
+        [
+            _pv(datetime(2026, 9, 3, 10, 0, tzinfo=UTC), "old", visit=""),
+            _pv(datetime(2026, 9, 3, 10, 4, tzinfo=UTC), "old", visit=""),
+            _pv(datetime(2026, 9, 3, 11, 0, tzinfo=UTC), "older", visit=""),
+        ]
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.status == "ok", "the read succeeded; only one part of it is unanswerable"
+    assert out.pageviews == 3, "the rest of the panel is unaffected"
+    assert out.visits is None
+    assert "visits" in out.unrecorded
+
+
+@pytest.mark.asyncio
+async def test_a_quiet_window_reports_zero_visits_rather_than_calling_them_unrecorded(
+    beanie_test_db,
+):
+    """The state next door, which must not collapse into the one above. Nothing was
+    recorded because nobody came, not because the rows cannot answer — so the block is
+    served with a real zero, and only the two RATIOS are None, because a bounce rate over
+    zero visits is undefined rather than zero."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _RawRowsCF([])
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.status == "ok"
+    assert out.pageviews == 0
+    assert out.visits is not None, "a quiet week is not a version skew"
+    assert out.visits.visits == 0
+    assert out.visits.bounce_rate is None
+    assert out.visits.visit_duration_seconds is None
+    assert "visits" not in out.unrecorded
+
+
+@pytest.mark.asyncio
+async def test_a_window_spanning_the_republish_measures_the_rows_that_can_be(beanie_test_db):
+    """THE CASE THAT ACTUALLY HAPPENS on the day a site republishes: old rows with no
+    visit id and new rows with one, inside a single window. The measurable ones are
+    reported and the block does NOT go unrecorded — refusing it while any old row survives
+    would black the panel out for up to ninety days after the upgrade that fixed it.
+
+    The cost is that visits under-state the window until it has rolled past the publish,
+    which is the shape ``counting_since`` already has and is transient by the window's own
+    length."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _RawRowsCF(
+        [
+            _pv(datetime(2026, 9, 3, 9, 0, tzinfo=UTC), "before", visit=""),
+            _pv(datetime(2026, 9, 3, 9, 30, tzinfo=UTC), "before", visit=""),
+            _pv(datetime(2026, 9, 3, 12, 0, tzinfo=UTC), "after"),
+            _pv(datetime(2026, 9, 3, 12, 4, tzinfo=UTC), "after"),
+        ]
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
+    )
+
+    assert out.pageviews == 4, "every row still counts as a pageview"
+    assert out.visits.visits == 1, "only the rows that carry a visit id can be a visit"
+    assert out.visits.bounce_rate == 0.0
+    assert out.visits.visit_duration_seconds == 240.0
+    assert "visits" not in out.unrecorded
+
+
+@pytest.mark.asyncio
+async def test_the_visit_statement_is_the_one_cloudflare_will_run(beanie_test_db):
+    """The statement is the artifact, so it is asserted as text.
+
+    Nothing in this suite executes SQL — Cloudflare is the only thing that can — and a
+    fake will happily answer a query that reads the wrong column, aggregates the wrong
+    way, or filters nothing. The sampling rule is already pinned this way for the totals
+    query above; these are the same assertions for a statement that has two levels and
+    four expressions to get wrong.
+
+    ``blob6`` rather than ``blob5`` is the one that raises nothing anywhere: the device
+    class sits in the slot next door, and grouping by it would report the number of device
+    classes as the number of visits and look entirely plausible on a chart."""
+    site = await _seed_site(counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _RawRowsCF([_pv(datetime(2026, 9, 3, 10, 0, tzinfo=UTC), "one")])
+
+    await sites_service.site_analytics(workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf)
+
+    visit_sql = next(sql for sql in cf.queries if "AS visits" in sql)
+    assert "blob6 AS visit" in visit_sql, "blob5 is the device class"
+    assert "SUM(_sample_interval) AS pageviews" in visit_sql
+    assert "SUM(sample_interval) AS visits" in visit_sql
+    assert "COUNT(" not in visit_sql, "a plain count under-reports a downsampled index"
+    assert "sumIf(sample_interval, pageviews = 1) AS bounces" in visit_sql
+    assert "sumIf(seconds * sample_interval, pageviews > 1) AS total_seconds" in visit_sql
+    assert "blob6 != ''" in visit_sql, "rows with no visit id would merge into one visit"
+    assert "GROUP BY visit" in visit_sql
+    assert visit_sql.count("SELECT") == 2, "the subquery form is what makes this reachable"
+    # The site and the window still scope it, because both live on the inner half.
+    assert f"index1 = '{site.id}'" in visit_sql
+    assert "INTERVAL '7' DAY" in visit_sql
+    # Neither is supported by the SQL API, and both are the shapes a reader reaches for
+    # first when a query needs two levels.
+    assert "WITH " not in visit_sql
+    assert "JOIN" not in visit_sql
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_serves_the_visit_metrics(client, monkeypatch):
+    """End to end, which is where the nested block's serialisation is enforced. The
+    service tests above would pass against a model the wire cannot render."""
+    site = await _seed_site(
+        workspace_id="ws-http", counting_since=datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+    )
+    cf = _RawRowsCF(
+        [
+            _pv(datetime(2026, 9, 3, 14, 0, tzinfo=UTC), "reader"),
+            _pv(datetime(2026, 9, 3, 14, 30, tzinfo=UTC), "reader"),
+            _pv(datetime(2026, 9, 3, 14, 5, tzinfo=UTC), "passer-by"),
+        ]
+    )
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+
+    resp = await client.get(f"/api/v1/sites/{site.id}/analytics")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["visits"]["visits"] == 2
+    assert body["visits"]["bounce_rate"] == 0.5
+    assert body["visits"]["visit_duration_seconds"] == 1800.0
+    assert "visits" not in body["unrecorded"]
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_says_republish_rather_than_zero_bounce(client, monkeypatch):
+    """The fourth empty state on the wire, where a client will read it. A null block plus
+    a named reason is a message; a zeroed one is a claim about the site's traffic that
+    nothing recorded."""
+    site = await _seed_site(workspace_id="ws-http", counting_since=datetime(2026, 8, 1, tzinfo=UTC))
+    cf = _RawRowsCF([_pv(datetime(2026, 9, 3, 10, 0, tzinfo=UTC), "old", visit="")])
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+
+    resp = await client.get(f"/api/v1/sites/{site.id}/analytics")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["pageviews"] == 1
+    assert body["visits"] is None
+    assert "visits" in body["unrecorded"]

--- a/tests/ee/sites/test_sites_analytics_read.py
+++ b/tests/ee/sites/test_sites_analytics_read.py
@@ -1005,11 +1005,11 @@ async def test_a_visit_that_crosses_the_top_of_the_hour_counts_as_two(beanie_tes
 
     assert out.pageviews == 3
     assert out.visitors == 1, "one person, whatever the visit id was split into"
-    assert out.visits.visits == 2, "the hourly salt cut one reading session in two"
+    assert out.visits.count == 2, "the hourly salt cut one reading session in two"
     # The first visit ran 10:50 to 10:58. The second is a single pageview and therefore a
     # bounce, which is what the tail of a split visit always looks like.
     assert out.visits.bounce_rate == 0.5
-    assert out.visits.visit_duration_seconds == 480.0
+    assert out.visits.duration_seconds == 480.0
 
 
 @pytest.mark.asyncio
@@ -1034,9 +1034,9 @@ async def test_a_one_page_visit_is_a_bounce_and_never_dilutes_the_duration(beani
     )
 
     assert (out.pageviews, out.visitors) == (4, 2)
-    assert out.visits.visits == 2
+    assert out.visits.count == 2
     assert out.visits.bounce_rate == 0.5
-    assert out.visits.visit_duration_seconds == 300.0, "300 / 1 measurable visit, not 300 / 2"
+    assert out.visits.duration_seconds == 300.0, "300 / 1 measurable visit, not 300 / 2"
 
 
 @pytest.mark.asyncio
@@ -1058,9 +1058,9 @@ async def test_every_visit_a_bounce_leaves_the_duration_unmeasurable(beanie_test
         workspace_id="ws-read", site_id=str(site.id), _cloudflare=cf
     )
 
-    assert out.visits.visits == 3
+    assert out.visits.count == 3
     assert out.visits.bounce_rate == 1.0
-    assert out.visits.visit_duration_seconds is None
+    assert out.visits.duration_seconds is None
 
 
 @pytest.mark.asyncio
@@ -1109,9 +1109,9 @@ async def test_a_quiet_window_reports_zero_visits_rather_than_calling_them_unrec
     assert out.status == "ok"
     assert out.pageviews == 0
     assert out.visits is not None, "a quiet week is not a version skew"
-    assert out.visits.visits == 0
+    assert out.visits.count == 0
     assert out.visits.bounce_rate is None
-    assert out.visits.visit_duration_seconds is None
+    assert out.visits.duration_seconds is None
     assert "visits" not in out.unrecorded
 
 
@@ -1140,9 +1140,9 @@ async def test_a_window_spanning_the_republish_measures_the_rows_that_can_be(bea
     )
 
     assert out.pageviews == 4, "every row still counts as a pageview"
-    assert out.visits.visits == 1, "only the rows that carry a visit id can be a visit"
+    assert out.visits.count == 1, "only the rows that carry a visit id can be a visit"
     assert out.visits.bounce_rate == 0.0
-    assert out.visits.visit_duration_seconds == 240.0
+    assert out.visits.duration_seconds == 240.0
     assert "visits" not in out.unrecorded
 
 
@@ -1204,9 +1204,9 @@ async def test_the_endpoint_serves_the_visit_metrics(client, monkeypatch):
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["status"] == "ok"
-    assert body["visits"]["visits"] == 2
+    assert body["visits"]["count"] == 2
     assert body["visits"]["bounce_rate"] == 0.5
-    assert body["visits"]["visit_duration_seconds"] == 1800.0
+    assert body["visits"]["duration_seconds"] == 1800.0
     assert "visits" not in body["unrecorded"]
 
 

--- a/tests/ee/sites/test_sites_analytics_shim.py
+++ b/tests/ee/sites/test_sites_analytics_shim.py
@@ -5,6 +5,14 @@
 #
 # Created 2026-09-02 (feat/sites-analytics-shim).
 #
+# Updated 2026-09-04 (feat/sites-analytics-visit-id, AD-1) — the row grew ``blobs[5]``,
+# the visit id. The derivation and its rotation are pinned beside the counter, where the
+# row contract lives; what belongs HERE is that the shim branch writes the same six
+# columns as the assets-only one. The two entries share one counting core precisely so
+# they cannot drift, and this file is where that stops being an assumption: a dataset
+# holding two positional shapes with no column names to tell them apart is unreadable,
+# and nothing would raise.
+#
 # THE TWO CLAIMS THIS FILE EXISTS TO KEEP HONEST, because both fail silently:
 #
 #   1. THE SITE STILL WORKS. The shim sits in front of the module that RENDERS a
@@ -665,6 +673,8 @@ emit({ rows: rec.rows });
     assert row["blobs"][2] == "DE"
     assert re.fullmatch(r"[0-9a-f]{32}", row["blobs"][3])
     assert row["blobs"][4] == "desktop"
+    assert re.fullmatch(r"[0-9a-f]{32}", row["blobs"][5])
+    assert len(row["blobs"]) == 6
     assert row["doubles"] == [1]
 
 

--- a/tests/mutations/sites_analytics_counter.json
+++ b/tests/mutations/sites_analytics_counter.json
@@ -89,5 +89,33 @@
     "tests": [
       "tests/ee/sites/test_sites_analytics_counter.py"
     ]
+  },
+  {
+    "label": "the visit id drops the visitor (every visitor browsing in the same hour shares one id, so the visit count becomes an hour count and still reads as a plausible number)",
+    "file": "ee/pocketpaw_ee/sites/analytics_worker.py",
+    "find": "  return sha256Hex16(`${{secret}}|${{hour}}|${{visitor}}`);",
+    "replace": "  return sha256Hex16(`${{secret}}|${{hour}}`);",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_counter.py"
+    ]
+  },
+  {
+    "label": "the visit id stops rotating hourly (a visit becomes a whole UTC day, so pages-per-visit collapses and a returning visitor is never a second visit)",
+    "file": "ee/pocketpaw_ee/sites/analytics_worker.py",
+    "find": "  return new Date(nowMs).toISOString().slice(0, 13);",
+    "replace": "  return \"static\";",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_counter.py"
+    ]
+  },
+  {
+    "label": "the visit id is written first instead of last (Analytics Engine columns are positional, so every row already stored is silently re-labelled and there is no update to fix them with)",
+    "file": "ee/pocketpaw_ee/sites/analytics_worker.py",
+    "find": "        visitor,\n        deviceClass(ua),\n        visit,",
+    "replace": "        visit,\n        visitor,\n        deviceClass(ua),",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_counter.py",
+      "tests/ee/sites/test_sites_analytics_shim.py"
+    ]
   }
 ]

--- a/tests/mutations/sites_analytics_read.json
+++ b/tests/mutations/sites_analytics_read.json
@@ -262,5 +262,95 @@
       "tests/ee/sites/test_sites_analytics_since.py::test_a_shim_build_stamps_the_start_like_any_other_counter",
       "tests/ee/sites/test_sites_analytics_since.py::test_a_republish_that_keeps_the_shim_keeps_the_original_stamp"
     ]
+  },
+  {
+    "label": "the visit subquery counts rows instead of summing the sampling interval — visits and pageviews end up on different scales, so pages-per-visit and the bounce rate are both wrong on exactly the busiest sites",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    \"blob6 AS visit, \"\n    \"SUM(_sample_interval) AS pageviews, \"",
+    "replace": "    \"blob6 AS visit, \"\n    \"COUNT() AS pageviews, \"",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the outer aggregate counts visit rows instead of weighting them — a downsampled index reports a fraction of its visits with no error anywhere",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    \"SUM(sample_interval) AS visits, \"",
+    "replace": "    \"COUNT() AS visits, \"",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the visits are grouped by the device class in the slot next door — the number of device classes is reported as the number of visits, which is a plausible small number on a chart and raises nothing",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "_ANALYTICS_VISIT_SELECT = (\n    \"blob6 AS visit, \"",
+    "replace": "_ANALYTICS_VISIT_SELECT = (\n    \"blob5 AS visit, \"",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a bounce becomes a visit of MORE than one pageview — the bounce rate inverts, and a site whose visitors all leave immediately reports 0%",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    \"sumIf(sample_interval, pageviews = 1) AS bounces, \"",
+    "replace": "    \"sumIf(sample_interval, pageviews > 1) AS bounces, \"",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the duration total stops excluding single-pageview visits — every bounce adds a zero to a sum that is then divided by the visits that are not bounces",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    \"sumIf(seconds * sample_interval, pageviews > 1) AS total_seconds\"",
+    "replace": "    \"SUM(seconds * sample_interval) AS total_seconds\"",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "rows carrying no visit id are no longer filtered out — every pageview written before the visit id existed groups into ONE fabricated visit spanning the window, and the fourth empty state can never be reached",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            where=_ANALYTICS_VISIT_RECORDED,",
+    "replace": "            where=\"\",",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the mean visit duration is divided by visits rather than by the visits that have one — a site's time-on-page falls every time somebody reads one page and leaves, which is backwards",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    measured = visits - bounces",
+    "replace": "    measured = visits",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a window written before the visit id reports zero visits instead of saying so — a 0% bounce rate does not look like an empty panel, it looks like a triumph, and it would be printed for every site that has not republished",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        if pageviews > 0:\n            return None, [\"visits\"]",
+    "replace": "        if False:\n            return None, [\"visits\"]",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a genuinely quiet window invents a zero bounce rate — a ratio over zero visits is undefined, and 0.0 says nobody bounced",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        return SiteAnalyticsVisits(visits=0), []",
+    "replace": "        return SiteAnalyticsVisits(visits=0, bounce_rate=0.0, visit_duration_seconds=0.0), []",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a window of nothing but bounces reports a mean duration of zero seconds — a claim that everyone left instantly, from rows that carry one timestamp each and can measure no duration at all",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            visit_duration_seconds=round(total_seconds / measured, 1) if measured else None,",
+    "replace": "            visit_duration_seconds=round(total_seconds / measured, 1) if measured else 0.0,",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
   }
 ]

--- a/tests/mutations/sites_analytics_read.json
+++ b/tests/mutations/sites_analytics_read.json
@@ -338,8 +338,8 @@
   {
     "label": "a genuinely quiet window invents a zero bounce rate — a ratio over zero visits is undefined, and 0.0 says nobody bounced",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "        return SiteAnalyticsVisits(visits=0), []",
-    "replace": "        return SiteAnalyticsVisits(visits=0, bounce_rate=0.0, visit_duration_seconds=0.0), []",
+    "find": "        return SiteAnalyticsVisits(count=0), []",
+    "replace": "        return SiteAnalyticsVisits(count=0, bounce_rate=0.0, duration_seconds=0.0), []",
     "tests": [
       "tests/ee/sites/test_sites_analytics_read.py"
     ]
@@ -347,8 +347,8 @@
   {
     "label": "a window of nothing but bounces reports a mean duration of zero seconds — a claim that everyone left instantly, from rows that carry one timestamp each and can measure no duration at all",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "            visit_duration_seconds=round(total_seconds / measured, 1) if measured else None,",
-    "replace": "            visit_duration_seconds=round(total_seconds / measured, 1) if measured else 0.0,",
+    "find": "            duration_seconds=round(total_seconds / measured, 1) if measured else None,",
+    "replace": "            duration_seconds=round(total_seconds / measured, 1) if measured else 0.0,",
     "tests": [
       "tests/ee/sites/test_sites_analytics_read.py"
     ]


### PR DESCRIPTION
Stacked on #2063, which added the visit id this reads. Merge that one first, and merge
it with `--rebase` rather than `--squash` or this branch will conflict on duplicated
content.

`GET /sites/{site_id}/analytics` now answers visits, bounce rate and visit duration.

## The definitions are Umami's, deliberately

A bounce is a visit with exactly one pageview, and the rate is bounces over visits.
Duration is the mean over visits of more than one pageview. That last exclusion is the
one worth stating: a single-pageview visit has one row carrying one timestamp, so it has
no measurable duration, and averaging it in as a zero would drag the mean down in
proportion to how well the landing page holds people. Backwards, and quietly so.

Taking the definitions from an analytics product customers already know means our
numbers mean what they expect rather than what was convenient to compute.

## Absence is not zero

`bounce_rate` is None when there were no visits, because a ratio over zero is undefined
and 0.0 claims nobody bounced. `duration_seconds` is None when every visit was a bounce,
for the same reason.

The block itself is None, with `"visits"` named in `unrecorded`, when every row in the
window predates the visit id. That is the fourth empty state: the site is counting, but
by a publish too old to stamp visits, and it must read as "republish to start measuring
visits". A zero bounce rate does not look like an empty panel, it looks like a triumph,
and it would otherwise be printed for every site that has not republished. This follows
the device class, which solved the same problem one metric over.

## One statement, and the SQL dialect is narrow

An inner query groups by the visit id, an outer aggregate weighs the result. No JOIN, no
UNION, no CTE, because Analytics Engine supports none of them. Every function used is in
the published SQL reference, which was fetched rather than recalled.

`SUM(_sample_interval)` at both levels, never `COUNT()`. Analytics Engine downsamples a
hot index, so counting rows under-reports exactly the busiest sites, and visits would end
up on a different scale from the pageviews they get divided into.

Rows with no visit id are filtered out. Left in, every pre-visit-id pageview would group
into one fabricated visit spanning the window, and the fourth empty state would be
unreachable.

## Query cost

Six per uncached read, up from five. The cache is unchanged.

## Verification

```
127 passed in 8.51s
```

```
OK: 962 anchors across 75 plans each resolve exactly once.
all 39 mutations caught
```

Ten mutations are new, and they are the point rather than paperwork. Among them: reading
the device-class slot instead of the visit slot, which reports the number of device
classes as the number of visits and raises nothing; inverting the bounce definition, so
a site whose visitors all leave immediately reports zero percent; and dividing duration
by visits rather than by measurable visits.

## A naming change on top of the agent's work

The block first read `visits.visits`, because it took its field names from the task doc
rather than from the response it joins. `pageviews` and `visitors` are flat siblings
there. It is now `visits.count` and `visits.duration_seconds`. No consumer exists yet,
so it was free to change now and would have cost three slices later.
