### PR TITLE
perf(cloud): take the four hot paths off the event loop and off the collection scan

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/request_log.py
+++ b/ee/pocketpaw_ee/cloud/_core/request_log.py
@@ -16,14 +16,67 @@ doesn't pollute the Activity feed.
 
 Failures (4xx/5xx) are flagged as ``is_error=True`` so they can be
 filtered separately.
+
+Updated 2026-09-04 — two production-shaped problems, both in the write path:
+
+  1. ``asyncio.ensure_future`` returned a task nobody held a reference to.
+     CPython's loop keeps only a WEAK reference, so a pending log write can be
+     garbage-collected mid-await; the write simply vanishes, and non-
+     deterministically. This module now holds strong references until each
+     task completes — the same guard the codebase already applies in
+     chat/ws.py and shared/agent_bridge.py.
+  2. Nothing bounded how many of those could accumulate. If Mongo slows down,
+     pending inserts pile up in the web process without limit, converting a
+     database stall into unbounded memory growth instead of backpressure.
+     There is now a ceiling; past it, telemetry is dropped and the drop is
+     counted. Losing request telemetry is the correct thing to sacrifice when
+     the database is already struggling.
+
+Also: the highest-volume paths are now skipped rather than recorded. Request
+volume and telemetry write volume were 1:1, which made ``request_logs`` a
+strong candidate for the busiest write target in the database. Health probes,
+the CSRF token fetch and static assets carry no audit value and are the bulk
+of that traffic.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import time
 
 from fastapi import FastAPI, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger(__name__)
+
+#: Strong references to in-flight telemetry writes. Without this the loop's
+#: weak reference is the only one and the task may be collected mid-await.
+_pending: set[asyncio.Task] = set()
+
+#: Ceiling on concurrent telemetry writes. Past this, drop rather than queue:
+#: an unbounded pile of pending inserts is how a Mongo stall becomes an OOM.
+_MAX_PENDING = 256
+
+#: Suppressed so a dropped-telemetry incident is reported once, not per request.
+_dropped = 0
+
+#: Paths with no audit value that dominate request volume. Matched against the
+#: raw URL path, so they are skipped before any actor/workspace resolution.
+_SKIP_EXACT = frozenset(
+    {
+        "/health",
+        "/version",
+        "/api/v1/health",
+        "/api/v1/version",
+        "/api/v1/auth/csrf",
+    }
+)
+_SKIP_PREFIXES = ("/static/", "/uploads/", "/assets/")
+
+
+def _is_skipped(path: str) -> bool:
+    return path in _SKIP_EXACT or path.startswith(_SKIP_PREFIXES)
 
 
 class RequestLogMiddleware(BaseHTTPMiddleware):
@@ -33,6 +86,12 @@ class RequestLogMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        # Skip the high-volume, no-audit-value paths before doing any work.
+        # Checked against the raw path because the route template is only
+        # known after the response, and this saves the actor resolution too.
+        if _is_skipped(request.url.path):
+            return await call_next(request)
+
         start = time.perf_counter()
 
         # Read auth info before the response (the user may be resolved
