### PR TITLE
perf: put ceilings on request bodies and on the client pools

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/redis_client.py
+++ b/ee/pocketpaw_ee/cloud/_core/redis_client.py
@@ -1,12 +1,71 @@
-"""Process-wide Redis client singleton. URL from ``POCKETPAW_REDIS_URL``."""
+"""Process-wide Redis client singleton. URL from ``POCKETPAW_REDIS_URL``.
+
+Changes: 2026-09-04 (fix/pool-and-body-ceilings, backend-perf H6) — the client
+was built with no pool ceiling and no connect timeout. redis-py's async
+``ConnectionPool`` defaults ``max_connections`` to an effectively unbounded
+value, which matters here more than it would in most apps: every open SSE run
+stream holds a connection parked in ``XREAD BLOCK 15000`` for as long as the
+client stays subscribed. Connections were therefore a direct function of open
+browser tabs, with no ceiling and no early signal on the way to exhausting the
+server's own ``maxclients``.
+"""
 
 from __future__ import annotations
 
+import logging
 import os
 
 from redis.asyncio import Redis
 
+logger = logging.getLogger(__name__)
+
 _client: Redis | None = None
+
+# Ceiling on connections this process will open.
+#
+# Sized against the thing that actually consumes them: one parked connection
+# per live SSE subscription. 128 is comfortably above the concurrent-stream
+# count a single-process deploy can serve (arq's cluster-wide job ceiling is
+# 10 by default, and a stream outlives its run only by the grace window) while
+# still being a number rather than "however many the tab count implies".
+#
+# What exhaustion looks like now: redis-py raises "Too many connections", which
+# surfaces as a fast, attributable error. Before, the pool kept opening
+# sockets until the Redis server refused them, and the failure surfaced
+# somewhere else entirely.
+_DEFAULT_MAX_CONNECTIONS = 128
+
+# Bound on establishing a connection. Deliberately NOT ``socket_timeout``:
+# that one bounds every read, and the run-stream reader parks in
+# ``XREAD BLOCK 15000`` by design, so a read timeout would sever healthy
+# streams on a 15-second cycle.
+_DEFAULT_CONNECT_TIMEOUT_SECONDS = 5.0
+
+# Ping an idle pooled connection before reuse if it has been sitting this long.
+# A NAT or proxy that silently drops an idle TCP flow otherwise hands back a
+# dead connection on the next checkout, which fails the caller rather than the
+# health check.
+_DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS = 30
+
+
+def _int_env(name: str, default: int) -> int:
+    """Read a positive int from the environment, falling back on anything else.
+
+    Fail-soft in the same shape as the other knobs in this codebase: a typo
+    must not remove a ceiling, and must not crash boot either.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an int; using default %d", name, raw, default)
+        return default
+    if val <= 0:
+        logger.warning("%s=%d is not positive; using default %d", name, val, default)
+        return default
+    return val
 
 
 def get_redis() -> Redis:
@@ -15,7 +74,14 @@ def get_redis() -> Redis:
         url = os.environ.get("POCKETPAW_REDIS_URL", "").strip()
         if not url:
             raise RuntimeError("POCKETPAW_REDIS_URL is not set — resumable chat runs need Redis.")
-        _client = Redis.from_url(url, decode_responses=True)
+        _client = Redis.from_url(
+            url,
+            decode_responses=True,
+            max_connections=_int_env("POCKETPAW_REDIS_MAX_CONNECTIONS", _DEFAULT_MAX_CONNECTIONS),
+            socket_connect_timeout=_DEFAULT_CONNECT_TIMEOUT_SECONDS,
+            health_check_interval=_DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS,
+            retry_on_timeout=True,
+        )
     return _client
 
 

--- a/ee/pocketpaw_ee/cloud/shared/db.py
+++ b/ee/pocketpaw_ee/cloud/shared/db.py
@@ -1,5 +1,25 @@
 """MongoDB connection and Beanie ODM initialization.
 
+2026-09-04 (fix/pool-and-body-ceilings, backend-perf H6): the client is built
+with explicit timeouts. It had none, so it ran on PyMongo's defaults, and two of
+those are the wrong shape for a request-serving process. ``serverSelectionTimeoutMS``
+defaults to 30s, which turns a brief Mongo blip into 30-second request hangs
+instead of fast failures — and every hung request holds a worker slot for the
+duration. ``socketTimeoutMS`` defaults to None, so a socket that stops
+responding without closing hangs its operation forever. ``waitQueueTimeoutMS``
+is also None, meaning a saturated pool queues callers indefinitely rather than
+telling them.
+
+Note for anyone reading the audit alongside this: the finding says the client
+has "no pool tuning", which is true, but the pool is NOT unbounded — PyMongo
+already defaults ``maxPoolSize`` to 100. It is set explicitly below at that same
+100 so the number is visible and tunable, which changes nothing on any existing
+deploy. The unbounded pool in that finding is the Redis one, fixed separately in
+``_core/redis_client.py``.
+
+Options already present in the connection URI WIN over these defaults, which is
+the opposite of PyMongo's own precedence — see ``_client_options``.
+
 2026-09-04 (fix/wallet-migration-guard): ``init_cloud_db`` now awaits
 ``credits.service.verify_wallet_migrated()`` alongside the memory and storage
 guards, and refuses the boot when any wallet document still carries a pre-micro
@@ -238,6 +258,49 @@ async def migrate_workspace_vm_map_to_db() -> None:
         logger.exception("Workspace VM map migration failed; continuing boot")
 
 
