### PR TITLE
perf: stop the event loop being held for the sum of its work

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/bus.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/bus.py
@@ -3,6 +3,13 @@
 #   "Files as Knowledge"). publish() now fans out to local handlers as well
 #   as WebSocket clients. Failures are isolated per-handler so one bad
 #   listener can't block the rest of the dispatch.
+# Updated: 2026-09-04 (fix/unblock-event-loop, backend-perf H1) — the WebSocket
+#   fan-out is concurrent and bounded instead of one serial await per audience
+#   member. publish() runs INLINE in the emitting HTTP request, so the old loop
+#   charged that request the SUM of every recipient's send latency. With the 5s
+#   per-socket timeout in ws.py that is up to 5s x audience size for one
+#   `message.new`. See _core/realtime/fanout.py for why the concurrency is
+#   capped rather than a bare gather.
 """EventBus protocol and in-process implementation.
 
 Services call ``emit(event)`` (see ``emit.py``) which delegates to the active
@@ -28,6 +35,7 @@ from typing import Protocol
 
 from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
 from pocketpaw_ee.cloud._core.realtime.events import Event
+from pocketpaw_ee.cloud._core.realtime.fanout import map_bounded
 
 logger = logging.getLogger(__name__)
 
@@ -84,13 +92,25 @@ class InProcessBus:
 
         if audience:
             payload = WsOutbound(type=event.type, data=event.data)
-            for uid in audience:
+
+            async def _deliver(uid: str) -> None:
+                # Containment stays per recipient, exactly as the serial loop
+                # had it: one unreachable member must not abort delivery to the
+                # rest. Keeping the try INSIDE the coroutine (rather than
+                # reaching for gather's return_exceptions) also keeps
+                # cancellation honest — see fanout.map_bounded.
                 try:
                     await self._conn.send_to_user(uid, payload)
                 except Exception:
                     logger.warning(
                         "ws send failed; user=%s event=%s", uid, event.type, exc_info=True
                     )
+
+            # Concurrent, capped. The old serial loop charged the emitting
+            # request the sum of every member's send latency; a single
+            # back-pressured socket burning its full 5s timeout therefore
+            # delayed every member after it in the list.
+            await map_bounded(list(audience), _deliver)
 
         # Local in-process handlers — run regardless of WebSocket audience so
         # bus listeners (e.g. the upload indexer) fire even when no client is

--- a/ee/pocketpaw_ee/cloud/_core/realtime/fanout.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/fanout.py
@@ -1,0 +1,84 @@
+# ee/pocketpaw_ee/cloud/_core/realtime/fanout.py
+# Created: 2026-09-04 (fix/unblock-event-loop, backend-perf H1) — bounded
+# concurrency for realtime delivery.
+#
+# Why this exists: every realtime fan-out in the cloud package was a `for`
+# loop with one `await` per recipient, running INLINE in the emitting HTTP
+# request. Delivery cost was therefore the SUM over recipients, not the max.
+#
+# The codebase had already found the failure mode and half-fixed it:
+# `ws.SEND_TIMEOUT_SECONDS = 5.0` exists precisely so "one stuck socket would
+# stall delivery to every other member and the sender's own request". But a
+# per-send timeout bounds ONE send. It does nothing about the loop around it.
+# A 200-member workspace with ten backgrounded mobile tabs cost the sender's
+# POST up to 50 seconds, serially, with the 5s timeout working exactly as
+# designed the whole time.
+#
+# Fanning out concurrently makes the cost max-per-recipient instead. The bound
+# matters as much as the concurrency: an unbounded `gather` over a large
+# workspace would mint one task per member, which trades a latency problem for
+# a memory-and-scheduler one.
+
+"""Bounded-concurrency fan-out helper for realtime delivery.
+
+Deliberately import-free beyond the stdlib. ``_core.realtime.bus`` already has
+to import ``chat.schemas`` lazily to dodge a cycle, so anything both it and
+``chat.ws`` depend on has to be a leaf.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Final, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+#: Maximum sends in flight for a single fan-out.
+#:
+#: Chosen to be far above a normal workspace's online membership (so the common
+#: case is fully parallel and costs one round of sends) while still capping the
+#: task count for a pathologically large audience. Delivery to a 1000-member
+#: workspace is then 32 concurrent sends deep rather than 1000 tasks wide, and
+#: worst-case latency is ceil(1000/32) * SEND_TIMEOUT rather than 1000 *
+#: SEND_TIMEOUT.
+FANOUT_CONCURRENCY: Final = 32
+
+
+async def map_bounded(
+    items: Sequence[T],
+    fn: Callable[[T], Awaitable[R]],
+    *,
+    limit: int = FANOUT_CONCURRENCY,
+) -> list[R]:
+    """Await ``fn`` over ``items`` with at most ``limit`` in flight.
+
+    Results come back positionally, so a caller can zip them against ``items``
+    to attribute each outcome.
+
+    Exceptions are NOT captured here. Every caller on the fan-out path already
+    contains its own failures (``_send_bounded`` returns a bool and swallows;
+    the bus logs per recipient), and swallowing here as well would hide a real
+    bug in a new caller. It also keeps cancellation honest: ``gather`` with
+    ``return_exceptions=True`` turns a child's ``CancelledError`` into a
+    RESULT, so a cancelled request would look like a successful fan-out.
+    """
+    if not items:
+        return []
+    if len(items) == 1:
+        # Skip the semaphore and the task machinery for the overwhelmingly
+        # common case of one recipient — that is the single-socket user, and
+        # it is the whole steady-state load of a small workspace.
+        return [await fn(items[0])]
+
+    sem = asyncio.Semaphore(limit)
+
+    async def _one(item: T) -> R:
+        async with sem:
+            return await fn(item)
+
+    return list(await asyncio.gather(*(_one(item) for item in items)))
+
+
+__all__ = ["FANOUT_CONCURRENCY", "map_bounded"]

--- a/ee/pocketpaw_ee/cloud/chat/runs/domain.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/domain.py
@@ -26,6 +26,21 @@ outside this entity — ``ee.cloud.agent_activity``, which answers "which of my
 agents are working right now" — reads runs as these Beanie-free value objects
 rather than importing the document class.
 
+Changes: 2026-09-04 (fix/unblock-event-loop, backend-perf M7) — this module also
+holds the per-run TIMEOUT resolver now. It used to be private to ``worker.py``,
+which meant the SSE reader in ``router.py`` could not see it: the stream loop
+had no maximum lifetime at all, so a run whose terminal event never arrived
+(worker OOM-killed after the events key existed, which defeats the
+``stream_exists`` fallback) heartbeated forever, holding a blocked Redis
+connection and a live asyncio task per abandoned client. The stream's natural
+bound is the run's own timeout, and the two must not drift apart — raising
+``POCKETPAW_CLOUD_RUN_JOB_TIMEOUT`` has to lengthen the stream cap too, or the
+cap starts killing streams of runs that are still legitimately working. So both
+read one resolver. It lives here rather than in ``worker.py`` because
+``router.py`` importing the worker would pull arq and the whole executor graph
+into the web process. Same reasoning, and the same shape, as
+``jobs/domain.py::job_timeout_seconds``.
+
 Changes: 2026-07-26 (concierge transcripts) — ``RunSpec`` grows
 ``persist_user_text``: the user's message text to WRITE DOWN on the run doc, as
 opposed to ``content``, which is what the agent is asked. Every authed surface
@@ -37,10 +52,66 @@ rest."""
 
 from __future__ import annotations
 
+import logging
+import os
 from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
+
+# arq's DEFAULT job_timeout is 300s, which CANCELS a long chat run mid-generation,
+# so a big coding task halts after ~5 minutes. 30 minutes instead; the 10-minute
+# stale-run sweeper remains the backstop against a genuinely runaway run holding
+# a worker slot.
+DEFAULT_RUN_JOB_TIMEOUT_SECONDS = 1800  # 30 minutes
+
+# How long the SSE reader keeps a stream open PAST the run's own timeout before
+# giving up. A run cancelled at the timeout boundary still has to write its
+# terminal frame and have the reader observe it, and ``read_events`` blocks in
+# 15s slices — so a cap equal to the job timeout would race the very frame it is
+# waiting for and report a spurious error on a healthy run.
+STREAM_LIFETIME_GRACE_SECONDS = 120
+
+
+def run_job_timeout_seconds() -> int:
+    """Resolve the per-run arq job_timeout from ``POCKETPAW_CLOUD_RUN_JOB_TIMEOUT``.
+
+    Defaults to 30 minutes. An unparseable or non-positive value falls back to the
+    default (rather than 0 / negative, which would disable or break the cap), so a
+    typo can't silently let runs run forever or crash the worker.
+    """
+    raw = os.environ.get("POCKETPAW_CLOUD_RUN_JOB_TIMEOUT", "").strip()
+    if not raw:
+        return DEFAULT_RUN_JOB_TIMEOUT_SECONDS
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.warning(
+            "POCKETPAW_CLOUD_RUN_JOB_TIMEOUT=%r is not an int; using default %ds",
+            raw,
+            DEFAULT_RUN_JOB_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_RUN_JOB_TIMEOUT_SECONDS
+    if val <= 0:
+        logger.warning(
+            "POCKETPAW_CLOUD_RUN_JOB_TIMEOUT=%d is not positive; using default %ds",
+            val,
+            DEFAULT_RUN_JOB_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_RUN_JOB_TIMEOUT_SECONDS
+    return val
+
+
+def stream_max_lifetime_seconds() -> int:
+    """Hard ceiling on one SSE subscription, derived from the run's own timeout.
+
+    Derived rather than configured on purpose: an independent knob would drift,
+    and the failure mode of drift is a cap SHORTER than the run it is watching,
+    which severs healthy long runs and looks exactly like a backend bug.
+    """
+    return run_job_timeout_seconds() + STREAM_LIFETIME_GRACE_SECONDS
 
 
 class RunSpec(BaseModel):

--- a/ee/pocketpaw_ee/cloud/chat/runs/router.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/router.py
@@ -1,6 +1,16 @@
 """Run streaming + control endpoints.
 
 Changes:
+- 2026-09-04 (fix/unblock-event-loop, backend-perf M7) — the stream loop has a
+  maximum lifetime. It previously had none: the only exits were a terminal
+  event or a failed ``yield`` (which is how a client disconnect is noticed).
+  A run that never writes its terminal frame therefore heartbeated forever,
+  and the ``stream_exists`` fallback below does not catch that case — it only
+  fires when the events key is GONE, whereas a worker OOM-killed mid-run
+  leaves the key present and unfinished. Each abandoned subscription costs a
+  live asyncio task plus a Redis connection blocked in 15s slices, on a client
+  pool with no configured cap. The ceiling is derived from the run's own
+  ``POCKETPAW_CLOUD_RUN_JOB_TIMEOUT`` so the two cannot drift apart.
 - 2026-06-10 (sov/w3a-igw — per-run token metering) — the history-replay
   ``stream_end`` frame (served when a terminal run's live stream has expired) now
   carries the persisted ``doc.usage`` so a reconnecting client still gets the
@@ -11,6 +21,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, Query
@@ -18,6 +29,7 @@ from fastapi.responses import StreamingResponse
 
 from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.chat.runs import service as run_service
+from pocketpaw_ee.cloud.chat.runs.domain import stream_max_lifetime_seconds
 from pocketpaw_ee.cloud.chat.runs.dto import StopRunResponse
 from pocketpaw_ee.cloud.chat.runs.transport import get_stream_transport
 from pocketpaw_ee.cloud.license import require_license
@@ -74,6 +86,14 @@ async def get_run_stream(
                 },
             )
             return
