### PR TITLE
perf(cloud): bound every unbounded map on a request path

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/rate_limit.py
+++ b/ee/pocketpaw_ee/cloud/_core/rate_limit.py
@@ -13,6 +13,8 @@ assumption.
 
 from __future__ import annotations
 
+from ipaddress import ip_address
+
 from fastapi import Depends, Request
 
 from pocketpaw.security.rate_limiter import RateLimiter
@@ -37,13 +39,44 @@ _invite_resend_limiter = RateLimiter(rate=5.0 / 1800.0, capacity=5)
 _social_exchange_limiter = RateLimiter(rate=10.0 / 60.0, capacity=10)
 
 
+def _client_ip(request: Request) -> str:
+    """Best available client address for rate-limit bucketing.
+
+    Reads the RIGHTMOST ``X-Forwarded-For`` entry, not the leftmost.
+
+    The leftmost entry is whatever the caller sent. A proxy APPENDS the address
+    it actually observed, so on a request through our edge the header reads
+    ``<whatever the client claimed>, <real client>`` and only the last element
+    is trustworthy. Keying on the first one meant an attacker chose their own
+    bucket: a fresh value per request both evaded the limit entirely and minted
+    an unbounded number of ``_Bucket`` objects on an endpoint that requires no
+    authentication.
+
+    This assumes exactly one trusted proxy in front of the app, which matches
+    the current deployment (Traefik terminating for a single backend). Adding a
+    second hop means trusting the last N entries instead, and that wants real
+    trusted-proxy configuration — uvicorn's ``forwarded_allow_ips`` is unset
+    today, which is tracked separately in the operability audit.
+
+    Values are validated as IP addresses so a malformed header cannot become a
+    cache key on its own.
+    """
+    peer = request.client.host if request.client else "unknown"
+    forwarded = request.headers.get("x-forwarded-for", "")
+    if not forwarded:
+        return peer
+    candidate = forwarded.rsplit(",", 1)[-1].strip()
+    if not candidate:
+        return peer
+    try:
+        return str(ip_address(candidate))
+    except ValueError:
+        return peer
+
+
 async def rate_limit_social_exchange(request: Request) -> None:
     """Per-IP bucket guarding POST /auth/social/exchange."""
-    client = request.client.host if request.client else "unknown"
-    forwarded = request.headers.get("x-forwarded-for", "")
-    if forwarded:
-        # Left-most entry is the originating client when behind a proxy.
-        client = forwarded.split(",")[0].strip() or client
+    client = _client_ip(request)
     if not _social_exchange_limiter.check(f"social-exchange:{client}").allowed:
         raise RateLimited(
             "social.exchange_rate_limited",

--- a/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
@@ -1,4 +1,10 @@
 # audience.py — resolves an Event into the user_ids that should receive it.
+# Updated: 2026-09-04 — the member cache is now an LRU with single-flight.
+#   It was a plain dict whose 2-second TTL was only a freshness check on read,
+#   so nothing was ever removed and one entry per group/workspace/user ever
+#   seen was retained for the process lifetime. Concurrent misses for the same
+#   key also each issued their own query; since this resolver runs on every
+#   workspace-scoped event, that fan-out is the normal case, not the rare one.
 # Updated: 2026-08-15 (HTN-5) — agent.plan_updated joins the agent runtime
 #   stream branch, scoped to the group's members like agent.tool_use.
 # Updated: 2026-08-11 — call.participant_joined / call.participant_left now
@@ -10,12 +16,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
+from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 
 from pocketpaw_ee.cloud._core.realtime.events import Event
 
 MemberFetcher = Callable[[str], Awaitable[list[str]]]
+
+#: Cache ceiling. Sized so a large deployment's active groups and workspaces
+#: fit comfortably — eviction is a backstop against unbounded growth, not a
+#: working constraint. Entries cost a short list of ids.
+_DEFAULT_CACHE_MAX = 10_000
 
 
 class AudienceResolver:
@@ -29,13 +42,23 @@ class AudienceResolver:
         workspace_admins: MemberFetcher | None = None,
         workspace_peers: MemberFetcher | None = None,
         cache_ttl_seconds: float = 2.0,
+        cache_max_entries: int = _DEFAULT_CACHE_MAX,
     ) -> None:
         self._group_members = group_members
         self._workspace_members = workspace_members
         self._workspace_admins = workspace_admins
         self._workspace_peers = workspace_peers
         self._ttl = cache_ttl_seconds
