### PR TITLE
The analytics read returns a time series

### DIFF
--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -2,6 +2,16 @@
 # plane. Distinct request and response shapes per the cloud 4-file rules.
 # Created: 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.5).
 #
+# Updated 2026-09-04 (AD-4 — the overview chart's data): added
+# ``SiteAnalyticsSeriesPoint`` / ``SiteAnalyticsSeries`` and ``SiteAnalyticsResponse.series``,
+# the per-bucket views and visitors the chart under the headline numbers draws. Two things
+# about it are contracts rather than implementation detail. EVERY bucket in the range is
+# present, including the ones nobody visited, because a chart handed only the buckets that
+# had traffic draws a straight line across a quiet Sunday and reports it as no Sunday at
+# all. And every ``bucket`` stamp is UTC, said out loud on the model, because an axis
+# labelled ``1PM`` that means UTC is five and a half hours wrong for a reader in Mumbai and
+# nothing on the screen would say so.
+#
 # Updated 2026-09-04 (AD-2 — the visit metrics on the wire): added
 # ``SiteAnalyticsVisits`` and ``SiteAnalyticsResponse.visits``, the visits / bounce rate /
 # visit duration block the overview leads with. It carries this model's absence rule
@@ -990,6 +1000,52 @@ class SiteAnalyticsVisits(BaseModel):
     duration_seconds: float | None = None
 
 
+class SiteAnalyticsSeriesPoint(BaseModel):
+    """One bucket of the overview chart — an hour or a day, and what happened in it.
+
+    ``bucket`` is the ISO-8601 stamp of the bucket's START, and it is UTC. That is said
+    here rather than left to be inferred because it is the field a chart turns into an
+    axis label: an hour rendered as ``1PM`` that actually means 13:00 UTC is five and a
+    half hours wrong for a reader in Mumbai, and nothing on the screen would say so. A
+    client that wants local labels has the offset it needs to shift them.
+
+    ``visitors`` is a distinct count WITHIN this bucket and does not sum down the column —
+    the same rule ``SiteAnalyticsBreakdown`` carries one field over. One person who reads
+    at nine and again at ten is one visitor on the response's total and one visitor in each
+    of two buckets, so a UI that adds this column gets a number that means nothing.
+    """
+
+    bucket: str
+    pageviews: int
+    visitors: int
+
+
+class SiteAnalyticsSeries(BaseModel):
+    """Views and visitors per time bucket, oldest first — the chart under the tiles.
+
+    ``interval`` is ``"hour"`` or ``"day"``, and a client needs it to label the axis: the
+    same list of points is a day of hours or three months of days depending on this field
+    alone. It is chosen from the window rather than requested, because a bar chart stops
+    being readable somewhere around a hundred bars and thirty days of hourly buckets is
+    seven hundred and twenty of them.
+
+    EVERY BUCKET IN THE RANGE IS HERE, including the ones nobody visited. A series that
+    listed only the buckets with traffic would be shorter, and every chart drawn from it
+    would join the two ends of a gap with a straight line — reporting a quiet Sunday as no
+    Sunday at all. A zero is a measurement; a missing entry is not.
+
+    THE RANGE ITSELF starts at the later of the window's own start and the moment counting
+    began, so a site that has been counting for two days does not answer a ninety-day
+    request with eighty-eight zeroes for a period nobody was recording. That is the one
+    rule this whole endpoint is built on, applied to a chart: those zeroes would look
+    exactly like a site nobody visits. ``counting_since`` on the response says where the
+    trim came from.
+    """
+
+    interval: str  # hour | day
+    points: list[SiteAnalyticsSeriesPoint] = []
+
+
 class SiteAnalyticsResponse(BaseModel):
     """Visitor analytics for one site over one window (GET
     /sites/{site_id}/analytics).
@@ -1030,6 +1086,12 @@ class SiteAnalyticsResponse(BaseModel):
     # stamp one. Never a zeroed block: a 0% bounce rate is not an empty panel, it is a
     # spectacular result, and this site has not measured a single visit.
     visits: SiteAnalyticsVisits | None = None
+    # AD-4: the chart's data. None unless ``status`` is ``ok``, like every other metric
+    # here — and unlike ``visits`` and ``devices`` it never lands in ``unrecorded``,
+    # because the column it is bucketed on is the row's own timestamp and every stored row
+    # has carried one since the first. A window with no traffic at all still answers a
+    # full range of zeroed points: nothing about a quiet week is unanswerable.
+    series: SiteAnalyticsSeries | None = None
     top_pages: list[SiteAnalyticsBreakdown] | None = None
     referrers: list[SiteAnalyticsBreakdown] | None = None
     countries: list[SiteAnalyticsBreakdown] | None = None

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,23 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-09-04 (AD-4 — the overview chart's data): ``site_analytics`` answers a
+# ``series`` block, the same totals grouped by a time bucket. SEVEN queries per uncached
+# read now, up from six. The bucket is an HOUR for the 24-hour window and a DAY for the
+# other three, which is a readability limit rather than a preference: a bar chart stops
+# being legible somewhere around a hundred bars, and a week of hourly buckets is a hundred
+# and sixty-eight of them before the month and the quarter are even considered.
+#
+# The part worth knowing before reading the code is that the RANGE IS BUILT IN PYTHON and
+# the query only fills it. Serving the rows Cloudflare returned would silently omit every
+# bucket nobody visited, and a chart handed a shorter list joins the ends of the gap with a
+# straight line — a quiet Sunday rendered as no Sunday at all. So the buckets are generated
+# and then filled, which also makes the series sum to the pageview total above it.
+#
+# It adds NO empty state. The column it groups on is the row's own timestamp, which every
+# stored row has carried since the first one, so unlike the device class and the visit id
+# there is no row shape this cannot answer.
+#
 # Updated 2026-09-04 (AD-2 — visits, bounce rate and visit duration): ``site_analytics``
 # answers a VISIT block beside the pageview totals, read off the visit id AD-1 stamps on
 # every row. It costs one more query — SIX per uncached read, up from five — and it is the
@@ -1055,6 +1072,8 @@ from pocketpaw_ee.sites.dto import (
     DomainStatusResponse,
     SiteAnalyticsBreakdown,
     SiteAnalyticsResponse,
+    SiteAnalyticsSeries,
+    SiteAnalyticsSeriesPoint,
     SiteAnalyticsVisits,
     SiteClientResponse,
     SiteClientUpdate,
@@ -5284,6 +5303,7 @@ def _analytics_sql(
     limit: int = 0,
     where: str = "",
     outer: str = "",
+    order: str = "pageviews DESC",
 ) -> str:
     """Build ONE Analytics Engine statement over this site's pageview rows.
 