+        # Hard ceiling on this subscription. Without it the loop below never
+        # exits on its own: a run whose terminal event never arrives (the
+        # worker was OOM-killed AFTER the events key existed, so the
+        # ``stream_exists`` fallback above does not trigger) heartbeats
+        # forever. Each iteration holds a Redis connection blocked for 15s and
+        # a live asyncio task, and disconnect is only noticed when a ``yield``
+        # fails — so an abandoned tab is retained indefinitely, not collected.
+        deadline = time.monotonic() + stream_max_lifetime_seconds()
         while True:
             saw_terminal = False
             async for ev in transport.read_events(run_id, after=cursor, block_ms=15000):
@@ -82,6 +102,25 @@ async def get_run_stream(
                 if ev.is_terminal:
                     saw_terminal = True
             if saw_terminal:
+                return
+            if time.monotonic() >= deadline:
+                # Terminate with a real ``error`` frame rather than closing
+                # silently: ``error`` is in TERMINAL_EVENTS, so the client
+                # stops waiting and surfaces a retry instead of showing a run
+                # that appears to still be thinking.
+                logger.warning(
+                    "run stream exceeded max lifetime; closing run_id=%s cursor=%s",
+                    run_id,
+                    cursor,
+                )
+                yield _sse(
+                    cursor,
+                    "error",
+                    {
+                        "code": "run.stream_timeout",
+                        "message": "This run's stream was open too long and was closed.",
+                    },
+                )
                 return
             # heartbeat so proxies keep the connection open
             yield b": ping\n\n"

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -91,7 +91,11 @@ from arq.worker import func
 # Imported at module scope so tests can ``monkeypatch.setattr(worker, …)``.
 from pocketpaw_ee.cloud import init_realtime
 from pocketpaw_ee.cloud._core.realtime import xproc
-from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+from pocketpaw_ee.cloud.chat.runs.domain import (
+    DEFAULT_RUN_JOB_TIMEOUT_SECONDS,
+    RunSpec,
+    run_job_timeout_seconds,
+)
 from pocketpaw_ee.cloud.chat.runs.run_core import execute_run
 from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
 from pocketpaw_ee.cloud.jobs.domain import job_timeout_seconds
@@ -236,36 +240,14 @@ def _redis_settings() -> RedisSettings:
 # env-tunable; the 10-minute stale-run sweeper remains the backstop against a
 # genuinely runaway run holding a worker slot. (Workspace jobs get their OWN
 # per-function timeout below, so the two can't clip each other.)
-_DEFAULT_RUN_JOB_TIMEOUT_SECONDS = 1800  # 30 minutes
-
-
-def _job_timeout_seconds() -> int:
-    """Resolve the per-run arq job_timeout from ``POCKETPAW_CLOUD_RUN_JOB_TIMEOUT``.
-
-    Defaults to 30 minutes. An unparseable or non-positive value falls back to the
-    default (rather than 0 / negative, which would disable or break the cap), so a
-    typo can't silently let runs run forever or crash the worker.
-    """
-    raw = os.environ.get("POCKETPAW_CLOUD_RUN_JOB_TIMEOUT", "").strip()
-    if not raw:
-        return _DEFAULT_RUN_JOB_TIMEOUT_SECONDS
-    try:
-        val = int(raw)
-    except ValueError:
-        logger.warning(
-            "POCKETPAW_CLOUD_RUN_JOB_TIMEOUT=%r is not an int; using default %ds",
-            raw,
-            _DEFAULT_RUN_JOB_TIMEOUT_SECONDS,
-        )
-        return _DEFAULT_RUN_JOB_TIMEOUT_SECONDS
-    if val <= 0:
-        logger.warning(
-            "POCKETPAW_CLOUD_RUN_JOB_TIMEOUT=%d is not positive; using default %ds",
-            val,
-            _DEFAULT_RUN_JOB_TIMEOUT_SECONDS,
-        )
-        return _DEFAULT_RUN_JOB_TIMEOUT_SECONDS
-    return val
+#
+# The resolver itself moved to ``runs/domain.py`` on 2026-09-04 so the SSE
+# reader in ``router.py`` can share it: the stream's maximum lifetime is derived
+# from this timeout, and a second copy of the parse would let the two drift.
+# Re-exported under the old private names because they are the module's
+# established surface and the worker config tests read them here.
+_DEFAULT_RUN_JOB_TIMEOUT_SECONDS = DEFAULT_RUN_JOB_TIMEOUT_SECONDS
+_job_timeout_seconds = run_job_timeout_seconds
 
 
 # arq's own default is max_jobs=10 (arq/worker.py). That ceiling is shared by

--- a/ee/pocketpaw_ee/cloud/chat/ws.py
+++ b/ee/pocketpaw_ee/cloud/chat/ws.py
@@ -10,6 +10,19 @@ Handles:
 - Presence tracking with grace period (30s before marking offline)
 - Per-socket liveness (see below)
 
+Updated: 2026-09-04 (fix/unblock-event-loop, backend-perf H1) — the three
+fan-out loops (``send_to_user``, ``broadcast_to_group``, ``send_to_room``) now
+send CONCURRENTLY under a bounded gather instead of one serial await per
+recipient. ``SEND_TIMEOUT_SECONDS`` below already bounds a single send, and the
+note on it explains exactly why: "one stuck socket would stall delivery to
+every other member and the sender's own request". That is true of one send, but
+the serial loop around it re-introduced the very stall the timeout was added to
+prevent — the cost was the SUM over recipients, so a 200-member workspace with
+ten back-pressured tabs held the emitting POST for ~50s with every individual
+timeout behaving perfectly. Delivery is now max-per-socket. The freshness gate,
+the dead-socket bookkeeping, and the ``delivered`` count (which
+``push/dispatch.py`` reads to choose WS over Web Push) are unchanged.
+
 Updated: 2026-08-18 (fix/ws-fanout-stale-sockets) — the liveness verdict below
 was only consulted by ``is_online``. Fan-out (``send_to_user`` /
 ``send_to_room``) still wrote to every registered socket, so a zombie kept
@@ -59,6 +72,7 @@ import time
 
 from fastapi import WebSocket
 
+from pocketpaw_ee.cloud._core.realtime.fanout import map_bounded
 from pocketpaw_ee.cloud.chat.schemas import WsOutbound
 
 logger = logging.getLogger(__name__)
@@ -323,13 +337,12 @@ class ConnectionManager:
         dropping the notification.
         """
         data = message.model_dump(mode="json")
-        delivered = 0
-        dead: list[WebSocket] = []
         now = time.monotonic()
         # Iterate a COPY: a concurrent _close_stale → disconnect mutates the
         # live set, and the resulting "set changed size during iteration" fires
         # at the for statement — outside the per-send try — so it would escape
         # to notify() and be mistaken for a WS failure, skipping the fallback.
+        fresh: list[WebSocket] = []
         for ws in list(self.get_user_connections(user_id)):
             # Same verdict as is_online: a stale ping-capable socket is a
             # zombie. Writing to it "succeeds" (kernel buffer) and would count
@@ -338,8 +351,22 @@ class ConnectionManager:
             # loop then runs the normal disconnect/presence path.
             if not self._is_fresh(ws, now=now):
                 self._close_stale(ws)
-                continue
-            if await self._send_bounded(ws, data):
+            else:
+                fresh.append(ws)
+        if not fresh:
+            return 0
+
+        # One user's sockets are their open tabs and devices. Sending serially
+        # made a single back-pressured tab cost every OTHER device on this user
+        # the full SEND_TIMEOUT_SECONDS before its own frame was even
+        # attempted. _send_bounded contains its own failures and returns a
+        # bool, so nothing raises out of the gather.
+        results = await map_bounded(fresh, lambda ws: self._send_bounded(ws, data))
+
+        delivered = 0
+        dead: list[WebSocket] = []
+        for ws, accepted in zip(fresh, results, strict=True):
+            if accepted:
                 delivered += 1
                 self._mark_outbound(ws)
             else:
@@ -357,10 +384,11 @@ class ConnectionManager:
         exclude_user: str | None = None,
     ) -> None:
         """Broadcast a message to all online members of a group."""
-        for uid in member_ids:
-            if uid == exclude_user:
-                continue
-            await self.send_to_user(uid, message)
+        targets = [uid for uid in member_ids if uid != exclude_user]
+        # Concurrent for the same reason as send_to_user, one level up: a
+        # group's members are independent recipients, so the broadcast should
+        # cost the slowest member rather than all of them added together.
+        await map_bounded(targets, lambda uid: self.send_to_user(uid, message))
 
     # ------------------------------------------------------------------
     # Room tracking (at most one current room per socket)
@@ -392,8 +420,8 @@ class ConnectionManager:
         in the group before calling ``join_room``).
         """
         data = message.model_dump(mode="json")
-        dead: list[WebSocket] = []
         now = time.monotonic()
+        fresh: list[WebSocket] = []
         for ws, room in list(self._ws_to_room.items()):
             if room != group_id:
                 continue
@@ -402,8 +430,16 @@ class ConnectionManager:
             # Same freshness gate as send_to_user — see the note there.
             if not self._is_fresh(ws, now=now):
                 self._close_stale(ws)
-                continue
-            if await self._send_bounded(ws, data):
+            else:
+                fresh.append(ws)
+        if not fresh:
+            return
+
+        results = await map_bounded(fresh, lambda ws: self._send_bounded(ws, data))
+
+        dead: list[WebSocket] = []
+        for ws, accepted in zip(fresh, results, strict=True):
+            if accepted:
                 self._mark_outbound(ws)
             else:
                 dead.append(ws)

--- a/src/pocketpaw/api/v1/cloud_projects.py
+++ b/src/pocketpaw/api/v1/cloud_projects.py
@@ -14,6 +14,10 @@ Updated: 2026-06-23 — added POST /cloud/projects/clone (git clone into project
 Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — the workspace-VM store
     accessors are now async + Mongo-backed; ``await`` the VM lookups in
     ``_ensure_vm_project_dir`` / ``_clone_into_vm``.
+Updated: 2026-09-04 — ``_upload_directory`` no longer walks the cloned tree on
+    the event loop. The ``os.walk`` moved into ``_walk_repo_files`` and is
+    reached through ``asyncio.to_thread``; the uploads themselves stay in the
+    coroutine because each one awaits the storage adapter.
 """
 
 from __future__ import annotations
@@ -182,6 +186,25 @@ def _extract_project_name(repo_url: str) -> str:
     return parts[-1] if parts else "cloned-repo"
 
 
+def _walk_repo_files(base: Path, include_git: bool) -> list[Path]:
+    """Materialise every file under ``base``, in ``os.walk`` order.
+
+    Deliberately synchronous so ``_upload_directory`` can hand it to
+    ``asyncio.to_thread``. The ``.git`` prune has to live in here with the walk:
+    it works by mutating ``dirs`` in place, which only stops os.walk descending
+    if it happens mid-traversal.
+    """
+    found: list[Path] = []
+    for root, dirs, files in os.walk(base):
+        # Skip the .git directory by default.
+        if not include_git:
+            dirs[:] = [d for d in dirs if d != ".git"]
+
+        for file_name in files:
+            found.append(Path(root) / file_name)
+    return found
+
+
 async def _upload_directory(local_dir: str, project_key: str, include_git: bool = False) -> None:
     """Recursively upload a local directory tree into the storage adapter.
 
@@ -192,42 +215,42 @@ async def _upload_directory(local_dir: str, project_key: str, include_git: bool 
     """
     base = Path(local_dir)
 
-    for root, dirs, files in os.walk(base):
-        # Skip the .git directory by default.
-        if not include_git:
-            dirs[:] = [d for d in dirs if d != ".git"]
+    # The walk is done in a worker thread: os.walk stats every entry in the
+    # tree, and a freshly cloned repo is thousands of syscalls. We serve from a
+    # single uvicorn process with no --workers, so traversing inline held the
+    # event loop — and every other in-flight request — until it finished. Only
+    # the traversal moves; the upload loop stays in the coroutine because each
+    # iteration awaits the storage adapter.
+    for local_path in await asyncio.to_thread(_walk_repo_files, base, include_git):
+        relative = local_path.relative_to(base).as_posix()
+        full_key = f"{project_key}{relative}"
 
-        for file_name in files:
-            local_path = Path(root) / file_name
-            relative = local_path.relative_to(base).as_posix()
-            full_key = f"{project_key}{relative}"
+        mime, _ = mimetypes.guess_type(str(local_path))
 
-            mime, _ = mimetypes.guess_type(str(local_path))
+        async def _stream(path: Path = local_path) -> AsyncIterator[bytes]:
+            with open(path, "rb") as fh:
+                while True:
+                    chunk = fh.read(65536)
+                    if not chunk:
+                        break
+                    yield chunk
 
-            async def _stream(path: Path = local_path) -> AsyncIterator[bytes]:
-                with open(path, "rb") as fh:
-                    while True:
-                        chunk = fh.read(65536)
-                        if not chunk:
-                            break
-                        yield chunk
-
-            try:
-                await _ADAPTER.put(
-                    full_key,
-                    _stream(),
-                    mime or "application/octet-stream",
-                )
-            except Exception as exc:
-                logger.warning(
-                    "Failed to upload %s to cloud project: %s",
-                    relative,
-                    exc,
-                )
-                raise HTTPException(
-                    status_code=500,
-                    detail=f"Failed to upload {relative}: {exc}",
-                ) from exc
+        try:
+            await _ADAPTER.put(
+                full_key,
+                _stream(),
+                mime or "application/octet-stream",
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to upload %s to cloud project: %s",
+                relative,
+                exc,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to upload {relative}: {exc}",
+            ) from exc
 
 
 # ── Workspace VM project subdirectory helpers (NEW) ────────────────────────

--- a/src/pocketpaw/api/v1/files.py
+++ b/src/pocketpaw/api/v1/files.py
@@ -5,9 +5,16 @@
 # 2026-06-10: expanduser() in browse + _resolve_path so "~/foo" paths resolve
 # to home — the /code IDE roots its tree at "~" and addresses children that
 # way. Jail checks unchanged.
+# 2026-09-04: the git subprocess calls in /git/status and /git/diff, and the
+# deflate loop in /files/download-zip, now run through asyncio.to_thread. All
+# three are synchronous and were being executed directly inside async handlers,
+# which pins the single uvicorn event loop (we run one process, no --workers)
+# for the whole duration — a slow `git status` on a large repo, or a 500 MB
+# zip, stalled every other in-flight request on the box.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import mimetypes
@@ -385,24 +392,17 @@ async def delete_file_or_directory(
     return FileActionResponse(ok=True)
 
 
-@router.get("/files/download-zip")
-async def download_dir_as_zip(path: str):
-    """Download a directory (recursively) as a zip archive."""
-    from pocketpaw.config import get_settings
+def _build_zip_bytes(resolved: Path, jail: Path) -> bytes:
+    """Walk ``resolved`` and return the deflated archive as bytes.
+
+    Deliberately synchronous: the caller hands the whole thing to
+    ``asyncio.to_thread``. Deflating a directory tree is CPU-bound and can run
+    for seconds on a large source checkout, so running it inline in the async
+    handler froze the event loop — and therefore every other request — for its
+    full duration. The jail and size guards stay in here with the walk so the
+    archive is never assembled from paths that were not checked.
+    """
     from pocketpaw.tools.fetch import is_safe_path
-
-    settings = get_settings()
-    resolved = _resolve_path(path)
-    jail = settings.file_jail_path.resolve()
-
-    if not is_safe_path(resolved, jail):
-        raise HTTPException(status_code=403, detail="Access denied: path outside allowed directory")
-    if not resolved.exists():
-        raise HTTPException(status_code=404, detail="Path not found")
-    if not resolved.is_dir():
-        raise HTTPException(
-            status_code=400, detail="Not a directory — use /files/download for files"
-        )  # noqa: E501
 
     buf = io.BytesIO()
     file_count = 0
@@ -460,7 +460,29 @@ async def download_dir_as_zip(path: str):
                         "Skipping unreadable file during zip: %s",
                         file_path,
                     )
-    zip_bytes = buf.getvalue()
+    return buf.getvalue()
+
+
+@router.get("/files/download-zip")
+async def download_dir_as_zip(path: str):
+    """Download a directory (recursively) as a zip archive."""
+    from pocketpaw.config import get_settings
+    from pocketpaw.tools.fetch import is_safe_path
+
+    settings = get_settings()
+    resolved = _resolve_path(path)
+    jail = settings.file_jail_path.resolve()
+
+    if not is_safe_path(resolved, jail):
+        raise HTTPException(status_code=403, detail="Access denied: path outside allowed directory")
+    if not resolved.exists():
+        raise HTTPException(status_code=404, detail="Path not found")
+    if not resolved.is_dir():
+        raise HTTPException(
+            status_code=400, detail="Not a directory — use /files/download for files"
+        )  # noqa: E501
+
+    zip_bytes = await asyncio.to_thread(_build_zip_bytes, resolved, jail)
     zip_name = f"{resolved.name}.zip"
     return Response(
         content=zip_bytes,
@@ -564,7 +586,8 @@ async def git_status(
 
     try:
         # Get the current branch name
-        branch_result = subprocess.run(
+        branch_result = await asyncio.to_thread(
+            subprocess.run,
             ["git", "-C", str(resolved), "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
             text=True,
@@ -573,7 +596,8 @@ async def git_status(
         branch = branch_result.stdout.strip() if branch_result.returncode == 0 else None
 
         # Get the status in porcelain format
-        status_result = subprocess.run(
+        status_result = await asyncio.to_thread(
+            subprocess.run,
             ["git", "-C", str(resolved), "status", "--porcelain"],
             capture_output=True,
             text=True,
@@ -657,7 +681,8 @@ async def git_diff(
 
     try:
         relative_path = resolved.relative_to(git_root)
-        result = subprocess.run(
+        result = await asyncio.to_thread(
+            subprocess.run,
             [
                 "git",
                 "-C",
@@ -716,7 +741,8 @@ async def git_diff(
                 current_new_line += 1
 
         # Get branch name for display
-        branch_result = subprocess.run(
+        branch_result = await asyncio.to_thread(
+            subprocess.run,
             ["git", "-C", str(git_root), "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
             text=True,

--- a/src/pocketpaw/api/v1/terminal.py
+++ b/src/pocketpaw/api/v1/terminal.py
@@ -11,6 +11,11 @@ output is read from its PTY and broadcast to all connected SSE clients via
 an in-memory publish/subscribe pattern.
 
 Created: 2026-06-16
+Updated: 2026-09-04 — the lsof probe that seeds the shell's initial CWD now runs
+    through asyncio.to_thread. It is a blocking subprocess.run with a 5s
+    timeout, and ensure_running() is awaited from the SSE, input and resize
+    endpoints, so on a host where lsof is missing or slow the first terminal
+    connect stalled the whole single-process event loop.
 """
 
 from __future__ import annotations
@@ -129,7 +134,8 @@ class ShellProcess:
         # Seed the initial CWD by reading /proc/<pid>/cwd (Linux) or
         # using lsof (macOS). Fall back to $HOME.
         try:
-            result = subprocess.run(
+            result = await asyncio.to_thread(
+                subprocess.run,
                 ["lsof", "-p", str(self._proc.pid), "-d", "cwd", "-Fn"],
                 capture_output=True,
                 text=True,

--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -7,6 +7,15 @@ Extracted from dashboard.py — contains:
 - ``shutdown_event()`` — tears down all services
 
 Changes:
+- 2026-09-04 (fix/unblock-event-loop, backend-perf H1): every broadcast helper
+  here was its own copy of "iterate ``active_connections``, ``await
+  ws.send_json`` with no timeout". Six copies, none bounded. A client that
+  stopped reading held the loop on TCP back-pressure with no deadline, and the
+  dashboard is one uvicorn process, so that await stalled every other request.
+  All six now go through ``_fanout``, which sends concurrently and gives each
+  socket its own 5s deadline. The cloud package had already learned this the
+  hard way — see ``SEND_TIMEOUT_SECONDS`` in ``ee/.../chat/ws.py`` — but the
+  OSS dashboard path never got the fix.
 - 2026-08-01: ``startup_event`` installs the asyncio accept-noise filter
   (``pocketpaw.asyncio_noise``) as its first act, so the Windows proactor
   stops logging a full traceback every time a client aborts a connection
@@ -60,6 +69,57 @@ logger = logging.getLogger(__name__)
 # Broadcast helpers
 # ---------------------------------------------------------------------------
 
+# A single send must not be able to hold the dashboard's event loop open
+# indefinitely. A client that stops reading (backgrounded tab, sleeping laptop,
+# a NAT that dropped the flow without a FIN) leaves ``send_json`` waiting on
+# TCP back-pressure with no deadline of its own, and the dashboard runs one
+# uvicorn process: that await blocks every other request on the box.
+#
+# 5.0s matches ``SEND_TIMEOUT_SECONDS`` in the cloud package's ws.py, which
+# carries the reasoning in full — far above any healthy RTT, short enough that
+# a stalled fan-out is noticed.
+WS_SEND_TIMEOUT_SECONDS = 5.0
+
+# Cap on sends in flight per broadcast. The dashboard is single-tenant and
+# rarely has more than a handful of tabs open, so this is a guard rail rather
+# than a throttle.
+WS_FANOUT_CONCURRENCY = 32
+
+
+async def _fanout(message: dict) -> None:
+    """Deliver ``message`` to every dashboard socket, concurrently and bounded.
+
+    Every broadcast helper in this module used to be its own ``for`` loop with
+    one unbounded ``await ws.send_json(...)`` per socket, so delivery cost the
+    SUM of the connected clients' latencies and a single wedged client stalled
+    the rest indefinitely. Sends now run together, each with its own deadline.
+
+    A socket that raises OR times out is dropped from ``active_connections``.
+    Dropping on timeout is the part that matters: without it a wedged client
+    would be re-attempted on every subsequent broadcast, so adding the timeout
+    alone would have made the stall recur forever instead of once.
+    """
+    targets = list(active_connections)
+    if not targets:
+        return
+
+    sem = asyncio.Semaphore(WS_FANOUT_CONCURRENCY)
+
+    async def _send(ws):
+        async with sem:
+            try:
+                await asyncio.wait_for(ws.send_json(message), timeout=WS_SEND_TIMEOUT_SECONDS)
+            except Exception:
+                # Includes TimeoutError. CancelledError is a BaseException on
+                # 3.8+, so a cancelled broadcast still propagates rather than
+                # being mistaken for a dead socket.
+                return ws
+        return None
+
+    for ws in await asyncio.gather(*(_send(w) for w in targets)):
+        if ws is not None and ws in active_connections:
+            active_connections.remove(ws)
+
 
 async def broadcast_reminder(reminder: dict):
     """Broadcast a reminder notification to all connected clients."""
@@ -68,11 +128,7 @@ async def broadcast_reminder(reminder: dict):
 
     # Legacy broadcast (backup)
     message = {"type": "reminder", "reminder": reminder}
-    for ws in active_connections[:]:
-        try:
-            await ws.send_json(message)
-        except Exception:
-            pass
+    await _fanout(message)
 
     # Persist reminder as an assistant message in every active WebSocket session
     # so it survives session switches and page reloads.
@@ -113,12 +169,7 @@ async def broadcast_reminder(reminder: dict):
 async def broadcast_intention(intention_id: str, chunk: dict):
     """Broadcast intention execution results to all connected clients."""
     message = {"type": "intention_event", "intention_id": intention_id, **chunk}
-    for ws in active_connections[:]:
-        try:
-            await ws.send_json(message)
-        except Exception:
-            if ws in active_connections:
-                active_connections.remove(ws)
+    await _fanout(message)
 
     # Push message-type intention chunks to notification channels
     if chunk.get("type") == "message":
@@ -133,23 +184,13 @@ async def broadcast_intention(intention_id: str, chunk: dict):
 async def _broadcast_audit_entry(entry: dict):
     """Broadcast a new audit log entry to all connected WebSocket clients."""
     message = {"type": "system_event", "event_type": "audit_entry", "data": entry}
-    for ws in active_connections[:]:
-        try:
-            await ws.send_json(message)
-        except Exception:
-            if ws in active_connections:
-                active_connections.remove(ws)
+    await _fanout(message)
 
 
 async def _broadcast_health_update(summary: dict):
     """Broadcast health status update to all connected WebSocket clients."""
     message = {"type": "health_update", "data": summary}
-    for ws in active_connections[:]:
-        try:
-            await ws.send_json(message)
-        except Exception:
-            if ws in active_connections:
-                active_connections.remove(ws)
+    await _fanout(message)
 
 
 async def push_open_path(path: str, action: str = "navigate"):
@@ -164,11 +205,7 @@ async def push_open_path(path: str, action: str = "navigate"):
         ``"view"`` to open a file in the viewer.
     """
     message = {"type": "open_path", "path": path, "action": action}
-    for ws in active_connections[:]:
-        try:
-            await ws.send_json(message)
-        except Exception:
-            pass
+    await _fanout(message)
 
 
 # ---------------------------------------------------------------------------
@@ -466,11 +503,7 @@ async def startup_event(
 
         async def _mcp_ws_broadcast(message: dict) -> None:
             """Broadcast an MCP message to all connected WebSocket clients."""
-            for ws in active_connections[:]:
-                try:
-                    await ws.send_json(message)
-                except Exception:
-                    pass
+            await _fanout(message)
 
         set_ws_broadcast(_mcp_ws_broadcast)
 

--- a/tests/cloud/test_event_loop_blocking.py
+++ b/tests/cloud/test_event_loop_blocking.py
@@ -1,0 +1,392 @@
+# Regression: nothing on a request path may hold the event loop for the SUM of
+# its recipients, and no stream may live forever.
+#
+# Created 2026-09-04 (backend-perf H1, M7). PocketPaw runs ONE uvicorn process
+# with no --workers, so a coroutine that awaits serially over N recipients does
+# not just make itself slow — it is the only thing the box is doing for that
+# whole time.
+#
+#   H1  Every realtime fan-out was `for x in recipients: await send(x)`, running
+#       inline in the emitting HTTP request. ws.py already had a 5s per-socket
+#       timeout added for exactly this failure, but a per-send timeout bounds
+#       one send; the loop around it re-summed them. 200 members with ten
+#       back-pressured tabs = ~50s holding the sender's POST, with every
+#       individual timeout behaving perfectly.
+#   M7  The SSE run stream had no maximum lifetime. Its only exits were a
+#       terminal event or a failed yield, so a run that never wrote its terminal
+#       frame heartbeated forever.
+#
+# What each test would catch — see the repo's mutation rule, and
+# tests/mutations/event_loop.json for the mutations actually run:
+#   - revert bus.publish to a serial for-loop        -> TestBusFanOut
+#   - revert send_to_user's gather to a serial loop  -> TestConnectionManagerFanOut
+#   - drop the semaphore from map_bounded            -> test_concurrency_is_capped
+#   - delete the SSE deadline check                  -> TestStreamLifetime
+#   - make the stream cap a constant, not derived    -> test_cap_follows_job_timeout
+#
+# NOTE ON MEASURING CONCURRENCY: these tests assert on OBSERVED OVERLAP (how
+# many sends were in flight at once) and on ordering, never on wall-clock
+# duration. A timing assertion would be flaky on Windows, whose monotonic clock
+# ticks at ~15.6ms — the same granularity that already broke a sweep test in
+# this suite when it used max_age=0.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.bus import InProcessBus
+from pocketpaw_ee.cloud._core.realtime.fanout import FANOUT_CONCURRENCY, map_bounded
+from pocketpaw_ee.cloud.chat.runs import domain as runs_domain
+
+
+class _Tracker:
+    """Records maximum observed overlap across calls."""
+
+    def __init__(self) -> None:
+        self.in_flight = 0
+        self.max_in_flight = 0
+        self.order: list[str] = []
+
+    async def call(self, key: str, gate: asyncio.Event | None = None) -> str:
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        try:
+            if gate is not None:
+                await gate.wait()
+            else:
+                await asyncio.sleep(0)
+            self.order.append(key)
+            return key
+        finally:
+            self.in_flight -= 1
+
+
+class TestMapBounded:
+    @pytest.mark.asyncio
+    async def test_calls_run_concurrently(self):
+        t = _Tracker()
+        gate = asyncio.Event()
+
+        async def _run():
+            return await map_bounded([f"u{i}" for i in range(10)], lambda k: t.call(k, gate))
+
+        task = asyncio.create_task(_run())
+        # Let every coroutine reach the gate before releasing it. If the fan-out
+        # were serial only ONE would be waiting, because the second could not
+        # start until the first returned.
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert t.in_flight == 10, f"only {t.in_flight} sends were in flight; fan-out is serial"
+        gate.set()
+        assert await task == [f"u{i}" for i in range(10)]
+
+    @pytest.mark.asyncio
+    async def test_concurrency_is_capped(self):
+        """Unbounded gather would trade a latency problem for a task-count one."""
+        t = _Tracker()
+        gate = asyncio.Event()
+        n = FANOUT_CONCURRENCY * 3
+
+        async def _run():
+            return await map_bounded([f"u{i}" for i in range(n)], lambda k: t.call(k, gate))
+
+        task = asyncio.create_task(_run())
+        for _ in range(n + 5):
+            await asyncio.sleep(0)
+        assert t.max_in_flight == FANOUT_CONCURRENCY, (
+            f"{t.max_in_flight} sends in flight, expected the cap of {FANOUT_CONCURRENCY}"
+        )
+        gate.set()
+        await task
+
+    @pytest.mark.asyncio
+    async def test_results_stay_positional(self):
+        """Callers zip results against their input to attribute outcomes, so
+        completion order must not reorder them."""
+        delays = {"a": 0.03, "b": 0.0, "c": 0.015}
+
+        async def _slow(key: str) -> str:
+            await asyncio.sleep(delays[key])
+            return key.upper()
+
+        assert await map_bounded(["a", "b", "c"], _slow) == ["A", "B", "C"]
+
+    @pytest.mark.asyncio
+    async def test_empty_input_is_a_no_op(self):
+        assert await map_bounded([], lambda _: asyncio.sleep(0)) == []
+
+    @pytest.mark.asyncio
+    async def test_an_exception_propagates_instead_of_becoming_a_result(self):
+        """Do NOT reach for gather(return_exceptions=True) here.
+
+        Callers zip the returned list against their input and read each entry as
+        the outcome for that recipient. ``send_to_user`` reads it as a bool: an
+        exception OBJECT sitting in that list is truthy, so a socket that raised
+        would be counted as DELIVERED. That count is the signal
+        ``push/dispatch.py`` uses to skip Web Push, so the notification would be
+        dropped on the floor and every layer would report success.
+
+        Callers that want containment wrap their own coroutine — see
+        ``InProcessBus.publish``.
+        """
+
+        async def _boom(key: str) -> str:
+            if key == "bad":
+                raise RuntimeError("socket exploded")
+            return key
+
+        with pytest.raises(RuntimeError, match="socket exploded"):
+            await map_bounded(["ok", "bad"], _boom)
+
+
+class _StubConn:
+    """Stands in for ConnectionManager. Blocks until released, like a socket
+    that is not being read."""
+
+    def __init__(self, gate: asyncio.Event) -> None:
+        self.gate = gate
+        self.in_flight = 0
+        self.max_in_flight = 0
+        self.sent: list[str] = []
+
+    async def send_to_user(self, uid: str, payload) -> int:
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        try:
+            await self.gate.wait()
+            self.sent.append(uid)
+            return 1
+        finally:
+            self.in_flight -= 1
+
+
+class _StubResolver:
+    def __init__(self, audience: list[str]) -> None:
+        self._audience = audience
+
+    async def audience(self, event) -> list[str]:
+        return self._audience
+
+
+class _Event:
+    type = "message.new"
+    data = {"hello": "world"}
+
+
+class TestBusFanOut:
+    """publish() runs INLINE in the emitting HTTP request, which is why the
+    serial loop was charged to the sender."""
+
+    @pytest.mark.asyncio
+    async def test_publish_fans_out_concurrently(self):
+        gate = asyncio.Event()
+        conn = _StubConn(gate)
+        audience = [f"u{i}" for i in range(12)]
+        bus = InProcessBus(resolver=_StubResolver(audience), conn_manager=conn)
+
+        task = asyncio.create_task(bus.publish(_Event()))
+        for _ in range(20):
+            await asyncio.sleep(0)
+        assert conn.max_in_flight == 12, (
+            f"{conn.max_in_flight} of 12 recipients were in flight; "
+            "publish is still serial and charges the sender the sum"
+        )
+        gate.set()
+        await task
+        assert sorted(conn.sent) == sorted(audience)
+
+    @pytest.mark.asyncio
+    async def test_one_failing_recipient_does_not_abort_the_rest(self):
+        """Containment was per-recipient in the serial loop and must stay so."""
+        delivered: list[str] = []
+
+        class _Flaky:
+            async def send_to_user(self, uid: str, payload) -> int:
+                if uid == "bad":
+                    raise RuntimeError("socket exploded")
+                delivered.append(uid)
+                return 1
+
+        bus = InProcessBus(resolver=_StubResolver(["a", "bad", "b"]), conn_manager=_Flaky())
+        await bus.publish(_Event())
+        assert sorted(delivered) == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_local_handlers_still_run(self):
+        """The fan-out change must not disturb in-process subscribers."""
+        seen: list[str] = []
+
+        class _NoConn:
+            async def send_to_user(self, uid: str, payload) -> int:
+                return 1
+
+        bus = InProcessBus(resolver=_StubResolver([]), conn_manager=_NoConn())
+
+        async def _handler(event):
+            seen.append(event.type)
+
+        bus.subscribe("message.new", _handler)
+        await bus.publish(_Event())
+        assert seen == ["message.new"]
+
+
+class _FakeWS:
+    def __init__(self, name: str, gate: asyncio.Event | None = None) -> None:
+        self.name = name
+        self.gate = gate
+        self.received: list[dict] = []
+        # Tracks whether this socket's send has STARTED, which is the only
+        # thing that separates concurrent from serial here. Asserting on
+        # "hasn't finished" instead is vacuous: under a gate that nothing has
+        # released, no socket has finished in EITHER arrangement. That version
+        # of this test passed the serial mutation.
+        self.in_flight = False
+
+    async def send_json(self, data: dict) -> None:
+        self.in_flight = True
+        try:
+            if self.gate is not None:
+                await self.gate.wait()
+            self.received.append(data)
+        finally:
+            self.in_flight = False
+
+    async def close(self, *a, **kw) -> None:  # pragma: no cover - bookkeeping only
+        pass
+
+
+class TestConnectionManagerFanOut:
+    """One user's sockets are their open tabs and devices. Serially, one
+    back-pressured tab cost every other device the full 5s before its own frame
+    was even attempted."""
+
+    @pytest.mark.asyncio
+    async def test_send_to_user_sends_to_all_sockets_at_once(self):
+        from pocketpaw_ee.cloud.chat import ws as ws_mod
+
+        gate = asyncio.Event()
+        cm = ws_mod.ConnectionManager()
+        socks = [_FakeWS(f"s{i}", gate) for i in range(4)]
+        cm.active_connections["u1"] = set(socks)
+        for s in socks:
+            cm._ws_to_user[s] = "u1"
+
+        class _Msg:
+            def model_dump(self, mode="json"):
+                return {"type": "x"}
+
+        task = asyncio.create_task(cm.send_to_user("u1", _Msg()))
+        for _ in range(10):
+            await asyncio.sleep(0)
+        started = sum(1 for s in socks if s.in_flight)
+        assert started == 4, (
+            f"only {started} of 4 sockets had started; they are being written one at a time"
+        )
+        gate.set()
+        assert await task == 4
+        assert all(s.received for s in socks)
+
+    @pytest.mark.asyncio
+    async def test_delivered_count_survives_a_dead_socket(self):
+        """``delivered`` is the signal push/dispatch.py reads to choose WS over
+        Web Push. Getting it wrong silently eats notifications."""
+        from pocketpaw_ee.cloud.chat import ws as ws_mod
+
+        good = _FakeWS("good")
+        bad = _FakeWS("bad")
+
+        async def _explode(data):
+            raise RuntimeError("broken pipe")
+
+        bad.send_json = _explode
+
+        cm = ws_mod.ConnectionManager()
+        cm.active_connections["u1"] = {good, bad}
+        cm._ws_to_user[good] = "u1"
+        cm._ws_to_user[bad] = "u1"
+
+        class _Msg:
+            def model_dump(self, mode="json"):
+                return {"type": "x"}
+
+        assert await cm.send_to_user("u1", _Msg()) == 1
+        assert good.received == [{"type": "x"}]
+
+
+class _StubTransport:
+    """read_events yields nothing and returns, which is what a stream with no
+    new entries does after its block window expires."""
+
+    def __init__(self) -> None:
+        self.reads = 0
+
+    async def stream_exists(self, run_id: str) -> bool:
+        return True
+
+    async def read_events(self, run_id: str, *, after: str = "0", block_ms: int = 15000):
+        self.reads += 1
+        await asyncio.sleep(0)
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+
+class TestStreamLifetime:
+    @pytest.mark.asyncio
+    async def test_stream_terminates_at_the_deadline(self, monkeypatch):
+        """Without the cap this loop is infinite. The test would HANG rather
+        than fail on a revert, so it carries its own timeout."""
+        from pocketpaw_ee.cloud.chat.runs import router as runs_router
+
+        monkeypatch.setattr(runs_router, "stream_max_lifetime_seconds", lambda: 0)
+
+        transport = _StubTransport()
+        monkeypatch.setattr(runs_router, "get_stream_transport", lambda: transport)
+
+        class _Doc:
+            status = "running"
+            assistant_message_id = "m1"
+            usage: dict = {}
+            workspace = "w1"
+            user_id = "u1"
+
+        async def _authorize(run_id, workspace_id, user_id):
+            return _Doc()
+
+        monkeypatch.setattr(runs_router, "_authorize", _authorize)
+
+        response = await runs_router.get_run_stream(
+            "r1", after="0", user_id="u1", workspace_id="w1"
+        )
+        frames = []
+        async with asyncio.timeout(10):
+            async for chunk in response.body_iterator:
+                frames.append(chunk if isinstance(chunk, bytes) else chunk.encode())
+
+        body = b"".join(frames)
+        assert b"event: error" in body, f"stream did not terminate; got {body!r}"
+        assert b"run.stream_timeout" in body
+        assert transport.reads >= 1, "the deadline fired before reading anything"
+
+    def test_cap_follows_the_job_timeout(self, monkeypatch):
+        """Derived, not a second knob. A cap SHORTER than the run it watches
+        severs healthy long runs and reads as a backend bug."""
+        monkeypatch.setenv("POCKETPAW_CLOUD_RUN_JOB_TIMEOUT", "7200")
+        assert runs_domain.run_job_timeout_seconds() == 7200
+        assert runs_domain.stream_max_lifetime_seconds() > 7200
+
+    def test_cap_is_never_shorter_than_the_run(self, monkeypatch):
+        for raw in ("", "1800", "60", "not-a-number", "-1", "0"):
+            monkeypatch.setenv("POCKETPAW_CLOUD_RUN_JOB_TIMEOUT", raw)
+            assert (
+                runs_domain.stream_max_lifetime_seconds() > runs_domain.run_job_timeout_seconds()
+            ), f"cap would cut a healthy run short at POCKETPAW_CLOUD_RUN_JOB_TIMEOUT={raw!r}"
+
+    def test_worker_and_stream_read_one_resolver(self, monkeypatch):
+        """Two copies of the parse would let the cap and the run drift apart."""
+        from pocketpaw_ee.cloud.chat.runs import worker as worker_mod
+
+        assert worker_mod._job_timeout_seconds is runs_domain.run_job_timeout_seconds
+        monkeypatch.setenv("POCKETPAW_CLOUD_RUN_JOB_TIMEOUT", "2400")
+        assert worker_mod._job_timeout_seconds() == 2400
+        assert runs_domain.stream_max_lifetime_seconds() > 2400

--- a/tests/mutations/event_loop.json
+++ b/tests/mutations/event_loop.json
@@ -1,0 +1,72 @@
+[
+  {
+    "label": "bus.publish goes back to a serial per-recipient await",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/bus.py",
+    "find": "            await map_bounded(list(audience), _deliver)",
+    "replace": "            for _uid in list(audience):\n                await _deliver(_uid)",
+    "tests": ["tests/cloud/test_event_loop_blocking.py::TestBusFanOut::test_publish_fans_out_concurrently"]
+  },
+  {
+    "label": "map_bounded drops the concurrency cap",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/fanout.py",
+    "find": "    sem = asyncio.Semaphore(limit)\n\n    async def _one(item: T) -> R:\n        async with sem:\n            return await fn(item)",
+    "replace": "    async def _one(item: T) -> R:\n        return await fn(item)",
+    "tests": ["tests/cloud/test_event_loop_blocking.py::TestMapBounded::test_concurrency_is_capped"]
+  },
+  {
+    "label": "map_bounded captures exceptions as results, hiding cancellation",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/fanout.py",
+    "find": "    return list(await asyncio.gather(*(_one(item) for item in items)))",
+    "replace": "    return list(await asyncio.gather(*(_one(item) for item in items), return_exceptions=True))",
+    "tests": ["tests/cloud/test_event_loop_blocking.py::TestMapBounded::test_an_exception_propagates_instead_of_becoming_a_result"]
+  },
+  {
+    "label": "send_to_user writes one socket at a time again",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "        results = await map_bounded(fresh, lambda ws: self._send_bounded(ws, data))\n\n        delivered = 0",
+    "replace": "        results = [await self._send_bounded(_w, data) for _w in fresh]\n\n        delivered = 0",
+    "tests": ["tests/cloud/test_event_loop_blocking.py::TestConnectionManagerFanOut::test_send_to_user_sends_to_all_sockets_at_once"]
+  },
+  {
+    "label": "the SSE stream loses its maximum lifetime",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/router.py",
+    "find": "            if time.monotonic() >= deadline:",
+    "replace": "            if False:",
+    "tests": ["tests/cloud/test_event_loop_blocking.py::TestStreamLifetime::test_stream_terminates_at_the_deadline"]
+  },
+  {
+    "label": "the stream cap becomes a fixed constant instead of following the run",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/domain.py",
+    "find": "    return run_job_timeout_seconds() + STREAM_LIFETIME_GRACE_SECONDS",
+    "replace": "    return DEFAULT_RUN_JOB_TIMEOUT_SECONDS + STREAM_LIFETIME_GRACE_SECONDS",
+    "tests": ["tests/cloud/test_event_loop_blocking.py::TestStreamLifetime::test_cap_follows_the_job_timeout"]
+  },
+  {
+    "label": "the worker keeps a second private copy of the timeout parse",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "_job_timeout_seconds = run_job_timeout_seconds",
+    "replace": "_job_timeout_seconds = lambda: DEFAULT_RUN_JOB_TIMEOUT_SECONDS  # noqa: E731",
+    "tests": ["tests/cloud/test_event_loop_blocking.py::TestStreamLifetime::test_worker_and_stream_read_one_resolver"]
+  },
+  {
+    "label": "the dashboard broadcast loses its per-socket timeout",
+    "file": "src/pocketpaw/dashboard_lifecycle.py",
+    "find": "                await asyncio.wait_for(ws.send_json(message), timeout=WS_SEND_TIMEOUT_SECONDS)",
+    "replace": "                await ws.send_json(message)",
+    "tests": ["tests/test_dashboard_fanout.py::test_a_wedged_socket_cannot_stall_the_broadcast"]
+  },
+  {
+    "label": "the dashboard broadcast goes back to a serial loop",
+    "file": "src/pocketpaw/dashboard_lifecycle.py",
+    "find": "    for ws in await asyncio.gather(*(_send(w) for w in targets)):",
+    "replace": "    for ws in [await _send(w) for w in targets]:",
+    "tests": ["tests/test_dashboard_fanout.py::test_sends_run_concurrently"]
+  },
+  {
+    "label": "a timed-out dashboard socket is kept, so the stall recurs forever",
+    "file": "src/pocketpaw/dashboard_lifecycle.py",
+    "find": "        if ws is not None and ws in active_connections:\n            active_connections.remove(ws)",
+    "replace": "        if ws is not None and False:\n            active_connections.remove(ws)",
+    "tests": ["tests/test_dashboard_fanout.py::test_a_timed_out_socket_is_dropped"]
+  }
+]

--- a/tests/mutations/event_loop.json
+++ b/tests/mutations/event_loop.json
@@ -4,69 +4,152 @@
     "file": "ee/pocketpaw_ee/cloud/_core/realtime/bus.py",
     "find": "            await map_bounded(list(audience), _deliver)",
     "replace": "            for _uid in list(audience):\n                await _deliver(_uid)",
-    "tests": ["tests/cloud/test_event_loop_blocking.py::TestBusFanOut::test_publish_fans_out_concurrently"]
+    "tests": [
+      "tests/cloud/test_event_loop_blocking.py::TestBusFanOut::test_publish_fans_out_concurrently"
+    ]
   },
   {
     "label": "map_bounded drops the concurrency cap",
     "file": "ee/pocketpaw_ee/cloud/_core/realtime/fanout.py",
     "find": "    sem = asyncio.Semaphore(limit)\n\n    async def _one(item: T) -> R:\n        async with sem:\n            return await fn(item)",
     "replace": "    async def _one(item: T) -> R:\n        return await fn(item)",
-    "tests": ["tests/cloud/test_event_loop_blocking.py::TestMapBounded::test_concurrency_is_capped"]
+    "tests": [
+      "tests/cloud/test_event_loop_blocking.py::TestMapBounded::test_concurrency_is_capped"
+    ]
   },
   {
     "label": "map_bounded captures exceptions as results, hiding cancellation",
     "file": "ee/pocketpaw_ee/cloud/_core/realtime/fanout.py",
     "find": "    return list(await asyncio.gather(*(_one(item) for item in items)))",
     "replace": "    return list(await asyncio.gather(*(_one(item) for item in items), return_exceptions=True))",
-    "tests": ["tests/cloud/test_event_loop_blocking.py::TestMapBounded::test_an_exception_propagates_instead_of_becoming_a_result"]
+    "tests": [
+      "tests/cloud/test_event_loop_blocking.py::TestMapBounded::test_an_exception_propagates_instead_of_becoming_a_result"
+    ]
   },
   {
     "label": "send_to_user writes one socket at a time again",
     "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
     "find": "        results = await map_bounded(fresh, lambda ws: self._send_bounded(ws, data))\n\n        delivered = 0",
     "replace": "        results = [await self._send_bounded(_w, data) for _w in fresh]\n\n        delivered = 0",
-    "tests": ["tests/cloud/test_event_loop_blocking.py::TestConnectionManagerFanOut::test_send_to_user_sends_to_all_sockets_at_once"]
+    "tests": [
+      "tests/cloud/test_event_loop_blocking.py::TestConnectionManagerFanOut::test_send_to_user_sends_to_all_sockets_at_once"
+    ]
   },
   {
     "label": "the SSE stream loses its maximum lifetime",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/router.py",
     "find": "            if time.monotonic() >= deadline:",
     "replace": "            if False:",
-    "tests": ["tests/cloud/test_event_loop_blocking.py::TestStreamLifetime::test_stream_terminates_at_the_deadline"]
+    "tests": [
+      "tests/cloud/test_event_loop_blocking.py::TestStreamLifetime::test_stream_terminates_at_the_deadline"
+    ]
   },
   {
     "label": "the stream cap becomes a fixed constant instead of following the run",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/domain.py",
     "find": "    return run_job_timeout_seconds() + STREAM_LIFETIME_GRACE_SECONDS",
     "replace": "    return DEFAULT_RUN_JOB_TIMEOUT_SECONDS + STREAM_LIFETIME_GRACE_SECONDS",
-    "tests": ["tests/cloud/test_event_loop_blocking.py::TestStreamLifetime::test_cap_follows_the_job_timeout"]
+    "tests": [
+      "tests/cloud/test_event_loop_blocking.py::TestStreamLifetime::test_cap_follows_the_job_timeout"
+    ]
   },
   {
     "label": "the worker keeps a second private copy of the timeout parse",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
     "find": "_job_timeout_seconds = run_job_timeout_seconds",
     "replace": "_job_timeout_seconds = lambda: DEFAULT_RUN_JOB_TIMEOUT_SECONDS  # noqa: E731",
-    "tests": ["tests/cloud/test_event_loop_blocking.py::TestStreamLifetime::test_worker_and_stream_read_one_resolver"]
+    "tests": [
+      "tests/cloud/test_event_loop_blocking.py::TestStreamLifetime::test_worker_and_stream_read_one_resolver"
+    ]
   },
   {
     "label": "the dashboard broadcast loses its per-socket timeout",
     "file": "src/pocketpaw/dashboard_lifecycle.py",
     "find": "                await asyncio.wait_for(ws.send_json(message), timeout=WS_SEND_TIMEOUT_SECONDS)",
     "replace": "                await ws.send_json(message)",
-    "tests": ["tests/test_dashboard_fanout.py::test_a_wedged_socket_cannot_stall_the_broadcast"]
+    "tests": [
+      "tests/test_dashboard_fanout.py::test_a_wedged_socket_cannot_stall_the_broadcast"
+    ]
   },
   {
     "label": "the dashboard broadcast goes back to a serial loop",
     "file": "src/pocketpaw/dashboard_lifecycle.py",
     "find": "    for ws in await asyncio.gather(*(_send(w) for w in targets)):",
     "replace": "    for ws in [await _send(w) for w in targets]:",
-    "tests": ["tests/test_dashboard_fanout.py::test_sends_run_concurrently"]
+    "tests": [
+      "tests/test_dashboard_fanout.py::test_sends_run_concurrently"
+    ]
   },
   {
     "label": "a timed-out dashboard socket is kept, so the stall recurs forever",
     "file": "src/pocketpaw/dashboard_lifecycle.py",
     "find": "        if ws is not None and ws in active_connections:\n            active_connections.remove(ws)",
     "replace": "        if ws is not None and False:\n            active_connections.remove(ws)",
-    "tests": ["tests/test_dashboard_fanout.py::test_a_timed_out_socket_is_dropped"]
+    "tests": [
+      "tests/test_dashboard_fanout.py::test_a_timed_out_socket_is_dropped"
+    ]
+  },
+  {
+    "label": "git_status runs its subprocess inline again",
+    "file": "src/pocketpaw/api/v1/files.py",
+    "find": "        status_result = await asyncio.to_thread(\n            subprocess.run,\n            [\"git\", \"-C\", str(resolved), \"status\", \"--porcelain\"],",
+    "replace": "        status_result = subprocess.run(\n            [\"git\", \"-C\", str(resolved), \"status\", \"--porcelain\"],",
+    "tests": [
+      "tests/test_blocking_offload.py::test_git_status_keeps_the_loop_running"
+    ]
+  },
+  {
+    "label": "git_diff runs its subprocess inline again",
+    "file": "src/pocketpaw/api/v1/files.py",
+    "find": "        result = await asyncio.to_thread(\n            subprocess.run,\n            [\n                \"git\",",
+    "replace": "        result = subprocess.run(\n            [\n                \"git\",",
+    "tests": [
+      "tests/test_blocking_offload.py::test_git_diff_keeps_the_loop_running"
+    ]
+  },
+  {
+    "label": "the zip deflate goes back on the event loop",
+    "file": "src/pocketpaw/api/v1/files.py",
+    "find": "    zip_bytes = await asyncio.to_thread(_build_zip_bytes, resolved, jail)",
+    "replace": "    zip_bytes = _build_zip_bytes(resolved, jail)",
+    "tests": [
+      "tests/test_blocking_offload.py::test_download_zip_keeps_the_loop_running"
+    ]
+  },
+  {
+    "label": "the clone tree walk goes back on the event loop",
+    "file": "src/pocketpaw/api/v1/cloud_projects.py",
+    "find": "    for local_path in await asyncio.to_thread(_walk_repo_files, base, include_git):",
+    "replace": "    for local_path in _walk_repo_files(base, include_git):",
+    "tests": [
+      "tests/test_blocking_offload.py::test_upload_directory_walk_keeps_the_loop_running"
+    ]
+  },
+  {
+    "label": "the .git prune is lost when the walk moves to a thread",
+    "file": "src/pocketpaw/api/v1/cloud_projects.py",
+    "find": "        if not include_git:\n            dirs[:] = [d for d in dirs if d != \".git\"]",
+    "replace": "        if False:\n            dirs[:] = [d for d in dirs if d != \".git\"]",
+    "tests": [
+      "tests/test_blocking_offload.py::test_walk_repo_files_still_prunes_dot_git"
+    ]
+  },
+  {
+    "label": "the terminal lsof probe runs inline again",
+    "file": "src/pocketpaw/api/v1/terminal.py",
+    "find": "            result = await asyncio.to_thread(\n                subprocess.run,\n                [\"lsof\", \"-p\", str(self._proc.pid), \"-d\", \"cwd\", \"-Fn\"],",
+    "replace": "            result = subprocess.run(\n                [\"lsof\", \"-p\", str(self._proc.pid), \"-d\", \"cwd\", \"-Fn\"],",
+    "tests": [
+      "tests/test_blocking_offload.py::test_terminal_lsof_probe_keeps_the_loop_running"
+    ]
+  },
+  {
+    "label": "to_thread wraps the subprocess timeout instead of re-raising it",
+    "file": "src/pocketpaw/api/v1/files.py",
+    "find": "    except subprocess.TimeoutExpired:\n        return GitStatusResponse(",
+    "replace": "    except RuntimeError:\n        return GitStatusResponse(",
+    "tests": [
+      "tests/test_blocking_offload.py::test_git_status_still_reports_a_subprocess_timeout"
+    ]
   }
 ]

--- a/tests/test_blocking_offload.py
+++ b/tests/test_blocking_offload.py
@@ -1,0 +1,385 @@
+"""Proof that the known blocking calls on request paths run off the event loop.
+
+Added: 2026-09-04 (fix/unblock-event-loop). PocketPaw serves from a single
+uvicorn process with no ``--workers``, so a synchronous call inside an ``async
+def`` handler freezes *every* concurrent request for its full duration. Six
+sites did exactly that: the git subprocesses in /git/status and /git/diff, the
+deflate loop in /files/download-zip, the lsof CWD probe in the terminal shell,
+and the os.walk in the cloud-project uploader.
+
+Each test drives the real handler with the blocking call stubbed to sleep,
+while a ticker coroutine runs alongside it. The assertion is on the ticker: if
+the offload is reverted the ticker records nothing while the handler runs, and
+the test fails. Nothing here inspects source text, so a rewrite that keeps the
+work off the loop by some other means still passes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import subprocess
+import sys
+import time
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pocketpaw.api.v1 import cloud_projects, files
+
+# The stub sleeps this long; the ticker wakes this often. Windows timer
+# resolution is ~15.6 ms, so a 0.4 s window still affords ~25 ticks even when
+# the 10 ms interval rounds up. _MIN_TICKS sits well under that, and a blocked
+# loop records zero, so the two cases can never be confused.
+_BLOCK_SECONDS = 0.4
+_TICK_SECONDS = 0.01
+_MIN_TICKS = 5
+
+# Fraction of the ACHIEVABLE tick rate a handler must deliver.
+#
+# Why a fraction and not a floor: /git/status and /git/diff each make TWO
+# subprocess calls. A floor of "some ticks happened" is satisfied by offloading
+# only ONE of them — the other half of the call blocks the loop and the test
+# still passes. Both mutations that revert a single call escaped exactly that
+# way before this assertion was proportional.
+#
+# Why the baseline is MEASURED rather than computed as elapsed/_TICK_SECONDS:
+# Windows' timer granularity is ~15.6 ms, so `asyncio.sleep(0.01)` really takes
+# ~15.6 ms and the loop delivers roughly 64 ticks/s, not 100. The theoretical
+# figure overstates by about 40% — enough to fail a handler that is behaving
+# perfectly, which is exactly what it did on the first attempt here.
+# Calibrating against an idle window takes the platform out of the assertion.
+#
+# A fully offloaded handler scores ~1.0 against that baseline and a half-blocked
+# one ~0.5, so 0.75 has real margin in both directions.
+_MIN_TICK_COVERAGE = 0.75
+
+
+def _assert_loop_stayed_free(during: int, elapsed: float, rate: float, label: str) -> None:
+    """Assert the ticker ran for essentially the whole handler call."""
+    expected = rate * elapsed
+    assert during >= _MIN_TICKS, f"{label}: loop was blocked outright ({during} ticks)"
+    assert during >= expected * _MIN_TICK_COVERAGE, (
+        f"{label}: {during} ticks in {elapsed:.2f}s against an idle baseline of "
+        f"~{expected:.0f} — part of the handler is still on the event loop"
+    )
+
+
+async def _idle_tick_rate() -> float:
+    """Ticks per second this machine actually delivers when the loop is free.
+
+    The control for the measurements below. Any figure derived from
+    ``_TICK_SECONDS`` instead describes the sleep we REQUESTED, not the one the
+    platform granted.
+    """
+    _, during, elapsed = await _run_with_ticker(lambda: asyncio.sleep(_BLOCK_SECONDS * 2))
+    return during / elapsed
+
+
+async def _run_with_ticker(factory):
+    """Await ``factory()`` while a ticker runs, and count ticks landing inside.
+
+    Returns ``(result, ticks_during, elapsed)``. Only ticks recorded strictly
+    between the start and the end of the awaited call are counted — that is
+    what makes the assertion sharp, since ticks before and after happen either
+    way.
+    """
+    ticks: list[float] = []
+    stop = asyncio.Event()
+
+    async def _ticker() -> None:
+        while not stop.is_set():
+            ticks.append(time.perf_counter())
+            await asyncio.sleep(_TICK_SECONDS)
+
+    task = asyncio.create_task(_ticker())
+    await asyncio.sleep(0)  # let the ticker reach its first sleep
+    started = time.perf_counter()
+    try:
+        result = await factory()
+    finally:
+        finished = time.perf_counter()
+        stop.set()
+        await task
+    during = sum(1 for t in ticks if started < t < finished)
+    return result, during, finished - started
+
+
+def _blocking_run(stdout: str = ""):
+    """A ``subprocess.run`` stand-in that blocks, then reports success."""
+
+    def _run(*args, **kwargs):
+        time.sleep(_BLOCK_SECONDS)
+        return subprocess.CompletedProcess(
+            args=args[0] if args else [],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+
+    return _run
+
+
+@pytest.fixture
+def jail(tmp_path):
+    """A file jail holding a fake git repo, with settings pointed at it."""
+    root = tmp_path / "jail"
+    repo = root / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "tracked.txt").write_text("hello\n", encoding="utf-8")
+
+    settings = MagicMock()
+    settings.file_jail_path = root
+    with patch("pocketpaw.config.get_settings", return_value=settings):
+        yield repo
+
+
+# ── files.py — /git/status ────────────────────────────────────────────────
+
+
+async def test_git_status_keeps_the_loop_running(jail):
+    rate = await _idle_tick_rate()
+    with patch.object(subprocess, "run", _blocking_run("main\n")):
+        response, during, elapsed = await _run_with_ticker(lambda: files.git_status(path=str(jail)))
+
+    # Two git invocations (rev-parse + status), so the stub slept twice — and
+    # BOTH have to be offloaded. Asserting only that some ticks landed passes
+    # when just one of them is.
+    assert elapsed >= _BLOCK_SECONDS * 2
+    _assert_loop_stayed_free(during, elapsed, rate, "git_status")
+    assert response.is_git_repo is True
+    assert response.branch == "main"
+
+
+async def test_git_status_still_reports_a_subprocess_timeout(jail):
+    """to_thread has to re-raise the original exception, not wrap it.
+
+    The handler catches ``subprocess.TimeoutExpired`` by type. If the offload
+    swallowed or wrapped it the call would fall through to the generic
+    ``except Exception`` branch and the error string would change.
+    """
+
+    def _timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["git"], timeout=10)
+
+    with patch.object(subprocess, "run", _timeout):
+        response = await files.git_status(path=str(jail))
+
+    assert response.is_git_repo is True
+    assert response.error == "Git operation timed out"
+
+
+# ── files.py — /git/diff ──────────────────────────────────────────────────
+
+
+async def test_git_diff_keeps_the_loop_running(jail):
+    target = jail / "tracked.txt"
+    rate = await _idle_tick_rate()
+
+    with patch.object(subprocess, "run", _blocking_run("")):
+        response, during, elapsed = await _run_with_ticker(lambda: files.git_diff(path=str(target)))
+
+    # Two git invocations (diff + rev-parse) — both must be offloaded.
+    assert elapsed >= _BLOCK_SECONDS * 2
+    _assert_loop_stayed_free(during, elapsed, rate, "git_diff")
+    assert response.is_git_repo is True
+
+
+# ── files.py — /files/download-zip ────────────────────────────────────────
+
+
+class _BlockingZipFile:
+    """A ``zipfile.ZipFile`` stand-in whose ``write`` blocks like a deflate."""
+
+    def __init__(self, buf, mode="w", compression=0):
+        self._buf = buf
+
+    def __enter__(self) -> _BlockingZipFile:
+        return self
+
+    def __exit__(self, *exc_info) -> bool:
+        # Minimal end-of-central-directory record, so the response body is at
+        # least shaped like an archive.
+        self._buf.write(b"PK\x05\x06" + b"\x00" * 18)
+        return False
+
+    def write(self, filename, arcname=None) -> None:
+        time.sleep(_BLOCK_SECONDS)
+
+
+async def test_download_zip_keeps_the_loop_running(jail):
+    # One eligible file in the directory → exactly one blocking write().
+    with patch.object(files.zipfile, "ZipFile", _BlockingZipFile):
+        response, during, elapsed = await _run_with_ticker(
+            lambda: files.download_dir_as_zip(path=str(jail))
+        )
+
+    assert elapsed >= _BLOCK_SECONDS
+    assert during >= _MIN_TICKS, f"loop was blocked: {during} ticks in {elapsed:.2f}s"
+    assert response.media_type == "application/zip"
+
+
+# ── cloud_projects.py — the clone uploader's tree walk ────────────────────
+
+
+class _RecordingAdapter:
+    """Storage adapter stand-in that drains each stream and records the key."""
+
+    def __init__(self) -> None:
+        self.keys: list[str] = []
+
+    async def put(self, key, stream, mime) -> None:
+        async for _ in stream:
+            pass
+        self.keys.append(key)
+
+
+async def test_upload_directory_walk_keeps_the_loop_running(tmp_path):
+    base = tmp_path / "clone"
+    base.mkdir()
+    (base / "a.txt").write_bytes(b"a")
+
+    def _blocking_walk(top, *args, **kwargs):
+        time.sleep(_BLOCK_SECONDS)
+        return [(str(base), [], ["a.txt"])]
+
+    adapter = _RecordingAdapter()
+    with (
+        patch.object(cloud_projects.os, "walk", _blocking_walk),
+        patch.object(cloud_projects, "_ADAPTER", adapter),
+    ):
+        _, during, elapsed = await _run_with_ticker(
+            lambda: cloud_projects._upload_directory(str(base), "projects/w/u/p/")
+        )
+
+    assert elapsed >= _BLOCK_SECONDS
+    assert during >= _MIN_TICKS, f"loop was blocked: {during} ticks in {elapsed:.2f}s"
+    assert adapter.keys == ["projects/w/u/p/a.txt"]
+
+
+def test_walk_repo_files_still_prunes_dot_git(tmp_path):
+    """The .git prune works by mutating ``dirs`` mid-walk, so it has to live
+    inside the helper that runs the walk rather than alongside it."""
+    base = tmp_path / "repo"
+    (base / ".git" / "objects").mkdir(parents=True)
+    (base / ".git" / "config").write_text("x", encoding="utf-8")
+    (base / "src").mkdir()
+    (base / "src" / "main.py").write_text("y", encoding="utf-8")
+
+    pruned = cloud_projects._walk_repo_files(base, include_git=False)
+    kept = cloud_projects._walk_repo_files(base, include_git=True)
+
+    assert [p.name for p in pruned] == ["main.py"]
+    assert sorted(p.name for p in kept) == ["config", "main.py"]
+
+
+# ── terminal.py — the lsof CWD probe ──────────────────────────────────────
+
+
+@pytest.fixture
+def terminal_module():
+    """Import the terminal router, faking the POSIX-only modules it needs.
+
+    ``pocketpaw.api.v1.terminal`` imports fcntl / pty / termios at module
+    scope, so on Windows it cannot be imported at all — and this is a Windows
+    dev machine. The fakes go in only when the real modules are missing, so on
+    Linux the test exercises the genuine imports.
+    """
+    injected: list[str] = []
+
+    try:
+        importlib.import_module("fcntl")
+    except ImportError:
+        fake_fcntl = types.ModuleType("fcntl")
+        fake_fcntl.F_GETFL = 3
+        fake_fcntl.F_SETFL = 4
+        fake_fcntl.fcntl = lambda *a, **k: 0
+        fake_fcntl.ioctl = lambda *a, **k: 0
+        sys.modules["fcntl"] = fake_fcntl
+        injected.append("fcntl")
+
+        fake_termios = types.ModuleType("termios")
+        for name, value in (
+            ("TIOCSWINSZ", 0x5414),
+            ("TCSANOW", 0),
+            ("OPOST", 0x1),
+            ("ONLCR", 0x4),
+            ("ICANON", 0x2),
+            ("ECHO", 0x8),
+            ("ECHOE", 0x10),
+            ("ECHOK", 0x20),
+            ("ECHONL", 0x40),
+            ("ISIG", 0x80),
+        ):
+            setattr(fake_termios, name, value)
+        fake_termios.tcgetattr = lambda fd: [0, 0, 0, 0, 0, 0, []]
+        fake_termios.tcsetattr = lambda *a, **k: None
+        sys.modules["termios"] = fake_termios
+        injected.append("termios")
+
+        fake_pty = types.ModuleType("pty")
+        fake_pty.openpty = lambda: (0, 0)
+        sys.modules["pty"] = fake_pty
+        injected.append("pty")
+
+    module = importlib.import_module("pocketpaw.api.v1.terminal")
+    try:
+        yield module
+    finally:
+        # Leaving fakes in sys.modules would let an unrelated import of a real
+        # POSIX module silently pick them up later in the run.
+        if injected:
+            sys.modules.pop("pocketpaw.api.v1.terminal", None)
+        for name in injected:
+            sys.modules.pop(name, None)
+
+
+async def test_terminal_lsof_probe_keeps_the_loop_running(terminal_module):
+    """``ensure_running`` is awaited by the SSE, input and resize endpoints.
+
+    Everything around the probe is faked out; the subject is the probe itself,
+    a ``subprocess.run`` with a 5 s timeout that used to run inline.
+    """
+    terminal = terminal_module
+    read_fd, write_fd = os.pipe()
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 4242
+    fake_proc.returncode = None
+
+    async def _fake_exec(*args, **kwargs):
+        return fake_proc
+
+    async def _noop_reader(self) -> None:
+        return None
+
+    session = terminal.ShellProcess()
+
+    try:
+        with (
+            # openpty hands back a real pipe so the PROMPT_COMMAND os.write
+            # lands somewhere; os.close is neutered so the read end survives
+            # it and the write cannot raise BrokenPipeError.
+            patch.object(terminal.pty, "openpty", lambda: (write_fd, read_fd)),
+            patch.object(terminal.os, "close", lambda fd: None),
+            patch.object(terminal.os, "O_NONBLOCK", 0, create=True),
+            patch.object(terminal.fcntl, "ioctl", lambda *a, **k: 0),
+            patch.object(terminal.fcntl, "fcntl", lambda *a, **k: 0),
+            patch.object(terminal.termios, "tcgetattr", lambda fd: [0, 0, 0, 0, 0, 0, []]),
+            patch.object(terminal.termios, "tcsetattr", lambda *a, **k: None),
+            patch.object(terminal.asyncio, "create_subprocess_exec", _fake_exec),
+            patch.object(terminal.ShellProcess, "_reader_loop", _noop_reader),
+            patch.object(subprocess, "run", _blocking_run("p4242\nfcwdn/tmp\n")),
+        ):
+            _, during, elapsed = await _run_with_ticker(session.ensure_running)
+    finally:
+        if session._task is not None:
+            session._task.cancel()
+        os.close(read_fd)
+        os.close(write_fd)
+
+    assert elapsed >= _BLOCK_SECONDS
+    assert during >= _MIN_TICKS, f"loop was blocked: {during} ticks in {elapsed:.2f}s"
+    assert session._cwd == "/tmp"

--- a/tests/test_dashboard_fanout.py
+++ b/tests/test_dashboard_fanout.py
@@ -1,0 +1,154 @@
+# Regression: the OSS dashboard's WebSocket broadcasts must be bounded.
+#
+# Created 2026-09-04 (backend-perf H1, OSS half). The cloud package learned this
+# in August — see SEND_TIMEOUT_SECONDS in ee/.../chat/ws.py, added because "one
+# stuck socket would stall delivery to every other member and the sender's own
+# request". The OSS dashboard path never got the fix: six copies of "iterate
+# active_connections, await ws.send_json, no timeout", so a client that stopped
+# reading held the loop on TCP back-pressure with no deadline at all. The
+# dashboard is one uvicorn process, so that await is the whole box.
+#
+# What each test would catch (mutations in tests/mutations/event_loop.json):
+#   - drop the asyncio.wait_for wrapper  -> test_a_wedged_socket_cannot_stall
+#   - go back to a serial for-loop       -> test_sends_run_concurrently
+#   - stop removing timed-out sockets    -> test_a_timed_out_socket_is_dropped
+#
+# The last one is the subtle one. Adding a timeout WITHOUT dropping the socket
+# would have made things worse, not better: a wedged client would then be
+# re-attempted, and re-time-out, on every subsequent broadcast forever.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pocketpaw import dashboard_lifecycle as dl
+from pocketpaw.dashboard_state import active_connections
+
+
+class _FakeWS:
+    def __init__(self, name: str, gate: asyncio.Event | None = None, hang: bool = False):
+        self.name = name
+        self.gate = gate
+        self.hang = hang
+        self.received: list[dict] = []
+        self.in_flight = False
+
+    async def send_json(self, data: dict) -> None:
+        self.in_flight = True
+        try:
+            if self.hang:
+                await asyncio.sleep(3600)
+            if self.gate is not None:
+                await self.gate.wait()
+            self.received.append(data)
+        finally:
+            self.in_flight = False
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """active_connections is a module-level singleton shared with the running
+    dashboard, so leaving entries in it leaks into unrelated tests."""
+    active_connections.clear()
+    yield
+    active_connections.clear()
+
+
+async def test_sends_run_concurrently():
+    gate = asyncio.Event()
+    socks = [_FakeWS(f"s{i}", gate) for i in range(6)]
+    active_connections.extend(socks)
+
+    task = asyncio.create_task(dl._fanout({"type": "ping"}))
+    for _ in range(12):
+        await asyncio.sleep(0)
+
+    assert sum(1 for s in socks if s.in_flight) == 6, (
+        "sockets are being written one at a time; a slow client delays the rest"
+    )
+    gate.set()
+    await task
+    assert all(s.received == [{"type": "ping"}] for s in socks)
+
+
+async def test_a_wedged_socket_cannot_stall_the_broadcast(monkeypatch):
+    """The point of the timeout. A client that stopped reading leaves send_json
+    waiting on TCP back-pressure with no deadline of its own."""
+    monkeypatch.setattr(dl, "WS_SEND_TIMEOUT_SECONDS", 0.05)
+
+    wedged = _FakeWS("wedged", hang=True)
+    healthy = _FakeWS("healthy")
+    active_connections.extend([wedged, healthy])
+
+    async with asyncio.timeout(5):
+        await dl._fanout({"type": "ping"})
+
+    assert healthy.received == [{"type": "ping"}]
+
+
+async def test_a_timed_out_socket_is_dropped(monkeypatch):
+    """Without removal, adding the timeout would make the stall RECUR on every
+    later broadcast instead of happening once."""
+    monkeypatch.setattr(dl, "WS_SEND_TIMEOUT_SECONDS", 0.05)
+
+    wedged = _FakeWS("wedged", hang=True)
+    healthy = _FakeWS("healthy")
+    active_connections.extend([wedged, healthy])
+
+    async with asyncio.timeout(5):
+        await dl._fanout({"type": "ping"})
+
+    assert wedged not in active_connections, "a timed-out socket stayed in the registry"
+    assert healthy in active_connections
+
+
+async def test_a_raising_socket_is_dropped():
+    """Unchanged behaviour from the original loops — kept under test because
+    the rewrite unified two variants (one dropped, one swallowed) into one."""
+
+    async def _explode(_data):
+        raise RuntimeError("broken pipe")
+
+    bad = _FakeWS("bad")
+    bad.send_json = _explode
+    good = _FakeWS("good")
+    active_connections.extend([bad, good])
+
+    await dl._fanout({"type": "ping"})
+
+    assert bad not in active_connections
+    assert good in active_connections
+    assert good.received == [{"type": "ping"}]
+
+
+async def test_no_connections_is_a_no_op():
+    await dl._fanout({"type": "ping"})
+
+
+async def test_every_broadcast_helper_goes_through_the_bounded_path(monkeypatch):
+    """Six helpers each had their own copy of the unbounded loop. This asserts
+    none of them grew a private one back."""
+    calls: list[dict] = []
+
+    async def _record(message: dict) -> None:
+        calls.append(message)
+
+    monkeypatch.setattr(dl, "_fanout", _record)
+
+    await dl._broadcast_audit_entry({"id": "a1"})
+    await dl._broadcast_health_update({"ok": True})
+    # No "type" key in the chunk on purpose: broadcast_intention spreads the
+    # chunk OVER its own envelope, so a chunk carrying "type" overwrites
+    # "intention_event". Pre-existing behaviour, not something this change
+    # introduced — but it makes a careless fixture here assert the wrong thing.
+    await dl.broadcast_intention("i1", {"content": "hello"})
+    await dl.push_open_path("/tmp/x", action="view")
+
+    assert [c["type"] for c in calls] == [
+        "system_event",
+        "health_update",
+        "intention_event",
+        "open_path",
+    ]


### PR DESCRIPTION
Third slice of the backend performance audit. Closes H1, M6 and M7.

One theme: PocketPaw serves from a single uvicorn process with no `--workers`, so a coroutine that blocks does not merely make itself slow. It is the only thing the box is doing for that whole time. Four places took that literally.

## Realtime fan-out was serial (H1)

Every fan-out was `for x in recipients: await send(x)`, running inline in the emitting HTTP request. Cost was the sum over recipients, not the slowest one.

The interesting part is that the codebase had already diagnosed this and half-fixed it. `SEND_TIMEOUT_SECONDS = 5.0` exists in `chat/ws.py` with a comment saying "one stuck socket would stall delivery to every other member and the sender's own request". That is exactly right, and it bounds one send. The loop around it re-summed them. A 200-member workspace with ten backgrounded mobile tabs held the sender's POST for about fifty seconds while every individual timeout behaved perfectly.

The bus, both `ConnectionManager` fan-outs, and all six OSS dashboard broadcast helpers now send concurrently under a cap of 32 in flight. Delivery is max-per-socket.

The OSS dashboard half had no timeout at all, so it gained one. Dropping the timed-out socket is the load-bearing part there: a deadline without removal would leave a wedged client to stall every later broadcast forever, which is worse than the original bug rather than better.

Untouched on purpose: the freshness gate, the dead-socket bookkeeping, and the `delivered` count that push dispatch reads to choose WebSocket over Web Push.

## Six blocking calls inside async handlers (M6)

Two `subprocess.run` calls each in `/git/status` and `/git/diff`, the deflate loop in `/files/download-zip`, the terminal's `lsof` probe, and the `os.walk` in the cloud-project uploader. All move to `asyncio.to_thread`.

`to_thread` over `create_subprocess_exec` deliberately: it preserves the existing `timeout`, `cwd` and `capture_output` arguments and still raises `subprocess.TimeoutExpired`, which the surrounding handlers catch by type. A test covers that, because a wrapped exception would fall through to the generic branch and quietly change the error a user sees.

Two extractions had to carry their guards with them. The jail and size checks moved into the threaded zip helper so an archive can never be built from unchecked paths, and the `.git` prune moved with the walk because it prunes by mutating the `dirs` list in place, which only works mid-traversal.

The wider scan found 226 blocking calls inside `async def`. The rest are small local-filesystem operations on cold paths and are deliberately left alone.

## The run stream had no maximum lifetime (M7)

The SSE reader's only exits were a terminal event or a failed yield. A run that never wrote its terminal frame heartbeated forever, and the `stream_exists` fallback does not catch that case: it fires when the events key is *gone*, whereas a worker killed mid-run leaves the key present and unfinished. Each abandoned subscription held a live task plus a Redis connection blocked in fifteen-second slices, on a pool with no configured cap.

The ceiling is derived from the run's own `POCKETPAW_CLOUD_RUN_JOB_TIMEOUT` rather than configured separately. The failure mode of drift is a cap shorter than the run it watches, which severs healthy long runs and reads as a backend bug. Sharing the value meant lifting the resolver out of `runs/worker.py`, which the web process cannot import without pulling in arq.

## Verification

All 17 mutations in `tests/mutations/event_loop.json` were run and caught. Four escaped on the first pass, and all four were bugs in the tests rather than curiosities:

- A fan-out test asserted sockets had *not finished* rather than *had started*, which is true either way under a gate nobody released.
- One reached for `gather(return_exceptions=True)`, where an exception object sitting in the results list is truthy and would have been counted as a delivered socket.
- Both git tests asserted that *some* ticks landed during the call. Each handler makes two subprocess calls, so that passes when only one is offloaded.

Fixing the last one took two attempts. Comparing against `elapsed / tick_interval` failed the correct code, because Windows' timer granularity is about 15.6ms, so a 10ms sleep delivers roughly 64 ticks per second rather than 100. It calibrates against a measured idle window now.

Regression check against a pristine `origin/dev` worktree, same interpreter both sides:

| | baseline | branch |
|---|---|---|
| OSS suite | 67 failed | 67 failed, identical test names |
| cloud areas touched | 10 failed / 627 passed | 10 failed / 647 passed |

The +20 is exactly the new tests. Every failure is pre-existing and environmental.

Worth repeating from the last two PRs: CI excludes `tests/cloud/`, so a green run here does not exercise most of what this changes. The numbers above are the real evidence.