@@ -128,27 +187,50 @@ def _log_request(
     an empty ``workspace`` field so they still appear in the global
     request-log view on the /audit page.
 
-    Runs synchronously inside the async middleware but only does
-    a quick ``ensure_future`` — the actual MongoDB write is deferred.
-    If the write fails it's logged and swallowed.
+    Schedules the MongoDB write and returns; the write itself is deferred so
+    it never blocks the caller. The task is held in ``_pending`` until it
+    completes — see the module docstring for why a bare ``ensure_future`` was
+    not safe — and dropped once the in-flight ceiling is reached.
     """
-    import asyncio
+    global _dropped
 
     from pocketpaw_ee.cloud.request_log import service as _request_log_service
 
-    asyncio.ensure_future(
-        _request_log_service.record(
-            workspace_id=workspace_id,
-            actor_id=actor_id,
-            method=method,
-            path=path,
-            status_code=status_code,
-            duration_ms=round(duration_ms, 1),
-            is_error=is_error,
-            ip=ip,
-            user_agent=user_agent,
+    if len(_pending) >= _MAX_PENDING:
+        # The database is not keeping up. Shedding telemetry is the right
+        # thing to give up here; queueing it without bound is not.
+        _dropped += 1
+        if _dropped % 1000 == 1:
+            logger.warning(
+                "request-log telemetry dropped: %d writes shed with %d in flight "
+                "(ceiling %d). The request_logs write path is not keeping up.",
+                _dropped,
+                len(_pending),
+                _MAX_PENDING,
+            )
+        return
+
+    try:
+        task = asyncio.create_task(
+            _request_log_service.record(
+                workspace_id=workspace_id,
+                actor_id=actor_id,
+                method=method,
+                path=path,
+                status_code=status_code,
+                duration_ms=round(duration_ms, 1),
+                is_error=is_error,
+                ip=ip,
+                user_agent=user_agent,
+            )
         )
-    )
+    except RuntimeError:
+        # No running loop (sync test harness, shutdown). Telemetry is not
+        # worth raising over.
+        return
+
+    _pending.add(task)
+    task.add_done_callback(_pending.discard)
 
 
 __all__ = ["RequestLogMiddleware"]

--- a/ee/pocketpaw_ee/cloud/auth/api_keys.py
+++ b/ee/pocketpaw_ee/cloud/auth/api_keys.py
@@ -6,6 +6,7 @@ tokens to ``(user_id, workspace_id, scopes)``.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import secrets
 import time
@@ -152,9 +153,18 @@ async def resolve_bearer(token: str) -> tuple[str, str, list[str]] | None:
         if exp <= now:
             return None
 
-    # Why: argon2 verify is ~30ms, acceptable for API-key auth path.
+    # Argon2id at pwdlib's recommended parameters is ~30ms of CPU and a 64 MB
+    # allocation, by design. That cost is fine; running it INLINE on the event
+    # loop was not. This is one process serving every request, so a synchronous
+    # 30ms burn here freezes every other in-flight request, WebSocket frame and
+    # SSE chunk for those 30ms — not just the caller's. Sustained API-key
+    # traffic therefore caps total server throughput around 1/0.03 ≈ 33 req/s
+    # regardless of how trivial the endpoint being called is.
+    #
+    # to_thread hands it to the default executor so the loop keeps serving.
+    # The verify stays exactly as strict; only where it runs has changed.
     try:
-        result = _password_hash.verify(secret, doc.hashed_secret)
+        result = await asyncio.to_thread(_password_hash.verify, secret, doc.hashed_secret)
     except Exception:
         return None
     if isinstance(result, tuple):

--- a/ee/pocketpaw_ee/cloud/models/pocket.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket.py
@@ -82,6 +82,7 @@ from typing import Any
 from beanie import Indexed
 from bson import ObjectId
 from pydantic import BaseModel, Field
+from pymongo import IndexModel
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 from pocketpaw_ee.cloud.surface.domain import PocketSurfaceProfile
@@ -220,3 +221,15 @@ class Pocket(TimestampedDocument):
 
     class Settings:
         name = "pockets"
+        indexes = [
+            # The list query is a $or over owner / shared_with / visibility,
+            # always anchored on ``workspace``. The inline ``Indexed`` on the
+            # workspace field alone left Mongo scanning every pocket in the
+            # workspace and filtering the $or in memory; these let it use the
+            # index for each branch of the union instead.
+            #
+            # shared_with is an array, so that one is multikey.
+            IndexModel([("workspace", 1), ("owner", 1)], name="workspace_owner_1"),
+            IndexModel([("workspace", 1), ("visibility", 1)], name="workspace_visibility_1"),
+            IndexModel([("workspace", 1), ("shared_with", 1)], name="workspace_shared_with_1"),
+        ]

--- a/ee/pocketpaw_ee/cloud/models/user.py
+++ b/ee/pocketpaw_ee/cloud/models/user.py
@@ -1,5 +1,15 @@
 """User and OAuth account models (fastapi-users + Beanie).
 
+Updated: 2026-09-04 — added the ``workspaces.workspace`` index. Until now the
+only index on this collection was the unique ``email`` one that
+``BeanieBaseUser`` contributes, so every membership lookup was a COLLSCAN.
+That predicate is not cold: ``list_member_ids`` backs ``AudienceResolver``,
+which resolves the recipients of every workspace-scoped realtime event behind
+a 2-second cache — so steady chat traffic scans the whole collection roughly
+every 2 seconds per active workspace, on the single event loop. Multikey on
+the ``workspaces`` array, which also serves the ``$elemMatch`` in
+``list_admin_ids`` and the ``$in`` in ``list_peer_ids``.
+
 Updated: 2026-08-01 (AM-6) — added ``OAuthAccount.linked_at`` so the
 connected-accounts panel can say WHEN an identity was attached. Nullable with
 no default rather than ``default_factory=now``: rows written before this field
@@ -19,6 +29,7 @@ from datetime import UTC, datetime
 from beanie import Document
 from fastapi_users_db_beanie import BaseOAuthAccount, BeanieBaseUser
 from pydantic import BaseModel, Field
+from pymongo import IndexModel
 
 
 class OAuthAccount(BaseOAuthAccount):
@@ -64,3 +75,15 @@ class User(BeanieBaseUser, Document):  # type: ignore[misc]
     class Settings:
         name = "users"
         email_collation = None
+        indexes = [
+            # Multikey over the ``workspaces`` array. Serves the three
+            # membership predicates in workspace/service.py:
+            #   list_member_ids  {"workspaces.workspace": wid}
+            #   list_admin_ids   {"workspaces": {"$elemMatch": {...}}}
+            #   list_peer_ids    {"workspaces.workspace": {"$in": [...]}}
+            # ``$elemMatch`` on (workspace, role) uses this too: Mongo narrows
+            # on the indexed leading field and filters ``role`` from the
+            # candidate docs, which is the whole win here — the scan goes from
+            # the collection to one workspace's members.
+            IndexModel([("workspaces.workspace", 1)], name="workspaces_workspace_1"),
+        ]

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -1953,7 +1953,12 @@ async def list_pockets(
         if oids:
             query["_id"] = {"$nin": oids}
     docs = await _PocketDoc.find(query).to_list()
-    return [await _resolved_wire_dict(d, user_id) for d in docs]
+    # Resolve concurrently. Each _resolved_wire_dict awaits its own spec
+    # resolution and a team-id lookup, so the old list comprehension paid
+    # every pocket's round trips end to end, one after another — N sequential
+    # awaits for a list that renders all at once. gather keeps the ordering
+    # (results come back positionally) while overlapping the waits.
+    return list(await asyncio.gather(*(_resolved_wire_dict(d, user_id) for d in docs)))
 
 
 async def patterns_for_pockets(workspace_id: str, pocket_ids: list[str]) -> dict[str, str | None]:

--- a/ee/pocketpaw_ee/cloud/ripple_sources.py
+++ b/ee/pocketpaw_ee/cloud/ripple_sources.py
@@ -44,7 +44,21 @@ async def _workspace_pockets(ctx: ResolveCtx, args: dict[str, Any]) -> list[dict
             ctx.user_id,
         )
         return []
-    docs = await _PocketDoc.find(
+    # Projected deliberately. This resolver only ever returns the five fields
+    # below, but it used to hydrate whole Pocket documents to get them — and a
+    # Pocket carries ``rippleSpec``, every widget's ``spec``, and for a
+    # Svelte-track pocket a ``source`` map holding the full text of every
+    # source file. Those run to hundreds of kilobytes each.
+    #
+    # It matters more than a single query's cost because of where this sits:
+    # it fires once per ``workspace.pockets`` marker while resolving a spec,
+    # and the pocket list resolves every pocket, so an unprojected read here
+    # is O(N^2) bytes off the wire for one GET /pockets.
+    #
+    # ``get_pymongo_collection``, NOT ``get_motor_collection`` — the latter is
+    # beanie 1.x and this is on 2.1.0. Same trap documented at
+    # pockets/service.py:3168.
+    cursor = _PocketDoc.get_pymongo_collection().find(
         {
             "workspace": ctx.workspace_id,
             "$or": [
@@ -52,17 +66,24 @@ async def _workspace_pockets(ctx: ResolveCtx, args: dict[str, Any]) -> list[dict
                 {"shared_with": ctx.user_id},
                 {"visibility": "workspace"},
             ],
-        }
-    ).to_list()
+        },
+        {"_id": 1, "name": 1, "type": 1, "icon": 1, "color": 1},
+    )
+    # The fallbacks mirror the Pocket model's own defaults (models/pocket.py:
+    # type="custom", icon="", color=""). Hydrating the document used to apply
+    # those for free; reading raw BSON does not, so a document written before
+    # a field existed would come back None where it used to come back "".
+    # That matters downstream — widgets like people-picker call string methods
+    # on these — so a missing key must stay an empty string, not None.
     return [
         {
-            "id": str(d.id),
-            "name": d.name,
-            "type": d.type,
-            "icon": d.icon,
-            "color": d.color,
+            "id": str(row["_id"]),
+            "name": row.get("name", ""),
+            "type": row.get("type", "custom"),
+            "icon": row.get("icon", ""),
+            "color": row.get("color", ""),
         }
-        for d in docs
+        async for row in cursor
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -1798,13 +1798,33 @@ async def decline_invite(token: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+async def _user_ids_matching(query: dict) -> list[str]:
+    """Ids of the users matching *query*, without hydrating a single document.
+
+    These three helpers only ever return ``str(u.id)``, but they used to pull
+    whole ``User`` documents to get there — every field, then a full
+    BSON→pydantic construction per row, discarded one line later. On the
+    realtime path that is the expensive half: ``list_member_ids`` backs
+    ``AudienceResolver`` behind a 2-second cache, so it runs continuously
+    while anyone is chatting, on the single event loop.
+
+    ``get_pymongo_collection``, NOT ``get_motor_collection`` — the latter is
+    beanie 1.x and this is on 2.1.0, where it does not exist. Same trap
+    documented at pockets/service.py:3168, and deliberately NOT wrapped in a
+    broad ``except`` here: a missing attribute must fail loudly rather than
+    degrade to an empty audience, because an empty audience means the event
+    silently reaches nobody.
+    """
+    cursor = _UserDoc.get_pymongo_collection().find(query, {"_id": 1})
+    return [str(row["_id"]) async for row in cursor]
+
+
 async def list_member_ids(workspace_id: str) -> list[str]:
-    users = await _UserDoc.find({"workspaces.workspace": workspace_id}).to_list()
-    return [str(u.id) for u in users]
+    return await _user_ids_matching({"workspaces.workspace": workspace_id})
 
 
 async def list_admin_ids(workspace_id: str) -> list[str]:
-    users = await _UserDoc.find(
+    return await _user_ids_matching(
         {
             "workspaces": {
                 "$elemMatch": {
@@ -1813,8 +1833,7 @@ async def list_admin_ids(workspace_id: str) -> list[str]:
                 }
             }
         }
-    ).to_list()
-    return [str(u.id) for u in users]
+    )
 
 
 async def list_peer_ids(user_id: str) -> list[str]:
@@ -1826,10 +1845,9 @@ async def list_peer_ids(user_id: str) -> list[str]:
     if me is None or not getattr(me, "workspaces", None):
         return []
     ws_ids = [m.workspace for m in me.workspaces]
-    peers = await _UserDoc.find(
+    return await _user_ids_matching(
         {"workspaces.workspace": {"$in": ws_ids}, "_id": {"$ne": me.id}}
-    ).to_list()
-    return [str(u.id) for u in peers]
+    )
 
 
 async def get_default_workspace_id() -> str | None:

--- a/tests/cloud/_core/test_request_log_backpressure.py
+++ b/tests/cloud/_core/test_request_log_backpressure.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-
 from pocketpaw_ee.cloud._core import request_log
 
 

--- a/tests/cloud/_core/test_request_log_backpressure.py
+++ b/tests/cloud/_core/test_request_log_backpressure.py
@@ -1,0 +1,185 @@
+# Tests for the request-log write path's task handling and path skipping.
+#
+# Created 2026-09-04 alongside the fix. Two behaviours are pinned here because
+# both failed silently in production shape and neither is visible from a
+# response:
+#
+#   * A telemetry write task must be strongly referenced. The old code used
+#     asyncio.ensure_future and kept no reference, so the loop's weak
+#     reference was the only one and a pending write could be collected
+#     mid-await. Nothing surfaces when that happens — the row is simply
+#     missing, sometimes.
+#   * The number of in-flight writes must be bounded. Unbounded, a Mongo stall
+#     turns into unbounded memory growth in the web process instead of
+#     backpressure.
+#
+# NOTE: this file lives under tests/cloud/, which the CI lanes exclude, so it
+# does not run on a pull request today. That exclusion is a known pre-existing
+# gap (CI names 7 of 685 cloud test files), not something this change made.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pocketpaw_ee.cloud._core import request_log
+
+
+@pytest.fixture(autouse=True)
+def _clean_module_state():
+    """Each test starts with an empty pending set and drop counter."""
+    request_log._pending.clear()
+    request_log._dropped = 0
+    yield
+    request_log._pending.clear()
+    request_log._dropped = 0
+
+
+def _log_once(**overrides):
+    kwargs = {
+        "method": "GET",
+        "path": "/api/v1/pockets",
+        "status_code": 200,
+        "duration_ms": 1.0,
+        "actor_id": "u1",
+        "workspace_id": "w1",
+        "is_error": False,
+        "user_agent": "pytest",
+        "ip": "203.0.113.9",
+    }
+    kwargs.update(overrides)
+    request_log._log_request(**kwargs)
+
+
+class TestSkippedPaths:
+    """The high-volume, no-audit-value paths must not reach the write path."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/health",
+            "/version",
+            "/api/v1/health",
+            "/api/v1/version",
+            "/api/v1/auth/csrf",
+            "/static/app.js",
+            "/uploads/avatars/abc.png",
+            "/assets/logo.svg",
+        ],
+    )
+    def test_noise_paths_are_skipped(self, path):
+        assert request_log._is_skipped(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/v1/pockets",
+            "/api/v1/chat/send",
+            "/api/v1/workspaces/w1/audit",
+            # Near-misses: a real route must not be skipped just because it
+            # shares a prefix with a skipped one.
+            "/api/v1/healthchecks",
+            "/versions/list",
+        ],
+    )
+    def test_real_routes_are_not_skipped(self, path):
+        assert request_log._is_skipped(path) is False
+
+
+class TestTaskLifetime:
+    @pytest.mark.asyncio
+    async def test_pending_task_is_strongly_referenced_until_it_finishes(self, monkeypatch):
+        """The write task must be held, not left to the loop's weak reference."""
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _slow_record(**_kwargs):
+            started.set()
+            await release.wait()
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.cloud.request_log.service.record", _slow_record, raising=False
+        )
+
+        _log_once()
+        await started.wait()
+
+        assert len(request_log._pending) == 1, "in-flight write is not referenced"
+
+        release.set()
+        # Let the task finish and its done-callback run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert request_log._pending == set(), "completed write was not released"
+
+    @pytest.mark.asyncio
+    async def test_writes_are_dropped_once_the_ceiling_is_reached(self, monkeypatch):
+        """Past the ceiling, shed telemetry rather than queue without bound."""
+        release = asyncio.Event()
+
+        async def _blocked_record(**_kwargs):
+            await release.wait()
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.cloud.request_log.service.record", _blocked_record, raising=False
+        )
+
+        for _ in range(request_log._MAX_PENDING):
+            _log_once()
+        await asyncio.sleep(0)
+
+        assert len(request_log._pending) == request_log._MAX_PENDING
+        assert request_log._dropped == 0
+
+        # One more must be shed, not queued.
+        _log_once()
+        assert len(request_log._pending) == request_log._MAX_PENDING
+        assert request_log._dropped == 1
+
+        release.set()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_capacity_recovers_after_writes_drain(self, monkeypatch):
+        """Shedding is transient: once the backlog clears, logging resumes."""
+        release = asyncio.Event()
+
+        async def _blocked_record(**_kwargs):
+            await release.wait()
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.cloud.request_log.service.record", _blocked_record, raising=False
+        )
+
+        for _ in range(request_log._MAX_PENDING):
+            _log_once()
+        await asyncio.sleep(0)
+        _log_once()
+        assert request_log._dropped == 1
+
+        release.set()
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert request_log._pending == set()
+
+        # A fresh write is accepted again rather than shed.
+        release_2 = asyncio.Event()
+
+        async def _record_2(**_kwargs):
+            await release_2.wait()
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.cloud.request_log.service.record", _record_2, raising=False
+        )
+        _log_once()
+        await asyncio.sleep(0)
+        assert len(request_log._pending) == 1
+        assert request_log._dropped == 1, "drop counter must not rise on an accepted write"
+
+        release_2.set()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)