-        self._cache: dict[tuple[str, str], tuple[float, list[str]]] = {}
+        self._max = cache_max_entries
+        # LRU, not a plain dict. The TTL is only a freshness check on read —
+        # it never removed anything, so one entry per group/workspace/user
+        # ever seen was retained for the life of the process.
+        self._cache: OrderedDict[tuple[str, str], tuple[float, list[str]]] = OrderedDict()
+        # Single-flight. Without it, N concurrent events for the same group
+        # all miss together and issue N identical queries; this resolver runs
+        # on every workspace-scoped event, so that fan-out is the common case
+        # rather than the rare one.
+        self._inflight: dict[tuple[str, str], asyncio.Future[list[str]]] = {}
 
     def invalidate_group(self, group_id: str) -> None:
         self._cache.pop(("group", group_id), None)
@@ -53,12 +76,40 @@ class AudienceResolver:
     async def _cached(self, kind: str, key: str, fn: MemberFetcher | None) -> list[str]:
         if fn is None:
             return []
+        ck = (kind, key)
         now = time.monotonic()
-        entry = self._cache.get((kind, key))
+
+        entry = self._cache.get(ck)
         if entry and now - entry[0] < self._ttl:
+            self._cache.move_to_end(ck)
             return list(entry[1])
-        value = await fn(key)
-        self._cache[(kind, key)] = (now, value)
+
+        # Single-flight: the first caller to miss owns the fetch and everyone
+        # else awaits the same task. Nothing is awaited between the lookup and
+        # the insert, so no second caller can interleave and start a duplicate.
+        # A task rather than a bare future because a failure then propagates to
+        # every waiter by itself, and the exception is retrieved by whoever
+        # awaits — no "exception was never retrieved" warning to hand-manage.
+        pending = self._inflight.get(ck)
+        if pending is not None:
+            return list(await pending)
+
+        # ensure_future, not create_task: MemberFetcher is typed as returning
+        # an Awaitable, and a caller is free to hand back a future rather than
+        # a coroutine. create_task rejects the former.
+        task = asyncio.ensure_future(fn(key))
+        self._inflight[ck] = task
+        try:
+            value = await task
+        finally:
+            # Popped on failure too, so one transient error does not pin a
+            # permanently-failing task in front of every later caller.
+            self._inflight.pop(ck, None)
+
+        self._cache[ck] = (now, value)
+        self._cache.move_to_end(ck)
+        while len(self._cache) > self._max:
+            self._cache.popitem(last=False)
         return list(value)
 
     async def _group(self, gid: str) -> list[str]:

--- a/ee/pocketpaw_ee/cloud/_core/timing.py
+++ b/ee/pocketpaw_ee/cloud/_core/timing.py
@@ -10,6 +10,15 @@ keeps the slice small.
 Capacity defaults to 10k samples per endpoint. With the default
 capacity the buffer uses ~80 KB per distinct endpoint at steady state
 (two `float` per sample is conservative).
