### PR TITLE
perf: bound the reads that grow with the database

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/service.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/service.py
@@ -263,10 +263,24 @@ async def find_active_run_scopes() -> set[tuple[str, str, str]]:
     run for the same scope, which re-protects the jail, so a retry can't race a
     GC pass into deleting a jail it's about to reuse.
     """
-    docs = await ChatRunDoc.find(
+    # Projected to the three fields the scope tuple needs. The unprojected read
+    # hydrated a full ChatRunDoc per active run, and a run document carries the
+    # model's entire answer in `partial_text` plus, on the concierge surface,
+    # the visitor's own text in `user_text`. This call is the jail GC's guard
+    # and runs every five minutes forever, so it was pulling every active run's
+    # complete answer over the wire and building a Pydantic model from it, to
+    # read three short strings.
+    #
+    # get_pymongo_collection(), not get_motor_collection() — Beanie 2.1.0
+    # renamed it, and the old name is an AttributeError at runtime.
+    cursor = ChatRunDoc.get_pymongo_collection().find(
         {"status": {"$in": list(ACTIVE_RUN_STATUSES)}},
-    ).to_list()
-    return {(d.workspace, d.context_type, d.scope_id) for d in docs}
+        {"workspace": 1, "context_type": 1, "scope_id": 1},
+    )
+    return {
+        (row.get("workspace", ""), row.get("context_type", ""), row.get("scope_id", ""))
+        async for row in cursor
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/memory/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/memory/mongo_store.py
@@ -36,7 +36,11 @@ from datetime import UTC, datetime
 from beanie import PydanticObjectId
 from bson.errors import InvalidId
 
-from pocketpaw.memory.protocol import MemoryEntry, MemoryType  # type: ignore[import-untyped]
+from pocketpaw.memory.protocol import (  # type: ignore[import-untyped]
+    DEFAULT_SESSION_HISTORY_LIMIT,
+    MemoryEntry,
+    MemoryType,
+)
 from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
 from pocketpaw_ee.cloud.models.message import Message
 from pocketpaw_ee.cloud.models.session import Session
@@ -282,13 +286,20 @@ class MongoMemoryStore:
         facts = await MemoryFactDoc.find(filters).sort("-createdAt").limit(limit).to_list()
         return [_fact_to_entry(f) for f in facts]
 
-    async def get_session(self, session_key: str) -> list[MemoryEntry]:
+    async def get_session(
+        self, session_key: str, limit: int | None = DEFAULT_SESSION_HISTORY_LIMIT
+    ) -> list[MemoryEntry]:
         key = _normalize_session_key(session_key)
-        messages = (
-            await Message.find({"context_type": "pocket", "session_key": key})
-            .sort("createdAt")
-            .to_list()
-        )
+        query = Message.find({"context_type": "pocket", "session_key": key})
+        if limit is None:
+            messages = await query.sort("createdAt").to_list()
+        else:
+            # NEWEST `limit`, then reversed back to ascending. Sorting ascending
+            # and limiting would return the OLDEST `limit` — the exact defect
+            # #2075 fixed in the chat history window, where the agent was
+            # rehydrated with the first fifty messages a scope ever had.
+            recent = await query.sort("-createdAt").limit(limit).to_list()
+            messages = list(reversed(recent))
         return [_message_to_entry(m) for m in messages]
 
     async def clear_session(self, session_key: str) -> int:

--- a/ee/pocketpaw_ee/cloud/models/chat_run.py
+++ b/ee/pocketpaw_ee/cloud/models/chat_run.py
@@ -99,4 +99,20 @@ class ChatRunDoc(Document):
             # scan per tick. This two-key index makes the window a real bound and
             # the sort an index walk.
             IndexModel([("workspace", 1), ("createdAt", -1)]),
+            # backend-perf H4. `find_active_run_scopes` — the jail GC's guard,
+            # which runs on startup and every five minutes — filters on
+            # `status` alone, with no workspace. No index above leads on
+            # status, so that query is a COLLSCAN of the whole collection.
+            #
+            # That would be tolerable against a bounded collection. `chat_runs`
+            # has NO TTL and no archival, so it grows forever, and every row
+            # carries the run's complete assistant answer in `partial_text`.
+            # At 10k runs/day it passes a million documents in three months,
+            # and the GC then walks all of them, every five minutes.
+            #
+            # The index makes it a walk of only the active runs, which is a
+            # handful. It does NOT bound the collection — see the note on the
+            # retention gap in the audit; a TTL deletes customer data and is
+            # not a call to make inside a performance change.
+            IndexModel([("status", 1), ("createdAt", -1)]),
         ]

--- a/ee/pocketpaw_ee/cloud/models/message.py
+++ b/ee/pocketpaw_ee/cloud/models/message.py
@@ -124,6 +124,14 @@ class Message(TimestampedDocument):
         name = "messages"
         indexes = [
             [("context_type", 1), ("group", 1), ("createdAt", -1)],
+            # backend-perf M3. `get_by_type(SESSION)` filters on context_type
+            # ALONE and sorts -createdAt. The index above cannot serve it: with
+            # `group` unbounded in the middle, createdAt can supply neither a
+            # range bound nor the sort, so Mongo fetches every pocket message
+            # in the collection and sorts them in memory — which does not
+            # merely get slow, it HARD-FAILS past the 32 MB in-memory sort
+            # limit. This two-key index makes the sort an index walk.
+            [("context_type", 1), ("createdAt", -1)],
             [("workspace_id", 1), ("session_key", 1), ("createdAt", 1)],
             [("session_key", 1), ("createdAt", 1)],
             [("group", 1), ("createdAt", -1)],

--- a/src/pocketpaw/memory/file_store.py
+++ b/src/pocketpaw/memory/file_store.py
@@ -24,7 +24,11 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 
 from pocketpaw._compat import require_extra
-from pocketpaw.memory.protocol import MemoryEntry, MemoryType
+from pocketpaw.memory.protocol import (
+    DEFAULT_SESSION_HISTORY_LIMIT,
+    MemoryEntry,
+    MemoryType,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2433,8 +2437,18 @@ class FileMemoryStore:
                 break
         return results
 
-    async def get_session(self, session_key: str) -> list[MemoryEntry]:
-        """Get session history."""
+    async def get_session(
+        self, session_key: str, limit: int | None = DEFAULT_SESSION_HISTORY_LIMIT
+    ) -> list[MemoryEntry]:
+        """Get session history, oldest first, bounded by default.
+
+        The file store reads the whole session file either way — there is no
+        cheaper way to get the tail of a JSON array — so the bound here saves
+        the DESERIALIZATION and the retained MemoryEntry objects, not the read.
+        That is still the bulk of the cost on a long session, and it keeps the
+        adapter's contract identical to the Mongo one, which is what callers
+        depend on.
+        """
         session_file = self._get_session_file(session_key)
 
         if not session_file.exists():
@@ -2454,6 +2468,11 @@ class FileMemoryStore:
 
             raw = await asyncio.to_thread(safe_read)
             data = json.loads(raw)
+            # The file is stored oldest-first, so the newest `limit` is the
+            # TAIL. Slicing the head would return the oldest — the shape of the
+            # bug #2075 fixed in the chat history window.
+            if limit is not None:
+                data = data[-limit:]
             return [
                 MemoryEntry(
                     id=item["id"],

--- a/src/pocketpaw/memory/manager.py
+++ b/src/pocketpaw/memory/manager.py
@@ -359,7 +359,15 @@ class MemoryManager:
         page. An invalid cursor yields an empty page (defensive; the client
         only ever echoes back a cursor it received).
         """
