### PR TITLE
fix(sites): import from URL failed on most real sites

### DIFF
--- a/ee/pocketpaw_ee/sites/url_crawler.py
+++ b/ee/pocketpaw_ee/sites/url_crawler.py
@@ -34,6 +34,19 @@
 # Cross-origin refs are left as-is and counted for the import report.
 # Edited 2026-07-23 (SSRF review): redirect scope guard (off-host 30x rejected
 # for non-seed fetches) + seed apex->www re-seed; opposite-scheme origin rewrite.
+# Edited 2026-09-04 (page/dir collision): the asset loop gained the page loop's
+# content-type guard, the other way round. A <link href> that answers text/html
+# (rel="canonical" above all) now claims the PAGE path, so /about stops landing at
+# the file "about" beside the directory "about/" the same page claims through
+# <a href="/about/">. That FileMap cannot exist on a filesystem: the generator
+# mkdirs over the file, EEXIST, and the whole URL import reports "failed". On one
+# real site 48 of 112 harvested files collided this way. Such a page counts
+# against MAX_CRAWL_PAGES, and against the asset loop's fetch ceiling (which is
+# now counted in slots, not stored files, so re-routing a fetch out of
+# assets_fetched cannot widen it). _LinkScan also stops queueing navigational
+# <link rel> values outright (canonical, prefetch, alternate & co) — the
+# content-type guard stays as the backstop for the ones it can't know about.
+# Scope, SSRF, robots and byte-budget behaviour are unchanged.
 
 """Same-site crawler with SSRF-hardened fetching for Paw Sites URL imports."""
 
@@ -364,10 +377,32 @@ class SafeFetcher:
 # --------------------------------------------------------------------------- #
 
 
+# <link rel> values that are NAVIGATIONAL, not asset refs: they address pages
+# (or, for the connection hints, a bare host). Queueing them buys a fetch whose
+# only possible product is a duplicate of a page the crawl already holds — 48 of
+# them on one real site. A DENYLIST, deliberately: an unfamiliar rel is still
+# fetched, and the asset loop's content-type guard catches it if it turns out to
+# be a page, so a site can hide a page behind any rel it likes and still import.
+_NON_ASSET_LINK_RELS = frozenset(
+    {
+        "canonical",
+        "alternate",
+        "prefetch",
+        "prerender",
+        "dns-prefetch",
+        "preconnect",
+        "next",
+        "prev",
+        "pingback",
+    }
+)
+
+
 class _LinkScan(HTMLParser):
     """One-pass scan of a fetched page: same-site page links (<a href>) and asset
-    refs (<link href>, <script src>, <img src/srcset>, <source src/srcset>,
-    <video/audio src>) — classification against the seed host happens later."""
+    refs (<link href> minus the navigational rels, <script src>, <img src/srcset>,
+    <source src/srcset>, <video/audio src>) — classification against the seed host
+    happens later."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -379,7 +414,11 @@ class _LinkScan(HTMLParser):
         if tag == "a" and attr_map.get("href"):
             self.page_links.append(attr_map["href"])
         elif tag == "link" and attr_map.get("href"):
-            self.asset_refs.append(attr_map["href"])
+            # Navigational only when EVERY token is: rel="alternate stylesheet"
+            # is a stylesheet, and a <link> with no rel at all stays an asset.
+            rels = attr_map.get("rel", "").lower().split()
+            if not (rels and all(r in _NON_ASSET_LINK_RELS for r in rels)):
+                self.asset_refs.append(attr_map["href"])
         elif tag == "script" and attr_map.get("src"):
             self.asset_refs.append(attr_map["src"])
         elif tag in ("img", "source", "video", "audio", "embed"):