+
+That "per distinct endpoint" sizing only holds if the key space is bounded,
+which it was not until 2026-09-04. A MATCHED request keys on the route
+template, and the route table is fixed at startup — bounded. An UNMATCHED
+request has no ``route`` in its ASGI scope, so the key fell back to the raw
+URL path and every distinct 404 minted a permanent buffer. This middleware
+wraps everything and runs before authentication, so one scanner walking a
+million URLs was a million retained entries in a 6 GB container whose only
+recovery is a restart. Unmatched requests now share a single bucket.
 """
 
 from __future__ import annotations
@@ -22,6 +31,11 @@ from fastapi import FastAPI, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
 _DEFAULT_CAPACITY: Final = 10_000
+
+#: Key for every request that matched no route. Collapsing them is the whole
+#: bound: a 404's path is attacker-chosen, a route template is not.
+UNMATCHED_PATH: Final = "<unmatched>"
+
 _buffers: dict[tuple[str, str], deque[float]] = {}
 
 
@@ -36,13 +50,17 @@ class TimingMiddleware(BaseHTTPMiddleware):
         start = time.perf_counter()
         response: Response = await call_next(request)
         duration_ms = (time.perf_counter() - start) * 1000.0
-        # Prefer the matched route template (e.g. /workspaces/{id}) so we
-        # don't get one buffer per id; fall back to the raw URL path.
+        # Use the matched route template (e.g. /workspaces/{id}) so we don't
+        # get one buffer per id. When nothing matched there is no template to
+        # use, and the raw path is caller-controlled, so those all share one
+        # bucket rather than minting an entry each. The aggregate is still
+        # useful — it says how much time is going into 404s — and it cannot
+        # grow.
         scope_route = request.scope.get("route")
         path = (
             scope_route.path
             if scope_route is not None and hasattr(scope_route, "path")
-            else request.url.path
+            else UNMATCHED_PATH
         )
         key = (request.method, path)
         buf = _buffers.get(key)

--- a/ee/pocketpaw_ee/cloud/files/tree.py
+++ b/ee/pocketpaw_ee/cloud/files/tree.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import OrderedDict
 from collections.abc import Callable
 from typing import Literal, overload
 
@@ -92,8 +93,21 @@ async def build_tree(
 
 # In-process TTL cache for /tree.
 # Key is (user_id, workspace_id). Value is (expires_at, tree, warnings).
-_TREE_CACHE: dict[tuple[str, str | None], tuple[float, FolderNode, list[dict[str, str]]]] = {}
+#
+# An OrderedDict used as an LRU, not a plain dict. The TTL is checked on read
+# and decides whether an entry is USABLE; until 2026-09-04 nothing ever removed
+# an expired one, so a deployment retained one whole folder tree per (user,
+# workspace) pair ever seen, for the life of the process. Each value holds a
+# full FolderNode, which is the expensive part.
+_TREE_CACHE: OrderedDict[tuple[str, str | None], tuple[float, FolderNode, list[dict[str, str]]]] = (
+    OrderedDict()
+)
 _TREE_TTL_SECONDS = 30.0
+
+#: Ceiling on retained trees. Generous — with a 30-second TTL the working set
+#: is however many distinct users hit /tree in half a minute, so eviction is a
+#: backstop against growth, not something a real deployment should reach.
+_TREE_CACHE_MAX = 2_000
 
 
 def invalidate_tree_cache(*, user_id: str | None = None, workspace_id: str | None = None) -> None:
@@ -142,6 +156,7 @@ class CachedTreeBuilder:
         cached = _TREE_CACHE.get(key)
         if cached is not None and cached[0] > now:
             _, tree, warnings = cached
+            _TREE_CACHE.move_to_end(key)
             return tree, list(warnings)
         tree, warnings = await build_tree(
             ctx=ctx,
@@ -150,4 +165,9 @@ class CachedTreeBuilder:
             collect_warnings=True,
         )
         _TREE_CACHE[key] = (now + self._ttl, tree, warnings)
+        _TREE_CACHE.move_to_end(key)
+        # Drop the coldest entries past the ceiling. Evicting is always safe:
+        # a miss rebuilds, it does not return anything wrong.
+        while len(_TREE_CACHE) > _TREE_CACHE_MAX:
+            _TREE_CACHE.popitem(last=False)
         return tree, list(warnings)

--- a/src/pocketpaw/security/rate_limiter.py
+++ b/src/pocketpaw/security/rate_limiter.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import math
 import threading
 import time
+import weakref
 
 __all__ = [
     "RateLimiter",
@@ -62,6 +63,21 @@ class RateLimitInfo:
         return h
 
 
+#: Every live RateLimiter, so ``cleanup_all()`` can sweep them all.
+#:
+#: This used to be a hand-written list inside ``cleanup_all``, naming the six
+#: limiters defined in this module. The three cloud limiters in
+#: ``pocketpaw_ee.cloud._core.rate_limit`` were therefore never swept, and
+#: could not have been added: the OSS core must not import ``pocketpaw_ee``
+#: (an import-linter contract enforces it), so the list was structurally
+#: incapable of naming them. One of those three keys its buckets on a
+#: caller-supplied header on an unauthenticated endpoint.
+#:
+#: A WeakSet so a limiter built in a test, or any other short-lived one, is
+#: collected normally instead of being pinned here for the process lifetime.
+_REGISTRY: weakref.WeakSet[RateLimiter] = weakref.WeakSet()
+
+
 class RateLimiter:
     """Token-bucket rate limiter keyed by client identifier (IP address or API key).
 