-        entries = await self._store.get_session(session_key)
+        # limit=None on purpose. This pages BACKWARD through older messages
+        # via the `before` cursor, so a bounded read would make the transcript
+        # appear to end at the bound: everything older than the newest N would
+        # be unreachable, and the client would show an empty page rather than
+        # an error. The real fix is to push the cursor into the query as a
+        # keyset filter instead of loading the session and slicing it in
+        # Python — that is a change to three store implementations and is not
+        # folded into a perf pass. Tracked with H4 in the backend-perf audit.
+        entries = await self._store.get_session(session_key, limit=None)
         try:
             if before:
                 before_iso, before_id = before.split("|", 1)
@@ -464,7 +472,11 @@ class MemoryManager:
         Returns:
             List of {"role": "...", "content": "..."} dicts.
         """
-        entries = await self._store.get_session(session_key)
+        # limit=None on purpose: this feeds summarization, and silently
+        # changing which messages are summarized would change agent behaviour
+        # in a way no test would catch. It has its own `char_budget`, so the
+        # OUTPUT is already bounded — the read is not.
+        entries = await self._store.get_session(session_key, limit=None)
         if not entries:
             return []
 

--- a/src/pocketpaw/memory/mem0_store.py
+++ b/src/pocketpaw/memory/mem0_store.py
@@ -17,7 +17,11 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
-from pocketpaw.memory.protocol import MemoryEntry, MemoryType
+from pocketpaw.memory.protocol import (
+    DEFAULT_SESSION_HISTORY_LIMIT,
+    MemoryEntry,
+    MemoryType,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -417,15 +421,24 @@ class Mem0MemoryStore:
                 self.user_id = old_uid
         return await self._get_filtered(memory_type, None, limit)
 
-    async def get_session(self, session_key: str) -> list[MemoryEntry]:
-        """Get session history for a specific session."""
+    async def get_session(
+        self, session_key: str, limit: int | None = DEFAULT_SESSION_HISTORY_LIMIT
+    ) -> list[MemoryEntry]:
+        """Get session history for a specific session, oldest first.
+
+        This adapter already had a hard 1000 ceiling of its own, so it was
+        never the unbounded one. It takes the parameter to keep every
+        MemoryStoreProtocol implementation interchangeable — a caller that
+        passes ``limit`` must not get a different contract depending on which
+        backend is configured.
+        """
         self._ensure_initialized()
 
         try:
             result = await self._run_sync(
                 self._memory.get_all,
                 run_id=session_key,
-                limit=1000,
+                limit=1000 if limit is None else min(limit, 1000),
             )
 
             entries = []
@@ -436,6 +449,11 @@ class Mem0MemoryStore:
 
             # Sort by creation time
             entries.sort(key=lambda e: e.created_at)
+            # mem0's own `limit` is not documented to return the NEWEST rows,
+            # so the tail is taken after sorting rather than trusted from the
+            # query. Tail, not head — the head is the oldest.
+            if limit is not None:
+                entries = entries[-limit:]
             return entries
 
         except Exception as e:

--- a/src/pocketpaw/memory/protocol.py
+++ b/src/pocketpaw/memory/protocol.py
@@ -1,10 +1,22 @@
 # Memory storage protocol - defines the interface for swappable backends.
 # Created: 2026-02-02 - Memory System
+# Updated: 2026-09-04 (fix/bound-growing-queries, backend-perf M2) - get_session
+#   takes a `limit` and is bounded by default. It previously read every message
+#   a session had ever accumulated, from the agent loop, the sessions API and
+#   the dashboard alike.
 
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 from typing import Any, Protocol
+
+#: Messages returned by ``get_session`` when the caller does not say otherwise.
+#:
+#: Generous on purpose. This is a ceiling on an unbounded read, not a display
+#: window — the display paths apply their own, smaller limit on top (50 for the
+#: chat transcript). A number in the hundreds keeps every realistic session
+#: whole while refusing to load the pathological one.
+DEFAULT_SESSION_HISTORY_LIMIT = 500
 
 
 class MemoryType(StrEnum):
@@ -69,8 +81,28 @@ class MemoryStoreProtocol(Protocol):
         """Get all memories of a specific type."""
         ...
 
-    async def get_session(self, session_key: str) -> list[MemoryEntry]:
-        """Get session history for a specific session."""
+    async def get_session(
+        self, session_key: str, limit: int | None = DEFAULT_SESSION_HISTORY_LIMIT
+    ) -> list[MemoryEntry]:
+        """Get session history for a specific session, oldest first.
+
+        Bounded by default. This used to read every message a session had ever
+        accumulated, on a call made from the agent loop, the sessions API and
+        the dashboard alike — so a session with 10,000 turns loaded all 10,000
+        into memory each time.
+
+        ``limit`` selects the NEWEST ``limit`` messages and still returns them
+        oldest-first. Newest, not oldest: taking the first N of an ascending
+        sort is the exact defect fixed in #2075, where the chat history window
+        rehydrated the first fifty messages a scope ever had and the agent
+        answered as if the last hour had not happened. The cheap-looking
+        ``.sort(asc).limit(n)`` is the wrong shape here, every time.
+
+        ``limit=None`` restores the unbounded read. Two callers genuinely need
+        it — see ``MemoryManager.get_session_history_page``, which pages
+        BACKWARD through older messages, and ``get_compacted_history``, whose
+        summarization input must not change silently.
+        """
         ...
 
     async def clear_session(self, session_key: str) -> int:

--- a/tests/cloud/test_growing_query_bounds.py
+++ b/tests/cloud/test_growing_query_bounds.py
@@ -1,0 +1,166 @@
+# Regression: the queries that grow with the database are indexed and projected.
+#
+# Created 2026-09-04 (backend-perf H4, M2, M3). Three reads got slower as the
+# database filled rather than as traffic rose, which is the kind of problem that
+# passes every test and every staging soak and then arrives all at once.
+#
+#   H4  find_active_run_scopes filters on `status` alone. No index led on
+#       status, so it was a COLLSCAN of `chat_runs` — a collection with no TTL
+#       that grows forever, where every row carries the model's full answer in
+#       `partial_text`. It is the jail GC's guard and runs every five minutes.
+#       It also hydrated a full document per active run to read three strings.
+#   M3  get_by_type(SESSION) filters on `context_type` alone and sorts
+#       -createdAt. The available index had `group` unbounded in the middle, so
+#       createdAt could supply neither bound nor sort: Mongo fetched every
+#       matching document and sorted in memory, which HARD-FAILS past 32 MB.
+#   M2  get_session was unbounded — covered in tests/test_session_history_bounds.
+#
+# These assert on the declared index set and the projection rather than on a
+# live explain plan, because the suite runs on mongomock, which does not model
+# index selection. That is a real limit of this file: it proves the index is
+# DECLARED, not that the planner picks it. The reasoning for why each index
+# shape serves each query is written next to the index in the model.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.chat.runs import service as run_service
+from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+from pocketpaw_ee.cloud.models.message import Message
+
+
+def _index_keys(doc_cls) -> list[list[tuple]]:
+    """Normalise Beanie's mixed index declarations to lists of key tuples.
+
+    Settings.indexes accepts both bare lists and IndexModel instances, and this
+    model uses both.
+    """
+    out = []
+    for idx in doc_cls.Settings.indexes:
+        if hasattr(idx, "document"):
+            out.append([tuple(k) for k in idx.document["key"].items()])
+        else:
+            out.append([tuple(k) for k in idx])
+    return out
+
+
+class TestChatRunIndexes:
+    def test_an_index_leads_on_status(self):
+        """Without one, the jail GC's every-five-minutes guard is a full scan
+        of a collection that grows forever."""
+        leading = {keys[0][0] for keys in _index_keys(ChatRunDoc)}
+        assert "status" in leading, (
+            "no chat_runs index leads on `status`, so find_active_run_scopes is a COLLSCAN"
+        )
+
+    def test_the_status_index_also_carries_created_at(self):
+        """So the sweeper's age-ordered variants are an index walk too."""
+        status_indexes = [k for k in _index_keys(ChatRunDoc) if k[0][0] == "status"]
+        assert any(len(k) > 1 and k[1][0] == "createdAt" for k in status_indexes)
+
+    def test_the_existing_workspace_indexes_are_untouched(self):
+        """This PR adds an index; it must not have moved the tenant-scoped
+        ones the activity board depends on."""
+        leading = [keys[0][0] for keys in _index_keys(ChatRunDoc)]
+        assert leading.count("workspace") >= 2
+        assert "run_id" in leading
+
+
+class TestMessageIndexes:
+    def test_context_type_plus_created_at_exists(self):
+        """get_by_type(SESSION) filters context_type and sorts -createdAt. The
+        older three-key index has `group` unbounded in the middle, so it can
+        serve neither the bound nor the sort."""
+        keys = _index_keys(Message)
+        assert [("context_type", 1), ("createdAt", -1)] in keys, (
+            "the in-memory sort this avoids does not degrade, it hard-fails "
+            "past Mongo's 32 MB sort limit"
+        )
+
+    def test_the_sort_direction_matches_the_query(self):
+        """A -createdAt sort served by an ascending index still walks, but the
+        pair must exist as declared; an ascending second key here would be a
+        different index and a silent no-op for this query."""
+        keys = _index_keys(Message)
+        pair = [k for k in keys if len(k) == 2 and k[0][0] == "context_type"]
+        assert pair, "no two-key context_type index at all"
+        assert pair[0][1] == ("createdAt", -1)
+
+    def test_the_session_key_indexes_survive(self):
+        keys = _index_keys(Message)
+        assert [("session_key", 1), ("createdAt", 1)] in keys
+
+
+class _FakeCursor:
+    def __init__(self, rows, recorder):
+        self._rows = rows
+        self._recorder = recorder
+
+    def __aiter__(self):
+        async def _gen():
+            for r in self._rows:
+                yield r
+
+        return _gen()
+
+
+class _FakeCollection:
+    def __init__(self, rows):
+        self.rows = rows
+        self.calls: list[tuple] = []
+
+    def find(self, query, projection=None):
+        self.calls.append((query, projection))
+        return _FakeCursor(self.rows, self)
+
+
+class TestActiveRunScopesProjection:
+    @pytest.fixture
+    def collection(self, monkeypatch):
+        rows = [
+            {"workspace": "w1", "context_type": "session", "scope_id": "s1"},
+            {"workspace": "w1", "context_type": "dm", "scope_id": "s2"},
+            {"workspace": "w2", "context_type": "session", "scope_id": "s1"},
+        ]
+        fake = _FakeCollection(rows)
+        monkeypatch.setattr(ChatRunDoc, "get_pymongo_collection", classmethod(lambda cls: fake))
+        return fake
+
+    async def test_returns_the_scope_tuples(self, collection):
+        scopes = await run_service.find_active_run_scopes()
+        assert scopes == {
+            ("w1", "session", "s1"),
+            ("w1", "dm", "s2"),
+            ("w2", "session", "s1"),
+        }
+
+    async def test_only_the_three_needed_fields_are_requested(self, collection):
+        """A run document carries the model's whole answer in `partial_text`
+        and, on the concierge surface, the visitor's own text in `user_text`.
+        An unprojected read pulls both across the wire, for every active run,
+        every five minutes, to read three short strings."""
+        await run_service.find_active_run_scopes()
+
+        _query, projection = collection.calls[0]
+        assert projection is not None, "the read is unprojected"
+        assert set(projection) == {"workspace", "context_type", "scope_id"}
+        assert "partial_text" not in projection
+        assert "user_text" not in projection
+
+    async def test_the_active_status_filter_is_unchanged(self, collection):
+        """The jail GC must keep protecting exactly queued + running: an
+        interrupted run the user retries spawns a NEW queued run, which
+        re-protects the jail."""
+        await run_service.find_active_run_scopes()
+
+        query, _projection = collection.calls[0]
+        assert set(query["status"]["$in"]) == set(run_service.ACTIVE_RUN_STATUSES)
+
+    async def test_a_row_missing_a_field_does_not_raise(self, monkeypatch):
+        """Projection returns what the document has. A legacy row written
+        before a field existed must not crash the GC guard, because the GC
+        failing open would evict a jail that is in use."""
+        fake = _FakeCollection([{"workspace": "w1"}])
+        monkeypatch.setattr(ChatRunDoc, "get_pymongo_collection", classmethod(lambda cls: fake))
+
+        assert await run_service.find_active_run_scopes() == {("w1", "", "")}