+# Defaults applied to the Mongo client when the connection URI does not already
+# say otherwise. Each exists to convert an unbounded wait into a fast, visible
+# failure — a request that hangs holds a worker slot, and a single-process
+# deploy has very few of them.
+_MONGO_DEFAULTS: dict[str, int] = {
+    # How long to hunt for a reachable server before giving up. PyMongo's 30s
+    # default is tuned for a batch job that would rather wait than fail; a
+    # request path would rather fail in five and let the client retry.
+    "serverSelectionTimeoutMS": 5_000,
+    "connectTimeoutMS": 5_000,
+    # Ceiling on a single operation's socket read. PyMongo's default is None,
+    # i.e. wait forever. 30s is generous for every query this app issues — it
+    # opens no change streams and no tailable cursors, both of which would be
+    # severed by a socket timeout, so the only thing this can cut short is a
+    # query that has already gone very wrong.
+    "socketTimeoutMS": 30_000,
+    # How long a caller waits for a free pooled connection. Also None by
+    # default, which means a saturated pool queues callers silently instead of
+    # telling anyone it is saturated.
+    "waitQueueTimeoutMS": 10_000,
+    # PyMongo's own default, set explicitly so the number is visible and
+    # tunable from the URI. Changes nothing on any existing deploy.
+    "maxPoolSize": 100,
+}
+
+
+def _client_options(mongo_uri: str) -> dict[str, int]:
+    """Client kwargs, minus anything the URI already configures.
+
+    PyMongo's own precedence is the other way round: a keyword argument beats
+    the same option in the URI. Applying these blind would therefore let a
+    library default silently overrule an operator who deliberately tuned the
+    connection string — and they would have no way to win the argument, because
+    the URI is the only knob a deploy actually exposes. So the URI wins here.
+
+    Option names in a MongoDB URI are case-insensitive, so the comparison is
+    lowered on both sides.
+    """
+    query = mongo_uri.partition("?")[2]
+    present = {pair.partition("=")[0].strip().lower() for pair in query.split("&") if pair.strip()}
+    return {key: value for key, value in _MONGO_DEFAULTS.items() if key.lower() not in present}
+
+
 async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterprise") -> None:
     """Initialize Beanie ODM with all document models."""
     global _client
@@ -249,7 +312,7 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
     from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
     from pocketpaw_ee.cloud.models import ALL_DOCUMENTS
 
-    _client = AsyncMongoClient(mongo_uri)
+    _client = AsyncMongoClient(mongo_uri, **_client_options(mongo_uri))
     db_name = mongo_uri.rsplit("/", 1)[-1].split("?")[0] or "paw-enterprise"
     db = _client[db_name]
 

--- a/src/pocketpaw/api/serve.py
+++ b/src/pocketpaw/api/serve.py
@@ -65,6 +65,26 @@ def create_api_app():
 
     app.add_middleware(AuthMiddleware)
 
+    # --- Body-size ceiling ----------------------------------------------
+    # Registered after AuthMiddleware so it sits OUTSIDE it. That ordering is
+    # load-bearing twice over: the upload limits in uploads/service.py only run
+    # after Starlette has spooled the entire multipart body to disk, and
+    # AuthMiddleware itself reads the body on the login paths. A ceiling inside
+    # either of those cannot stop the buffering it exists to prevent.
+    #
+    # mount_cloud() and install_cors() add their layers after this one, so the
+    # final order is CORS → CSRF → RequestLog → Timing → EEAuthBridge → this →
+    # Auth. None of those four cloud layers touches the body, so it is still
+    # unread when this runs — and CORS being outermost means a 413 keeps its
+    # headers, which matters because a header-less rejection reads to the
+    # browser as a CORS failure rather than as the size limit it is.
+    #
+    # See H5 in the backend-perf audit. Pure ASGI, so it adds no fifth
+    # BaseHTTPMiddleware layer (audit M8 counts the four that already exist).
+    from pocketpaw.security.body_limit import BodySizeLimitMiddleware
+
+    app.add_middleware(BodySizeLimitMiddleware)
+
     # --- Mount Mission Control + Deep Work routers ----------------------
     from pocketpaw.deep_work.api import router as deep_work_router
     from pocketpaw.mission_control.api import router as mission_control_router

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -101,6 +101,7 @@ from pocketpaw.deep_work.api import router as deep_work_router
 from pocketpaw.memory import MemoryType, get_memory_manager
 from pocketpaw.mission_control.api import router as mission_control_router
 from pocketpaw.security import get_audit_logger
+from pocketpaw.security.body_limit import BodySizeLimitMiddleware
 from pocketpaw.security.redact import safe_install_error
 from pocketpaw.skills import get_skill_loader
 from pocketpaw.tunnel import get_tunnel_manager
@@ -240,6 +241,15 @@ app.include_router(auth_router)
 # Auth must be registered BEFORE CORS so CORS is outermost and handles
 # OPTIONS preflight requests before auth can reject them.
 app.add_middleware(AuthMiddleware)
+# Body-size ceiling, registered after AuthMiddleware so it sits OUTSIDE it.
+# That ordering is load-bearing twice over: the upload limits are enforced only
+# after Starlette has spooled the whole multipart body to disk, and
+# AuthMiddleware itself reads the body on the login paths. A ceiling inside
+# either of those cannot stop the buffering it exists to prevent. CORS is
+# installed below and stays outermost, so a 413 still carries its headers — a
+# header-less rejection reads to the browser as a CORS failure. See H5 in the
+# backend-perf audit.
+app.add_middleware(BodySizeLimitMiddleware)
 # Also registers the CORS-aware unhandled-error handler — a 500 is minted by
 # ServerErrorMiddleware, which sits OUTSIDE CORSMiddleware, so without it every
 # crash returns header-less and the browser blames CORS. See api/cors.py.