@@ -81,6 +97,9 @@ class RateLimiter:
         # can't both see `tokens >= 1.0` and both decrement (issue #891).
         # The operation is O(1), so the lock is near-zero cost in practice.
         self._lock = threading.Lock()
+        # Self-register so the periodic sweep finds this limiter without
+        # anyone remembering to add it anywhere. See _REGISTRY.
+        _REGISTRY.add(self)
 
     def allow(self, key: str) -> bool:
         """Return True if the request is allowed, consuming one token."""
@@ -174,15 +193,18 @@ def get_api_key_limiter() -> RateLimiter:
     return _api_key_limiter
 
 
-def cleanup_all() -> int:
-    """Run cleanup on all global limiters. Returns total entries removed."""
-    total = (
-        api_limiter.cleanup()
-        + auth_limiter.cleanup()
-        + login_limiter.cleanup()
-        + mfa_challenge_limiter.cleanup()
-        + ws_limiter.cleanup()
-    )
-    if _api_key_limiter is not None:
-        total += _api_key_limiter.cleanup()
-    return total
+def cleanup_all(max_age: float = 3600.0) -> int:
+    """Sweep every live limiter. Returns total entries removed.
+
+    Walks the registry rather than a hand-written list of the limiters defined
+    in this module. That list silently excluded the cloud limiters, which are
+    defined in a package the OSS core is forbidden to import — so the omission
+    could not have been fixed by adding a name to it. Anything that constructs
+    a RateLimiter is now swept, wherever it lives.
+    """
+    return sum(limiter.cleanup(max_age) for limiter in list(_REGISTRY))
+
+
+def registered_limiter_count() -> int:
+    """How many live limiters the sweep currently covers. For tests and /doctor."""
+    return len(_REGISTRY)

