### PR TITLE
fix(chat): rehydrate the newest turns, not the first fifty ever written

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -2843,7 +2843,14 @@ def session_key_for(ctx: ScopeContext) -> str:
 
 
 async def load_history_for_scope(ctx: ScopeContext, *, limit: int = 50) -> list[dict[str, str]]:
-    """Return prior turns as ``[{"role", "content"}]``, oldest first.
+    """Return the most recent ``limit`` turns as ``[{"role", "content"}]``,
+    ordered oldest first.
+
+    Note both halves of that: the window is the NEWEST ``limit`` messages,
+    and within the window the order is ascending. Until 2026-09-04 the query
+    sorted ascending before limiting, which silently made it the OLDEST
+    ``limit`` instead — an agent whose memory froze at turn 50 while the
+    visible transcript kept growing.
 
     Why: the agent backend keeps conversation state in an in-process SDK
     subprocess keyed by ``session_key``. That state is wiped by any
@@ -2879,7 +2886,21 @@ async def load_history_for_scope(ctx: ScopeContext, *, limit: int = 50) -> list[
                 "group": ctx.scope_id,
                 "deleted": False,
             }
-        msgs = await Message.find(query).sort("createdAt").limit(limit).to_list()
+        # Newest-first in the query, then reversed back for the caller.
+        #
+        # Ascending + limit() returns the first ``limit`` messages ever
+        # written to the scope, so past that many turns the agent replayed
+        # the opening exchange forever and never saw anything recent. The
+        # window is meant to be the END of the conversation; only its
+        # internal ordering is oldest-first.
+        #
+        # Sorting descending in Mongo rather than fetching everything and
+        # slicing here is what lets the (workspace_id, session_key,
+        # createdAt) compound index serve the window directly.
+        #
+        # Same shape as memory/mongo_store.py:372-374, which had it right.
+        recent = await Message.find(query).sort("-createdAt").limit(limit).to_list()
+        msgs = list(reversed(recent))
     except Exception:
         logger.exception("load_history_for_scope failed for %s/%s", ctx.kind.value, ctx.scope_id)
         return []

