### PR TITLE
Capture a design brief from a URL instead of mirroring its bytes

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,11 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-09-04 (IR-2a, feat/sites-import-design-brief) — added
+``SiteDesignBrief`` (the captured design brief a rebuild-mode site import
+generates from) to the imports, ``__all__`` and ``get_all_documents()`` so the
+``site_design_briefs`` collection is wired into ``init_beanie``. It is its own
+collection because rebuild mints neither a pocket nor a Site doc to hang it on.
+
 Updated: 2026-07-27 (integration/growth-v1) — G-6's ``WhatsAppSendLog`` is
 gone: it and G-5's ``MessageLog`` were the same send record built in parallel
 under two names, unified onto ``MessageLog`` (which gained the ``sending`` /
@@ -234,6 +240,7 @@ from pocketpaw_ee.cloud.models.session import Session
 from pocketpaw_ee.cloud.models.session_transcript import SessionTranscriptDoc
 from pocketpaw_ee.cloud.models.ship import ShipApp, ShipBox, ShipDeploy
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
+from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
 from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
 from pocketpaw_ee.cloud.models.subscription import Subscription
@@ -399,6 +406,7 @@ __all__ = [
     "SessionTranscriptDoc",
     "AgentSessionRuntimeDoc",
     "Site",
+    "SiteDesignBrief",
     "SiteDomain",
     "SiteRateCounter",
     "SpendReconciliation",
@@ -526,6 +534,7 @@ def get_all_documents():
         ChatRunDoc,
         Lead,
         Site,
+        SiteDesignBrief,
         SiteRateCounter,
         # Growth prospect store (G-1) — the /growth outbound engine's
         # workspace-scoped, domain-deduped prospect record. Only

--- a/ee/pocketpaw_ee/cloud/models/site_design_brief.py
+++ b/ee/pocketpaw_ee/cloud/models/site_design_brief.py
@@ -1,0 +1,57 @@
+# ee/pocketpaw_ee/cloud/models/site_design_brief.py — a captured design brief for
+# the site REGENERATION import path (rebuild), workspace-scoped.
+#
+# Created 2026-09-04 (IR-2a, feat/sites-import-design-brief).
+#
+# WHY THIS IS ITS OWN COLLECTION AND NOT A FIELD ON A POCKET OR A SITE: rebuild
+# mints neither. The /sites surface routes a run to REFINE whenever a pocket_id
+# rides in its meta, so a create flow must run with no pocket and let the agent
+# mint one through its own create tool. That leaves the brief with nothing to hang
+# on between the capture finishing and the generation starting, which is exactly
+# the window this document covers. The copy (mirror) path is unaffected — it still
+# mints an html pocket up front and stamps its report on the Site doc.
+#
+# The brief payload is stored as a plain dict rather than a typed sub-document on
+# purpose: ``sites.design_brief`` owns the shape and versions it, and reads go
+# through ``design_brief.load_brief`` so a version this build cannot read fails
+# loudly instead of being silently defaulted into something plausible.
+"""The captured design brief a rebuild-mode import generates from."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class SiteDesignBrief(TimestampedDocument):
+    """One captured source page, on its way to becoming a native site.
+
+    ``status`` is the only thing a reader needs to tell the three states apart
+    that otherwise look identical from outside: the capture has not run yet, it
+    ran and failed, or it ran and there is a brief to generate from. ``error``
+    carries a SAFE message only (the same rule the import report follows) because
+    every site viewer in the workspace can read it.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    owner: str
+    source_url: str
+    status: str = "queued"  # queued | capturing | ready | failed
+    error: str = ""
+    # The DesignBrief, dumped in json mode. Empty until the capture succeeds.
+    brief: dict[str, Any] = Field(default_factory=dict)
+    # Set once a generation run has been started from this brief, so a retry can
+    # tell "captured, never used" from "already generating". Empty otherwise.
+    consumed_by_run: str = ""
+
+    class Settings:
+        name = "site_design_briefs"
+        indexes = [
+            # The workspace's own briefs, newest first — the only read shape the
+            # import panel needs.
+            [("workspace", 1), ("createdAt", -1)],
+        ]

--- a/ee/pocketpaw_ee/sites/design_brief.py
+++ b/ee/pocketpaw_ee/sites/design_brief.py
@@ -1,0 +1,149 @@
+# ee/pocketpaw_ee/sites/design_brief.py — the typed, versioned description of a
+# source page that the SITE REGENERATION path hands to the generator, instead of
+# re-hosting the source's own bytes the way the html mirror does.
+#
+# Created 2026-09-04 (IR-2a, feat/sites-import-design-brief). Only ``meta`` is
+# filled at capture time; ``tokens`` (IR-4), ``sections`` (IR-3), ``forms`` (IR-9)
+# and ``assets`` (IR-5) are each filled by a later slice and land empty here. They
+# exist now so the persisted shape does not change under a stored brief every time
+# one of those slices lands.
+#
+# WHY A VERSION FIELD, CHECKED ON READ: a brief outlives the capture that made it
+# — the whole point of persisting one is that a regenerate does not re-crawl. So a
+# brief written by an older build will be read by a newer one. ``load_brief``
+# refuses a mismatch loudly (recapture, or a build that is too old to read this)
+# rather than letting pydantic quietly default away fields whose meaning changed.
+# A silently misread brief regenerates a site that looks nothing like its source
+# and reports no error, which is the failure mode this file exists to prevent.
+"""Typed design brief for regenerating a site from a URL."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# Bump on ANY change to the shape below that an older reader would misinterpret.
+# Adding a field with a default that reads correctly as "absent" does not need a
+# bump; renaming, re-typing, or changing what a field MEANS does.
+BRIEF_VERSION = 1
+
+# The closed section vocabulary. Deliberately the set the design-taste skill
+# already authors, so a brief never asks the generator for a section kind it has
+# no idiom for. Anything unrecognised becomes ``content`` plus a warning — see
+# IR-3 — because dropping a section silently loses a whole band of the page.
+SECTION_KINDS = (
+    "hero",
+    "features",
+    "pricing",
+    "testimonial",
+    "faq",
+    "cta",
+    "footer",
+    "content",
+)
+
+
+class BriefVersionError(ValueError):
+    """A stored brief cannot be read by this build. Recapture, or upgrade."""
+
+
+class BriefMeta(BaseModel):
+    """What the source page says it is. The only family filled at capture time."""
+
+    title: str = ""
+    description: str = ""
+    favicon_url: str | None = None
+    og_image_url: str | None = None
+
+
+class BriefTokens(BaseModel):
+    """The source's design language. Filled by IR-4 from its stylesheets.
+
+    ``palette`` is ORDERED most-referenced first, which is the whole reason it is
+    a list rather than a set: a real site declares dozens to hundreds of colour
+    tokens and a brief needs a handful, so the order is the selection.
+    """
+
+    palette: list[str] = Field(default_factory=list)
+    # {"heading": <family>, "body": <family>, "mono": <family>} — resolved
+    # families, never a raw ``var(--x)`` reference and never a bare fallback stack.
+    fonts: dict[str, str] = Field(default_factory=dict)
+    type_scale: list[str] = Field(default_factory=list)
+    spacing: list[str] = Field(default_factory=list)
+    radii: list[str] = Field(default_factory=list)
+    shadows: list[str] = Field(default_factory=list)
+
+
+class BriefSection(BaseModel):
+    """One band of the source page, in document order. Filled by IR-3."""
+
+    kind: str = "content"
+    order: int = 0
+    heading: str = ""
+    subcopy: str = ""
+    items: list[str] = Field(default_factory=list)
+    image_refs: list[str] = Field(default_factory=list)
+    # top / left / width / height as the rendered page reported them. Kept because
+    # the ORDER and relative size of bands is most of what "same layout" means.
+    geometry: dict[str, float] = Field(default_factory=dict)
+
+
+class BriefForm(BaseModel):
+    """A form the source page carried. Filled by IR-9.
+
+    ``fields`` carries the original NAMES because downstream lead handling keys on
+    them: a regenerated form with prettier field names captures leads that no
+    existing mapping recognises.
+    """
+
+    purpose: str = ""
+    fields: list[str] = Field(default_factory=list)
+    original_action: str = ""
+    method: str = "post"
+
+
+class DesignBrief(BaseModel):
+    """Everything the generator needs to author a native site that reads as the
+    source's, without ever taking ownership of the source's own tree."""
+
+    version: int = BRIEF_VERSION
+    source_url: str
+    captured_at: datetime
+    meta: BriefMeta = Field(default_factory=BriefMeta)
+    tokens: BriefTokens = Field(default_factory=BriefTokens)
+    sections: list[BriefSection] = Field(default_factory=list)
+    forms: list[BriefForm] = Field(default_factory=list)
+    # path -> the URL it was stored at in OUR blob storage, so a generated section
+    # never points at the original host. Filled by IR-5.
+    assets: dict[str, str] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+
+
+def load_brief(payload: Mapping[str, Any]) -> DesignBrief:
+    """Read a persisted brief, refusing a version this build cannot read.
+
+    Raises ``BriefVersionError`` rather than validating a mismatched payload: a
+    brief is persisted input to a generation run, so a quietly-defaulted field
+    produces a plausible site that is wrong about its source and reports nothing.
+    """
+    stored = payload.get("version")
+    try:
+        version = int(stored)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise BriefVersionError(
+            f"design brief has no readable version (got {stored!r}); recapture the source"
+        ) from None
+    if version > BRIEF_VERSION:
+        raise BriefVersionError(
+            f"design brief is version {version}, newer than this build reads "
+            f"({BRIEF_VERSION}); upgrade rather than reading it"
+        )
+    if version < BRIEF_VERSION:
+        raise BriefVersionError(
+            f"design brief is version {version}, older than this build reads "
+            f"({BRIEF_VERSION}); recapture the source"
+        )
+    return DesignBrief.model_validate(dict(payload))

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -220,7 +220,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, field_validator
 
@@ -709,19 +709,39 @@ class ImportFromUrlRequest(BaseModel):
     """Body for POST /sites/import/from-url (SI-4): the site URL to crawl-import.
     Shape validation (http(s), real host, length cap) runs in the import service so
     direct service callers are covered too; the crawler itself is the next stacked
-    slice — this endpoint only queues."""
+    slice — this endpoint only queues.
+
+    ``mode`` (IR-2a) picks what the URL is FOR. ``copy`` mirrors the source's own
+    bytes into an html site, which is what this endpoint has always done. Anything
+    else reads the URL as a DESIGN REFERENCE and captures a brief to regenerate a
+    native site from.
+
+    IT DEFAULTS TO ``copy`` ON PURPOSE, and IR-7 flips it. Today's client sends
+    only ``url`` and reads ``site_id`` out of the response to navigate; defaulting
+    to rebuild would hand that client a ``brief_id`` it does not understand and
+    break the shipped button before the picker exists. Flip the default in the
+    same PR that ships the picker, not before.
+    """
 
     url: str
+    mode: Literal["copy", "rebuild"] = "copy"
 
 
 class ImportFromUrlResponse(BaseModel):
-    """202 body of POST /sites/import/from-url (SI-4): the DRAFT site minted for the
-    queued crawl. ``status`` is "queued" — the crawler slice (SI-5) has not landed,
-    so the site's import_report carries a crawler-pending warning until it does."""
+    """202 body of POST /sites/import/from-url (SI-4).
 
-    site_id: str
-    pocket_id: str
+    ``copy`` mode answers exactly as it always has: the DRAFT site minted for the
+    queued crawl, with ``site_id`` and ``pocket_id`` set. ``rebuild`` mode mints
+    neither — the pocket is the generating agent's to create — so it answers with
+    ``brief_id`` instead and leaves those two None. ``mode`` echoes which of the
+    two happened, so a client never has to infer it from which fields are absent.
+    """
+
     status: str  # queued
+    mode: str = "copy"
+    site_id: str | None = None
+    pocket_id: str | None = None
+    brief_id: str | None = None
 
 
 class SiteInvoiceOut(BaseModel):

--- a/ee/pocketpaw_ee/sites/import_service.py
+++ b/ee/pocketpaw_ee/sites/import_service.py
@@ -1,5 +1,12 @@
 # ee/pocketpaw_ee/sites/import_service.py — Paw Sites IMPORT control plane (SI-4).
 #
+# Edited 2026-09-04 (IR-2a, feat/sites-import-design-brief): added REBUILD mode
+# beside the existing byte mirror. ``regenerate_from_url`` validates the same URL
+# floors, inserts a queued ``SiteDesignBrief`` and schedules a background capture
+# that harvests the page and persists a typed ``DesignBrief``. It mints NO pocket
+# and NO Site doc, deliberately — see the section header at the foot of the file.
+# The mirror path above is untouched.
+#
 # Edited 2026-07-23 (SI-FIX review): the zip path now persists the REWIRED source on
 # the pocket too (set_imported_source), not just the deployed artifact — a re-publish
 # from the builder was reading the raw upload and redeploying un-rewired forms.
@@ -66,8 +73,9 @@ import io
 import logging
 import zipfile
 from datetime import UTC, datetime
+from html.parser import HTMLParser
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 from uuid import uuid4
 
 from pocketpaw_ee.cloud._core.errors import CloudError, Internal, ValidationError
@@ -740,3 +748,250 @@ async def import_from_url(*, workspace_id: str, user_id: str, url: str) -> dict[
         _run_url_import(workspace_id=workspace_id, user_id=user_id, site_id=str(oid), url=candidate)
     )
     return {"site_id": str(oid), "pocket_id": pocket_id, "status": "queued"}
+
+
+# --------------------------------------------------------------------------- #
+# Rebuild mode (IR-2a) — capture a DESIGN BRIEF instead of mirroring the bytes
+# --------------------------------------------------------------------------- #
+# The mirror above re-hosts the source's own files. Rebuild reads the source as a
+# DESIGN REFERENCE and hands a typed brief to the generator, which authors a
+# native site from it. The two share the URL validation and the crawler, and
+# nothing else — in particular this path mints NO pocket and NO Site doc.
+#
+# WHY IT MINTS NOTHING: the /sites surface routes a run to REFINE whenever a
+# pocket_id rides in its meta, engine hint or not. A create flow therefore has to
+# run with no pocket, and the agent mints its own through ``create_svelte_site``
+# (which stamps engine="svelte" and the right pattern). Pre-minting a pocket here
+# to have an id to return would hand the agent the ripple refine toolset pointed
+# at an html pocket. It would also stamp IMPORT_PATTERN, which is what
+# ``service._refs_must_resolve`` reads to RELAX the publish smoke gate — correct
+# for a byte mirror that can reference something the crawl did not harvest, wrong
+# for a site we authored ourselves.
+
+
+class _MetaScan(HTMLParser):
+    """Pull the page's own account of itself: title, meta description, favicon
+    and og:image.
+
+    A real parser, never a regex: minified markup carries UNQUOTED attributes
+    (``<link href=/a.css rel=stylesheet>``), and a quote-assuming pattern returns
+    zero matches with no error, which is indistinguishable from a page that
+    genuinely declares nothing.
+    """
+
+    _ICON_RELS = {"icon", "shortcut icon", "apple-touch-icon", "mask-icon"}
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.title = ""
+        self.description = ""
+        self.og_title = ""
+        self.favicon = ""
+        self.og_image = ""
+        self._in_title = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "title":
+            self._in_title = True
+            return
+        attr = {k.lower(): (v or "") for k, v in attrs}
+        if tag == "meta":
+            key = (attr.get("name") or attr.get("property") or "").lower()
+            content = attr.get("content", "").strip()
+            if not content:
+                return
+            if key in ("description", "og:description") and not self.description:
+                self.description = content
+            elif key == "og:title" and not self.og_title:
+                self.og_title = content
+            elif key == "og:image" and not self.og_image:
+                self.og_image = content
+        elif tag == "link":
+            rels = " ".join((attr.get("rel") or "").lower().split())
+            href = attr.get("href", "").strip()
+            if href and rels in self._ICON_RELS and not self.favicon:
+                self.favicon = href
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title and not self.title:
+            self.title = data.strip()
+
+
+def _seed_page_file(url: str, files: dict[str, bytes]) -> tuple[str, bytes]:
+    """Find the crawled seed page in the harvest.
+
+    The crawler keys pages by PATH, not by "index.html": ``/landing`` lands at
+    ``landing/index.html``. Ask for the seed's own path first, fall back to the
+    root, then to the first html file in path order — a seed that redirects to
+    another host re-homes the crawl, and that final URL is not returned to us.
+    """
+    from pocketpaw_ee.sites.url_crawler import _rel_path_for_page
+
+    want = _rel_path_for_page(urlparse(url).path)
+    for candidate in (want, "index.html"):
+        blob = files.get(candidate)
+        if blob:
+            return candidate, blob
+    for path in sorted(files):
+        if path.endswith(".html") and files[path]:
+            return path, files[path]
+    raise ValidationError(
+        "sites.import_no_page", "the crawl of that URL did not yield a readable page"
+    )
+
+
+def _brief_from_crawl(url: str, crawl: Any) -> Any:
+    """Turn a harvest into a versioned brief. IR-2a fills ``meta`` only; sections,
+    tokens, forms and assets are each a later slice and land empty."""
+    from pocketpaw_ee.sites.design_brief import BriefMeta, DesignBrief
+
+    warnings = list(crawl.warnings)
+    path, blob = _seed_page_file(url, crawl.files)
+    scan = _MetaScan()
+    try:
+        scan.feed(blob.decode("utf-8", "replace"))
+    except Exception:  # noqa: BLE001 — a malformed page is a warning, not a failure
+        logger.warning("sites rebuild: meta scan of %s failed", path, exc_info=True)
+        warnings.append(f"could not read page metadata from {path}")
+    title = scan.title or scan.og_title
+    if not title:
+        warnings.append("the source page declares no title")
+    return DesignBrief(
+        source_url=url,
+        captured_at=datetime.now(UTC),
+        meta=BriefMeta(
+            title=title,
+            description=scan.description,
+            # Resolved against the SOURCE url so a stored brief carries an
+            # absolute address; the crawl's own rewrite made these site-relative.
+            favicon_url=urljoin(url, scan.favicon) if scan.favicon else None,
+            og_image_url=urljoin(url, scan.og_image) if scan.og_image else None,
+        ),
+        warnings=warnings,
+    )
+
+
+async def _mark_brief_failed(doc: Any, *, message: str) -> None:
+    """Stamp a readable failed state on the brief. ``message`` comes from
+    ``_safe_crawl_failure``, so it never carries a traceback or upstream text."""
+    doc.status = "failed"
+    doc.error = message
+    await doc.save()
+
+
+async def capture_design_brief(
+    *,
+    brief_id: str,
+    workspace_id: str,
+    url: str,
+    _transport: Any | None = None,
+    _resolver: Any | None = None,
+    _politeness_delay: float | None = None,
+) -> Any:
+    """Crawl ``url`` and persist a design brief on the queued brief document.
+
+    Runs under the SAME wall-clock cap and the SAME SSRF-pinned crawler as the
+    mirror path. Every failure lands as a readable ``failed`` status rather than
+    escaping: this runs detached from the request that queued it, so an exception
+    here has nobody to return to.
+    """
+    from bson import ObjectId
+    from bson.errors import InvalidId
+
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+    from pocketpaw_ee.sites import url_crawler
+
+    try:
+        oid = ObjectId(brief_id)
+    except (InvalidId, TypeError):
+        raise ValidationError("sites.brief_missing", "Unknown design brief id.") from None
+    doc = await SiteDesignBrief.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise ValidationError("sites.brief_missing", "Unknown design brief id.")
+
+    doc.status = "capturing"
+    await doc.save()
+    try:
+        async with asyncio.timeout(MAX_CRAWL_WALL_CLOCK_SEC):
+            crawl = await url_crawler.crawl_site(
+                url,
+                total_byte_cap=MAX_IMPORT_UNCOMPRESSED_BYTES,
+                transport=_transport,
+                resolver=_resolver,
+                politeness_delay=_politeness_delay,
+            )
+    except Exception as exc:  # noqa: BLE001 — every crawl failure becomes a safe status
+        logger.warning("sites rebuild: crawl of %s failed", url, exc_info=True)
+        await _mark_brief_failed(doc, message=_safe_crawl_failure(exc))
+        return doc
+
+    try:
+        brief = _brief_from_crawl(url, crawl)
+    except Exception as exc:  # noqa: BLE001 — same rule: a status, never an escape
+        logger.warning("sites rebuild: brief build for %s failed", url, exc_info=True)
+        await _mark_brief_failed(doc, message=_safe_crawl_failure(exc))
+        return doc
+
+    doc.brief = brief.model_dump(mode="json")
+    doc.error = ""
+    doc.status = "ready"
+    await doc.save()
+    _emit_import_journal(
+        action="site.design_brief_captured",
+        workspace_id=workspace_id,
+        user_id=doc.owner,
+        pocket_id="",
+        site_id="",
+        payload={
+            "kind": "rebuild",
+            "url": url,
+            "brief_id": brief_id,
+            "warnings": len(brief.warnings),
+        },
+    )
+    return doc
+
+
+async def _run_design_capture(*, brief_id: str, workspace_id: str, url: str) -> None:
+    """Background wrapper around ``capture_design_brief`` — it must NEVER let an
+    exception escape into the event loop (failures are already stamped on the
+    brief inside; this catches only the truly unexpected)."""
+    try:
+        await capture_design_brief(brief_id=brief_id, workspace_id=workspace_id, url=url)
+    except Exception:  # noqa: BLE001 — background task: log, never crash the loop
+        logger.exception("sites rebuild: background capture failed for brief %s", brief_id)
+
+
+async def regenerate_from_url(*, workspace_id: str, user_id: str, url: str) -> dict[str, str]:
+    """Queue a REBUILD-mode import: validate the URL (shape + SSRF floors → 422
+    before any write), insert a queued design-brief document, schedule the
+    background capture, and return ``{brief_id, status: "queued", mode: "rebuild"}``
+    immediately (the same 202 contract shape as the mirror path).
+
+    Deliberately mints no pocket and no Site doc — see the section header above.
+    """
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+
+    await sites_service.require_sites_plan(workspace_id)
+    candidate = _validate_import_url(url)
+    doc = SiteDesignBrief(
+        workspace=workspace_id, owner=user_id, source_url=candidate, status="queued"
+    )
+    await doc.insert()
+    brief_id = str(doc.id)
+    _emit_import_journal(
+        action="site.rebuild_queued",
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id="",
+        site_id="",
+        payload={"kind": "from_url_rebuild", "url": candidate, "brief_id": brief_id},
+    )
+    _default_crawl_scheduler(
+        _run_design_capture(brief_id=brief_id, workspace_id=workspace_id, url=candidate)
+    )
+    return {"brief_id": brief_id, "status": "queued", "mode": "rebuild"}

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -622,10 +622,23 @@ async def import_site_from_url(
     queued ``import_report``, schedule the background same-site crawl, and return
     202 {site_id, pocket_id, status:"queued"} immediately. The crawl runs the zip
     import pipeline and flips the report to "imported"/"failed" with crawl stats.
-    Tenant-scoped on ctx (fabric.write), like every sibling sites mutation."""
-    queued = await import_service.import_from_url(
-        workspace_id=ctx.workspace_id, user_id=ctx.user_id, url=body.url
-    )
+    Tenant-scoped on ctx (fabric.write), like every sibling sites mutation.
+
+    ``mode="rebuild"`` (IR-2a) takes the OTHER branch: the URL is read as a design
+    reference, so nothing is minted and the 202 carries a ``brief_id`` for the
+    captured design brief instead of a site. Both branches validate the URL
+    identically and 422 before any write. The default is ``copy``, so a client
+    that sends only ``url`` gets exactly the behaviour it always got.
+    """
+    if body.mode == "rebuild":
+        queued = await import_service.regenerate_from_url(
+            workspace_id=ctx.workspace_id, user_id=ctx.user_id, url=body.url
+        )
+    else:
+        queued = await import_service.import_from_url(
+            workspace_id=ctx.workspace_id, user_id=ctx.user_id, url=body.url
+        )
+        queued = {**queued, "mode": "copy"}
     return ImportFromUrlResponse(**queued)
 
 

--- a/tests/ee/sites/test_import_design_brief.py
+++ b/tests/ee/sites/test_import_design_brief.py
@@ -1,0 +1,335 @@
+# tests/ee/sites/test_import_design_brief.py — IR-2a (feat/sites-import-design-brief):
+# REBUILD mode on POST /sites/import/from-url.
+#
+# Created 2026-09-04. Covers:
+#   * The endpoint contract for both modes. ``mode="rebuild"`` returns 202
+#     {brief_id, status:"queued", mode:"rebuild"} and mints NO pocket and NO Site
+#     doc; the default (no mode sent) still mirrors, so the shipped client that
+#     posts only ``url`` reads the same fields it always did.
+#   * The design brief round-trips through persistence, and ``load_brief`` refuses
+#     a version this build cannot read instead of defaulting fields away.
+#   * The capture happy path: a fake harvest becomes a ready brief carrying the
+#     source's own title, description and an ABSOLUTE favicon URL.
+#   * Every capture failure lands as a readable ``failed`` status rather than
+#     escaping into the event loop, which has nobody to return to.
+#   * The regression this feature already tripped once: metadata is read with a
+#     real parser, so a MINIFIED page whose attributes carry no quotes is read
+#     correctly. A quote-assuming regex returns zero here with no error, which is
+#     indistinguishable from a page that declares nothing.
+#   * The seed page is found by its own PATH, not by assuming "index.html".
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.sites import import_service
+
+from tests.ee.sites.test_import import _assert_nothing_minted, _build_app
+
+_PAGE = (
+    "<!doctype html><html><head>"
+    "<title>Rohit Kushwaha</title>"
+    "<meta name='description' content='Full-Stack Engineer'>"
+    "<link rel='icon' href='/favicon.ico'>"
+    "<meta property='og:image' content='/og.png'>"
+    "</head><body><h1>Hello</h1></body></html>"
+)
+
+# The same page as a minifier emits it: no quotes around any attribute value.
+# This is the shape that broke metadata extraction once already.
+_PAGE_MINIFIED = (
+    "<!doctype html><html><head>"
+    "<title>Rohit Kushwaha</title>"
+    "<meta name=description content=Engineer>"
+    "<link href=/favicon.ico rel=icon>"
+    "</head><body></body></html>"
+)
+
+
+class _FakeCrawl:
+    """Stand-in for ``url_crawler.CrawlResult`` — files plus warnings."""
+
+    def __init__(self, files: dict[str, bytes], warnings: list[str] | None = None) -> None:
+        self.files = files
+        self.warnings = warnings or []
+
+
+def _patch_crawl(monkeypatch, result: Any) -> None:
+    """Replace the crawler with one that returns ``result`` (or raises it)."""
+
+    async def _fake(*_args: Any, **_kwargs: Any) -> Any:
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    from pocketpaw_ee.sites import url_crawler
+
+    monkeypatch.setattr(url_crawler, "crawl_site", _fake)
+
+
+# --------------------------------------------------------------------------- #
+# The brief itself — shape and version discipline
+# --------------------------------------------------------------------------- #
+
+
+def test_brief_round_trips_and_refuses_a_version_it_cannot_read():
+    from pocketpaw_ee.sites.design_brief import (
+        BRIEF_VERSION,
+        BriefVersionError,
+        DesignBrief,
+        load_brief,
+    )
+
+    brief = DesignBrief(source_url="https://example.test", captured_at=datetime.now(UTC))
+    dumped = brief.model_dump(mode="json")
+    assert load_brief(dumped).source_url == "https://example.test"
+
+    # A brief outlives the capture that made it, so a mismatched version must fail
+    # loudly. Defaulting a renamed field away produces a plausible site that is
+    # wrong about its source and reports nothing.
+    for bad in (BRIEF_VERSION + 1, BRIEF_VERSION - 1, "not-a-number", None):
+        with pytest.raises(BriefVersionError):
+            load_brief({**dumped, "version": bad})
+
+
+def test_metadata_is_read_from_minified_markup():
+    """The regression pin. A minifier strips attribute quotes; a quote-assuming
+    pattern finds nothing and reports it as a page that declares nothing."""
+    scan = import_service._MetaScan()
+    scan.feed(_PAGE_MINIFIED)
+    assert scan.title == "Rohit Kushwaha"
+    assert scan.description == "Engineer"
+    assert scan.favicon == "/favicon.ico"
+
+
+def test_seed_page_is_found_by_its_own_path_not_index_html():
+    """The crawler keys pages by path: ``/landing`` lands at ``landing/index.html``.
+    Assuming ``index.html`` reads the wrong page on any non-root seed."""
+    files = {
+        "index.html": b"<title>Home</title>",
+        "landing/index.html": b"<title>Landing</title>",
+    }
+    path, blob = import_service._seed_page_file("https://x.test/landing", files)
+    assert path == "landing/index.html"
+    assert b"Landing" in blob
+
+    # Root seed still resolves to the root page.
+    assert import_service._seed_page_file("https://x.test/", files)[0] == "index.html"
+
+
+def test_brief_from_crawl_carries_the_sources_own_words():
+    crawl = _FakeCrawl({"index.html": _PAGE.encode()}, warnings=["one crawl warning"])
+    brief = import_service._brief_from_crawl("https://rohitk06.test/", crawl)
+
+    assert brief.meta.title == "Rohit Kushwaha"
+    assert brief.meta.description == "Full-Stack Engineer"
+    # Resolved against the SOURCE url — a stored brief carries absolute addresses,
+    # because the crawl's own rewrite made these site-relative.
+    assert brief.meta.favicon_url == "https://rohitk06.test/favicon.ico"
+    assert brief.meta.og_image_url == "https://rohitk06.test/og.png"
+    assert "one crawl warning" in brief.warnings
+    # Every other family is a later slice and lands empty rather than guessed.
+    assert brief.sections == [] and brief.forms == [] and brief.assets == {}
+
+
+def test_a_page_with_no_title_warns_rather_than_failing():
+    crawl = _FakeCrawl({"index.html": b"<html><body><p>no head</p></body></html>"})
+    brief = import_service._brief_from_crawl("https://x.test/", crawl)
+    assert brief.meta.title == ""
+    assert any("no title" in w for w in brief.warnings)
+
+
+# --------------------------------------------------------------------------- #
+# The endpoint — both modes, and what each one mints
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_rebuild_mode_queues_a_brief_and_mints_nothing(beanie_test_db, monkeypatch):
+    """202 {brief_id, status:"queued", mode:"rebuild"}, the capture scheduled, and
+    NO pocket / Site doc — the generating agent mints its own pocket, and
+    pre-minting one here would route the run to refine against an html pocket."""
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+
+    scheduled: list[object] = []
+
+    def _capture(coro):
+        scheduled.append(coro)
+        coro.close()
+
+    monkeypatch.setattr(import_service, "_default_crawl_scheduler", _capture)
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/import/from-url",
+            json={"url": "https://example.com/landing", "mode": "rebuild"},
+        )
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["mode"] == "rebuild"
+    assert body["status"] == "queued"
+    assert body["brief_id"]
+    assert body["site_id"] is None and body["pocket_id"] is None
+    assert len(scheduled) == 1
+
+    await _assert_nothing_minted()
+    doc = await SiteDesignBrief.find_one({"workspace": "ws_owner"})
+    assert doc is not None
+    assert doc.status == "queued"
+    assert doc.source_url == "https://example.com/landing"
+    assert doc.brief == {}
+
+
+@pytest.mark.asyncio
+async def test_default_mode_still_mirrors(beanie_test_db, monkeypatch):
+    """The shipped client posts only ``url``. It must keep getting a site, not a
+    brief — the default flips in the PR that ships the picker, not before."""
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+
+    monkeypatch.setattr(import_service, "_default_crawl_scheduler", lambda coro: coro.close())
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/import/from-url", json={"url": "https://example.com/landing"}
+        )
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["mode"] == "copy"
+    assert body["site_id"] and body["pocket_id"]
+    assert body["brief_id"] is None
+    assert await SiteDesignBrief.find_one({"workspace": "ws_owner"}) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", ["notaurl", "ftp://example.com", "https://", "  "])
+async def test_rebuild_rejects_a_bad_url_before_any_write(beanie_test_db, monkeypatch, bad):
+    """Same SSRF + shape floors as the mirror path, and nothing is written first."""
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/import/from-url", json={"url": bad, "mode": "rebuild"})
+    assert resp.status_code == 422, resp.text
+    assert await SiteDesignBrief.find_one({"workspace": "ws_owner"}) is None
+    await _assert_nothing_minted()
+
+
+@pytest.mark.asyncio
+async def test_rebuild_rejects_a_loopback_target(beanie_test_db, monkeypatch):
+    """The crawler's SSRF floor binds this path too: a literal private IP is a 422
+    before a brief document exists."""
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/import/from-url",
+            json={"url": "http://127.0.0.1/admin", "mode": "rebuild"},
+        )
+    assert resp.status_code == 422, resp.text
+    assert await SiteDesignBrief.find_one({"workspace": "ws_owner"}) is None
+
+
+# --------------------------------------------------------------------------- #
+# The background capture — it must always land a status, never escape
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_capture_persists_a_ready_brief(beanie_test_db, monkeypatch):
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+    from pocketpaw_ee.sites.design_brief import load_brief
+
+    doc = SiteDesignBrief(
+        workspace="ws_owner", owner="user-test-1", source_url="https://rohitk06.test/"
+    )
+    await doc.insert()
+    _patch_crawl(monkeypatch, _FakeCrawl({"index.html": _PAGE.encode()}))
+
+    await import_service.capture_design_brief(
+        brief_id=str(doc.id), workspace_id="ws_owner", url="https://rohitk06.test/"
+    )
+
+    stored = await SiteDesignBrief.find_one({"_id": doc.id})
+    assert stored is not None
+    assert stored.status == "ready"
+    assert stored.error == ""
+    brief = load_brief(stored.brief)
+    assert brief.meta.title == "Rohit Kushwaha"
+    assert brief.source_url == "https://rohitk06.test/"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_crawl_becomes_a_readable_status(beanie_test_db, monkeypatch):
+    """The capture runs detached from the request that queued it, so a failure has
+    nobody to raise to. It has to be legible on the document instead."""
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+    from pocketpaw_ee.sites.url_crawler import CrawlError
+
+    doc = SiteDesignBrief(workspace="ws_owner", owner="u", source_url="https://x.test/")
+    await doc.insert()
+    _patch_crawl(monkeypatch, CrawlError("seed is blocked by robots.txt"))
+
+    await import_service.capture_design_brief(
+        brief_id=str(doc.id), workspace_id="ws_owner", url="https://x.test/"
+    )
+
+    stored = await SiteDesignBrief.find_one({"_id": doc.id})
+    assert stored is not None
+    assert stored.status == "failed"
+    assert "robots" in stored.error
+    assert stored.brief == {}
+
+
+@pytest.mark.asyncio
+async def test_a_harvest_with_no_page_becomes_a_readable_status(beanie_test_db, monkeypatch):
+    """A crawl that succeeds but yields nothing readable fails the same way — a
+    status, not a traceback and not a silently empty brief."""
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+
+    doc = SiteDesignBrief(workspace="ws_owner", owner="u", source_url="https://x.test/")
+    await doc.insert()
+    _patch_crawl(monkeypatch, _FakeCrawl({"style.css": b"body{}"}))
+
+    await import_service.capture_design_brief(
+        brief_id=str(doc.id), workspace_id="ws_owner", url="https://x.test/"
+    )
+
+    stored = await SiteDesignBrief.find_one({"_id": doc.id})
+    assert stored is not None
+    assert stored.status == "failed"
+    assert stored.brief == {}
+
+
+@pytest.mark.asyncio
+async def test_the_background_wrapper_never_raises(beanie_test_db, monkeypatch):
+    """``_run_design_capture`` is handed to the event loop. An unexpected error
+    inside it must be logged and swallowed, never left to crash the loop."""
+
+    async def _boom(**_kwargs: Any) -> Any:
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(import_service, "capture_design_brief", _boom)
+    await import_service._run_design_capture(
+        brief_id="deadbeefdeadbeefdeadbeef", workspace_id="ws_owner", url="https://x.test/"
+    )
+
+
+@pytest.mark.asyncio
+async def test_capture_is_tenant_scoped(beanie_test_db, monkeypatch):
+    """A brief id from another workspace is unknown here, not readable."""
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+
+    doc = SiteDesignBrief(workspace="ws_other", owner="u", source_url="https://x.test/")
+    await doc.insert()
+    _patch_crawl(monkeypatch, _FakeCrawl({"index.html": _PAGE.encode()}))
+
+    with pytest.raises(ValidationError):
+        await import_service.capture_design_brief(
+            brief_id=str(doc.id), workspace_id="ws_owner", url="https://x.test/"
+        )
+    stored = await SiteDesignBrief.find_one({"_id": doc.id})
+    assert stored is not None and stored.status == "queued"