--- a/tests/mutations/session_bounds.json
+++ b/tests/mutations/session_bounds.json
@@ -1,0 +1,86 @@
+[
+  {
+    "label": "the file store slices the HEAD, returning the oldest messages",
+    "file": "src/pocketpaw/memory/file_store.py",
+    "find": "            if limit is not None:\n                data = data[-limit:]",
+    "replace": "            if limit is not None:\n                data = data[:limit]",
+    "tests": ["tests/test_session_history_bounds.py::TestFileStoreBounds::test_returns_the_newest_not_the_oldest"]
+  },
+  {
+    "label": "the file store drops the bound entirely",
+    "file": "src/pocketpaw/memory/file_store.py",
+    "find": "            if limit is not None:\n                data = data[-limit:]",
+    "replace": "            if False:\n                data = data[-limit:]",
+    "tests": ["tests/test_session_history_bounds.py::TestFileStoreBounds::test_is_bounded_by_default"]
+  },
+  {
+    "label": "get_session defaults to unbounded again",
+    "file": "src/pocketpaw/memory/protocol.py",
+    "find": "DEFAULT_SESSION_HISTORY_LIMIT = 500",
+    "replace": "DEFAULT_SESSION_HISTORY_LIMIT = None",
+    "tests": ["tests/test_session_history_bounds.py::TestFileStoreBounds::test_is_bounded_by_default"]
+  },
+  {
+    "label": "the backward paginator is given the default bound, hiding older history",
+    "file": "src/pocketpaw/memory/manager.py",
+    "find": "        entries = await self._store.get_session(session_key, limit=None)\n        try:\n            if before:",
+    "replace": "        entries = await self._store.get_session(session_key)\n        try:\n            if before:",
+    "tests": ["tests/test_session_history_bounds.py::TestManagerCallers::test_paging_backward_still_reaches_the_oldest_message"]
+  },
+  {
+    "label": "compaction silently summarizes only the newest window",
+    "file": "src/pocketpaw/memory/manager.py",
+    "find": "        entries = await self._store.get_session(session_key, limit=None)\n        if not entries:\n            return []",
+    "replace": "        entries = await self._store.get_session(session_key)\n        if not entries:\n            return []",
+    "tests": ["tests/test_session_history_bounds.py::TestManagerCallers::test_compaction_still_sees_the_whole_session"]
+  },
+  {
+    "label": "the display path goes back to an unbounded read",
+    "file": "src/pocketpaw/memory/manager.py",
+    "find": "        entries = await self._store.get_session(session_key)\n        history: list[dict[str, Any]] = []",
+    "replace": "        entries = await self._store.get_session(session_key, limit=None)\n        history: list[dict[str, Any]] = []",
+    "tests": ["tests/test_session_history_bounds.py::TestManagerCallers::test_the_display_path_takes_the_default_bound"]
+  },
+  {
+    "label": "chat_runs loses the status index, restoring the collection scan",
+    "file": "ee/pocketpaw_ee/cloud/models/chat_run.py",
+    "find": "            IndexModel([(\"status\", 1), (\"createdAt\", -1)]),",
+    "replace": "",
+    "tests": ["tests/cloud/test_growing_query_bounds.py::TestChatRunIndexes::test_an_index_leads_on_status"]
+  },
+  {
+    "label": "messages loses the context_type + createdAt index, restoring the in-memory sort",
+    "file": "ee/pocketpaw_ee/cloud/models/message.py",
+    "find": "            [(\"context_type\", 1), (\"createdAt\", -1)],",
+    "replace": "",
+    "tests": ["tests/cloud/test_growing_query_bounds.py::TestMessageIndexes::test_context_type_plus_created_at_exists"]
+  },
+  {
+    "label": "find_active_run_scopes stops projecting and hydrates whole documents",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/service.py",
+    "find": "        {\"workspace\": 1, \"context_type\": 1, \"scope_id\": 1},",
+    "replace": "        None,",
+    "tests": ["tests/cloud/test_growing_query_bounds.py::TestActiveRunScopesProjection::test_only_the_three_needed_fields_are_requested"]
+  },
+  {
+    "label": "the projection grows to include the run's full answer text",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/service.py",
+    "find": "        {\"workspace\": 1, \"context_type\": 1, \"scope_id\": 1},",
+    "replace": "        {\"workspace\": 1, \"context_type\": 1, \"scope_id\": 1, \"partial_text\": 1},",
+    "tests": ["tests/cloud/test_growing_query_bounds.py::TestActiveRunScopesProjection::test_only_the_three_needed_fields_are_requested"]
+  },
+  {
+    "label": "a legacy row missing a field crashes the jail GC guard",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/service.py",
+    "find": "        (row.get(\"workspace\", \"\"), row.get(\"context_type\", \"\"), row.get(\"scope_id\", \"\"))",
+    "replace": "        (row[\"workspace\"], row[\"context_type\"], row[\"scope_id\"])",
+    "tests": ["tests/cloud/test_growing_query_bounds.py::TestActiveRunScopesProjection::test_a_row_missing_a_field_does_not_raise"]
+  },
+  {
+    "label": "the active-status filter widens, so the GC protects the wrong jails",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/service.py",
+    "find": "        {\"status\": {\"$in\": list(ACTIVE_RUN_STATUSES)}},\n        {\"workspace\": 1, \"context_type\": 1, \"scope_id\": 1},",
+    "replace": "        {\"status\": {\"$in\": [\"queued\"]}},\n        {\"workspace\": 1, \"context_type\": 1, \"scope_id\": 1},",
+    "tests": ["tests/cloud/test_growing_query_bounds.py::TestActiveRunScopesProjection::test_the_active_status_filter_is_unchanged"]
+  }
+]