@@ -5309,6 +5329,12 @@ def _analytics_sql(
     The dataset, the site filter and the window all stay on the INNER half — the only
     half that touches a table — so a subquery form is scoped by the same two conditions
     every other statement here is.
+
+    ``order`` names the sort a grouped statement gets. It defaults to the breakdowns'
+    ``pageviews DESC``, which is what makes their LIMIT a top-N; the time series overrides
+    it with the bucket, because a chart's rows are read by WHEN and sorting a quarter of
+    days by traffic would be a sort whose result nothing looks at. Another literal written
+    in this file, for the reason the paragraph above gives.
     """
     if not re.fullmatch(r"[0-9a-f]{24}", site_id):
         # Belt and braces behind ``_load``'s ObjectId round-trip. This is the last
@@ -5330,7 +5356,7 @@ def _analytics_sql(
             # The sort is what makes a breakdown's LIMIT a top-N. An aggregate reading a
             # subquery does not care what order its rows arrive in, so the outer form does
             # not pay Cloudflare to sort a site's whole visit table and then discard it.
-            parts.append("ORDER BY pageviews DESC")
+            parts.append(f"ORDER BY {order}")
     if limit:
         parts.append(f"LIMIT {int(limit)}")
     if outer:
@@ -5406,6 +5432,58 @@ _ANALYTICS_VISIT_TOTALS = (
 )
 
 
+# ── AD-4: the time series ────────────────────────────────────────────────────
+#
+# WHICH BUCKET EACH WINDOW GETS, and the reasoning, because the two long windows are the
+# ones a reader will question. A bar chart stops being readable somewhere around a hundred
+# bars — past that the bars are thinner than the gaps between them and the axis labels
+# collide — so the bucket has to divide the window into fewer than that:
+#
+#   24h → HOUR, 25 buckets. The only window short enough for hours, and the one where
+#         hours are what the reader actually wants: "when today did the traffic come".
+#   7d  → DAY, 8 buckets. Hourly would be 168, past the limit — and a week read hour by
+#         hour is a chart of the same daily shape drawn seven times, which answers a
+#         question ("what time of day do people read") that 24h already answers better.
+#   30d → DAY, 31 buckets. Hourly would be 720.
+#   90d → DAY, 91 buckets. Just inside the limit, and the reason there is no third bucket
+#         size: a week bucket would fit a quarter into 13 bars, but it would also make the
+#         series' units change twice across four windows for one bar's worth of clutter.
+#
+# The counts are one MORE than the window's name suggests because the window is a rolling
+# one — ``timestamp > NOW() - INTERVAL 'n' DAY``, not a calendar range — so its start lands
+# inside a bucket rather than on one. That leading bucket is genuinely partial and is kept
+# rather than dropped: dropping it would delete real traffic from the chart and leave the
+# series summing to less than the pageview total printed directly above it.
+_ANALYTICS_SERIES_HOUR = "hour"
+_ANALYTICS_SERIES_DAY = "day"
+_ANALYTICS_SERIES_INTERVALS: dict[str, str] = {
+    "24h": _ANALYTICS_SERIES_HOUR,
+    "7d": _ANALYTICS_SERIES_DAY,
+    "30d": _ANALYTICS_SERIES_DAY,
+    "90d": _ANALYTICS_SERIES_DAY,
+}
+
+# The bucketing expression per interval. ``toStartOfHour`` and ``toStartOfDay`` are both in
+# the SQL API's documented date-and-time set, and both work in UTC with no zone argument —
+# which is the zone every other stamp on this response is in, so nothing here has to
+# reconcile two.
+#
+# Wrapped in ``toUnixTimestamp`` — also documented, and already used by the visit statement
+# — so the bucket arrives as an INTEGER rather than as whatever string form the JSON
+# renderer picks for a DateTime. An integer needs no parsing contract with Cloudflare, goes
+# through ``_analytics_int`` like every other cell here, and cannot be read in the wrong
+# zone on the way in.
+_ANALYTICS_SERIES_BUCKET_SQL: dict[str, str] = {
+    _ANALYTICS_SERIES_HOUR: "toStartOfHour(timestamp)",
+    _ANALYTICS_SERIES_DAY: "toStartOfDay(timestamp)",
+}
+
+_ANALYTICS_SERIES_STEP: dict[str, timedelta] = {
+    _ANALYTICS_SERIES_HOUR: timedelta(hours=1),
+    _ANALYTICS_SERIES_DAY: timedelta(days=1),
+}
+
+
 async def site_analytics(
     *,
     workspace_id: str,
@@ -5444,6 +5522,11 @@ async def site_analytics(
     the oldest rows in a window were written, so one part of an otherwise healthy
     response can be unanswerable while the rest of it is real. See
     ``_analytics_devices`` and ``_analytics_visits``.
+
+    ``series`` is NOT one of those. It groups on the row's own timestamp, which every
+    stored row has carried since the first one, so there is no row shape it cannot answer
+    and no window in which it goes unrecorded — a quiet week is a full range of zeroes.
+    See ``_analytics_series`` for why the range is generated rather than returned.
     """
     doc = await _load(workspace_id, site_id)
 
@@ -5510,6 +5593,26 @@ async def site_analytics(
         visit_rows[0] if visit_rows else {}, pageviews=pageviews
     )
 
+    # THE SERIES. One more grouped read of the same rows the totals came from, bucketed by
+    # the row's own timestamp. It is ordered by the bucket rather than by traffic because a
+    # chart reads its rows by WHEN — and the range it fills is built below, not taken from
+    # what came back, so a bucket nobody visited is a zero instead of a hole.
+    interval = _ANALYTICS_SERIES_INTERVALS[window]
+    series_rows = await cf.query_analytics_sql(
+        _analytics_sql(
+            select=(
+                f"toUnixTimestamp({_ANALYTICS_SERIES_BUCKET_SQL[interval]}) AS bucket, "
+                "SUM(_sample_interval) AS pageviews, "
+                "COUNT(DISTINCT blob4) AS visitors"
+            ),
+            site_id=site_id,
+            days=days,
+            group="bucket",
+            order="bucket",
+        )
+    )
+    series = _analytics_series(series_rows, interval=interval, days=days, since=since)
+
     breakdowns: dict[str, list[SiteAnalyticsBreakdown]] = {}
     for field, blob, empty in _ANALYTICS_DIMENSIONS:
         rows = await cf.query_analytics_sql(
@@ -5536,6 +5639,7 @@ async def site_analytics(
         pageviews=pageviews,
         visitors=_analytics_int(totals, "visitors"),
         visits=visits,
+        series=series,
         top_pages=breakdowns["top_pages"],
         referrers=breakdowns["referrers"],
         countries=breakdowns["countries"],
@@ -5617,6 +5721,89 @@ def _analytics_visits(row: dict, *, pageviews: int) -> tuple[SiteAnalyticsVisits
             duration_seconds=round(total_seconds / measured, 1) if measured else None,
         ),
         [],
+    )
+
+
+def _analytics_series_floor(moment: datetime, interval: str) -> datetime:
+    """The start of the bucket a moment falls in, in UTC.
+
+    A NAIVE value is read as UTC, for the reason ``_analytics_iso`` gives one function
+    down: Mongo hands back a stamp written as tz-aware with no zone on it, and ``since``
+    arrives here straight off the document. Without this the comparison against an aware
+    window bound raises, and floor'ing whatever the host's local zone happens to be would
+    start the chart at the machine's midnight rather than at the day's.
+    """
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    moment = moment.astimezone(UTC)
+    if interval == _ANALYTICS_SERIES_HOUR:
+        return moment.replace(minute=0, second=0, microsecond=0)
+    return moment.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _analytics_series(
+    rows: list[dict], *, interval: str, days: int, since: datetime
+) -> SiteAnalyticsSeries:
+    """The chart's points for one window — every bucket in the range, oldest first.
+
+    THE RANGE IS GENERATED HERE AND THE QUERY ONLY FILLS IT, which is the whole reason
+    this is a function rather than a comprehension over ``rows``. Analytics Engine answers
+    one row per bucket that HAD traffic, and a chart drawn from that list joins the two
+    ends of every gap with a straight line: an hour nobody visited does not appear as an
+    empty hour, it stops existing, and a quiet Sunday is drawn as no Sunday at all. A zero
+    is a measurement. A missing entry is a different claim and it is not a true one.
+
+    IT STARTS AT THE LATER of the window's own start and the bucket holding
+    ``counting_since``. Eighty-eight zeroed days in front of a site that has been counting
+    for two would be this endpoint's one forbidden move — inventing a zero — drawn at
+    chart scale, and it is worse there than on the panel: a long flat run at the baseline
+    does not read as missing data, it reads as a site nobody visits.
+
+    ROWS OUTSIDE THE RANGE ARE FOLDED INTO THE NEAREST END rather than dropped, and two
+    ordinary things put them there. Our clock and Cloudflare's ``NOW()`` are not the same
+    clock, so the newest bucket can land a moment past the end; and a site that lapsed and
+    re-subscribed has rows still inside the ninety-day retention that predate the
+    ``counting_since`` its current subscription wrote. Dropping either would leave the
+    chart summing to less than the pageview total printed directly above it, with nothing
+    on screen to explain the gap. The fold moves traffic by at most one bucket at the top,
+    and at the bottom it lands in the bucket the trim has already marked as the edge of
+    what was recorded.
+    """
+    step = _ANALYTICS_SERIES_STEP[interval]
+    now = datetime.now(UTC)
+    end = _analytics_series_floor(now, interval)
+    start = max(
+        _analytics_series_floor(now - timedelta(days=days), interval),
+        _analytics_series_floor(since, interval),
+    )
+    # A ``counting_since`` in the future — a clock correction, a stamp written by a host
+    # running ahead — would otherwise make ``start`` later than ``end`` and produce an
+    # EMPTY series, which is the one answer this function must never give: a chart with no
+    # points reads as no data, and the truth is one bucket that has not finished yet.
+    start = min(start, end)
+
+    buckets: dict[datetime, list[int]] = {}
+    moment = start
+    while moment <= end:
+        buckets[moment] = [0, 0]
+        moment += step
+
+    for row in rows:
+        stamp = _analytics_series_floor(
+            datetime.fromtimestamp(_analytics_int(row, "bucket"), UTC), interval
+        )
+        cell = buckets[min(max(stamp, start), end)]
+        cell[0] += _analytics_int(row, "pageviews")
+        cell[1] += _analytics_int(row, "visitors")
+
+    return SiteAnalyticsSeries(
+        interval=interval,
+        points=[
+            SiteAnalyticsSeriesPoint(
+                bucket=_analytics_iso(moment), pageviews=pageviews, visitors=visitors
+            )
+            for moment, (pageviews, visitors) in buckets.items()
+        ],
     )
 
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -5759,22 +5759,43 @@ def _analytics_series(
     chart scale, and it is worse there than on the panel: a long flat run at the baseline
     does not read as missing data, it reads as a site nobody visits.
 
-    ROWS OUTSIDE THE RANGE ARE FOLDED INTO THE NEAREST END rather than dropped, and two
-    ordinary things put them there. Our clock and Cloudflare's ``NOW()`` are not the same
-    clock, so the newest bucket can land a moment past the end; and a site that lapsed and
-    re-subscribed has rows still inside the ninety-day retention that predate the
-    ``counting_since`` its current subscription wrote. Dropping either would leave the
-    chart summing to less than the pageview total printed directly above it, with nothing
-    on screen to explain the gap. The fold moves traffic by at most one bucket at the top,
-    and at the bottom it lands in the bucket the trim has already marked as the edge of
-    what was recorded.
+    ROWS OUTSIDE THE RANGE ARE FOLDED INTO THE NEAREST END rather than dropped, because
+    our clock and Cloudflare's ``NOW()`` are not the same clock and the newest bucket can
+    land a moment past the end. Dropping it would leave the chart summing to less than the
+    pageview total printed directly above it, with nothing on screen to explain the gap.
+    The fold moves that traffic by at most one bucket.
+
+    THE FOLD IS NOT LOAD-BEARING AT THE BOTTOM, and it must not become so. The start is
+    taken from the earliest bucket that carries traffic rather than from
+    ``counting_since`` alone, so a lapsed-and-re-subscribed site's older rows sit in the
+    buckets they happened in instead of piling onto the first one. See the comment on
+    ``start`` below for why that case exists at all.
     """
     step = _ANALYTICS_SERIES_STEP[interval]
     now = datetime.now(UTC)
     end = _analytics_series_floor(now, interval)
+    # The ``counting_since`` trim exists to keep a NEW site's chart from opening with a
+    # long flat run at the baseline. It must not also move a LAPSED site's older traffic.
+    # ``analytics_since`` is cleared by any publish that deploys no counter and re-stamped
+    # fresh on the next paid one, so a site that lapsed and re-subscribed inside the
+    # ninety-day retention holds rows that predate its current stamp. Trimming to the
+    # stamp alone would fold every one of them onto the first bucket — a spike drawn on a
+    # day that did not have it, which is worse than the empty run the trim was avoiding.
+    # Taking the EARLIEST bucket that actually carries traffic serves both: a new site has
+    # nothing before its stamp, so the trim still bites, and a lapsed one keeps its older
+    # rows in the buckets they happened in.
+    earliest = min(
+        (
+            _analytics_series_floor(
+                datetime.fromtimestamp(_analytics_int(row, "bucket"), UTC), interval
+            )
+            for row in rows
+        ),
+        default=_analytics_series_floor(since, interval),
+    )
     start = max(
         _analytics_series_floor(now - timedelta(days=days), interval),
-        _analytics_series_floor(since, interval),
+        min(_analytics_series_floor(since, interval), earliest),
     )
     # A ``counting_since`` in the future — a clock correction, a stamp written by a host
     # running ahead — would otherwise make ``start`` later than ``end`` and produce an

--- a/tests/ee/sites/test_sites_analytics_read.py
+++ b/tests/ee/sites/test_sites_analytics_read.py
@@ -1499,12 +1499,22 @@ async def test_the_series_does_not_chart_time_before_counting_began(beanie_test_
 
 
 @pytest.mark.asyncio
-async def test_a_row_from_before_counting_began_is_folded_rather_than_dropped(beanie_test_db):
+async def test_a_row_from_before_counting_began_stays_in_the_day_it_happened(beanie_test_db):
     """A site that lapsed and re-subscribed still holds rows inside the ninety-day
-    retention that predate the ``counting_since`` its current subscription wrote. Dropping
-    them would leave the chart summing to less than the pageview total printed directly
-    above it, with nothing on the screen to explain the difference — so they land in the
-    first bucket, which is the edge of what was recorded."""
+    retention that predate the ``counting_since`` its current subscription wrote —
+    ``analytics_since`` is cleared by any publish that deploys no counter and re-stamped
+    fresh on the next paid one.
+
+    Dropping those rows would leave the chart summing to less than the pageview total
+    printed directly above it, with nothing on screen to explain the difference. Folding
+    them onto the first bucket would keep the sum but draw a spike on a day that did not
+    have one, which is the worse of the two: a wrong number is at least visibly wrong,
+    while a wrong SHAPE is read as fact.
+
+    So the range opens at the earliest bucket that carries traffic. The row sits in the
+    day it happened, the chart still sums to the headline, and the ``counting_since`` trim
+    keeps working for the case it was written for — see the test above, where a new site
+    has nothing before its stamp and still gets three points rather than ninety."""
     now = datetime.now(UTC)
     site = await _seed_site(counting_since=now - timedelta(days=1))
     cf = _RawRowsCF(
@@ -1518,9 +1528,14 @@ async def test_a_row_from_before_counting_began_is_folded_rather_than_dropped(be
         workspace_id="ws-read", site_id=str(site.id), window="7d", _cloudflare=cf
     )
 
-    assert len(out.series.points) == 2
+    assert out.series.points[0].bucket == _bucket_of(now - timedelta(days=5), _DAY)
+    assert len(out.series.points) == 6, "the lapsed day through today, inclusive"
     assert sum(point.pageviews for point in out.series.points) == out.pageviews == 2
-    assert out.series.points[0].pageviews == 1, "folded onto the edge of what was recorded"
+    assert out.series.points[0].pageviews == 1, "in its own day, not piled onto an edge"
+    assert out.series.points[-1].pageviews == 1
+    assert all(
+        point.pageviews == 0 for point in out.series.points[1:-1]
+    ), "the quiet days between are zeros, not a gap and not a spike"
 
 
 @pytest.mark.asyncio
@@ -1598,3 +1613,34 @@ async def test_the_endpoint_serves_the_series(client, monkeypatch):
     assert len(busy) == 1
     assert (busy[0]["pageviews"], busy[0]["visitors"]) == (2, 2)
     assert busy[0]["bucket"].endswith("+00:00")
+
+
+@pytest.mark.asyncio
+async def test_a_row_stamped_past_our_clock_is_folded_onto_the_newest_bucket(beanie_test_db):
+    """Cloudflare's ``NOW()`` and ours are not the same clock, so the newest bucket the
+    query returns can sit a moment past the end of the range we generated.
+
+    Dropping that row would leave the chart summing to less than the pageview total
+    printed directly above it, with nothing on screen to explain the difference — the one
+    place a reader would go looking is the very number that disagrees. Folding moves it by
+    at most one bucket, which at the newest end is the bucket that has not finished yet.
+
+    This is the ONLY end the fold is load-bearing at. The older end is handled by opening
+    the range at the earliest bucket carrying traffic; see the lapsed-site test above."""
+    now = datetime.now(UTC)
+    site = await _seed_site(counting_since=now - timedelta(days=1))
+    cf = _RawRowsCF(
+        [
+            _pv(now, "ours"),
+            _pv(now + timedelta(hours=2), "cloudflare-ahead"),
+        ]
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="24h", _cloudflare=cf
+    )
+
+    assert sum(point.pageviews for point in out.series.points) == out.pageviews == 2, (
+        "the chart must sum to the headline printed above it"
+    )
+    assert out.series.points[-1].pageviews == 2, "folded onto the newest bucket"

--- a/tests/ee/sites/test_sites_analytics_read.py
+++ b/tests/ee/sites/test_sites_analytics_read.py
@@ -3,6 +3,14 @@
 #
 # Created 2026-09-02 (feat/sites-analytics-read).
 #
+# Updated 2026-09-04 (AD-4 — the overview chart's data): section 9 covers the ``series``
+# block. Its central claim is one no amount of arithmetic proves on its own: a bucket that
+# nobody visited has to be a ZERO IN THE LIST, not an absent entry, because a chart handed
+# the shorter list draws a straight line across the gap and reports a quiet Sunday as no
+# Sunday at all. So the tests count the points as well as reading them, and the fixtures
+# are relative to now — the range is anchored on the clock, so a fixture pinned to a date
+# would drift out of its own window the week after it was written.
+#
 # Updated 2026-09-04 (AD-2 — visits, bounce rate and visit duration): section 8 covers
 # the visit block and the FOURTH empty state, a window whose rows all predate the visit
 # id and which has to read as "republish to start measuring visits" rather than as a zero
@@ -826,8 +834,9 @@ async def test_the_endpoint_distinguishes_never_counted_from_a_quiet_week(client
 @pytest.mark.asyncio
 @pytest.mark.parametrize("failing", ["totals", "breakdown"])
 async def test_a_failure_on_ONE_query_still_fails_the_whole_read(beanie_test_db, failing):
-    """A read is FIVE queries — totals plus four breakdowns — and a swallow on ANY ONE of
-    them is the outage-as-quiet-week failure wearing a smaller hat. A panel whose totals
+    """A read is SEVEN queries — the totals, the visit aggregate, the time series and four
+    breakdowns — and a swallow on ANY ONE of them is the outage-as-quiet-week failure
+    wearing a smaller hat. A panel whose totals
     are real and whose referrer chart is silently empty is worse than an error, because
     nothing on screen says a query failed.
 
@@ -950,6 +959,11 @@ class _RawRowsCF:
         self.queries.append(sql)
         if "blob6 AS visit" in sql:
             return [self._visits(drop_unrecorded="blob6 != ''" in sql)]
+        if "AS bucket" in sql:
+            return self._series(
+                hourly="toStartOfHour(timestamp)" in sql,
+                sampled="SUM(_sample_interval) AS pageviews" in sql,
+            )
         if "GROUP BY" in sql:
             return []
         return [
@@ -977,6 +991,37 @@ class _RawRowsCF:
                 span = max(row["when"] for row in group) - min(row["when"] for row in group)
                 total_seconds += int(span.total_seconds()) * weight
         return {"visits": visits, "bounces": bounces, "total_seconds": total_seconds}
+
+    def _series(self, *, hourly: bool, sampled: bool) -> list[dict]:
+        """The bucketed rows, grouped the way the statement it was handed asks for.
+
+        ONLY THE BUCKETS THAT HAD TRAFFIC, which is what Analytics Engine returns and is
+        the point of faking it this way: the quiet buckets in the reader's answer can only
+        have come from the reader, so a test that counts them is testing the range it
+        generates rather than the fixture it was handed.
+
+        The two things it reads out of the statement are the two that change the answer —
+        which bucketing function was asked for, and whether the sampling interval is summed
+        or the rows are merely counted. A query that fixed the bucket size regardless of
+        the window, or that swapped ``COUNT()`` in for the sampled sum, therefore gets a
+        DIFFERENT answer here instead of the same one."""
+        grouped: dict[datetime, list[dict]] = {}
+        for row in self.rows:
+            when = row["when"]
+            bucket = (
+                when.replace(minute=0, second=0, microsecond=0)
+                if hourly
+                else when.replace(hour=0, minute=0, second=0, microsecond=0)
+            )
+            grouped.setdefault(bucket, []).append(row)
+        return [
+            {
+                "bucket": int(bucket.timestamp()),
+                "pageviews": sum(r["sample"] for r in rows) if sampled else len(rows),
+                "visitors": len({r["visitor"] for r in rows}),
+            }
+            for bucket, rows in sorted(grouped.items())
+        ]
 
 
 @pytest.mark.asyncio
@@ -1226,3 +1271,330 @@ async def test_the_endpoint_says_republish_rather_than_zero_bounce(client, monke
     assert body["pageviews"] == 1
     assert body["visits"] is None
     assert "visits" in body["unrecorded"]
+
+
+# ── 9. AD-4: the time series behind the overview chart ───────────────────────
+#
+# WHAT THESE ARE ABOUT IS THE BUCKETS THAT ARE NOT IN THE QUERY'S ANSWER. Analytics Engine
+# returns one row per bucket that had traffic and says nothing at all about the rest, so
+# every quiet hour in a response can only have been put there by the reader. That is why
+# these tests count the points as often as they read them, and why ``_RawRowsCF._series``
+# deliberately answers only the buckets the fixture put traffic in: a fake that helpfully
+# padded the range would test itself.
+#
+# THE FIXTURES ARE RELATIVE TO NOW, unlike section 8's. The range is anchored on the clock
+# rather than on the data, so a row pinned to a date would slide out of its own window some
+# weeks after the test was written and start being folded into the first bucket — a suite
+# still green while asserting something other than what it says.
+
+_HOUR = "hour"
+_DAY = "day"
+
+
+def _bucket_of(moment: datetime, interval: str = _HOUR) -> str:
+    """The bucket stamp the response will carry for a moment, worked out independently of
+    the code under test."""
+    floored = (
+        moment.replace(minute=0, second=0, microsecond=0)
+        if interval == _HOUR
+        else moment.replace(hour=0, minute=0, second=0, microsecond=0)
+    )
+    return floored.isoformat()
+
+
+def _points(out: Any) -> dict[str, tuple[int, int]]:
+    return {point.bucket: (point.pageviews, point.visitors) for point in out.series.points}
+
+
+def _mid_hour(moment: datetime) -> datetime:
+    """The half-hour mark of the hour a moment falls in.
+
+    Anchoring a fixture here is what lets several rows be asserted into ONE bucket: two
+    rows a minute apart around an arbitrary instant sit in the same hour almost always, and
+    a test that is right almost always is a test that fails for somebody else."""
+    return moment.replace(minute=30, second=0, microsecond=0)
+
+
+@pytest.mark.asyncio
+async def test_traffic_in_three_hours_still_returns_a_full_day_of_buckets(beanie_test_db):
+    """THE CLAIM THE WHOLE SLICE RESTS ON. Three hours had visitors and the rest had none,
+    and every silent one of them is a zero in the list.
+
+    Handed only the three, a chart draws a line from the first to the second and renders
+    the quiet hours between as a gradual decline that never happened. The list being the
+    right LENGTH is the assertion; the fake returns only the buckets it has traffic for, so
+    the other twenty-two came from the reader or they came from nowhere."""
+    now = datetime.now(UTC)
+    site = await _seed_site(counting_since=now - timedelta(days=30))
+    cf = _RawRowsCF(
+        [
+            _pv(now - timedelta(hours=8), "a"),
+            _pv(now - timedelta(hours=5), "b"),
+            _pv(now - timedelta(hours=5), "c"),
+            _pv(now - timedelta(hours=2), "d"),
+        ]
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="24h", _cloudflare=cf
+    )
+
+    assert out.series is not None
+    assert out.series.interval == _HOUR
+    assert len(out.series.points) == 25, "a rolling 24-hour window spans 25 hour buckets"
+    points = _points(out)
+    assert points[_bucket_of(now - timedelta(hours=8))] == (1, 1)
+    assert points[_bucket_of(now - timedelta(hours=5))] == (2, 2)
+    assert points[_bucket_of(now - timedelta(hours=2))] == (1, 1)
+    for quiet in (7, 6, 4, 3):
+        assert points[_bucket_of(now - timedelta(hours=quiet))] == (0, 0), "a quiet hour"
+    # And the chart adds up to the number printed above it, which is the property a person
+    # looking at the panel can actually check.
+    assert sum(point.pageviews for point in out.series.points) == out.pageviews == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "window,interval,count",
+    [("24h", _HOUR, 25), ("7d", _DAY, 8), ("30d", _DAY, 31), ("90d", _DAY, 91)],
+)
+async def test_the_bucket_size_is_chosen_from_the_window(beanie_test_db, window, interval, count):
+    """A bar chart stops being readable somewhere around a hundred bars, so the bucket has
+    to divide the window into fewer than that: a week of hourly buckets is 168 and a month
+    is 720. Only the shortest window gets hours, and it is the one where an hour is what
+    the reader wants anyway.
+
+    Asserted PER WINDOW rather than once, because a reader that fixed the interval would
+    still answer plausibly on whichever window its author had in mind."""
+    now = datetime.now(UTC)
+    site = await _seed_site(pocket_id=f"pk-{window}", counting_since=now - timedelta(days=200))
+    cf = _RawRowsCF([_pv(now - timedelta(hours=2), "one")])
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window=window, _cloudflare=cf
+    )
+
+    assert out.series.interval == interval
+    assert len(out.series.points) == count
+
+
+def test_every_window_the_endpoint_accepts_has_a_bucket_size():
+    """Two tables, keyed the same, with nothing joining them. A window added to one and not
+    the other is a KeyError on a live read of a window the endpoint has already accepted —
+    a 500 rather than a lint failure, and cheap to pin here instead."""
+    assert set(sites_service._ANALYTICS_WINDOWS) == set(sites_service._ANALYTICS_SERIES_INTERVALS)
+
+
+@pytest.mark.asyncio
+async def test_a_sampled_row_contributes_its_weight_to_its_bucket(beanie_test_db):
+    """Analytics Engine downsamples a hot index and sets ``_sample_interval`` on each
+    survivor to the number of rows it stands for. A bucket that counted rows would draw a
+    bar of 1 where the truth is 40 — and it would do it on precisely the busiest sites,
+    which are the ones whose owner is watching the chart."""
+    now = datetime.now(UTC)
+    site = await _seed_site(counting_since=now - timedelta(days=30))
+    cf = _RawRowsCF([_pv(now - timedelta(hours=3), "busy", sample=40)])
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="24h", _cloudflare=cf
+    )
+
+    assert _points(out)[_bucket_of(now - timedelta(hours=3))] == (40, 1)
+    assert sum(point.pageviews for point in out.series.points) == 40
+
+
+@pytest.mark.asyncio
+async def test_a_window_with_no_rows_is_a_series_of_zeros_and_not_an_empty_list(beanie_test_db):
+    """Nobody visited, and there is no series, are different claims — and only the first of
+    them is true here. An empty list tells a chart there is nothing to draw; a full range of
+    zeroes tells it to draw a flat line along the baseline, which is what a quiet week
+    actually looks like."""
+    now = datetime.now(UTC)
+    site = await _seed_site(counting_since=now - timedelta(days=30))
+    cf = _RawRowsCF([])
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="24h", _cloudflare=cf
+    )
+
+    assert out.status == "ok"
+    assert out.series is not None, "a quiet window is not an unanswerable one"
+    assert len(out.series.points) == 25
+    assert all(point.pageviews == 0 and point.visitors == 0 for point in out.series.points)
+    assert out.pageviews == 0
+
+
+@pytest.mark.asyncio
+async def test_a_bucket_reports_its_pageviews_and_its_visitors_separately(beanie_test_db):
+    """Two people, three pageviews, one hour. A reader that filled both fields from the
+    same column would answer (3, 3) or (2, 2) and raise nothing anywhere: on a real site
+    the two numbers sit close together, so the wrong one looks entirely plausible on a
+    chart."""
+    now = datetime.now(UTC)
+    anchor = _mid_hour(now - timedelta(hours=4))
+    site = await _seed_site(counting_since=now - timedelta(days=30))
+    cf = _RawRowsCF(
+        [
+            _pv(anchor, "reader"),
+            _pv(anchor + timedelta(minutes=1), "reader"),
+            _pv(anchor + timedelta(minutes=2), "passer-by"),
+        ]
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="24h", _cloudflare=cf
+    )
+
+    assert _points(out)[_bucket_of(anchor)] == (3, 2)
+
+
+@pytest.mark.asyncio
+async def test_every_bucket_stamp_is_utc_and_the_points_run_forwards(beanie_test_db):
+    """The zone travels with every stamp because the stamp becomes an axis label: an hour
+    rendered as ``1PM`` that means 13:00 UTC is five and a half hours wrong for a reader in
+    Mumbai, and nothing on the screen would say so.
+
+    The ORDER is asserted for a related reason — a chart draws the list in the order it
+    arrives, so a series sorted by traffic would render a plausible-looking day whose hours
+    are in no order at all."""
+    now = datetime.now(UTC)
+    site = await _seed_site(counting_since=now - timedelta(days=30))
+    cf = _RawRowsCF([_pv(now - timedelta(hours=6), "one"), _pv(now - timedelta(hours=1), "two")])
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="24h", _cloudflare=cf
+    )
+
+    stamps = [point.bucket for point in out.series.points]
+    assert all(stamp.endswith("+00:00") for stamp in stamps), "an unzoned hour is a wrong hour"
+    parsed = [datetime.fromisoformat(stamp) for stamp in stamps]
+    assert parsed == sorted(parsed)
+    assert all(
+        later - earlier == timedelta(hours=1) for earlier, later in zip(parsed, parsed[1:])
+    ), "no bucket is skipped, so the gaps are all one hour"
+
+
+@pytest.mark.asyncio
+async def test_the_series_does_not_chart_time_before_counting_began(beanie_test_db):
+    """A site that has been counting for two days answering a ninety-day request with
+    eighty-eight zeroed days would be this endpoint's one forbidden move — inventing a
+    zero — drawn at chart scale, and worse there than on the panel: a long flat run along
+    the baseline does not look like missing data, it looks like a site nobody visits.
+
+    ``counting_since`` is on the response so a client can say where the short chart came
+    from."""
+    now = datetime.now(UTC)
+    began = now - timedelta(days=2)
+    site = await _seed_site(counting_since=began)
+    cf = _RawRowsCF([_pv(now - timedelta(hours=2), "one")])
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="90d", _cloudflare=cf
+    )
+
+    assert out.series.interval == _DAY
+    assert len(out.series.points) == 3, "the day counting began, and the two days since"
+    assert out.series.points[0].bucket == _bucket_of(began, _DAY)
+    assert out.counting_since is not None
+
+
+@pytest.mark.asyncio
+async def test_a_row_from_before_counting_began_is_folded_rather_than_dropped(beanie_test_db):
+    """A site that lapsed and re-subscribed still holds rows inside the ninety-day
+    retention that predate the ``counting_since`` its current subscription wrote. Dropping
+    them would leave the chart summing to less than the pageview total printed directly
+    above it, with nothing on the screen to explain the difference — so they land in the
+    first bucket, which is the edge of what was recorded."""
+    now = datetime.now(UTC)
+    site = await _seed_site(counting_since=now - timedelta(days=1))
+    cf = _RawRowsCF(
+        [
+            _pv(now - timedelta(days=5), "lapsed"),
+            _pv(now, "current"),
+        ]
+    )
+
+    out = await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="7d", _cloudflare=cf
+    )
+
+    assert len(out.series.points) == 2
+    assert sum(point.pageviews for point in out.series.points) == out.pageviews == 2
+    assert out.series.points[0].pageviews == 1, "folded onto the edge of what was recorded"
+
+
+@pytest.mark.asyncio
+async def test_the_states_that_report_no_numbers_report_no_series(beanie_test_db):
+    """A range of zeroes for a site whose plan does not buy analytics is the panel of
+    confident zeros in chart form, and it is the more convincing of the two: an empty table
+    reads as an empty table, while a flat line reads as a measurement."""
+    now = datetime.now(UTC)
+    unentitled = await _seed_site(pocket_id="pk-s1", plan_tier="free", counting_since=now)
+    never = await _seed_site(pocket_id="pk-s2", counting_since=None)
+
+    for site in (unentitled, never):
+        out = await sites_service.site_analytics(
+            workspace_id="ws-read", site_id=str(site.id), _cloudflare=_RawRowsCF([])
+        )
+        assert out.status != "ok"
+        assert out.series is None
+
+
+@pytest.mark.asyncio
+async def test_the_series_statement_is_the_one_cloudflare_will_run(beanie_test_db):
+    """The statement is the artifact, so it is asserted as text — nothing in this suite
+    executes SQL, and a fake will happily answer a query that groups on the wrong column.
+
+    ``toStartOfHour`` and ``toStartOfDay`` are both in the SQL API's published date-and-time
+    set, checked against the reference rather than recalled, and both work in UTC with no
+    zone argument. ``toUnixTimestamp`` around them is what makes the bucket arrive as an
+    integer instead of as whatever string form the JSON renderer picks for a DateTime."""
+    now = datetime.now(UTC)
+    site = await _seed_site(counting_since=now - timedelta(days=200))
+    cf = _RawRowsCF([_pv(now - timedelta(hours=2), "one")])
+
+    await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="24h", _cloudflare=cf
+    )
+    await sites_service.site_analytics(
+        workspace_id="ws-read", site_id=str(site.id), window="30d", _cloudflare=cf
+    )
+
+    hourly = next(sql for sql in cf.queries if "toStartOfHour" in sql)
+    assert "toUnixTimestamp(toStartOfHour(timestamp)) AS bucket" in hourly
+    assert "SUM(_sample_interval) AS pageviews" in hourly, "a plain count under-reports"
+    assert "COUNT(DISTINCT blob4) AS visitors" in hourly
+    assert "COUNT() AS pageviews" not in hourly
+    assert "GROUP BY bucket" in hourly
+    assert "ORDER BY bucket" in hourly, "a chart reads its rows by when, not by traffic"
+    # The site and the window scope it exactly as they scope every other statement here.
+    assert f"index1 = '{site.id}'" in hourly
+    assert "INTERVAL '1' DAY" in hourly
+    # Neither is supported by the SQL API, and both are what a reader reaches for first.
+    assert "WITH " not in hourly
+    assert "JOIN" not in hourly
+
+    daily = next(sql for sql in cf.queries if "toStartOfDay" in sql)
+    assert "toUnixTimestamp(toStartOfDay(timestamp)) AS bucket" in daily
+    assert "INTERVAL '30' DAY" in daily
+
+
+@pytest.mark.asyncio
+async def test_the_endpoint_serves_the_series(client, monkeypatch):
+    """End to end, which is where the nested list's serialisation is enforced. Every
+    service test above would pass against a model the wire cannot render."""
+    now = datetime.now(UTC)
+    site = await _seed_site(workspace_id="ws-http", counting_since=now - timedelta(days=30))
+    cf = _RawRowsCF([_pv(now - timedelta(hours=2), "one"), _pv(now - timedelta(hours=2), "two")])
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+
+    resp = await client.get(f"/api/v1/sites/{site.id}/analytics?window=24h")
+
+    assert resp.status_code == 200, resp.text
+    series = resp.json()["series"]
+    assert series["interval"] == "hour"
+    assert len(series["points"]) == 25, "the quiet hours are on the wire too"
+    busy = [point for point in series["points"] if point["pageviews"]]
+    assert len(busy) == 1
+    assert (busy[0]["pageviews"], busy[0]["visitors"]) == (2, 2)
+    assert busy[0]["bucket"].endswith("+00:00")