--- a/tests/cloud/_core/test_unbounded_maps.py
+++ b/tests/cloud/_core/test_unbounded_maps.py
@@ -1,0 +1,245 @@
+# Regression: every in-process map on a request path must be bounded.
+#
+# Created 2026-09-04. Four maps grew without limit, three of them reachable
+# before authentication. None of these is visible from a response — the symptom
+# is a container that grows until it is restarted, and the only recovery in the
+# current deploy is `restart: unless-stopped`.
+#
+#   H3  TimingMiddleware keyed on the raw URL when no route matched, so every
+#       distinct 404 minted a permanent 10k-slot deque.
+#   M4  The realtime audience cache and the /tree cache both checked a TTL on
+#       read and never removed anything, so entries accumulated for the life of
+#       the process. The audience cache also had no single-flight, so N
+#       concurrent events for one group issued N identical queries.
+#   M5  cleanup_all() swept a hand-written list of the six limiters defined in
+#       the OSS module. The three cloud limiters were never swept, and could
+#       not have been added: the OSS core is forbidden to import pocketpaw_ee.
+#
+# What each test would catch, stated so a future reader can check the test
+# rather than trust it — see the repo's mutation rule:
+#   - revert the UNMATCHED_PATH fallback to request.url.path  -> first class
+#   - drop the popitem(last=False) loops                      -> the LRU classes
+#   - drop the _inflight single-flight                        -> fetch-count test
+#   - restore the hand-written cleanup_all list               -> registry test
+#   - read forwarded.split(",")[0] again                      -> proxy class
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud._core import timing
+from pocketpaw_ee.cloud._core.rate_limit import _client_ip
+from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
+
+from pocketpaw.security.rate_limiter import (
+    RateLimiter,
+    cleanup_all,
+    registered_limiter_count,
+)
+
+
+class _Req:
+    """Minimal stand-in for the two attributes _client_ip reads."""
+
+    def __init__(self, peer: str | None, headers: dict[str, str] | None = None):
+        self.client = type("C", (), {"host": peer})() if peer else None
+        self.headers = headers or {}
+
+
+class TestTimingKeySpace:
+    def setup_method(self):
+        timing.reset_buffers()
+
+    def teardown_method(self):
+        timing.reset_buffers()
+
+    @pytest.mark.asyncio
+    async def test_unmatched_paths_share_one_bucket(self):
+        """A scanner walking distinct URLs must not grow the buffer map."""
+        mw = timing.TimingMiddleware.__new__(timing.TimingMiddleware)
+        mw.capacity = 16
+
+        async def _call_next(_request):
+            return type("R", (), {"status_code": 404})()
+
+        for i in range(500):
+            req = type(
+                "Rq",
+                (),
+                {
+                    "scope": {},  # no matched route
+                    "url": type("U", (), {"path": f"/nope/{i}"})(),
+                    "method": "GET",
+                },
+            )()
+            await timing.TimingMiddleware.dispatch(mw, req, _call_next)
+
+        assert len(timing._buffers) == 1, (
+            f"500 distinct unmatched paths produced {len(timing._buffers)} buffers"
+        )
+        assert ("GET", timing.UNMATCHED_PATH) in timing._buffers
+
+    @pytest.mark.asyncio
+    async def test_matched_routes_still_key_on_the_template(self):
+        """The bound must not cost the signal: real routes stay separable."""
+        mw = timing.TimingMiddleware.__new__(timing.TimingMiddleware)
+        mw.capacity = 16
+
+        async def _call_next(_request):
+            return type("R", (), {"status_code": 200})()
+
+        for path in ("/workspaces/{id}", "/pockets", "/pockets/{id}"):
+            req = type(
+                "Rq",
+                (),
+                {
+                    "scope": {"route": type("Rt", (), {"path": path})()},
+                    "url": type("U", (), {"path": "/irrelevant"})(),
+                    "method": "GET",
+                },
+            )()
+            await timing.TimingMiddleware.dispatch(mw, req, _call_next)
+
+        assert len(timing._buffers) == 3
+        assert ("GET", timing.UNMATCHED_PATH) not in timing._buffers
+
+
+class TestAudienceCache:
+    @pytest.mark.asyncio
+    async def test_cache_is_bounded(self):
+        async def members(key: str) -> list[str]:
+            return [f"u-{key}"]
+
+        r = AudienceResolver(
+            workspace_members=members, cache_ttl_seconds=60.0, cache_max_entries=50
+        )
+        for i in range(500):
+            await r._workspace(f"ws-{i}")
+
+        assert len(r._cache) == 50, f"cache grew to {len(r._cache)}"
+
+    @pytest.mark.asyncio
+    async def test_eviction_is_least_recently_used(self):
+        async def members(key: str) -> list[str]:
+            return [f"u-{key}"]
+
+        r = AudienceResolver(workspace_members=members, cache_ttl_seconds=60.0, cache_max_entries=3)
+        for k in ("a", "b", "c"):
+            await r._workspace(k)
+        await r._workspace("a")  # 'a' becomes most recent, so 'b' is coldest
+        await r._workspace("d")
+
+        keys = {k for _kind, k in r._cache}
+        assert keys == {"a", "c", "d"}, f"evicted the wrong entry: kept {keys}"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_misses_issue_one_query(self):
+        """Single-flight. This resolver runs on every workspace-scoped event,
+        so a fan-out of identical concurrent misses is the normal case."""
+        calls = 0
+        release = asyncio.Event()
+
+        async def slow_members(key: str) -> list[str]:
+            nonlocal calls
+            calls += 1
+            await release.wait()
+            return ["u1"]
+
+        r = AudienceResolver(workspace_members=slow_members, cache_ttl_seconds=60.0)
+        waiters = [asyncio.create_task(r._workspace("ws-1")) for _ in range(25)]
+        await asyncio.sleep(0)
+        release.set()
+        results = await asyncio.gather(*waiters)
+
+        assert calls == 1, f"25 concurrent misses issued {calls} queries"
+        assert all(res == ["u1"] for res in results)
+
+    @pytest.mark.asyncio
+    async def test_a_failed_fetch_is_not_cached_and_does_not_wedge(self):
+        """One transient error must not pin a failing entry in front of callers."""
+        attempts = 0
+
+        async def flaky(key: str) -> list[str]:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("mongo hiccup")
+            return ["u1"]
+
+        r = AudienceResolver(workspace_members=flaky, cache_ttl_seconds=60.0)
+        with pytest.raises(RuntimeError):
+            await r._workspace("ws-1")
+
+        assert r._inflight == {}, "failed fetch left an entry in the in-flight map"
+        assert await r._workspace("ws-1") == ["u1"], "retry after a failure did not work"
+
+
+class TestLimiterRegistry:
+    def test_a_new_limiter_is_swept_without_being_registered_by_hand(self):
+        """The defect was a hand-written list that could not name the cloud
+        limiters, because the OSS core may not import pocketpaw_ee."""
+        before = registered_limiter_count()
+        limiter = RateLimiter(rate=1.0, capacity=5)
+        assert registered_limiter_count() == before + 1
+
+        limiter.check("some-key")
+        assert len(limiter._buckets) == 1
+
+        # A negative max_age makes every bucket stale regardless of clock
+        # granularity. Windows monotonic ticks at ~15.6ms, so `now - last_refill
+        # > 0` is false for a bucket created in the same tick and max_age=0
+        # would sweep nothing.
+        removed = cleanup_all(max_age=-1.0)
+        assert removed >= 1
+        assert limiter._buckets == {}, "cleanup_all did not reach a limiter it never named"
+
+    def test_the_cloud_limiters_are_registered(self):
+        """The three that were previously unreachable by the sweep."""
+        import pocketpaw_ee.cloud._core.rate_limit as rl
+
+        for name in (
+            "_invite_create_limiter",
+            "_invite_resend_limiter",
+            "_social_exchange_limiter",
+        ):
+            limiter = getattr(rl, name)
+            limiter.check(f"probe:{name}")
+            assert limiter._buckets, f"{name} did not record a bucket"
+
+        cleanup_all(max_age=-1.0)
+
+        for name in (
+            "_invite_create_limiter",
+            "_invite_resend_limiter",
+            "_social_exchange_limiter",
+        ):
+            limiter = getattr(rl, name)
+            assert limiter._buckets == {}, f"{name} was not swept"
+
+
+class TestForwardedForTrust:
+    """The bucket key must be the address the proxy observed, not the one the
+    caller claimed. Getting this wrong is a rate-limit bypass, not just a leak:
+    a fresh value per request gets a fresh bucket."""
+
+    def test_rightmost_entry_wins(self):
+        req = _Req("10.0.0.1", {"x-forwarded-for": "1.2.3.4, 203.0.113.9"})
+        assert _client_ip(req) == "203.0.113.9"
+
+    def test_a_spoofed_leftmost_value_is_ignored(self):
+        spoofed = _Req("10.0.0.1", {"x-forwarded-for": "9.9.9.9, 203.0.113.9"})
+        honest = _Req("10.0.0.1", {"x-forwarded-for": "203.0.113.9"})
+        assert _client_ip(spoofed) == _client_ip(honest), (
+            "a caller-chosen prefix changed the bucket, which is the bypass"
+        )
+
+    def test_no_header_falls_back_to_the_peer(self):
+        assert _client_ip(_Req("203.0.113.9", {})) == "203.0.113.9"
+
+    def test_a_malformed_value_falls_back_to_the_peer(self):
+        req = _Req("203.0.113.9", {"x-forwarded-for": "not-an-ip"})
+        assert _client_ip(req) == "203.0.113.9"
+
+    def test_missing_client_is_survivable(self):
+        assert _client_ip(_Req(None, {})) == "unknown"