--- a/tests/test_session_history_bounds.py
+++ b/tests/test_session_history_bounds.py
@@ -1,0 +1,178 @@
+# Regression: get_session is bounded, and bounded from the RIGHT END.
+#
+# Created 2026-09-04 (backend-perf M2). get_session read every message a
+# session had ever accumulated. It is called from the agent loop, the sessions
+# API, the dashboard and the memory manager, so a session with 10,000 turns
+# loaded all 10,000 on each of those calls.
+#
+# The direction is the part that needs a guard, not the bound. Taking the first
+# N of an ascending sort is the cheap-looking thing to write and is exactly the
+# defect #2075 fixed in the chat history window: the agent was rehydrated with
+# the first fifty messages a scope ever had and answered as if the last hour had
+# not happened. Nothing about that failure is visible in a status code, and a
+# test that only counts results cannot see it either.
+#
+# So every store here is checked for CONTENT, not length alone.
+#
+# What each test would catch (mutations in tests/mutations/session_bounds.json):
+#   - slice the head instead of the tail   -> test_*_returns_the_newest
+#   - drop the bound entirely              -> test_*_is_bounded
+#   - bound the backward paginator         -> test_paging_backward_still_reaches
+#   - drop the projection in the run query -> tests/cloud/test_active_run_scopes.py
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from pocketpaw.memory.file_store import FileMemoryStore
+from pocketpaw.memory.protocol import DEFAULT_SESSION_HISTORY_LIMIT, MemoryEntry, MemoryType
+
+
+def _entries(n: int) -> list[dict]:
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    return [
+        {
+            "id": f"m{i:04d}",
+            "content": f"message-{i}",
+            "role": "user" if i % 2 == 0 else "assistant",
+            "timestamp": (base + timedelta(minutes=i)).isoformat(),
+            "metadata": {},
+        }
+        for i in range(n)
+    ]
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_DATA_DIR", str(tmp_path))
+    s = FileMemoryStore(base_path=tmp_path / "memory")
+    return s
+
+
+def _seed(store, session_key: str, n: int) -> None:
+    path = store._get_session_file(session_key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_entries(n)), encoding="utf-8")
+
+
+class TestFileStoreBounds:
+    async def test_is_bounded_by_default(self, store):
+        _seed(store, "s1", DEFAULT_SESSION_HISTORY_LIMIT + 250)
+        got = await store.get_session("s1")
+        assert len(got) == DEFAULT_SESSION_HISTORY_LIMIT
+
+    async def test_returns_the_newest_not_the_oldest(self, store):
+        """The whole point. A bound applied to the head silently rewinds the
+        conversation, and every count-based assertion still passes."""
+        total = DEFAULT_SESSION_HISTORY_LIMIT + 250
+        _seed(store, "s1", total)
+        got = await store.get_session("s1")
+
+        assert got[-1].content == f"message-{total - 1}", (
+            f"newest message is {got[-1].content!r}, so the bound took the "
+            "OLDEST rows — the #2075 defect in a new place"
+        )
+        assert got[0].content == f"message-{total - DEFAULT_SESSION_HISTORY_LIMIT}"
+
+    async def test_order_stays_ascending(self, store):
+        """Callers slice with entries[-limit:] and render top to bottom, so a
+        reversed list would silently invert every transcript."""
+        _seed(store, "s1", 20)
+        got = await store.get_session("s1")
+        assert [e.created_at for e in got] == sorted(e.created_at for e in got)
+
+    async def test_an_explicit_limit_is_honoured(self, store):
+        _seed(store, "s1", 100)
+        got = await store.get_session("s1", limit=10)
+        assert len(got) == 10
+        assert got[-1].content == "message-99"
+
+    async def test_limit_none_restores_the_unbounded_read(self, store):
+        total = DEFAULT_SESSION_HISTORY_LIMIT + 250
+        _seed(store, "s1", total)
+        got = await store.get_session("s1", limit=None)
+        assert len(got) == total
+
+    async def test_a_short_session_is_returned_whole(self, store):
+        _seed(store, "s1", 7)
+        assert len(await store.get_session("s1")) == 7
+
+    async def test_a_missing_session_is_still_empty(self, store):
+        assert await store.get_session("nope") == []
+
+
+class _RecordingStore:
+    """Captures the limit each caller passes, without touching a backend."""
+
+    def __init__(self, count: int = 1000) -> None:
+        base = datetime(2026, 1, 1, tzinfo=UTC)
+        self._all = [
+            MemoryEntry(
+                id=f"m{i:04d}",
+                type=MemoryType.SESSION,
+                content=f"message-{i}",
+                role="user",
+                session_key="s1",
+                created_at=base + timedelta(minutes=i),
+                updated_at=base + timedelta(minutes=i),
+            )
+            for i in range(count)
+        ]
+        self.limits: list[int | None] = []
+
+    async def get_session(
+        self, session_key: str, limit: int | None = DEFAULT_SESSION_HISTORY_LIMIT
+    ) -> list[MemoryEntry]:
+        self.limits.append(limit)
+        return self._all if limit is None else self._all[-limit:]
+
+
+class TestManagerCallers:
+    """Two callers must stay unbounded, and it is not a matter of taste."""
+
+    def _manager(self, store):
+        from pocketpaw.memory.manager import MemoryManager
+
+        m = MemoryManager.__new__(MemoryManager)
+        m._store = store
+        return m
+
+    async def test_paging_backward_still_reaches_the_oldest_message(self):
+        """get_session_history_page filters by a `before` cursor in Python. A
+        bounded read makes everything older than the bound unreachable, so the
+        transcript appears to end and the client shows an empty page."""
+        store = _RecordingStore(count=1000)
+        manager = self._manager(store)
+
+        oldest = store._all[0]
+        cursor = f"{store._all[600].created_at.isoformat()}|{store._all[600].id}"
+        page = await manager.get_session_history_page("s1", limit=50, before=cursor)
+
+        assert store.limits == [None], f"the paginator asked for limit={store.limits}"
+        assert page["messages"], "paging backward returned nothing"
+        assert page["has_more"] is True
+        assert any(m["_id"] <= oldest.id for m in page["messages"]) or page["messages"]
+
+    async def test_compaction_still_sees_the_whole_session(self):
+        """Summarization input must not change silently; it has its own
+        char budget, so the OUTPUT was already bounded."""
+        store = _RecordingStore(count=1000)
+        manager = self._manager(store)
+
+        await manager.get_compacted_history("s1")
+
+        assert store.limits == [None]
+
+    async def test_the_display_path_takes_the_default_bound(self):
+        store = _RecordingStore(count=1000)
+        manager = self._manager(store)
+
+        history = await manager.get_session_history("s1", limit=50)
+
+        assert store.limits == [DEFAULT_SESSION_HISTORY_LIMIT], (
+            "the display path reads unbounded; it is the hot one"
+        )
+        assert history[-1]["content"] == "message-999", "display path lost the newest message"


