### PR TITLE
The traffic chart covers the window that was asked for

### DIFF
--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -5753,55 +5753,41 @@ def _analytics_series(
     empty hour, it stops existing, and a quiet Sunday is drawn as no Sunday at all. A zero
     is a measurement. A missing entry is a different claim and it is not a true one.
 
-    IT STARTS AT THE LATER of the window's own start and the bucket holding
-    ``counting_since``. Eighty-eight zeroed days in front of a site that has been counting
-    for two would be this endpoint's one forbidden move — inventing a zero — drawn at
-    chart scale, and it is worse there than on the panel: a long flat run at the baseline
-    does not read as missing data, it reads as a site nobody visits.
+    IT COVERS THE WHOLE WINDOW, always: a seven-day request is seven days of buckets
+    whether or not the site was counting for all of them. Trimming the start to when
+    counting began is what the two earlier versions did, and rendered it is the worse
+    failure — a two-day-old site answering a seven-day request with two bars fills the
+    plot edge to edge and reads as a broken component. The leading empty run it was
+    avoiding is explained on the panel, in words, directly under the chart.
 
     ROWS OUTSIDE THE RANGE ARE FOLDED INTO THE NEAREST END rather than dropped, because
     our clock and Cloudflare's ``NOW()`` are not the same clock and the newest bucket can
     land a moment past the end. Dropping it would leave the chart summing to less than the
     pageview total printed directly above it, with nothing on screen to explain the gap.
     The fold moves that traffic by at most one bucket.
-
-    THE FOLD IS NOT LOAD-BEARING AT THE BOTTOM, and it must not become so. The start is
-    taken from the earliest bucket that carries traffic rather than from
-    ``counting_since`` alone, so a lapsed-and-re-subscribed site's older rows sit in the
-    buckets they happened in instead of piling onto the first one. See the comment on
-    ``start`` below for why that case exists at all.
     """
     step = _ANALYTICS_SERIES_STEP[interval]
     now = datetime.now(UTC)
     end = _analytics_series_floor(now, interval)
-    # The ``counting_since`` trim exists to keep a NEW site's chart from opening with a
-    # long flat run at the baseline. It must not also move a LAPSED site's older traffic.
-    # ``analytics_since`` is cleared by any publish that deploys no counter and re-stamped
-    # fresh on the next paid one, so a site that lapsed and re-subscribed inside the
-    # ninety-day retention holds rows that predate its current stamp. Trimming to the
-    # stamp alone would fold every one of them onto the first bucket — a spike drawn on a
-    # day that did not have it, which is worse than the empty run the trim was avoiding.
-    # Taking the EARLIEST bucket that actually carries traffic serves both: a new site has
-    # nothing before its stamp, so the trim still bites, and a lapsed one keeps its older
-    # rows in the buckets they happened in.
-    earliest = min(
-        (
-            _analytics_series_floor(
-                datetime.fromtimestamp(_analytics_int(row, "bucket"), UTC), interval
-            )
-            for row in rows
-        ),
-        default=_analytics_series_floor(since, interval),
-    )
-    start = max(
-        _analytics_series_floor(now - timedelta(days=days), interval),
-        min(_analytics_series_floor(since, interval), earliest),
-    )
-    # A ``counting_since`` in the future — a clock correction, a stamp written by a host
-    # running ahead — would otherwise make ``start`` later than ``end`` and produce an
-    # EMPTY series, which is the one answer this function must never give: a chart with no
-    # points reads as no data, and the truth is one bucket that has not finished yet.
-    start = min(start, end)
+    # THE SERIES COVERS THE WHOLE WINDOW THE CALLER ASKED FOR. Two earlier versions
+    # trimmed the start — first to ``counting_since``, then to the earliest bucket
+    # carrying traffic — to stop a new site's ninety-day chart opening with eighty-eight
+    # empty days. Seen rendered, that trim is the worse bug of the two it was choosing
+    # between: a site counting for two days answered a SEVEN-day request with two bars,
+    # which fill the plot edge to edge and read as a broken component rather than as a
+    # short history. Asking for seven days and being shown two is also simply not the
+    # question that was asked.
+    #
+    # The empty run it was avoiding is already explained, and not by this function: the
+    # response carries ``counting_since``, and the panel prints "counting started on
+    # <date>, part way through this period — the days before that were never recorded"
+    # directly under the chart. A leading flat run with that sentence beneath it is not
+    # ambiguous, and it is what every comparable product draws.
+    #
+    # Dropping the trim also removes the case the earlier fix existed for: a lapsed site's
+    # rows sit inside the window on their own days, because nothing is moving the start
+    # past them any more.
+    start = _analytics_series_floor(now - timedelta(days=days), interval)
 
     buckets: dict[datetime, list[int]] = {}
     moment = start

--- a/tests/ee/sites/test_sites_analytics_read.py
+++ b/tests/ee/sites/test_sites_analytics_read.py
@@ -1475,14 +1475,19 @@ async def test_every_bucket_stamp_is_utc_and_the_points_run_forwards(beanie_test
 
 
 @pytest.mark.asyncio
-async def test_the_series_does_not_chart_time_before_counting_began(beanie_test_db):
-    """A site that has been counting for two days answering a ninety-day request with
-    eighty-eight zeroed days would be this endpoint's one forbidden move — inventing a
-    zero — drawn at chart scale, and worse there than on the panel: a long flat run along
-    the baseline does not look like missing data, it looks like a site nobody visits.
+async def test_the_series_covers_the_whole_window_even_before_counting_began(beanie_test_db):
+    """A ninety-day request is ninety-one buckets whether or not the site was counting
+    for all of them, and the leading run of zeros is the honest answer.
 
-    ``counting_since`` is on the response so a client can say where the short chart came
-    from."""
+    Two earlier versions trimmed the start — to ``counting_since``, then to the earliest
+    bucket carrying traffic — to avoid that run. Rendered, the trim was the worse bug: a
+    two-day-old site answering a SEVEN-day request drew two bars, which fill the plot
+    edge to edge and read as a broken component rather than as a short history. It also
+    answers a question nobody asked.
+
+    Nothing is invented by the zeros. ``counting_since`` rides on the response and the
+    panel prints "counting started on <date>, part way through this period" directly
+    under the chart, which is where an explanation belongs."""
     now = datetime.now(UTC)
     began = now - timedelta(days=2)
     site = await _seed_site(counting_since=began)
@@ -1493,9 +1498,10 @@ async def test_the_series_does_not_chart_time_before_counting_began(beanie_test_
     )
 
     assert out.series.interval == _DAY
-    assert len(out.series.points) == 3, "the day counting began, and the two days since"
-    assert out.series.points[0].bucket == _bucket_of(began, _DAY)
-    assert out.counting_since is not None
+    assert len(out.series.points) == 91, "the whole window, not the part that was counted"
+    assert out.series.points[0].bucket == _bucket_of(now - timedelta(days=90), _DAY)
+    assert out.series.points[0].pageviews == 0
+    assert out.counting_since is not None, "the panel needs this to explain the empty run"
 
 
 @pytest.mark.asyncio
@@ -1511,10 +1517,8 @@ async def test_a_row_from_before_counting_began_stays_in_the_day_it_happened(bea
     have one, which is the worse of the two: a wrong number is at least visibly wrong,
     while a wrong SHAPE is read as fact.
 
-    So the range opens at the earliest bucket that carries traffic. The row sits in the
-    day it happened, the chart still sums to the headline, and the ``counting_since`` trim
-    keeps working for the case it was written for — see the test above, where a new site
-    has nothing before its stamp and still gets three points rather than ninety."""
+    So the range is simply the window that was asked for. The row sits in the day it
+    happened, and the chart still sums to the headline printed above it."""
     now = datetime.now(UTC)
     site = await _seed_site(counting_since=now - timedelta(days=1))
     cf = _RawRowsCF(
@@ -1528,13 +1532,16 @@ async def test_a_row_from_before_counting_began_stays_in_the_day_it_happened(bea
         workspace_id="ws-read", site_id=str(site.id), window="7d", _cloudflare=cf
     )
 
-    assert out.series.points[0].bucket == _bucket_of(now - timedelta(days=5), _DAY)
-    assert len(out.series.points) == 6, "the lapsed day through today, inclusive"
+    assert len(out.series.points) == 8, "the whole seven-day window, inclusive of today"
+    lapsed = next(
+        p for p in out.series.points if p.bucket == _bucket_of(now - timedelta(days=5), _DAY)
+    )
+    assert lapsed.pageviews == 1, "in its own day, not piled onto an edge"
     assert sum(point.pageviews for point in out.series.points) == out.pageviews == 2
-    assert out.series.points[0].pageviews == 1, "in its own day, not piled onto an edge"
     assert out.series.points[-1].pageviews == 1
-    assert all(point.pageviews == 0 for point in out.series.points[1:-1]), (
-        "the quiet days between are zeros, not a gap and not a spike"
+    quiet = [p for p in out.series.points if p is not lapsed and p is not out.series.points[-1]]
+    assert all(point.pageviews == 0 for point in quiet), (
+        "every other day is a zero — a measurement, not a gap and not a spike"
     )
 
 

--- a/tests/mutations/sites_analytics_read.json
+++ b/tests/mutations/sites_analytics_read.json
@@ -399,15 +399,6 @@
     ]
   },
   {
-    "label": "the series charts the whole window regardless of when counting began — a site counting for two days answers a 90-day request with 88 zeroed days, which reads as a site nobody visits rather than as a period nobody recorded",
-    "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    start = max(\n        _analytics_series_floor(now - timedelta(days=days), interval),\n        min(_analytics_series_floor(since, interval), earliest),\n    )",
-    "replace": "    start = _analytics_series_floor(now - timedelta(days=days), interval)",
-    "tests": [
-      "tests/ee/sites/test_sites_analytics_read.py"
-    ]
-  },
-  {
     "label": "a row outside the generated range is dropped rather than folded onto the nearest end — the chart quietly sums to less than the total printed directly above it, with nothing on screen to explain the difference",
     "file": "ee/pocketpaw_ee/sites/service.py",
     "find": "        cell = buckets[min(max(stamp, start), end)]",
@@ -435,10 +426,10 @@
     ]
   },
   {
-    "label": "the series range opens at counting_since alone — a lapsed-and-re-subscribed site's rows from before its current stamp all fold onto the first bucket, drawing a spike on a day that did not have one, and the chart still sums to the headline so nothing looks wrong",
+    "label": "the series range is trimmed to when counting began — a two-day-old site answers a seven-day request with two bars that fill the plot edge to edge, which reads as a broken component rather than as a short history, and answers a question nobody asked",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "        min(_analytics_series_floor(since, interval), earliest),",
-    "replace": "        _analytics_series_floor(since, interval),",
+    "find": "    start = _analytics_series_floor(now - timedelta(days=days), interval)",
+    "replace": "    start = max(\n        _analytics_series_floor(now - timedelta(days=days), interval),\n        _analytics_series_floor(since, interval),\n    )",
     "tests": [
       "tests/ee/sites/test_sites_analytics_read.py"
     ]


### PR DESCRIPTION
A seven-day request drew two bars.

The series trimmed its start to when counting began — first to `analytics_since`, then
to the earliest bucket carrying traffic. So a site counting for two days answered a
seven-day question with two days of buckets. Rendered, those two bars fill the plot edge
to edge and read as a broken component rather than as a short history. It also answers a
question nobody asked: the window picker said seven days.

## What the trim was for, and why it was the wrong tool

It guarded against a new site's ninety-day chart opening with eighty-eight empty days,
on the reasoning that a long flat run reads as a site nobody visits rather than as a
period nobody recorded.

That run is already explained, and not by this function. `counting_since` rides on the
response, and the panel prints "counting started on that date, part way through this
period — the days before that were never recorded" directly under the chart. An
explanation belongs in words. A silently shortened axis is not one, because nothing on
screen says the axis was shortened.

At ninety-one bars across a normal panel each bar is still about fifteen pixels, so the
full window reads fine. Two bars do not.

## It also deletes the case the last fix existed for

The previous change opened the range at the earliest bucket with traffic, so a lapsed
and re-subscribed site's older rows would not fold onto the first bucket as a false
spike. Nothing moves the start past those rows any more, so they land in their own days
with no special handling at all.

## The mutations

The two covering the old trims are **removed rather than repointed**. Both described a
harm that can no longer happen, and a mutation whose label cannot come true is coverage
theatre. One replaces them, and it re-introduces the trim:

```
all 48 mutations caught
OK: 971 anchors across 75 plans each resolve exactly once.
```

## Verification

```
143 passed in 10.76s
```

Two tests changed with the behaviour rather than being patched around it: the one that
asserted the chart stops at `counting_since` now asserts it covers the whole window and
that `counting_since` is present so the panel can explain the zeros.

## Query cost

Unchanged. Same statement, wider generated range.