--- a/tests/ee/sites/test_sites_analytics_read.py
+++ b/tests/ee/sites/test_sites_analytics_read.py
@@ -1533,9 +1533,9 @@ async def test_a_row_from_before_counting_began_stays_in_the_day_it_happened(bea
     assert sum(point.pageviews for point in out.series.points) == out.pageviews == 2
     assert out.series.points[0].pageviews == 1, "in its own day, not piled onto an edge"
     assert out.series.points[-1].pageviews == 1
-    assert all(
-        point.pageviews == 0 for point in out.series.points[1:-1]
-    ), "the quiet days between are zeros, not a gap and not a spike"
+    assert all(point.pageviews == 0 for point in out.series.points[1:-1]), (
+        "the quiet days between are zeros, not a gap and not a spike"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/mutations/sites_analytics_read.json
+++ b/tests/mutations/sites_analytics_read.json
@@ -352,5 +352,86 @@
     "tests": [
       "tests/ee/sites/test_sites_analytics_read.py"
     ]
+  },
+  {
+    "label": "the series drops the buckets nobody visited — a chart handed only the hours that had traffic joins the ends of every gap with a straight line, so a quiet Sunday is drawn as no Sunday at all",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            for moment, (pageviews, visitors) in buckets.items()",
+    "replace": "            for moment, (pageviews, visitors) in buckets.items()\n            if pageviews or visitors",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the series counts rows instead of summing the sampling interval — every bar on a downsampled site is a fraction of its real height, and the chart stops agreeing with the pageview total printed above it",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "                f\"toUnixTimestamp({_ANALYTICS_SERIES_BUCKET_SQL[interval]}) AS bucket, \"\n                \"SUM(_sample_interval) AS pageviews, \"",
+    "replace": "                f\"toUnixTimestamp({_ANALYTICS_SERIES_BUCKET_SQL[interval]}) AS bucket, \"\n                \"COUNT() AS pageviews, \"",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the bucket size is fixed at an hour whatever the window — a month arrives as 720 bars, thinner than the gaps between them, and a quarter as 2160",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    interval = _ANALYTICS_SERIES_INTERVALS[window]",
+    "replace": "    interval = _ANALYTICS_SERIES_HOUR",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the bucket size is fixed at a day whatever the window — the 24-hour view collapses to two bars and answers 'when today did the traffic come' with 'today'",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "_ANALYTICS_SERIES_INTERVALS: dict[str, str] = {\n    \"24h\": _ANALYTICS_SERIES_HOUR,",
+    "replace": "_ANALYTICS_SERIES_INTERVALS: dict[str, str] = {\n    \"24h\": _ANALYTICS_SERIES_DAY,",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a bucket's pageviews are read off the visitors column — the two sit close together on every real site, so the wrong one draws a chart that looks entirely plausible",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        cell[0] += _analytics_int(row, \"pageviews\")\n        cell[1] += _analytics_int(row, \"visitors\")",
+    "replace": "        cell[0] += _analytics_int(row, \"visitors\")\n        cell[1] += _analytics_int(row, \"visitors\")",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the series charts the whole window regardless of when counting began — a site counting for two days answers a 90-day request with 88 zeroed days, which reads as a site nobody visits rather than as a period nobody recorded",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    start = max(\n        _analytics_series_floor(now - timedelta(days=days), interval),\n        _analytics_series_floor(since, interval),\n    )",
+    "replace": "    start = _analytics_series_floor(now - timedelta(days=days), interval)",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a row outside the generated range is dropped rather than folded onto the nearest end — the chart quietly sums to less than the total printed directly above it, with nothing on screen to explain the difference",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        cell = buckets[min(max(stamp, start), end)]",
+    "replace": "        if stamp not in buckets:\n            continue\n        cell = buckets[stamp]",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "a bucket stamp reaches the wire with no zone — the axis label '1PM' means 13:00 UTC and reads as local time, so the chart is five and a half hours wrong in Mumbai and says nothing about it",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "                bucket=_analytics_iso(moment), pageviews=pageviews, visitors=visitors",
+    "replace": "                bucket=moment.replace(tzinfo=None).isoformat(),\n                pageviews=pageviews,\n                visitors=visitors,",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the series statement stops asking for chronological order and inherits the breakdowns' sort by traffic — the points arrive ranked by how busy they were, which a chart draws in exactly that order",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            group=\"bucket\",\n            order=\"bucket\",",
+    "replace": "            group=\"bucket\",",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
   }
 ]

--- a/tests/mutations/sites_analytics_read.json
+++ b/tests/mutations/sites_analytics_read.json
@@ -401,7 +401,7 @@
   {
     "label": "the series charts the whole window regardless of when counting began — a site counting for two days answers a 90-day request with 88 zeroed days, which reads as a site nobody visits rather than as a period nobody recorded",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    start = max(\n        _analytics_series_floor(now - timedelta(days=days), interval),\n        _analytics_series_floor(since, interval),\n    )",
+    "find": "    start = max(\n        _analytics_series_floor(now - timedelta(days=days), interval),\n        min(_analytics_series_floor(since, interval), earliest),\n    )",
     "replace": "    start = _analytics_series_floor(now - timedelta(days=days), interval)",
     "tests": [
       "tests/ee/sites/test_sites_analytics_read.py"
@@ -430,6 +430,15 @@
     "file": "ee/pocketpaw_ee/sites/service.py",
     "find": "            group=\"bucket\",\n            order=\"bucket\",",
     "replace": "            group=\"bucket\",",
+    "tests": [
+      "tests/ee/sites/test_sites_analytics_read.py"
+    ]
+  },
+  {
+    "label": "the series range opens at counting_since alone — a lapsed-and-re-subscribed site's rows from before its current stamp all fold onto the first bucket, drawing a spike on a day that did not have one, and the chart still sums to the headline so nothing looks wrong",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        min(_analytics_series_floor(since, interval), earliest),",
+    "replace": "        _analytics_series_floor(since, interval),",
     "tests": [
       "tests/ee/sites/test_sites_analytics_read.py"
     ]


### PR DESCRIPTION
Stacked on #2067, which is stacked on #2063. Merge the base with `--rebase`, not
`--squash`, or the dependents conflict on duplicated content.

`GET /sites/{site_id}/analytics` now returns a `series` block: one point per time bucket,
carrying views and visitors. This is the data behind the chart, not the chart.

## Empty buckets are present, not skipped

Analytics Engine answers one row per bucket that had traffic. A chart drawn straight from
that list joins the two ends of every gap with a straight line, so an hour nobody visited
does not appear as an empty hour, it stops existing, and a quiet Sunday is drawn as no
Sunday at all.

So the range is generated here and the query only fills it. A zero is a measurement. A
missing entry is a different claim and it is not a true one.

## Bucket size, and why there are only two

An hour for `24h`, a day for the rest. A week of hourly buckets is 168 bars and a month is
720, both past the point a bar chart reads. Ninety days of daily buckets is 91, which just
fits, so there is no third size.

Point counts come out one higher than the window's name suggests: 25, 8, 31, 91. The
window is rolling, so its start lands inside a bucket rather than on one. That leading
bucket is genuinely partial and is kept, because dropping it would delete real traffic and
leave the series summing to less than the pageview total above it.

## The range's start, which is where the interesting bug was

The start is trimmed so a new site's chart does not open with a long flat run at the
baseline. A site counting for two days answering a ninety-day request with eighty-eight
zeroed days would be this endpoint's one forbidden move, inventing a zero, drawn at chart
scale. A long flat run does not read as missing data, it reads as a site nobody visits.

The first implementation trimmed to `counting_since` alone. That is wrong for a site that
lapsed and re-subscribed: `analytics_since` is cleared by any publish that deploys no
counter and re-stamped fresh on the next paid one, so such a site holds rows inside the
retention window that predate its current stamp. Every one of them folded onto the first
bucket.

**The sum still matched the headline, which is what made it dangerous.** A wrong number is
visibly wrong. A wrong shape is read as fact, and this one drew a spike on a day that did
not have it.

The range now opens at the earliest bucket that carries traffic. A new site has nothing
before its stamp, so the trim still does its job; a lapsed one keeps its rows in the days
they happened.

## The fold, now only at one end

A row past the end is folded onto the newest bucket, because our clock and Cloudflare's
`NOW()` are not the same clock. That moves traffic by at most one bucket and keeps the
chart summing to the headline printed directly above it.

It no longer carries the older end. When the mutation sweep was re-run after the fix, it
reported the fold escaping: the older end had been its only coverage. It now has a test of
its own for the clock-skew case.

## Query cost

Seven per uncached read, up from six.

## Verification

```
145 passed in 9.43s
```

```
OK: 972 anchors across 75 plans each resolve exactly once.
all 49 mutations caught
```

Ten mutations are new. Two are worth naming: the series inheriting the breakdowns' sort by
traffic, so points arrive ranked by how busy they were and a chart draws them in exactly
that order; and the range opening at `counting_since` alone, which is the bug above,
pinned so it cannot come back quietly.

## For the chart slice

Every bucket stamp is UTC. A chart labelled `1PM` means UTC, which is off by five and a
half hours for a customer in Mumbai, and nothing on screen would say so. Converting to the
viewer's zone is a UI decision and belongs with the chart, not the query.