--- a/src/pocketpaw/security/body_limit.py
+++ b/src/pocketpaw/security/body_limit.py
@@ -1,0 +1,212 @@
+# src/pocketpaw/security/body_limit.py
+# Created: 2026-09-04 (fix/pool-and-body-ceilings, backend-perf H5) — a hard
+# ceiling on request bodies, enforced BEFORE the body is read.
+#
+# The gap this closes: `max_file_bytes` (25 MiB) and `max_files_per_batch` (50)
+# are real limits, but they live in `uploads/service.py::_upload_one`, which
+# runs AFTER Starlette has already parsed the whole multipart body into a
+# SpooledTemporaryFile on disk. A 20 GB POST to /api/v1/uploads therefore fills
+# the container's disk before any of those checks execute. The limit was never
+# wrong; it was just downstream of the damage.
+#
+# Two things this deliberately does NOT do, so nobody mistakes it for a
+# complete fix:
+#   1. It does not make concurrent uploads safe. A legitimate 50-file batch is
+#      still ~1.25 GB spooled to disk, and ten at once is still ~12.5 GB. That
+#      needs streaming straight to object storage plus a concurrency cap, which
+#      is a larger change (audit H5, "M for S3 multipart").
+#   2. It is not a per-route policy. See the note on the ceiling below.
+
+"""Reject over-sized request bodies before they are buffered."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Awaitable, Callable, MutableMapping
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+Scope = MutableMapping[str, Any]
+Message = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[Message]]
+Send = Callable[[Message], Awaitable[None]]
+
+#: Slack over the app's own maximum legitimate payload, for multipart framing:
+#: per-part headers, boundaries, and the trailing epilogue. 16 MiB is far more
+#: than any real client adds and costs nothing when the ceiling is only ever
+#: consulted to reject the absurd.
+_MULTIPART_OVERHEAD_BYTES = 16 * 1024 * 1024
+
+
+def _configured_ceiling() -> int:
+    """The maximum body this process will accept, in bytes.
+
+    DERIVED from the upload settings rather than invented, and deliberately a
+    single global number rather than a per-path table.
+
+    Why not per-path: seventeen modules in this repo accept an ``UploadFile``,
+    across both packages. A path allowlist would have to name each of them, and
+    a route missing from that list breaks silently the first time somebody
+    uploads to it. This session has already found two hand-maintained lists
+    that had rotted exactly that way — the v1 route-auth audit list, and the
+    rate-limiter sweep list that structurally could not name the cloud
+    limiters. A derived global ceiling has nothing to forget.
+
+    What it is for, stated plainly: stopping a body that no route in this
+    application could ever legitimately accept, before it is written to disk.
+    The per-route limits downstream stay exactly as they are and remain the
+    thing that decides whether a 30 MiB file is allowed.
+
+    ``POCKETPAW_MAX_REQUEST_BYTES`` overrides. A malformed or non-positive
+    value falls back to the derived default rather than disabling the ceiling,
+    because a typo must not silently remove a guard.
+    """
+    raw = os.environ.get("POCKETPAW_MAX_REQUEST_BYTES", "").strip()
+    if raw:
+        try:
+            val = int(raw)
+        except ValueError:
+            logger.warning(
+                "POCKETPAW_MAX_REQUEST_BYTES=%r is not an int; using the derived default", raw
+            )
+        else:
+            if val > 0:
+                return val
+            logger.warning(
+                "POCKETPAW_MAX_REQUEST_BYTES=%d is not positive; using the derived default", val
+            )
+
+    # Imported lazily: this module is installed on the app at construction
+    # time, and the upload config pulls in the wider settings graph.
+    from pocketpaw.uploads.config import UploadSettings
+
+    settings = UploadSettings()
+    return settings.max_file_bytes * settings.max_files_per_batch + _MULTIPART_OVERHEAD_BYTES
+
+
+class BodySizeLimitMiddleware:
+    """Pure-ASGI ceiling on request body size.
+
+    Pure ASGI, not ``BaseHTTPMiddleware``, on purpose. Four
+    ``BaseHTTPMiddleware`` layers already wrap every cloud request, each one
+    costing an anyio task group and a memory object stream per request (audit
+    M8). This one adds a couple of dict lookups instead, and it has to sit
+    outermost to be worth anything — a ceiling that runs after the body is
+    parsed is the bug it exists to fix.
+    """
+
+    def __init__(self, app, max_bytes: int | None = None) -> None:
+        self.app = app
+        self._max_bytes = max_bytes
+
+    @property
+    def max_bytes(self) -> int:
+        # Resolved on first use, not in __init__: the app is constructed at
+        # import time in dashboard.py, before the environment is necessarily
+        # loaded, so reading the override eagerly would miss it.
+        if self._max_bytes is None:
+            self._max_bytes = _configured_ceiling()
+        return self._max_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            # WebSocket and lifespan have no request body to bound.
+            await self.app(scope, receive, send)
+            return
+
+        limit = self.max_bytes
+
+        declared = _declared_length(scope)
+        if declared is not None and declared > limit:
+            # The cheap path, and the one that matters: reject on the client's
+            # own declaration, before a single byte of body is read.
+            logger.warning(
+                "rejecting over-sized request: declared %d bytes > limit %d (%s %s)",
+                declared,
+                limit,
+                scope.get("method", "?"),
+                scope.get("path", "?"),
+            )
+            await _send_too_large(send, limit)
+            return
+
+        # No Content-Length means chunked transfer-encoding, which is exactly
+        # how a declaration check alone is bypassed. Count as the body arrives.
+        state = {"seen": 0, "responded": False}
+
+        async def _receive() -> Message:
+            message = await receive()
+            if message.get("type") != "http.request":
+                return message
+            state["seen"] += len(message.get("body", b""))
+            if state["seen"] > limit:
+                if not state["responded"]:
+                    state["responded"] = True
+                    logger.warning(
+                        "rejecting over-sized request: streamed past limit %d (%s %s)",
+                        limit,
+                        scope.get("method", "?"),
+                        scope.get("path", "?"),
+                    )
+                    await _send_too_large(send, limit)
+                # Tell the app the client is gone. Returning a disconnect
+                # rather than raising keeps this independent of how any given
+                # body parser handles exceptions — several of them catch
+                # broadly and would turn a raise into a 500, which would report
+                # the wrong thing to the client and to the logs.
+                return {"type": "http.disconnect"}
+            return message
+
+        async def _send(message: Message) -> None:
+            # Once we have answered, swallow whatever the app tries to send.
+            # The app sees a disconnect and may still attempt a response;
+            # letting it through would be a second set of response-start
+            # headers on one request.
+            if state["responded"]:
+                return
+            await send(message)
+
+        await self.app(scope, _receive, _send)
+
+
+def _declared_length(scope: Scope) -> int | None:
+    """Parse ``Content-Length``, or None when absent or unparseable.
+
+    An unparseable value is treated as absent rather than as a rejection: the
+    streaming counter below still bounds it, and the server itself will reject
+    a malformed framing header on its own terms.
+    """
+    for key, value in scope.get("headers", []):
+        if key == b"content-length":
+            try:
+                return int(value)
+            except ValueError:
+                return None
+    return None
+
+
+async def _send_too_large(send: Send, limit: int) -> None:
+    body = (
+        b'{"detail":"Request body too large. Limit is '
+        + str(limit).encode()
+        + b' bytes.","error":{"code":"request.body_too_large"}}'
+    )
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 413,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+                # Nothing about this decision depends on the body, so a client
+                # retrying the identical request gets the identical answer.
+                (b"connection", b"close"),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+__all__ = ["BodySizeLimitMiddleware"]

--- a/tests/cloud/test_client_pool_ceilings.py
+++ b/tests/cloud/test_client_pool_ceilings.py
@@ -1,0 +1,142 @@
+# Regression: the Mongo and Redis clients are built with explicit ceilings.
+#
+# Created 2026-09-04 (backend-perf H6). Both were constructed with the URL and
+# nothing else, so both ran entirely on library defaults, and the defaults are
+# the wrong shape for a request-serving process:
+#
+#   Mongo   serverSelectionTimeoutMS defaults to 30s, so a brief blip becomes
+#           30-second request hangs rather than fast failures, and every hung
+#           request holds a worker slot. socketTimeoutMS and waitQueueTimeoutMS
+#           both default to None, i.e. wait forever.
+#   Redis   max_connections is effectively unbounded on the async pool. That is
+#           worse here than it would be elsewhere, because every open SSE run
+#           stream parks a connection in XREAD BLOCK 15000 for as long as the
+#           client stays subscribed — so connection count tracked open browser
+#           tabs, with no ceiling and no early signal.
+#
+# Two of these tests exist to stop a plausible-looking FIX rather than a
+# regression, which is why they assert on absence:
+#   - Redis must NOT get socket_timeout. It bounds every read, and the stream
+#     reader blocks by design, so it would sever healthy streams on a 15s cycle.
+#   - Mongo kwargs must NOT override options already in the URI. PyMongo's own
+#     precedence is the reverse, and the URI is the only knob a deploy exposes.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core import redis_client
+from pocketpaw_ee.cloud.shared.db import _MONGO_DEFAULTS, _client_options
+
+
+class TestMongoClientOptions:
+    def test_timeouts_are_set(self):
+        opts = _client_options("mongodb://localhost:27017/paw")
+        for key in (
+            "serverSelectionTimeoutMS",
+            "connectTimeoutMS",
+            "socketTimeoutMS",
+            "waitQueueTimeoutMS",
+        ):
+            assert key in opts, f"{key} is unset, so it falls back to the library default"
+            assert opts[key] > 0
+
+    def test_server_selection_fails_faster_than_the_30s_default(self):
+        """The whole point. 30s of hanging is 30s of a held worker slot."""
+        assert _client_options("mongodb://h/db")["serverSelectionTimeoutMS"] < 30_000
+
+    def test_socket_timeout_is_generous_enough_for_a_real_query(self):
+        """Set too tight this severs legitimate work. The app opens no change
+        streams or tailable cursors, so nothing here is meant to be long-lived,
+        but an aggregation can still take seconds."""
+        assert _client_options("mongodb://h/db")["socketTimeoutMS"] >= 15_000
+
+    def test_a_uri_option_wins_over_our_default(self):
+        opts = _client_options("mongodb://h/db?serverSelectionTimeoutMS=1234")
+        assert "serverSelectionTimeoutMS" not in opts, (
+            "passing this as a kwarg silently overrules the operator's URI, "
+            "and the URI is the only knob a deploy actually exposes"
+        )
+        assert "socketTimeoutMS" in opts, "unrelated defaults must still apply"
+
+    @pytest.mark.parametrize("written_as", ["maxpoolsize", "MAXPOOLSIZE", "MaxPoolSize"])
+    def test_uri_option_matching_is_case_insensitive(self, written_as):
+        """MongoDB URI option names are case-insensitive, so however the
+        operator spelled it, their value must still win.
+
+        Both spellings matter for the mutation, not just the lowercase one: a
+        lowercase URI matches even if the comparison folds only one side, so a
+        test using `maxpoolsize=` alone passes with the folding half removed.
+        `MAXPOOLSIZE` fails unless BOTH sides are folded.
+        """
+        opts = _client_options(f"mongodb://h/db?{written_as}=25")
+        assert "maxPoolSize" not in opts
+
+    def test_multiple_uri_options_are_all_honoured(self):
+        opts = _client_options("mongodb://h/db?maxPoolSize=25&socketTimeoutMS=1000&tls=true")
+        assert "maxPoolSize" not in opts
+        assert "socketTimeoutMS" not in opts
+        assert "serverSelectionTimeoutMS" in opts
+
+    def test_a_uri_with_no_query_string_gets_every_default(self):
+        assert _client_options("mongodb://h/db") == _MONGO_DEFAULTS
+
+    def test_max_pool_size_matches_pymongos_own_default(self):
+        """Set explicitly for visibility, not to change behaviour. If this
+        stops matching PyMongo's default it is a real deploy change and should
+        be a deliberate one."""
+        assert _MONGO_DEFAULTS["maxPoolSize"] == 100
+
+
+class TestRedisClientOptions:
+    @pytest.fixture(autouse=True)
+    def _reset(self, monkeypatch):
+        monkeypatch.setenv("POCKETPAW_REDIS_URL", "redis://localhost:6379/0")
+        redis_client._reset_for_tests()
+        yield
+        redis_client._reset_for_tests()
+
+    def _pool_kwargs(self):
+        return redis_client.get_redis().connection_pool.connection_kwargs
+
+    def test_the_pool_is_bounded(self):
+        pool = redis_client.get_redis().connection_pool
+        assert pool.max_connections is not None
+        assert pool.max_connections <= 512, (
+            f"max_connections={pool.max_connections} is not a ceiling in any "
+            "useful sense; every live SSE stream parks one connection"
+        )
+
+    def test_connect_timeout_is_set(self):
+        assert self._pool_kwargs().get("socket_connect_timeout") is not None
+
+    def test_no_read_timeout_is_set(self):
+        """socket_timeout would look like the obvious companion to
+        socket_connect_timeout and would be wrong. The run-stream reader parks
+        in XREAD BLOCK 15000 by design; a read timeout severs healthy streams
+        on that cycle, and the reconnect looks like a backend fault."""
+        assert self._pool_kwargs().get("socket_timeout") is None, (
+            "socket_timeout bounds every read, including the deliberate block "
+            "in the SSE stream reader"
+        )
+
+    def test_idle_connections_are_health_checked(self):
+        """A NAT or proxy that drops an idle flow otherwise hands back a dead
+        connection on the next checkout, failing the caller instead."""
+        assert self._pool_kwargs().get("health_check_interval", 0) > 0
+
+    def test_decode_responses_is_preserved(self):
+        """Pre-existing behaviour every caller depends on — the stream reader
+        indexes str keys, not bytes."""
+        assert self._pool_kwargs().get("decode_responses") is True
+
+    def test_max_connections_is_env_tunable(self, monkeypatch):
+        monkeypatch.setenv("POCKETPAW_REDIS_MAX_CONNECTIONS", "7")
+        redis_client._reset_for_tests()
+        assert redis_client.get_redis().connection_pool.max_connections == 7
+
+    @pytest.mark.parametrize("bad", ["nope", "0", "-3"])
+    def test_a_bad_env_value_falls_back_rather_than_unbounding_the_pool(self, monkeypatch, bad):
+        monkeypatch.setenv("POCKETPAW_REDIS_MAX_CONNECTIONS", bad)
+        redis_client._reset_for_tests()
+        pool = redis_client.get_redis().connection_pool
+        assert pool.max_connections == redis_client._DEFAULT_MAX_CONNECTIONS

--- a/tests/mutations/body_ceiling.json
+++ b/tests/mutations/body_ceiling.json
@@ -1,0 +1,119 @@
+[
+  {
+    "label": "the Content-Length check is dropped",
+    "file": "src/pocketpaw/security/body_limit.py",
+    "find": "        if declared is not None and declared > limit:",
+    "replace": "        if False:",
+    "tests": [
+      "tests/test_body_size_limit.py::TestDeclaredLength::test_declared_oversize_is_rejected_without_reading_the_body"
+    ]
+  },
+  {
+    "label": "the streamed byte counter is dropped, leaving chunked bodies unbounded",
+    "file": "src/pocketpaw/security/body_limit.py",
+    "find": "            if state[\"seen\"] > limit:",
+    "replace": "            if False:",
+    "tests": [
+      "tests/test_body_size_limit.py::TestStreamedLength::test_chunked_oversize_is_rejected"
+    ]
+  },
+  {
+    "label": "the app is allowed to respond after the 413 has been sent",
+    "file": "src/pocketpaw/security/body_limit.py",
+    "find": "            if state[\"responded\"]:\n                return\n            await send(message)",
+    "replace": "            await send(message)",
+    "tests": [
+      "tests/test_body_size_limit.py::TestStreamedLength::test_no_second_response_is_sent"
+    ]
+  },
+  {
+    "label": "a bad env override disables the ceiling instead of falling back",
+    "file": "src/pocketpaw/security/body_limit.py",
+    "find": "            if val > 0:\n                return val",
+    "replace": "            return val",
+    "tests": [
+      "tests/test_body_size_limit.py::TestCeilingResolution::test_a_bad_override_falls_back_rather_than_disabling_the_ceiling"
+    ]
+  },
+  {
+    "label": "the ceiling stops being wired into the dashboard app",
+    "file": "src/pocketpaw/dashboard.py",
+    "find": "app.add_middleware(BodySizeLimitMiddleware)",
+    "replace": "pass  # app.add_middleware(BodySizeLimitMiddleware)",
+    "tests": [
+      "tests/test_body_size_limit.py::TestItIsActuallyWired::test_registered_on_the_dashboard_app"
+    ]
+  },
+  {
+    "label": "the ceiling is registered INSIDE auth, which reads the body itself",
+    "file": "src/pocketpaw/dashboard.py",
+    "find": "app.add_middleware(BodySizeLimitMiddleware)\n# Also registers the CORS-aware unhandled-error handler",
+    "replace": "app.add_middleware(BodySizeLimitMiddleware)\napp.add_middleware(AuthMiddleware)\n# Also registers the CORS-aware unhandled-error handler",
+    "tests": [
+      "tests/test_body_size_limit.py::TestItIsActuallyWired::test_registered_outside_auth_on_the_dashboard_app"
+    ]
+  },
+  {
+    "label": "Mongo kwargs are applied over the operator's URI options",
+    "file": "ee/pocketpaw_ee/cloud/shared/db.py",
+    "find": "    return {key: value for key, value in _MONGO_DEFAULTS.items() if key.lower() not in present}",
+    "replace": "    return dict(_MONGO_DEFAULTS)",
+    "tests": [
+      "tests/cloud/test_client_pool_ceilings.py::TestMongoClientOptions::test_a_uri_option_wins_over_our_default"
+    ]
+  },
+  {
+    "label": "Mongo server selection goes back to the 30s default",
+    "file": "ee/pocketpaw_ee/cloud/shared/db.py",
+    "find": "    \"serverSelectionTimeoutMS\": 5_000,",
+    "replace": "    \"serverSelectionTimeoutMS\": 30_000,",
+    "tests": [
+      "tests/cloud/test_client_pool_ceilings.py::TestMongoClientOptions::test_server_selection_fails_faster_than_the_30s_default"
+    ]
+  },
+  {
+    "label": "the URI option match becomes case-sensitive",
+    "file": "ee/pocketpaw_ee/cloud/shared/db.py",
+    "find": "    present = {pair.partition(\"=\")[0].strip().lower() for pair in query.split(\"&\") if pair.strip()}",
+    "replace": "    present = {pair.partition(\"=\")[0].strip() for pair in query.split(\"&\") if pair.strip()}",
+    "tests": [
+      "tests/cloud/test_client_pool_ceilings.py::TestMongoClientOptions::test_uri_option_matching_is_case_insensitive"
+    ]
+  },
+  {
+    "label": "the Redis pool loses its ceiling",
+    "file": "ee/pocketpaw_ee/cloud/_core/redis_client.py",
+    "find": "            max_connections=_int_env(\"POCKETPAW_REDIS_MAX_CONNECTIONS\", _DEFAULT_MAX_CONNECTIONS),",
+    "replace": "",
+    "tests": [
+      "tests/cloud/test_client_pool_ceilings.py::TestRedisClientOptions::test_the_pool_is_bounded"
+    ]
+  },
+  {
+    "label": "socket_timeout is added to Redis, severing the blocking stream read",
+    "file": "ee/pocketpaw_ee/cloud/_core/redis_client.py",
+    "find": "            socket_connect_timeout=_DEFAULT_CONNECT_TIMEOUT_SECONDS,",
+    "replace": "            socket_connect_timeout=_DEFAULT_CONNECT_TIMEOUT_SECONDS,\n            socket_timeout=5.0,",
+    "tests": [
+      "tests/cloud/test_client_pool_ceilings.py::TestRedisClientOptions::test_no_read_timeout_is_set"
+    ]
+  },
+  {
+    "label": "a bad Redis env value unbounds the pool instead of falling back",
+    "file": "ee/pocketpaw_ee/cloud/_core/redis_client.py",
+    "find": "    if val <= 0:\n        logger.warning(\"%s=%d is not positive; using default %d\", name, val, default)\n        return default\n    return val",
+    "replace": "    return val",
+    "tests": [
+      "tests/cloud/test_client_pool_ceilings.py::TestRedisClientOptions::test_a_bad_env_value_falls_back_rather_than_unbounding_the_pool"
+    ]
+  },
+  {
+    "label": "idle Redis connections stop being health-checked",
+    "file": "ee/pocketpaw_ee/cloud/_core/redis_client.py",
+    "find": "            health_check_interval=_DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS,",
+    "replace": "",
+    "tests": [
+      "tests/cloud/test_client_pool_ceilings.py::TestRedisClientOptions::test_idle_connections_are_health_checked"
+    ]
+  }
+]

--- a/tests/test_body_size_limit.py
+++ b/tests/test_body_size_limit.py
@@ -1,0 +1,256 @@
+# Regression: an over-sized request body is rejected BEFORE it is buffered.
+#
+# Created 2026-09-04 (backend-perf H5). The upload limits (25 MiB per file, 50
+# files per batch) were never wrong — they are just downstream of the damage.
+# They live in uploads/service.py::_upload_one, which runs after Starlette has
+# already parsed the whole multipart body into a SpooledTemporaryFile on disk.
+# A 20 GB POST fills the container's disk before any of them execute.
+#
+# The assertion that matters throughout this file is not "a 413 came back". It
+# is "the application never saw the body". A middleware that returns 413 after
+# reading 20 GB has changed the status code and nothing else.
+#
+# What each test would catch (mutations in tests/mutations/body_ceiling.json):
+#   - drop the Content-Length check       -> test_declared_oversize_is_rejected
+#   - drop the streaming byte counter     -> test_chunked_oversize_is_rejected
+#   - let the app respond after the 413   -> test_no_second_response_is_sent
+#   - apply kwargs over URI options       -> TestMongoClientOptions
+#   - set socket_timeout on Redis         -> test_no_read_timeout_is_set
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.security.body_limit import BodySizeLimitMiddleware
+
+
+class _RecordingApp:
+    """An ASGI app that reads its whole body, and remembers how much it saw."""
+
+    def __init__(self) -> None:
+        self.body_bytes = 0
+        self.called = False
+        self.saw_disconnect = False
+
+    async def __call__(self, scope, receive, send):
+        self.called = True
+        while True:
+            message = await receive()
+            if message["type"] == "http.disconnect":
+                self.saw_disconnect = True
+                break
+            self.body_bytes += len(message.get("body", b""))
+            if not message.get("more_body"):
+                break
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+
+def _scope(headers: list[tuple[bytes, bytes]], method: str = "POST"):
+    return {
+        "type": "http",
+        "method": method,
+        "path": "/api/v1/uploads",
+        "headers": headers,
+    }
+
+
+async def _drive(middleware, scope, chunks: list[bytes]):
+    """Run one request through the middleware; return the sent ASGI messages."""
+    queued = [
+        {"type": "http.request", "body": chunk, "more_body": i < len(chunks) - 1}
+        for i, chunk in enumerate(chunks)
+    ] or [{"type": "http.request", "body": b"", "more_body": False}]
+    sent: list[dict] = []
+
+    async def receive():
+        return queued.pop(0) if queued else {"type": "http.disconnect"}
+
+    async def send(message):
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    return sent
+
+
+def _status(sent: list[dict]) -> int | None:
+    for message in sent:
+        if message["type"] == "http.response.start":
+            return message["status"]
+    return None
+
+
+class TestDeclaredLength:
+    async def test_declared_oversize_is_rejected_without_reading_the_body(self):
+        app = _RecordingApp()
+        mw = BodySizeLimitMiddleware(app, max_bytes=1000)
+        scope = _scope([(b"content-length", b"999999999")])
+
+        sent = await _drive(mw, scope, [b"x" * 50])
+
+        assert _status(sent) == 413
+        assert app.called is False, (
+            "the application ran, so the body was reaching a handler that would buffer it"
+        )
+        assert app.body_bytes == 0
+
+    async def test_a_body_within_the_limit_passes_through_untouched(self):
+        app = _RecordingApp()
+        mw = BodySizeLimitMiddleware(app, max_bytes=1000)
+        scope = _scope([(b"content-length", b"10")])
+
+        sent = await _drive(mw, scope, [b"0123456789"])
+
+        assert _status(sent) == 200
+        assert app.body_bytes == 10
+
+    async def test_exactly_at_the_limit_is_allowed(self):
+        """The limit is a ceiling, not a fence one short of it."""
+        app = _RecordingApp()
+        mw = BodySizeLimitMiddleware(app, max_bytes=10)
+        sent = await _drive(mw, _scope([(b"content-length", b"10")]), [b"0123456789"])
+
+        assert _status(sent) == 200
+        assert app.body_bytes == 10
+
+    async def test_an_unparseable_length_falls_through_to_the_counter(self):
+        """A malformed header must not become a way to skip the ceiling."""
+        app = _RecordingApp()
+        mw = BodySizeLimitMiddleware(app, max_bytes=10)
+        sent = await _drive(mw, _scope([(b"content-length", b"not-a-number")]), [b"x" * 50])
+
+        assert _status(sent) == 413
+
+
+class TestStreamedLength:
+    """Content-Length is client-supplied, and chunked transfer-encoding omits
+    it entirely. A declaration-only check is bypassed by not declaring."""
+
+    async def test_chunked_oversize_is_rejected(self):
+        app = _RecordingApp()
+        mw = BodySizeLimitMiddleware(app, max_bytes=100)
+        scope = _scope([(b"transfer-encoding", b"chunked")])
+
+        sent = await _drive(mw, scope, [b"x" * 60, b"x" * 60, b"x" * 60])
+
+        assert _status(sent) == 413
+
+    async def test_the_app_stops_reading_once_the_limit_is_passed(self):
+        """The point is bounded memory, so the app must not keep receiving."""
+        app = _RecordingApp()
+        mw = BodySizeLimitMiddleware(app, max_bytes=100)
+
+        await _drive(mw, _scope([]), [b"x" * 60, b"x" * 60, b"x" * 60, b"x" * 60])
+
+        assert app.saw_disconnect is True
+        assert app.body_bytes <= 120, f"app buffered {app.body_bytes} bytes past a 100-byte ceiling"
+
+    async def test_no_second_response_is_sent(self):
+        """The app sees a disconnect and still tries to respond. Letting that
+        through would put two response-start messages on one request, which is
+        an ASGI protocol violation and raises inside the server."""
+        app = _RecordingApp()
+        mw = BodySizeLimitMiddleware(app, max_bytes=100)
+
+        sent = await _drive(mw, _scope([]), [b"x" * 60, b"x" * 60])
+
+        starts = [m for m in sent if m["type"] == "http.response.start"]
+        assert len(starts) == 1, f"{len(starts)} response-start messages were sent"
+        assert starts[0]["status"] == 413
+
+    async def test_a_chunked_body_within_the_limit_passes(self):
+        app = _RecordingApp()
+        mw = BodySizeLimitMiddleware(app, max_bytes=1000)
+        sent = await _drive(mw, _scope([]), [b"x" * 100, b"x" * 100])
+
+        assert _status(sent) == 200
+        assert app.body_bytes == 200
+
+
+class TestNonHttpScopes:
+    async def test_websocket_scope_is_passed_straight_through(self):
+        """A WebSocket has no request body to bound, and touching its receive
+        channel would break the handshake."""
+        seen = {}
+
+        async def app(scope, receive, send):
+            seen["type"] = scope["type"]
+
+        mw = BodySizeLimitMiddleware(app, max_bytes=10)
+        await mw({"type": "websocket", "path": "/ws"}, None, None)
+
+        assert seen["type"] == "websocket"
+
+    async def test_lifespan_scope_is_passed_straight_through(self):
+        seen = {}
+
+        async def app(scope, receive, send):
+            seen["type"] = scope["type"]
+
+        mw = BodySizeLimitMiddleware(app, max_bytes=10)
+        await mw({"type": "lifespan"}, None, None)
+
+        assert seen["type"] == "lifespan"
+
+
+class TestCeilingResolution:
+    def test_the_default_is_derived_from_the_upload_settings(self, monkeypatch):
+        """Derived, not invented. Seventeen modules accept an UploadFile; a
+        hand-written path table would rot the first time one was added."""
+        monkeypatch.delenv("POCKETPAW_MAX_REQUEST_BYTES", raising=False)
+        from pocketpaw.security.body_limit import _configured_ceiling
+        from pocketpaw.uploads.config import UploadSettings
+
+        settings = UploadSettings()
+        floor = settings.max_file_bytes * settings.max_files_per_batch
+        assert _configured_ceiling() > floor, (
+            "the ceiling is below the app's own maximum legitimate batch, "
+            "so a valid 50-file upload would be rejected"
+        )
+
+    def test_the_env_override_wins(self, monkeypatch):
+        from pocketpaw.security.body_limit import _configured_ceiling
+
+        monkeypatch.setenv("POCKETPAW_MAX_REQUEST_BYTES", "4096")
+        assert _configured_ceiling() == 4096
+
+    @pytest.mark.parametrize("bad", ["nonsense", "0", "-1", "  "])
+    def test_a_bad_override_falls_back_rather_than_disabling_the_ceiling(self, monkeypatch, bad):
+        """A typo must never remove a guard."""
+        from pocketpaw.security.body_limit import _configured_ceiling
+
+        monkeypatch.setenv("POCKETPAW_MAX_REQUEST_BYTES", bad)
+        assert _configured_ceiling() > 1_000_000
+
+
+class TestItIsActuallyWired:
+    """A middleware class that nothing registers protects nothing, and every
+    test above would still pass. These assert the wiring, and the ORDER of the
+    wiring, which is the part that carries the fix.
+    """
+
+    def test_registered_on_the_dashboard_app(self):
+        from pocketpaw.dashboard import app
+
+        assert BodySizeLimitMiddleware in [m.cls for m in app.user_middleware]
+
+    def test_registered_outside_auth_on_the_dashboard_app(self):
+        """AuthMiddleware reads the request body on the login paths, so a
+        ceiling registered inside it cannot stop that buffering.
+
+        Starlette's user_middleware list is outermost-LAST-added, and the stack
+        is built by reversing it — so a LOWER index here means further out.
+        """
+        from pocketpaw.dashboard import app
+        from pocketpaw.dashboard_auth import AuthMiddleware
+
+        order = [m.cls for m in app.user_middleware]
+        assert order.index(BodySizeLimitMiddleware) < order.index(AuthMiddleware), (
+            "the body ceiling runs inside AuthMiddleware, which reads the body itself"
+        )


### PR DESCRIPTION
Fourth slice of the backend performance audit. Closes H5 and H6.

Two edges had no limit at all, and a third had limits that ran too late to matter.

## Request bodies (H5)

There is no body-size middleware anywhere in either package. The upload limits are real — 25 MiB per file, 50 files per batch — but they live in `uploads/service.py::_upload_one`, which runs *after* Starlette has already parsed the whole multipart body into a `SpooledTemporaryFile` on disk. A 20 GB POST fills the container's disk before any of them execute. The limit was never wrong. It was downstream of the damage.

The new middleware is pure ASGI rather than another `BaseHTTPMiddleware`. Four of those already wrap every cloud request, each costing an anyio task group and a memory object stream per request (audit M8), and adding a fifth just to enforce a ceiling would be a poor trade.

**The ceiling is derived, and global on purpose.** It comes from the upload settings rather than being invented, and it is one number instead of a per-path table. Seventeen modules in this repo accept an `UploadFile`. A path allowlist would have to name each of them, and a route missing from that list breaks silently the first time somebody uploads to it. This session has already found two hand-maintained lists that had rotted exactly that way: the v1 route-auth list, and the rate-limiter sweep list that structurally could not name the cloud limiters.

**Ordering carries the fix, so it is tested rather than commented.** The ceiling has to sit outside `AuthMiddleware`, which reads the body itself on the login paths, and CORS stays outermost so a 413 keeps its headers. A header-less rejection reads to a browser as a CORS failure rather than as the size limit it is.

**Content-Length alone is not enough.** It is client-supplied, and chunked transfer-encoding omits it entirely, so a running byte count backs it up and cuts the app off mid-stream.

What this deliberately does not fix: a legitimate 50-file batch is still about 1.25 GB spooled to disk, and ten at once is still 12.5 GB. That needs streaming straight to object storage plus a concurrency cap, which the audit sizes separately.

## Client pools (H6)

Both clients were built with a URL and nothing else, so both ran entirely on library defaults, and the defaults are the wrong shape for a request-serving process.

Mongo's `serverSelectionTimeoutMS` defaults to 30s, so a brief blip becomes 30-second request hangs rather than fast failures, and every hung request holds a worker slot. `socketTimeoutMS` and `waitQueueTimeoutMS` both default to waiting forever.

Redis' async pool is effectively unbounded, which matters more here than it usually would. Every open SSE run stream parks a connection in `XREAD BLOCK 15000` for as long as the client stays subscribed, so connection count tracked open browser tabs, with no ceiling and no early signal before the server's own `maxclients`.

Two things are deliberately **not** done, and both are tested by asserting absence, because each is a plausible-looking change someone would otherwise make later:

- **Redis gets no `socket_timeout`.** It looks like the obvious companion to `socket_connect_timeout` and would be wrong. It bounds every read, and the stream reader blocks by design, so it would sever healthy streams on a fifteen-second cycle and the reconnect would look like a backend fault.
- **Mongo kwargs do not override options already in the URI.** PyMongo's own precedence is the reverse. Applying them blind would let a library default overrule an operator who deliberately tuned the connection string, and they would have no way to win the argument, because the URI is the only knob a deploy actually exposes.

**One correction to the audit.** It reads Mongo's pool as untuned, which is true, but the pool is not unbounded: PyMongo already defaults `maxPoolSize` to 100. It is now set explicitly at that same 100 so the number is visible and tunable, which changes nothing on any existing deploy. The unbounded pool in that finding is Redis'.

## Verification

All 13 mutations in `tests/mutations/body_ceiling.json` were run and caught, including one that removes the middleware registration entirely and one that moves it inside auth — a middleware nothing registers protects nothing, and every other test would still pass.

One escaped on the first pass. The case-insensitivity test used an already-lowercase URI, so removing the case fold from one side of the comparison changed nothing and the test stayed green. It is parameterised over three spellings now.

The reformat pass then rotted one anchor, which `mutate.py --validate` caught. Worth noting because a plan with a bad anchor applies no mutations at all and reads as covered while proving nothing.

Targeted run over the new tests plus the existing suites for every file touched:

| | result |
|---|---|
| new + adjacent suites | 279 passed, 2 failed |

Both failures are in `tests/cloud/runs/test_run_core.py` and are the same pair confirmed pre-existing against a pristine `dev` worktree earlier today. This branch does not touch that module.

CI excludes `tests/cloud/`, so the client-pool tests here will not run there.