--- a/tests/mutations/bounded_maps.json
+++ b/tests/mutations/bounded_maps.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "H3: unmatched requests key on the raw URL again",
+    "file": "ee/pocketpaw_ee/cloud/_core/timing.py",
+    "find": "            else UNMATCHED_PATH",
+    "replace": "            else request.url.path",
+    "tests": ["tests/cloud/_core/test_unbounded_maps.py::TestTimingKeySpace"]
+  },
+  {
+    "label": "M4: audience cache stops evicting",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/audience.py",
+    "find": "        while len(self._cache) > self._max:\n            self._cache.popitem(last=False)",
+    "replace": "        pass",
+    "tests": ["tests/cloud/_core/test_unbounded_maps.py::TestAudienceCache"]
+  },
+  {
+    "label": "M4: single-flight removed, concurrent misses each query",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/audience.py",
+    "find": "        pending = self._inflight.get(ck)\n        if pending is not None:\n            return list(await pending)",
+    "replace": "        pending = None",
+    "tests": ["tests/cloud/_core/test_unbounded_maps.py::TestAudienceCache"]
+  },
+  {
+    "label": "M4: LRU recency not tracked on read, so eviction picks wrong",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/audience.py",
+    "find": "            self._cache.move_to_end(ck)\n            return list(entry[1])",
+    "replace": "            return list(entry[1])",
+    "tests": ["tests/cloud/_core/test_unbounded_maps.py::TestAudienceCache::test_eviction_is_least_recently_used"]
+  },
+  {
+    "label": "M5: cleanup_all reverts to the hand-written OSS-only list",
+    "file": "src/pocketpaw/security/rate_limiter.py",
+    "find": "    return sum(limiter.cleanup(max_age) for limiter in list(_REGISTRY))",
+    "replace": "    return api_limiter.cleanup(max_age) + auth_limiter.cleanup(max_age)",
+    "tests": ["tests/cloud/_core/test_unbounded_maps.py::TestLimiterRegistry"]
+  },
+  {
+    "label": "M5: trust the caller-supplied leftmost X-Forwarded-For again",
+    "file": "ee/pocketpaw_ee/cloud/_core/rate_limit.py",
+    "find": "    candidate = forwarded.rsplit(\",\", 1)[-1].strip()",
+    "replace": "    candidate = forwarded.split(\",\")[0].strip()",
+    "tests": ["tests/cloud/_core/test_unbounded_maps.py::TestForwardedForTrust"]
+  }
+]