### PR DESCRIPTION
Fifth slice of the backend performance audit. Closes M2 and M3, and the named worst case of H4.

One theme: these reads get slower as the database fills, not as traffic rises. That is the failure mode that passes every test and every staging soak and then arrives all at once, months after the code shipped.

## Session history (M2)

`get_session` read every message a session had ever accumulated, and it is called from the agent loop, the sessions API, the dashboard and the memory manager. A session with 10,000 turns loaded all 10,000 on each of those calls. It takes a `limit` now, defaulting to 500 across all three store implementations.

**The direction matters more than the bound.** Taking the first N of an ascending sort is the cheap-looking thing to write, and it is precisely the defect #2075 fixed in the chat history window, where the agent was rehydrated with the first fifty messages a scope ever had and answered as if the last hour had not happened. All three stores take the newest N and return them oldest-first, and the tests assert on message *content* rather than on length, because a length assertion cannot tell those two apart.

**Two callers keep the unbounded read**, and neither is a matter of taste:

- `get_session_history_page` filters by a cursor in Python to page *backward*. A bound would make everything older than it unreachable, so the transcript would appear to end and the client would render an empty page rather than an error.
- `get_compacted_history` feeds summarization. Silently changing which messages are summarized changes agent behaviour with nothing to catch it, and its output was already bounded by a character budget.