### PR DESCRIPTION
The from-url import re-hosts a source site's own files. That was a deliberate call and it works, but the result sits outside the native editor lane, so an imported site is leaf-editable rather than restructurable. This is the first slice of the other half: read the URL as a design reference and capture a typed brief that a generator can author a native site from.

Planning docs live on paw-workspace#195. This is IR-2a, the part common to both options in the fork raised there, so it is buildable while that call is open.

## What it does

`POST /sites/import/from-url` gains a `mode`. `copy` is what the endpoint has always done. `rebuild` validates the same URL, crawls it with the same SSRF-pinned crawler under the same wall-clock cap, and persists a versioned `DesignBrief`. The 202 carries a `brief_id` instead of a site.

Only `meta` is filled here. Tokens, sections, forms and assets are each a later slice and land empty rather than guessed.

## It mints no pocket, and that is the point

The sites surface routes a run to refine whenever a `pocket_id` rides in its meta, engine hint or not. A create flow therefore has to run with no pocket and let the agent mint its own through `create_svelte_site`, which already stamps the right engine and pattern.

Pre-minting one here to have an id to return would have handed the agent the ripple refine toolset pointed at an html pocket. It would also have stamped the imported pattern, which is what `_refs_must_resolve` reads to relax the publish smoke gate. Relaxing is right for a byte mirror that can legitimately reference something the crawl did not harvest, and wrong for a site we authored ourselves, where an unresolved reference is a real bug.