### PR DESCRIPTION
Four in-process maps grew without limit. Three are reachable before authentication. None of them is visible from a response — the symptom is a container that grows until something restarts it, and the only recovery this deploy has is `restart: unless-stopped`.

This is H3, M4 and M5 of the backend performance audit.

## The four

**Request timing kept one buffer per 404.** The key is the matched route template, which is bounded by the route table. When nothing matched there is no template, and it fell back to the raw URL — so every distinct 404 minted a permanent 10,000-slot deque. The middleware wraps everything and runs before auth, so a scanner walking a million URLs is a million retained entries. Unmatched requests now share one bucket. The aggregate is still useful, since it says how much time is going into 404s, and it cannot grow.

**Two caches expired logically but never actually removed anything.** The realtime audience cache and the `/tree` cache both check a TTL on read to decide whether an entry is *usable*; neither ever evicted. That is one entry per group, workspace or user ever seen for the first, and one whole folder tree per (user, workspace) pair for the second. Both are now LRUs with a generous ceiling — eviction is a backstop, not a working constraint, and a miss just rebuilds.

**The audience cache also had no single-flight.** N concurrent events for the same group each issued their own query. That resolver runs on every workspace-scoped event, so identical concurrent misses are the normal case, not the rare one. The first caller now owns the fetch and the rest await it. A failure is popped rather than cached, so one transient error cannot pin a permanently-failing entry in front of every later caller.