Both are marked `limit=None` with the reason inline. The paginator really wants a keyset query pushed down into the store, which is a change to three implementations and does not belong in a performance pass.

## Pocket message scan (M3)

`get_by_type(SESSION)` filters on `context_type` alone and sorts `-createdAt`. The only candidate index had `group` unbounded in the middle, so `createdAt` could supply neither a range bound nor the sort, and Mongo fetched every matching document to sort it in memory.

That does not merely get slow. It **hard-fails** past Mongo's 32 MB in-memory sort limit. A two-key index makes it an index walk.

## Jail GC guard (H4)

`find_active_run_scopes` filters on `status` alone, and no index led on `status`, so it was a full collection scan. `chat_runs` has no TTL and grows forever, every row carries the model's complete answer in `partial_text`, and this query runs on startup and every five minutes. At 10k runs/day the collection passes a million documents in three months.

It also hydrated a full document per active run to read three short strings, so it is projected now.

## What this deliberately does not do

**`chat_runs` still has no retention policy.** A TTL deletes customer conversation data, and that is not a decision to slip into a performance change. The index makes the scan cheap; it does not bound the collection. Flagged in the audit for a real decision.

**The other unbounded `to_list()` sites are untouched.** The audit counts 121. Adding `.limit()` to all of them mechanically would trade a slow query for silent truncation, which is worse than slow. The ones fixed here are the ones whose callers I actually read.

**`get_by_type` still has no workspace filter.** That is a tenant-isolation concern rather than a performance one, and half-doing an isolation change inside a perf PR is how those get missed. It belongs with the auth findings.

## Verification

All 12 mutations in `tests/mutations/session_bounds.json` caught, including head-versus-tail slicing on the file store, and a widened status filter that would make the jail GC protect the wrong directories.

The index tests assert the index is *declared*, not that the planner picks it. The suite runs on mongomock, which does not model index selection. That limit is written at the top of the test file rather than left for a reader to discover.

| suite | result |
|---|---|
| cloud memory + runs + new | 309 passed |
| OSS memory/session/agent-loop selection | 614 passed, 1 failed |

The single failure is `test_sdk_redacts_refresh_token_and_writes_0600`, which is in the set of 67 failures I baselined against a pristine `dev` worktree earlier today.