That is why the brief gets its own collection. It is also the only thing that can hold the brief between the capture finishing and the generation starting.

## The default is copy, not rebuild

The shipped client posts only a url and reads `site_id` out of the response to navigate. Defaulting to rebuild would hand it a `brief_id` it does not understand and break the button before the picker exists. The default flips in the PR that ships the picker, and the DTO says so where someone will read it.

## A regression pinned before it could happen again

Metadata is read with a real parser, not a regex. A minifier strips attribute quotes, and a quote-assuming pattern then matches nothing with no error, which is indistinguishable from a page that declares nothing. That exact failure reported a token-rich site as having zero design tokens once during the spike that preceded this, so there is a test feeding the minified shape.

The seed page is likewise found by its own path rather than by assuming `index.html`, because the crawler keys pages by path and a `/landing` seed lands at `landing/index.html`.

## Failure behaviour

The capture runs detached from the request that queued it, so it has nobody to raise to. Every failure lands as a readable status on the brief instead: a failed crawl, a harvest with no readable page, and an unexpected error in the background wrapper are each covered. A bad or private target is a 422 before anything is written at all.

## Tests

17 new tests. Three mutations were run against them to confirm they bite: forcing the seed page to `index.html`, making rebuild fall through to copy, and making a failed capture record itself as ready. Each was caught by the test named for it.

The full `tests/ee/sites` suite is 1676 passed, 3 failed. Those three fail identically on a clean checkout of dev, in the Paw Bar autoembed and a custom-domain plan limit. Nothing this branch touches.