**The rate-limit sweep could not reach half the limiters.** `cleanup_all()` walked a hand-written list naming the six limiters defined in the OSS module. The three cloud limiters were never swept — and could not have been added, because the OSS core is forbidden from importing `pocketpaw_ee` and an import-linter contract enforces it. The list was structurally incapable of naming them. Limiters now self-register in a `WeakSet` and the sweep walks that, so anything that constructs a `RateLimiter` is covered wherever it lives. A weak set so test-local limiters are collected normally instead of being pinned for the process lifetime.

## One of these is a bypass, not just a leak

`rate_limit_social_exchange` keyed its buckets on the **leftmost** `X-Forwarded-For` entry, on an endpoint that is unauthenticated by design. That entry is whatever the caller sent. A fresh value per request therefore got a fresh bucket, which both evaded the limit entirely and minted unbounded `_Bucket` objects.

A proxy *appends* the address it actually observed, so through our edge the header reads `<whatever the client claimed>, <real client>` and only the last element is trustworthy. It reads the rightmost entry now, validated as an IP address so a malformed header cannot become a cache key on its own.

That assumes exactly one trusted proxy in front of the app, which matches the current deployment. The docstring says so, and says what changes if a second hop appears. Related and still open: uvicorn's `forwarded_allow_ips` is unset, which is tracked in the operability audit.

## Verification

Gates were checked by mutation rather than assumed, per the repo's rule. `tests/mutations/bounded_maps.json` reverts each fix in turn:

```
caught   H3: unmatched requests key on the raw URL again
caught   M4: audience cache stops evicting
caught   M4: single-flight removed, concurrent misses each query
caught   M4: LRU recency not tracked on read, so eviction picks wrong
caught   M5: cleanup_all reverts to the hand-written OSS-only list
caught   M5: trust the caller-supplied leftmost X-Forwarded-For again

all 6 mutations caught
```

Regression baseline against `origin/dev`, because two tests in these directories fail on a clean checkout for environmental reasons:

| | Base | This branch |
|---|---|---|
| `tests/cloud/{realtime,_core,files}`, invite + api rate limits | 2 failed, 277 passed | 2 failed, 290 passed |

Same two failures by name. The 13 extra passes are the new tests.

One of those tests found a real trap while being written: a sweep asserting `max_age=0` swept nothing, because Windows' monotonic clock ticks at ~15.6ms and `now - last_refill > 0` is false for a bucket created in the same tick. The test uses a negative age so it is clock-independent. That was the test's bug, not the code's.

These live under `tests/cloud/`, which CI excludes, so they will not run on this PR. Pre-existing gap, noted rather than worked around.