--- a/tests/cloud/test_agent_history_window.py
+++ b/tests/cloud/test_agent_history_window.py
@@ -1,0 +1,188 @@
+"""Regression: rehydrated history must be the NEWEST turns, not the oldest.
+
+``load_history_for_scope`` sorted ascending and applied ``limit``, which
+returns the first N messages ever written to a scope. Past turn N the agent
+replayed the same opening exchange forever and stopped seeing anything recent
+— it appears to the user as an agent whose memory froze partway through the
+conversation, while the transcript on screen keeps growing.
+
+The correct form already exists a few files away, at
+``ee/pocketpaw_ee/cloud/memory/mongo_store.py:372-374``: sort descending,
+limit, then reverse so the caller still gets oldest-first ordering. The
+returned window's ORDER was never the bug; which messages land in it was.
+
+WHY THIS FILE HAS ITS OWN STUB
+------------------------------
+``tests/cloud/test_agent_router_history_rehydrate.py`` already covers this
+function, and it could not have caught this. Its ``_StubFindChain.sort()``
+records ``sorted = True`` and discards the argument, and its ``to_list()``
+returns the seeded list untouched, so the stub yields identical output for an
+ascending and a descending query. A fixture that cannot tell the two apart
+cannot fail on the difference between them.
+
+The stub below actually applies the sort key, the direction and the limit, so
+these assertions test the query rather than the fixture's assumptions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw_ee.cloud.chat.agent_service import (
+    ScopeContext,
+    ScopeKind,
+    load_history_for_scope,
+)
+
+
+class _Msg:
+    """Only the attributes the loader actually reads, plus a sort key."""
+
+    def __init__(self, *, created_at: int, role: str, content: str):
+        self.createdAt = created_at
+        self.role = role
+        self.sender_type = "user" if role == "user" else "agent"
+        self.content = content
+
+
+class _FindChain:
+    """Beanie's find(...).sort(...).limit(...).to_list(), honoured for real.
+
+    Unlike the stub in test_agent_router_history_rehydrate.py, this one obeys
+    the sort direction and the limit. That is the entire point: the bug lives
+    in the interaction between those two, so a stub that ignores either cannot
+    observe it.
+    """
+
+    def __init__(self, captured: dict, docs: list[_Msg]):
+        self._captured = captured
+        self._docs = list(docs)
+
+    def sort(self, key):
+        self._captured["sort"] = key
+        descending = isinstance(key, str) and key.startswith("-")
+        field = key.lstrip("-") if isinstance(key, str) else "createdAt"
+        self._docs.sort(key=lambda d: getattr(d, field), reverse=descending)
+        return self
+
+    def limit(self, n):
+        self._captured["limit"] = n
+        self._docs = self._docs[:n]
+        return self
+
+    async def to_list(self):
+        return list(self._docs)
+
+
+class _MessageModel:
+    _captured: dict = {}
+    _docs: list[_Msg] = []
+
+    @classmethod
+    def configure(cls, docs: list[_Msg]) -> dict:
+        cls._captured = {}
+        cls._docs = docs
+        return cls._captured
+
+    @classmethod
+    def find(cls, query):
+        cls._captured["query"] = query
+        return _FindChain(cls._captured, cls._docs)
+
+
+def _ctx() -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+    )
+
+
+def _conversation(turns: int) -> list[_Msg]:
+    """``turns`` user/assistant pairs, numbered in write order."""
+    docs: list[_Msg] = []
+    for i in range(turns):
+        docs.append(_Msg(created_at=2 * i, role="user", content=f"user {i}"))
+        docs.append(_Msg(created_at=2 * i + 1, role="assistant", content=f"reply {i}"))
+    return docs
+
+
+@pytest.mark.asyncio
+async def test_history_window_is_the_newest_turns(monkeypatch):
+    """A long conversation must rehydrate its END, not its beginning."""
+    captured = _MessageModel.configure(_conversation(turns=60))  # 120 messages
+    import pocketpaw_ee.cloud.models.message as message_mod
+
+    monkeypatch.setattr(message_mod, "Message", _MessageModel)
+
+    result = await load_history_for_scope(_ctx(), limit=50)
+
+    assert len(result) == 50
+    # 120 messages, newest 50 => contents "user 35" .. "reply 59".
+    assert result[0] == {"role": "user", "content": "user 35"}
+    assert result[-1] == {"role": "assistant", "content": "reply 59"}
+
+
+@pytest.mark.asyncio
+async def test_history_window_stays_oldest_first(monkeypatch):
+    """The window is the newest N, but the caller still gets them in order.
+
+    The agent backends replay this list as a transcript, so reversed ordering
+    would be its own bug. Pinned separately from the window itself so a
+    regression names which half broke.
+    """
+    _MessageModel.configure(_conversation(turns=60))
+    import pocketpaw_ee.cloud.models.message as message_mod
+
+    monkeypatch.setattr(message_mod, "Message", _MessageModel)
+
+    result = await load_history_for_scope(_ctx(), limit=50)
+
+    numbers = [int(entry["content"].split()[-1]) for entry in result]
+    assert numbers == sorted(numbers), "history must read oldest-first"
+
+
+@pytest.mark.asyncio
+async def test_short_conversation_is_returned_whole(monkeypatch):
+    """Under the limit, nothing is dropped and order is unchanged."""
+    _MessageModel.configure(_conversation(turns=3))  # 6 messages
+    import pocketpaw_ee.cloud.models.message as message_mod
+
+    monkeypatch.setattr(message_mod, "Message", _MessageModel)
+
+    result = await load_history_for_scope(_ctx(), limit=50)
+
+    assert result == [
+        {"role": "user", "content": "user 0"},
+        {"role": "assistant", "content": "reply 0"},
+        {"role": "user", "content": "user 1"},
+        {"role": "assistant", "content": "reply 1"},
+        {"role": "user", "content": "user 2"},
+        {"role": "assistant", "content": "reply 2"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_query_asks_mongo_for_the_newest_rows(monkeypatch):
+    """The narrowing must happen in the query, not after the fetch.
+
+    Sorting descending in Mongo and limiting there is what lets the compound
+    (workspace_id, session_key, createdAt) index serve the window. Pulling
+    everything and slicing in Python would satisfy the assertions above while
+    still reading the whole thread off the wire on every turn.
+    """
+    captured = _MessageModel.configure(_conversation(turns=60))
+    import pocketpaw_ee.cloud.models.message as message_mod
+
+    monkeypatch.setattr(message_mod, "Message", _MessageModel)
+
+    await load_history_for_scope(_ctx(), limit=50)
+
+    assert captured["sort"] == "-createdAt", (
+        "history must be fetched newest-first so limit() takes the recent end"
+    )
+    assert captured["limit"] == 50

--- a/tests/cloud/test_agent_history_window.py
+++ b/tests/cloud/test_agent_history_window.py
@@ -27,7 +27,6 @@ these assertions test the query rather than the fixture's assumptions.
 from __future__ import annotations
 
 import pytest
-
 from pocketpaw_ee.cloud.chat.agent_service import (
     ScopeContext,
     ScopeKind,
@@ -114,7 +113,7 @@ def _conversation(turns: int) -> list[_Msg]:
 @pytest.mark.asyncio
 async def test_history_window_is_the_newest_turns(monkeypatch):
     """A long conversation must rehydrate its END, not its beginning."""
-    captured = _MessageModel.configure(_conversation(turns=60))  # 120 messages
+    _MessageModel.configure(_conversation(turns=60))  # 120 messages
     import pocketpaw_ee.cloud.models.message as message_mod
 
     monkeypatch.setattr(message_mod, "Message", _MessageModel)

--- a/tests/cloud/test_agent_router_history_rehydrate.py
+++ b/tests/cloud/test_agent_router_history_rehydrate.py
@@ -60,25 +60,47 @@ class _StubTransport:
 
 
 class _StubMsg:
-    def __init__(self, *, role=None, sender_type="user", content=""):
+    def __init__(self, *, role=None, sender_type="user", content="", created_at=None):
         self.role = role
         self.sender_type = sender_type
         self.content = content
+        # Assigned by configure() in seed order when not given explicitly, so
+        # the stub can model a sort without every call site listing timestamps.
+        self.createdAt = created_at
 
 
 class _StubFindChain:
-    """Mimics Beanie's find(...).sort(...).limit(...).to_list() chain."""
+    """Mimics Beanie's find(...).sort(...).limit(...).to_list() chain.
+
+    2026-09-04: ``sort`` now applies the key and honours a leading ``-``.
+
+    It used to record ``sorted = True`` and discard the argument, which made
+    this stub return identical output for an ascending and a descending query.
+    That is precisely the difference ``load_history_for_scope`` got wrong — it
+    sorted ascending before limiting, so a long conversation rehydrated its
+    first N messages instead of its last N — and this stub could not have
+    failed on it. A fixture that cannot distinguish two queries cannot test
+    which one the code sends.
+
+    See tests/cloud/test_agent_history_window.py for the window's own tests.
+    """
 
     def __init__(self, captured: dict, docs: list[_StubMsg]):
         self._captured = captured