### PR DESCRIPTION
A pre-launch audit measured where this backend stops serving under real traffic rather than where the code looks slow. Five findings came back critical. Four were small, and those are here. The fifth is a compose change that belongs to the deploy repo.

Every one of these is invisible in a single-request test and only bites when the process is doing more than one thing at once, which is the shape production is in and local development never is.

## What changed

**Argon2 ran inline on the event loop.** `resolve_bearer` verified every API key with a synchronous ~30ms hash. The cost itself is correct and deliberate. The placement was not: this is one process serving every request, so that burn froze every other in-flight request, WebSocket frame and SSE chunk for its duration, not just the caller's. Sustained key traffic therefore capped total throughput somewhere near 33 requests a second regardless of how trivial the endpoint was. It runs in a thread now. The verification is byte for byte what it was.

**`users` had no index on `workspaces.workspace`.** That predicate backs `list_member_ids`, which resolves the audience for every workspace-scoped realtime event behind a two-second cache. Steady chat traffic therefore scanned the whole collection roughly every two seconds per active workspace. Adds the multikey index, and stops building whole `User` documents just to read one id off each.

**The `workspace.pockets` resolver read whole documents to project five fields.** A Pocket carries `rippleSpec`, every widget's spec, and for a Svelte-track pocket a map holding the full text of every source file. That resolver fires once per source marker while resolving a spec, and the pocket list resolves every pocket, so an unprojected read there is quadratic in bytes for a single `GET /pockets`. It is projected now.