@@ -572,16 +611,20 @@ async def crawl_site(
     def _same_site(candidate: Any) -> bool:
         return candidate.scheme in ("http", "https") and candidate.netloc.lower() == scope["netloc"]
 
-    def _claim_path(rel: str, source_url: str) -> str | None:
+    def _claim_path(rel: str, source_url: str, *, quiet_duplicate: bool = False) -> str | None:
         """Sanitize + reserve a FileMap path; None (with a warning) when unsafe
-        or already taken (first fetch wins)."""
+        or already taken (first fetch wins). ``quiet_duplicate`` drops the
+        already-taken warning for the one collision that is EXPECTED rather than
+        lossy: the same page claimed twice, once as a page and once through a
+        <link rel> that points at it."""
         try:
             safe = _safe_entry_path(rel)
         except ValidationError:
             result.warnings.append(f"skipped {source_url} — its path is not importable")
             return None
         if safe in result.files:
-            result.warnings.append(f"skipped {source_url} — path {safe!r} already imported")
+            if not quiet_duplicate:
+                result.warnings.append(f"skipped {source_url} — path {safe!r} already imported")
             return None
         return safe
 
@@ -706,7 +749,13 @@ async def crawl_site(
         # ------------------------------------------------------------------- #
         # Assets (CSS refs chase same-origin, so the queue can grow here).
         # ------------------------------------------------------------------- #
-        while asset_queue and result.stats.assets_fetched < MAX_CRAWL_ASSETS:
+        # MAX_CRAWL_ASSETS bounds FETCHES, not files: an entry that answers
+        # text/html is stored as a page below, and it burns a slot exactly as it
+        # did when it was (mis)stored as an asset. Gating on assets_fetched alone
+        # would let this loop drain the whole 2000-entry queue on a link-heavy
+        # site — several hundred page fetches where 200 was the ceiling.
+        asset_slots = 0
+        while asset_queue and asset_slots < MAX_CRAWL_ASSETS:
             asset_url = asset_queue.popleft()
             if not _allowed_by_robots(robots, asset_url):
                 result.stats.skipped_by_robots += 1
@@ -722,6 +771,38 @@ async def crawl_site(
                 result.warnings.append(f"skipped asset {asset_url} — HTTP {fetched.status}")
                 continue
             parsed_final = urlparse(fetched.url)
+            if fetched.content_type == "text/html":
+                # The page loop's content-type guard, mirrored: there a "page"
+                # serving a non-HTML body imports as an asset; here an "asset"
+                # serving HTML imports as a page. _NON_ASSET_LINK_RELS drops the
+                # rels we KNOW are navigational, but a site can hang a page off
+                # any other rel, so this is the guard that actually holds. Claimed
+                # by the asset rule, /about landed at the file "about" while the
+                # same page reached through <a href="/about/"> landed at
+                # "about/index.html"; a FileMap holding a file AND a directory of
+                # one name is unrepresentable, so the generator mkdirs over the
+                # file, dies EEXIST, and the whole import reports "failed". Both
+                # spellings now claim ONE page path and first-fetch-wins dedupes
+                # them. The body gets the page loop's exact treatment (same-origin
+                # rewrite, utf-8 text) — raw bytes would leave this one page
+                # pointing back at the site we imported FROM. Links are NOT
+                # re-scanned: the page loop has ended, so nothing found here could
+                # be fetched. Storing counts against MAX_CRAWL_PAGES, so a site
+                # cannot smuggle extra pages past the page cap through <link>.
+                asset_slots += 1
+                rel = _claim_path(
+                    _rel_path_for_page(parsed_final.path), asset_url, quiet_duplicate=True
+                )
+                if rel is None:
+                    continue
+                if result.stats.pages_fetched >= MAX_CRAWL_PAGES:
+                    pages_truncated = True
+                    continue
+                html_text = fetched.body.decode("utf-8", errors="replace")
+                rewritten = _rewrite_same_origin(html_text, scope["origins"])
+                result.files[rel] = rewritten.encode("utf-8")
+                result.stats.pages_fetched += 1
+                continue
             rel = _claim_path(_rel_path_for_asset(parsed_final.path), asset_url)
             if rel is None:
                 continue
@@ -743,6 +824,7 @@ async def crawl_site(
             else:
                 result.files[rel] = fetched.body
             result.stats.assets_fetched += 1
+            asset_slots += 1
 
         if asset_queue:
             result.warnings.append(

--- a/tests/ee/sites/test_import_crawler.py
+++ b/tests/ee/sites/test_import_crawler.py
@@ -528,3 +528,144 @@ async def test_seed_apex_to_www_redirect_reseeds_and_crawls_whole_site():
     assert "index.html" in result.files
     assert any("about" in p for p in result.files), result.files.keys()
     assert result.stats.pages_fetched == 2
+
+
+# --------------------------------------------------------------------------- #
+# A <link href> pointing at a PAGE (regression)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_link_rel_to_a_page_does_not_collide_with_its_directory():
+    """A ``<link rel="canonical|prefetch">`` whose href is a PAGE must not land at
+    the extension-less asset path.
+
+    The asset loop had no content-type guard (the page loop has the mirror of it),
+    so ``/about`` fetched as an asset was stored at ``about`` — while the same page
+    reached through ``<a href>`` was stored at ``about/index.html``. A FileMap
+    holding both is unrepresentable on a filesystem, and the generator's
+    ``materializeHtml`` dies with EEXIST when it mkdirs ``about/`` over the file.
+    Every static-site generator emits canonical links, so this fires on ordinary
+    sites, and the whole import ends as ``status:"failed"``.
+    """
+    body = (
+        "<html><head>"
+        '<link rel="canonical" href="/about">'
+        "</head><body>"
+        '<a href="/about/">About</a>'
+        "</body></html>"
+    )
+    pages = {
+        ("example.com", "/"): _html(body),
+        ("example.com", "/about"): _html("<html><body>about</body></html>"),
+        ("example.com", "/about/"): _html("<html><body>about</body></html>"),
+    }
+    result = await _crawl(pages)
+
+    directories = {
+        "/".join(path.split("/")[:i])
+        for path in result.files
+        for i in range(1, len(path.split("/")))
+    }
+    collisions = sorted(set(result.files) & directories)
+    assert collisions == [], f"path is both a file and a directory: {collisions}"
+    assert "about/index.html" in result.files
+
+
+@pytest.mark.asyncio
+async def test_navigational_link_rels_are_never_fetched():
+    """A ``<link>`` whose rel only ever addresses a page must not be queued.
+
+    ``canonical`` (which every static-site generator emits), ``prefetch``,
+    ``alternate``, and the connection hints buy a fetch whose only product is a
+    duplicate of a page the crawl already holds — 48 wasted fetches on one real
+    site, and on a link-heavy one enough to blow the import's wall clock. The
+    denylist is by rel TOKEN, so ``rel="alternate stylesheet"`` is still a
+    stylesheet and a ``<link>`` with no rel at all is still an asset.
+
+    Mutation: drop the ``_NON_ASSET_LINK_RELS`` filter from
+    ``_LinkScan.handle_starttag`` and the four navigational URLs get fetched.
+    """
+    seen: list[httpx.Request] = []
+    pages = {
+        ("example.com", "/"): _html(
+            "<html><head>"
+            '<link rel="canonical" href="/canon">'
+            '<link rel="prefetch" href="/prefetched">'
+            '<link rel="ALTERNATE" href="/fr">'
+            '<link rel="dns-prefetch" href="/warm">'
+            '<link rel="stylesheet" href="/site.css">'
+            '<link rel="alternate stylesheet" href="/alt.css">'
+            '<link href="/no-rel.css">'
+            "</head><body>hi</body></html>"
+        ),
+        ("example.com", "/site.css"): httpx.Response(
+            200, headers={"content-type": "text/css"}, content=b"a{}"
+        ),
+        ("example.com", "/alt.css"): httpx.Response(
+            200, headers={"content-type": "text/css"}, content=b"b{}"
+        ),
+        ("example.com", "/no-rel.css"): httpx.Response(
+            200, headers={"content-type": "text/css"}, content=b"c{}"
+        ),
+    }
+    result = await _crawl(pages, seen=seen)
+
+    fetched_paths = {r.url.path for r in seen}
+    assert fetched_paths.isdisjoint({"/canon", "/prefetched", "/fr", "/warm"})
+    assert {"site.css", "alt.css", "no-rel.css"} <= set(result.files)
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_link_rel_serving_html_claims_the_page_path():
+    """The content-type guard is the backstop the rel denylist can't be.
+
+    A site may hang a page off any rel it likes (here ``rel="me"``), so the
+    asset loop must classify on what the response IS, not on the tag it came
+    from. Without the guard ``/about`` lands at the file ``about`` beside the
+    directory ``about/`` the same page claims through ``<a href="/about/">``,
+    and that FileMap kills the generator's mkdir with EEXIST.
+
+    Mutation: change the asset loop's ``_rel_path_for_page`` back to
+    ``_rel_path_for_asset`` and the collision returns.
+    """
+    pages = {
+        ("example.com", "/"): _html(
+            '<html><head><link rel="me" href="/about"></head>'
+            '<body><a href="/about/">About</a></body></html>'
+        ),
+        ("example.com", "/about"): _html("<html><body>about</body></html>"),
+        ("example.com", "/about/"): _html("<html><body>about</body></html>"),
+    }
+    result = await _crawl(pages)
+
+    directories = {
+        "/".join(path.split("/")[:i])
+        for path in result.files
+        for i in range(1, len(path.split("/")))
+    }
+    assert sorted(set(result.files) & directories) == []
+    assert "about/index.html" in result.files
+
+
+@pytest.mark.asyncio
+async def test_html_in_the_asset_loop_still_burns_an_asset_slot(monkeypatch):
+    """MAX_CRAWL_ASSETS bounds FETCHES, not stored files.
+
+    An asset-queue entry that answers HTML is stored as a page, so counting the
+    ceiling on ``assets_fetched`` alone would exempt it — and a page full of
+    page-pointing links would drain the whole queue (bounded only by
+    MAX_TRACKED_URLS at 2000) where 200 fetches was the ceiling.
+
+    Mutation: gate the loop on ``result.stats.assets_fetched`` again and all
+    five targets get fetched.
+    """
+    monkeypatch.setattr(url_crawler, "MAX_CRAWL_ASSETS", 2)
+    seen: list[httpx.Request] = []
+    links = "".join(f'<link rel="me" href="/p{n}">' for n in range(5))
+    pages = {("example.com", "/"): _html(f"<html><head>{links}</head><body>hi</body></html>")}
+    for n in range(5):
+        pages[("example.com", f"/p{n}")] = _html(f"<html><body>page {n}</body></html>")
+    await _crawl(pages, seen=seen)
+
+    assert len([r for r in seen if r.url.path.startswith("/p")]) == 2


### PR DESCRIPTION
Importing a site from a URL fails on most real sites. It fails late, in the deploy, and the report the user ends up looking at says nothing useful.

## What happens

The link scanner queues every `<link href>` as an asset. Plenty of those address pages rather than assets, `rel="canonical"` above all, which every static-site generator emits on every page.

The page loop already handles the reverse case: a URL queued as a page that answers with a non-HTML content type gets re-routed and stored as an asset. The asset loop had no mirror of that check. So a page fetched through the asset queue was stored at its extension-less path, and `/about` landed at the file `about`.

The same page reached through `<a href="/about/">` lands at `about/index.html`. A file map holding the file `about` and the directory `about/` cannot exist on a filesystem. The generator's `materializeHtml` mkdirs over the file and dies:

```
EEXIST: file already exists, mkdir '.../about'
```

`crawl_site_from_url` catches that and writes `status:"failed"` on the report, so the whole import ends with nothing.

## Evidence

Crawling pocketpaw.xyz with the real crawler produced 112 files, 48 of them a path that is both a file and a directory. Handing that map to `materializeHtml` reproduces the EEXIST. Handing it the map this branch produces writes all 64 files with no error.

| | before | after |
|---|---|---|
| Files in the map | 112 | 64 |
| File and directory collisions | 48 | 0 |
| Assets fetched | 63 | 15 |
| Bytes fetched | 23.7 MB | 16.2 MB |

The two file sets are byte-identical where they overlap. The 48 that disappear are exactly the extension-less duplicates, and every one of them has its proper twin in the after map, so nothing was lost to buy the 32% drop in bytes.

## The fix

The asset loop gains the page loop's content-type guard in reverse. An asset that answers `text/html` claims the page path, so both spellings of a URL converge and first-fetch-wins deduplicates them. The body gets the page loop's exact treatment, same-origin rewrite included, because storing raw bytes would leave that one page linking back to the site it was imported from.

The scanner also stops queueing navigational rel values, so those fetches never happen at all. That is a denylist rather than an allowlist: an unfamiliar rel is still fetched, and the content-type guard catches it if it turns out to be a page, so a site can hang a page off any rel it likes and still import. A `<link>` with no rel, and `rel="alternate stylesheet"`, both stay assets.

The asset ceiling now counts fetch slots rather than stored assets. Gating on `assets_fetched` alone would have let a re-routed fetch escape the cap and drain the whole 2000-entry queue, several hundred fetches where 200 was the ceiling.

No SSRF, scope, robots, redirect, or byte-budget behavior changed.

## Testing

62 tests pass across the crawler and import suites, four of them new. Each new test was checked against a mutated copy of the module to confirm it actually gates: dropping the rel filter, routing the guard back to the asset path, and gating the loop on the old counter are all caught.

Worth knowing: the first test written for this, the canonical one, no longer reaches the content-type guard, because the denylist now filters canonical before it is queued. It exercises the filter instead. A second test uses `rel="me"` to reach the guard, and that one does fail under the mutation.

One report number moves. `cross_origin_refs` drops from 85 to 83 on the same site, because two external connection hints are no longer counted as content references.

The wider sites suite has three failures on this branch, in the concierge auto-embed and custom-domain billing tests. Neither file imports the crawler or the import service. They are pre-existing on dev.

## Still broken, not fixed here

When an import does fail, the frontend gives no sign. The backend writes both the failed status and a readable error, and both reach the browser, but the report panel only branches on the queued state. A failed import renders as an ordinary report with zero pages and zero assets. Nothing polls for the background crawl either. That is a paw-enterprise change and wants its own PR.