-        self._docs = docs
+        self._docs = list(docs)
 
-    def sort(self, *args, **kwargs):
+    def sort(self, key=None, *args, **kwargs):
         self._captured["sorted"] = True
+        self._captured["sort"] = key
+        if isinstance(key, str) and key:
+            descending = key.startswith("-")
+            field = key.lstrip("-")
+            self._docs.sort(key=lambda d: getattr(d, field, 0), reverse=descending)
         return self
 
     def limit(self, n):
         self._captured["limit"] = n
+        self._docs = self._docs[:n]
         return self
 
     async def to_list(self):
@@ -92,6 +114,11 @@ class _StubMessageModel:
     @classmethod
     def configure(cls, docs: list[_StubMsg]) -> dict:
         cls._captured = {}
+        # Stamp seed order as the write order so a sort has something honest
+        # to work with. Explicit timestamps are left alone.
+        for i, doc in enumerate(docs):
+            if getattr(doc, "createdAt", None) is None:
+                doc.createdAt = i
         cls._docs = docs
         return cls._captured
 


### PR DESCRIPTION
The agent's rehydrated history was the wrong end of the conversation.

`load_history_for_scope` sorted ascending and then applied `limit`, which returns the first fifty messages ever written to a scope rather than the last fifty. Past that many turns the agent replayed the same opening exchange after every restart or pool eviction and never saw anything recent, while the transcript on screen kept growing. From the outside it reads as an agent whose memory froze partway through the conversation.

The window is meant to be the end of the thread. Only its internal ordering is oldest-first, and that part was never wrong.

## The fix

Sort descending in the query, limit there, then reverse for the caller. Doing the narrowing in Mongo rather than fetching everything and slicing in Python is what lets the `(workspace_id, session_key, createdAt)` compound index serve the window directly.

This is the shape `ee/pocketpaw_ee/cloud/memory/mongo_store.py:372-374` already uses. The correct version was a few files away the whole time.

It came out of the pre-launch performance audit, but it is a correctness fix. The performance angle is only that the wrong fifty messages were also being shipped into every arq job payload.

## Why the existing test suite did not catch it

`tests/cloud/test_agent_router_history_rehydrate.py` already covers this function, and it could not have failed on this.

Its stub's `sort()` recorded a boolean and threw the argument away, and its `to_list()` returned the seeded list untouched. So an ascending query and a descending one produced byte-identical output, and the two assertions had quietly encoded the buggy ordering as the expected result. Applying the fix turned them red, which is the correct signal from an incorrect test.

I fixed the stub rather than flipping the expected lists. It now applies the sort key and honours a leading minus, so those two tests assert something about the code instead of something about the fixture. Reversing the expectations would have kept them green while still testing nothing.

## Verification

The four new tests in `tests/cloud/test_agent_history_window.py` fail on the parent commit and pass here. The failure is the real thing, not an import error:

```
assert result[0] == {"role": "user", "content": "user 35"}
E   AssertionError: assert {'content': 'user 0', ...} == {'content': 'user 35', ...}
```

Two of the four pass on the parent commit as well, deliberately: they pin the behaviours that were already correct, so a future regression names which half broke.

| Suite | Result |
|---|---|
| The five suites touching this function | 62 passed |
| `tests/cloud/chat` + `tests/cloud/credits` | 264 passed |

Note these live under `tests/cloud/`, which the CI lanes exclude, so they will not run on this pull request. That gap is pre-existing and not something this change introduced.

## Scope

One query and its docstring, plus the stub repair. The rest of the performance audit's findings are not in here; the four small criticals are in #2074 and the remainder is still open.