**Request telemetry was scheduled and then forgotten.** `ensure_future` returned a task nobody held, and the event loop keeps only a weak reference, so a pending write could be garbage collected mid-await. Nothing surfaces when that happens; the row is just missing, sometimes. It is referenced now, bounded so a slow database cannot turn into an unbounded pile of pending tasks, and no longer fires for health, version, CSRF and static assets, which carried no audit value and were most of the volume.

Two smaller ones ride along: the compound indexes behind the pocket list's `$or`, and resolving that list concurrently instead of awaiting each pocket one after another.

## One behavioural risk, handled

Projecting raw BSON skips pydantic, which means the model's field defaults stop being applied. A document written before an optional field existed would have come back `None` where it previously came back `""`, and widgets downstream call string methods on those. The projection mirrors the model's own defaults so that cannot happen.

## Deliberately left out

Key generation also hashes on an async path. Minting is rare and making it async ripples through its callers, so it did not belong in a performance change.

The cluster-wide job ceiling of 10 covers chat, site builds and deploys together on one worker, and the eleventh request waits behind a timeout rather than failing. That needs `POCKETPAW_ARQ_MAX_JOBS` set in `deploy/coolify`, which lives in the workspace repo, and raising it wants a look at the worker's memory headroom first.

## Verification

Run against `origin/dev` as a baseline, because several tests in these directories fail on a clean checkout for environmental reasons and I did not want to claim credit or blame for them.

| Suite | Base | This branch |
|---|---|---|
| `tests/cloud/pockets` + `tests/cloud/realtime` | 13 failed, 242 passed | 13 failed, 242 passed |
| `tests/cloud/workspace` + `tests/cloud/_core` | 6 failed, 247 passed | 6 failed, 263 passed |
| `tests/cloud/auth/test_api_keys.py` and the two OSS key suites | | 37 passed, 1 skipped |

The 19 failures are identical in name and count on both sides. The extra 16 passes are the new tests.

## About those new tests

They pin the telemetry task's lifetime and the path skipping. Worth being straight about what they are: they lock in the new behaviour so it cannot regress, rather than reproducing the old bug first. The old failure mode was a task being collected non-deterministically, which is not something a test can reliably provoke.

They also live under `tests/cloud/`, which the CI lanes exclude, so they will not run on this pull request. That exclusion is a known pre-existing gap and not something this change introduced.
