### PR TITLE
perf: dispatch the worker bridge by lane instead of one at a time

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/xproc.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/xproc.py
@@ -13,6 +13,21 @@ emitted from arq workers — typically zero, since Tier 1 doesn't run any.
 The stream + consumer group survives both worker and web restarts: arq
 workers keep XADD-ing; the web's consumer group XACKs each delivered entry,
 so a fresh web process resumes from the last unacked cursor.
+
+Changes: 2026-09-04 (fix/concurrent-dispatch, backend-perf H2) — the consumer
+dispatches a batch by ORDERING LANE instead of strictly one envelope at a
+time. Every worker-originated realtime frame in the deployment flows through
+this one loop, so a single slow dispatch stalled delivery for every tenant on
+the box, not just the one that caused it — one workspace with a back-pressured
+socket made agent replies appear frozen for every other customer.
+
+The lane split is what makes that safe. These envelopes carry streamed agent
+output, so the chunks of one reply must arrive in the order they were
+produced; a plain ``gather`` over the batch would remove the stall and
+scramble the answer instead. Envelopes sharing a lane still run in stream
+order, and ``_ordering_lane`` falls back to the event type when it cannot
+identify a scope, so an unfamiliar envelope stays serial rather than being
+parallelised on a guess.
 """
 
 from __future__ import annotations
@@ -155,21 +170,86 @@ async def run_consumer(
         if not resp:
             continue
 
+        # Dispatch the batch by ORDERING LANE: envelopes that share a lane run
+        # one after another, different lanes run at the same time.
+        #
+        # The old loop awaited every envelope in turn, so one slow dispatch
+        # held up every envelope behind it — and because this is the single
+        # bridge for all worker-originated realtime traffic, "behind it" means
+        # every other tenant on the box. One workspace with a wedged socket
+        # made agent replies look frozen for every customer.
+        #
+        # A plain gather over the batch would fix that and break something
+        # worse. These envelopes carry streamed agent output: the chunks of one
+        # reply must arrive in the order they were produced, or the answer
+        # renders scrambled. Concurrency is therefore only ever ACROSS lanes.
+        lanes: dict[tuple[str, str], list[tuple[str, dict | None]]] = {}
         for _key, entries in resp:
             for entry_id, fields in entries:
                 try:
                     envelope = json.loads(fields["envelope"])
-                    await _dispatch(envelope)
                 except Exception:
-                    logger.exception("xproc dispatch failed for entry %s", entry_id)
-                finally:
-                    # Always ack — a bad envelope must not stall the stream.
-                    # Worst case the side-effect is missed once and the user
-                    # observes a one-off glitch; better than blocking forever.
-                    try:
-                        await redis.xack(XPROC_STREAM, XPROC_GROUP, entry_id)
-                    except Exception:
-                        logger.debug("xproc xack failed for %s", entry_id, exc_info=True)
+                    logger.exception("xproc: unparseable envelope in entry %s", entry_id)
+                    # Still needs an ack, in its own lane so it cannot delay
+                    # anything real.
+                    lanes.setdefault(("bad", entry_id), []).append((entry_id, None))
+                    continue
+                lanes.setdefault(_ordering_lane(envelope), []).append((entry_id, envelope))
+
+        await asyncio.gather(*(_run_lane(redis, entries) for entries in lanes.values()))
+
+
+#: Fields, in priority order, that identify "the conversation this envelope
+#: belongs to" on a bus envelope. A bus envelope carries no explicit scope —
+#: the audience is resolved later from ``data`` — so the lane is read from the
+#: same identifiers the audience resolver uses.
+_BUS_SCOPE_FIELDS = ("group_id", "scope_id", "session_id", "session_key", "run_id", "pocket_id")
+
+
+def _ordering_lane(envelope: dict) -> tuple[str, str]:
+    """The lane an envelope must stay ordered within.
+
+    Two envelopes sharing a lane are dispatched in stream order. Envelopes in
+    different lanes may overtake each other, which is the entire point.
+
+    Conservative by construction: when no scope can be identified, the lane
+    falls back to the event TYPE rather than to something unique. That keeps
+    same-type envelopes serial — the old behaviour — instead of silently
+    parallelising a stream whose ordering requirements we could not read.
+    Getting this wrong does not raise; it scrambles a user's reply.
+    """
+    kind = envelope.get("kind")
+    if kind == "ws":
+        return ("ws", str(envelope.get("scope_id", "")))
+    if kind == "bus":
+        data = envelope.get("data") or {}
+        if isinstance(data, dict):
+            for field in _BUS_SCOPE_FIELDS:
+                value = data.get(field)
+                if value:
+                    return ("bus", str(value))
+        return ("bus-type", str(envelope.get("type", "")))
+    # Unknown kinds are forward-compatible no-ops in _dispatch, but keep them
+    # in one lane so a newer worker's stream can't fan out unbounded.
+    return ("unknown", str(kind))
+
+
+async def _run_lane(redis, entries: list[tuple[str, dict | None]]) -> None:
+    """Dispatch one lane's envelopes in order, acking each as it finishes."""
+    for entry_id, envelope in entries:
+        try:
+            if envelope is not None:
+                await _dispatch(envelope)
+        except Exception:
+            logger.exception("xproc dispatch failed for entry %s", entry_id)
+        finally:
+            # Always ack — a bad envelope must not stall the stream. Worst
+            # case the side-effect is missed once and the user observes a
+            # one-off glitch; better than blocking forever.
+            try:
+                await redis.xack(XPROC_STREAM, XPROC_GROUP, entry_id)
+            except Exception:
+                logger.debug("xproc xack failed for %s", entry_id, exc_info=True)
 
 
 async def _dispatch(envelope: dict) -> None:

--- a/ee/pocketpaw_ee/cloud/audit/webhooks.py
+++ b/ee/pocketpaw_ee/cloud/audit/webhooks.py
@@ -329,7 +329,11 @@ async def deliver(event: AuditEvent) -> None:
         payload = _event_payload(event)
         body = json.dumps(payload, default=str)
         timestamp = str(int(time.time()))
-        async with httpx.AsyncClient() as client:
+        # Explicit timeout. httpx's 5s default already bounded this, but the
+        # URL here is SUPPLIED BY THE WORKSPACE, and the loop below delivers
+        # to each hook in turn — so a deliberately slow endpoint delays every
+        # later hook's delivery. Stating the deadline keeps that visible.
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
             for hook in hooks:
                 try:
                     await _deliver_one(hook, body, timestamp, client)

--- a/ee/pocketpaw_ee/cloud/notifications/delivery.py
+++ b/ee/pocketpaw_ee/cloud/notifications/delivery.py
@@ -241,7 +241,10 @@ async def _deliver_external(notification: Notification) -> None:
         sinks = _resolve_sinks(config, notification.kind)
         if not sinks:
             return
-        async with httpx.AsyncClient() as client:
+        # Explicit timeout, same reasoning as audit/webhooks.py: the sink URL
+        # is workspace-supplied and the sinks are delivered serially, so an
+        # unhurried endpoint holds up the ones after it.
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
             for sink_name, url in sinks:
                 try:
                     await _post_one(client, sink_name, url, notification)

--- a/src/pocketpaw/agents/opencode.py
+++ b/src/pocketpaw/agents/opencode.py
@@ -79,9 +79,20 @@ class OpenCodeBackend(BaseAgentBackend):
         )
         self._policy = policy
 
+    # `timeout=None` used to apply to every phase, including CONNECT. An
+    # OpenCode server that was down or unreachable therefore hung the caller
+    # forever rather than failing — including `_check_health`, whose whole job
+    # is to answer that question quickly.
+    #
+    # READ stays unbounded on purpose: an agent generation legitimately runs
+    # for minutes, and a read deadline here would truncate long answers, which
+    # is a worse bug than the one being fixed. Only the phases that cannot
+    # legitimately take minutes are bounded.
+    _TIMEOUT = httpx.Timeout(connect=10.0, read=None, write=30.0, pool=10.0)
+
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=None)
+            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=self._TIMEOUT)
         return self._client
 
     async def _check_health(self) -> bool:

--- a/tests/cloud/test_xproc_lane_dispatch.py
+++ b/tests/cloud/test_xproc_lane_dispatch.py
@@ -1,0 +1,259 @@
+# Regression: the worker→web bridge dispatches concurrently, but only across
+# conversations — never within one.
+#
+# Created 2026-09-04 (backend-perf H2). Every worker-originated realtime frame
+# in the deployment flows through one consumer loop, which awaited each
+# envelope in turn. A single slow dispatch therefore stalled delivery for every
+# tenant on the box: one workspace with a back-pressured socket made agent
+# replies look frozen for every other customer.
+#
+# THE TRAP THIS FILE EXISTS FOR: a plain gather over the batch removes the
+# stall and introduces a worse bug. These envelopes carry streamed agent
+# output, so the chunks of one reply must arrive in the order they were
+# produced. Parallelising within a conversation renders the answer scrambled —
+# and nothing raises, no status code changes, and a test that only measures
+# concurrency reports success.
+#
+# So this file asserts BOTH directions. Every "runs concurrently" test has a
+# matching "stays ordered" test, and neither alone is sufficient.
+#
+# What each test would catch (mutations in tests/mutations/xproc_lanes.json):
+#   - go back to a fully serial loop      -> test_separate_lanes_run_concurrently
+#   - gather the whole batch flat         -> test_one_lane_stays_in_order
+#   - key the lane on the entry id        -> test_one_lane_stays_in_order
+#   - drop the ack on a failed dispatch   -> test_a_failing_dispatch_is_still_acked
+#   - let an unparseable envelope raise   -> test_an_unparseable_envelope_is_acked
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime import xproc
+
+
+def _entry(entry_id: str, envelope: dict) -> tuple[str, dict]:
+    return (entry_id, {"envelope": json.dumps(envelope)})
+
+
+def _ws(scope_id: str, seq: int) -> dict:
+    return {
+        "kind": "ws",
+        "scope_id": scope_id,
+        "recipients": ["u1"],
+        "type": "message.chunk",
+        "data": {"seq": seq},
+    }
+
+
+class _FakeRedis:
+    """Serves one batch, then blocks so the consumer loop parks."""
+
+    def __init__(self, batch: list[tuple[str, dict]]) -> None:
+        self._batch = batch
+        self._served = False
+        self.acked: list[str] = []
+
+    async def xgroup_create(self, *a, **kw) -> None:
+        return None
+
+    async def xreadgroup(self, *a, **kw):
+        if self._served:
+            await asyncio.sleep(3600)
+        self._served = True
+        return [(xproc.XPROC_STREAM, self._batch)]
+
+    async def xack(self, _stream, _group, entry_id) -> None:
+        self.acked.append(entry_id)
+
+
+async def _consume_one_batch(monkeypatch, batch, dispatch):
+    """Run the consumer just long enough to process one batch."""
+    redis = _FakeRedis(batch)
+    monkeypatch.setattr(xproc, "get_redis", lambda: redis)
+    monkeypatch.setattr(xproc, "_dispatch", dispatch)
+
+    task = asyncio.create_task(xproc.run_consumer(consumer_name="test", block_ms=1))
+    for _ in range(200):
+        await asyncio.sleep(0)
+        if len(redis.acked) >= len(batch):
+            break
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    return redis
+
+
+class TestLaneConcurrency:
+    async def test_separate_lanes_run_concurrently(self, monkeypatch):
+        """Different conversations must not queue behind each other. This is
+        the finding: one wedged workspace froze every tenant."""
+        gate = asyncio.Event()
+        in_flight = 0
+        peak = 0
+
+        async def _dispatch(envelope):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            try:
+                await gate.wait()
+            finally:
+                in_flight -= 1
+
+        batch = [_entry(f"e{i}", _ws(f"scope-{i}", 0)) for i in range(6)]
+        redis = _FakeRedis(batch)
+        monkeypatch.setattr(xproc, "get_redis", lambda: redis)
+        monkeypatch.setattr(xproc, "_dispatch", _dispatch)
+
+        task = asyncio.create_task(xproc.run_consumer(consumer_name="t", block_ms=1))
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+        assert peak == 6, f"only {peak} of 6 lanes were in flight; dispatch is still serial"
+        gate.set()
+        for _ in range(100):
+            await asyncio.sleep(0)
+            if len(redis.acked) >= 6:
+                break
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    async def test_one_lane_stays_in_order(self, monkeypatch):
+        """The chunks of a single reply. Out of order here is a scrambled
+        answer on someone's screen, with nothing raised anywhere.
+
+        Durations DESCEND deliberately. Equal durations are not enough: tasks
+        started in order that yield the same number of times finish in order
+        too, so a flat gather looks correct. Making the first envelope the
+        slowest means anything concurrent completes roughly backwards, and the
+        assertion can tell the two apart.
+        """
+        seen: list[int] = []
+        count = 6
+
+        async def _dispatch(envelope):
+            seq = envelope["data"]["seq"]
+            await asyncio.sleep((count - seq) * 0.01)
+            seen.append(seq)
+
+        batch = [_entry(f"e{i}", _ws("scope-A", i)) for i in range(count)]
+        redis = _FakeRedis(batch)
+        monkeypatch.setattr(xproc, "get_redis", lambda: redis)
+        monkeypatch.setattr(xproc, "_dispatch", _dispatch)
+
+        task = asyncio.create_task(xproc.run_consumer(consumer_name="t", block_ms=1))
+        async with asyncio.timeout(10):
+            while len(redis.acked) < count:
+                await asyncio.sleep(0.01)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert seen == list(range(count)), f"chunks arrived out of order: {seen}"
+
+    async def test_interleaved_lanes_keep_their_own_order(self, monkeypatch):
+        """Two conversations at once: each stays internally ordered."""
+        per_lane: dict[str, list[int]] = {}
+
+        async def _dispatch(envelope):
+            await asyncio.sleep(0)
+            per_lane.setdefault(envelope["scope_id"], []).append(envelope["data"]["seq"])
+
+        batch = []
+        for i in range(5):
+            batch.append(_entry(f"a{i}", _ws("scope-A", i)))
+            batch.append(_entry(f"b{i}", _ws("scope-B", i)))
+        await _consume_one_batch(monkeypatch, batch, _dispatch)
+
+        assert per_lane["scope-A"] == list(range(5))
+        assert per_lane["scope-B"] == list(range(5))
+
+
+class TestAcking:
+    async def test_every_entry_is_acked(self, monkeypatch):
+        async def _dispatch(envelope):
+            return None
+
+        batch = [_entry(f"e{i}", _ws(f"s{i}", 0)) for i in range(4)]
+        redis = await _consume_one_batch(monkeypatch, batch, _dispatch)
+
+        assert sorted(redis.acked) == ["e0", "e1", "e2", "e3"]
+
+    async def test_a_failing_dispatch_is_still_acked(self, monkeypatch):
+        """An unacked entry is redelivered forever and stalls the stream. The
+        original loop acked in a finally; concurrency must not lose that."""
+
+        async def _dispatch(envelope):
+            raise RuntimeError("handler exploded")
+
+        batch = [_entry("e0", _ws("s0", 0))]
+        redis = await _consume_one_batch(monkeypatch, batch, _dispatch)
+
+        assert redis.acked == ["e0"]
+
+    async def test_a_failing_lane_does_not_stop_the_others(self, monkeypatch):
+        delivered: list[str] = []
+
+        async def _dispatch(envelope):
+            if envelope["scope_id"] == "bad":
+                raise RuntimeError("boom")
+            delivered.append(envelope["scope_id"])
+
+        batch = [
+            _entry("e0", _ws("good-1", 0)),
+            _entry("e1", _ws("bad", 0)),
+            _entry("e2", _ws("good-2", 0)),
+        ]
+        redis = await _consume_one_batch(monkeypatch, batch, _dispatch)
+
+        assert sorted(delivered) == ["good-1", "good-2"]
+        assert sorted(redis.acked) == ["e0", "e1", "e2"]
+
+    async def test_an_unparseable_envelope_is_acked_and_isolated(self, monkeypatch):
+        """A malformed entry must not stall the stream, and must not be able
+        to delay a real one by sharing its lane."""
+        delivered: list[str] = []
+
+        async def _dispatch(envelope):
+            delivered.append(envelope["scope_id"])
+
+        batch = [
+            ("bad", {"envelope": "{not json"}),
+            _entry("e1", _ws("s1", 0)),
+        ]
+        redis = await _consume_one_batch(monkeypatch, batch, _dispatch)
+
+        assert delivered == ["s1"]
+        assert sorted(redis.acked) == ["bad", "e1"]
+
+
+class TestOrderingLane:
+    def test_ws_envelopes_key_on_scope(self):
+        assert xproc._ordering_lane(_ws("scope-A", 0)) == ("ws", "scope-A")
+
+    def test_bus_envelopes_key_on_a_scope_field_in_data(self):
+        env = {"kind": "bus", "type": "message.new", "data": {"group_id": "g1"}}
+        assert xproc._ordering_lane(env) == ("bus", "g1")
+
+    def test_a_bus_envelope_with_no_scope_falls_back_to_its_type(self):
+        """Conservative on purpose. Falling back to something UNIQUE would
+        parallelise a stream whose ordering needs we could not read, and the
+        symptom would be a scrambled reply rather than an error."""
+        env = {"kind": "bus", "type": "workspace.updated", "data": {"nothing": 1}}
+        assert xproc._ordering_lane(env) == ("bus-type", "workspace.updated")
+
+    def test_two_envelopes_of_the_same_unscoped_type_share_a_lane(self):
+        a = {"kind": "bus", "type": "x.y", "data": {}}
+        b = {"kind": "bus", "type": "x.y", "data": {}}
+        assert xproc._ordering_lane(a) == xproc._ordering_lane(b)
+
+    def test_unknown_kinds_share_one_lane(self):
+        env = {"kind": "from-a-newer-worker", "type": "?"}
+        assert xproc._ordering_lane(env) == ("unknown", "from-a-newer-worker")
+
+    def test_a_non_dict_data_does_not_raise(self):
+        env = {"kind": "bus", "type": "x.y", "data": "not-a-dict"}
+        assert xproc._ordering_lane(env) == ("bus-type", "x.y")

--- a/tests/mutations/xproc_lanes.json
+++ b/tests/mutations/xproc_lanes.json
@@ -1,0 +1,83 @@
+[
+  {
+    "label": "the consumer goes back to a fully serial dispatch",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/xproc.py",
+    "find": "        await asyncio.gather(*(_run_lane(redis, entries) for entries in lanes.values()))",
+    "replace": "        for _entries in lanes.values():\n            await _run_lane(redis, _entries)",
+    "tests": [
+      "tests/cloud/test_xproc_lane_dispatch.py::TestLaneConcurrency::test_separate_lanes_run_concurrently"
+    ]
+  },
+  {
+    "label": "the batch is gathered flat, scrambling one reply's chunks",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/xproc.py",
+    "find": "                lanes.setdefault(_ordering_lane(envelope), []).append((entry_id, envelope))",
+    "replace": "                lanes.setdefault((\"flat\", entry_id), []).append((entry_id, envelope))",
+    "tests": [
+      "tests/cloud/test_xproc_lane_dispatch.py::TestLaneConcurrency::test_one_lane_stays_in_order"
+    ]
+  },
+  {
+    "label": "ws envelopes stop keying on scope, so one conversation splits across lanes",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/xproc.py",
+    "find": "    if kind == \"ws\":\n        return (\"ws\", str(envelope.get(\"scope_id\", \"\")))",
+    "replace": "    if kind == \"ws\":\n        return (\"ws\", str(envelope.get(\"type\", \"\")))",
+    "tests": [
+      "tests/cloud/test_xproc_lane_dispatch.py::TestOrderingLane::test_ws_envelopes_key_on_scope"
+    ]
+  },
+  {
+    "label": "an unscoped bus envelope falls back to something unique instead of its type",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/xproc.py",
+    "find": "        return (\"bus-type\", str(envelope.get(\"type\", \"\")))",
+    "replace": "        return (\"bus-type\", str(id(envelope)))",
+    "tests": [
+      "tests/cloud/test_xproc_lane_dispatch.py::TestOrderingLane::test_two_envelopes_of_the_same_unscoped_type_share_a_lane"
+    ]
+  },
+  {
+    "label": "a failed dispatch is no longer acked, so the entry is redelivered forever",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/xproc.py",
+    "find": "        finally:\n            # Always ack",
+    "replace": "        else:\n            # Always ack",
+    "tests": [
+      "tests/cloud/test_xproc_lane_dispatch.py::TestAcking::test_a_failing_dispatch_is_still_acked"
+    ]
+  },
+  {
+    "label": "an unparseable envelope is never acked, so it is redelivered forever",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/xproc.py",
+    "find": "                    lanes.setdefault((\"bad\", entry_id), []).append((entry_id, None))\n                    continue",
+    "replace": "                    continue",
+    "tests": [
+      "tests/cloud/test_xproc_lane_dispatch.py::TestAcking::test_an_unparseable_envelope_is_acked_and_isolated"
+    ]
+  },
+  {
+    "label": "a non-dict data payload raises instead of falling back",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/xproc.py",
+    "find": "        if isinstance(data, dict):\n            for field in _BUS_SCOPE_FIELDS:",
+    "replace": "        if True:\n            for field in _BUS_SCOPE_FIELDS:",
+    "tests": [
+      "tests/cloud/test_xproc_lane_dispatch.py::TestOrderingLane::test_a_non_dict_data_does_not_raise"
+    ]
+  },
+  {
+    "label": "the opencode client goes back to an unbounded connect timeout",
+    "file": "src/pocketpaw/agents/opencode.py",
+    "find": "    _TIMEOUT = httpx.Timeout(connect=10.0, read=None, write=30.0, pool=10.0)",
+    "replace": "    _TIMEOUT = None",
+    "tests": [
+      "tests/test_opencode_timeouts.py::test_connect_is_bounded"
+    ]
+  },
+  {
+    "label": "the opencode client bounds READ, truncating long generations",
+    "file": "src/pocketpaw/agents/opencode.py",
+    "find": "    _TIMEOUT = httpx.Timeout(connect=10.0, read=None, write=30.0, pool=10.0)",
+    "replace": "    _TIMEOUT = httpx.Timeout(10.0)",
+    "tests": [
+      "tests/test_opencode_timeouts.py::test_read_stays_unbounded"
+    ]
+  }
+]

--- a/tests/test_opencode_timeouts.py
+++ b/tests/test_opencode_timeouts.py
@@ -1,0 +1,54 @@
+# Regression: the OpenCode client bounds the phases that cannot legitimately
+# take minutes, and leaves the one that can.
+#
+# Created 2026-09-04 (backend-perf L1). The client was built with
+# `timeout=None`, which applies to every phase including CONNECT — so an
+# OpenCode server that was down or unreachable hung the caller forever. That
+# included `_check_health`, whose entire job is to answer that question fast.
+#
+# The fix is not "add a timeout". A read deadline here truncates a long agent
+# generation, which is a worse bug than the one being fixed and would look like
+# the model stopping mid-sentence. Both directions are asserted, because either
+# one alone permits the other failure.
+
+from __future__ import annotations
+
+import httpx
+
+from pocketpaw.agents.opencode import OpenCodeBackend
+
+
+def _timeout() -> httpx.Timeout:
+    t = OpenCodeBackend._TIMEOUT
+    assert isinstance(t, httpx.Timeout), f"expected an httpx.Timeout, got {t!r}"
+    return t
+
+
+def test_connect_is_bounded():
+    """An unreachable server must fail, not hang."""
+    assert _timeout().connect is not None
+    assert _timeout().connect <= 30.0
+
+
+def test_read_stays_unbounded():
+    """An agent generation legitimately runs for minutes. A read deadline here
+    truncates the answer, and the user sees the model stop mid-sentence."""
+    assert _timeout().read is None, "a read timeout on this client cuts off long generations"
+
+
+def test_write_and_pool_are_bounded():
+    assert _timeout().write is not None
+    assert _timeout().pool is not None
+
+
+def test_the_client_is_actually_built_with_it():
+    """The constant existing proves nothing on its own — it has to reach the
+    client. No request is made; only the configured timeout is read."""
+    backend = OpenCodeBackend.__new__(OpenCodeBackend)
+    backend._client = None
+    backend._base_url = "http://localhost:9999"
+
+    client = backend._get_client()
+
+    assert client.timeout.connect == _timeout().connect
+    assert client.timeout.read is None


### PR DESCRIPTION
Sixth slice of the backend performance audit. Closes H2, the last HIGH finding, plus the concrete hazards in L1.

## The worker bridge was a single serialized consumer (H2)

Every worker-originated realtime frame in the deployment flows through one consumer loop, and that loop awaited each envelope in turn. A single slow dispatch stalled delivery for **every tenant on the box**, not just the one that caused it. One workspace with a back-pressured socket made agent replies appear frozen for every other customer.

**The obvious fix makes it worse.** A gather over the batch removes the stall and introduces a subtler bug: these envelopes carry streamed agent output, so the chunks of one reply have to arrive in the order they were produced. Parallelising within a conversation renders the answer scrambled. Nothing raises, no status code changes, and a test that measures only concurrency reports success.

So the batch is split into **ordering lanes**. Envelopes sharing a lane run in stream order; different lanes run at once.

- A WebSocket envelope keys on its scope.
- A bus envelope carries no explicit scope, so the lane is read from the same identifiers the audience resolver uses.
- When none is present it falls back to the event **type**, not to something unique. That is the conservative direction on purpose: an unfamiliar envelope stays serial rather than being parallelised on a guess.

Acking keeps its old contract. Every entry is acked whatever happens, and a malformed envelope now gets its own lane so it cannot delay real traffic while still being acked. An unacked entry is redelivered forever.

## Timeout hazards (L1)

The OpenCode client was built with `timeout=None`, which applies to every phase **including connect**, so an unreachable server hung the caller forever. That included the health check whose entire job is to answer that question quickly.

Connect, write and pool are bounded now. **Read stays unbounded deliberately**: an agent generation legitimately runs for minutes, and a read deadline would truncate long answers, which is a worse bug than the one being fixed. Both directions are tested, because either assertion alone permits the other failure.

The two outbound fan-outs that relied on httpx's implicit default now state a timeout. Both deliver to workspace-supplied URLs, serially, so a deliberately slow endpoint delays every later delivery.

## Deliberately not done

- **M8** (convert two middlewares to pure ASGI). PR #2076 is already open against both of those files, and the finding is explicitly marked unmeasured in the audit, which also notes that Starlette 0.52.1 improved `BaseHTTPMiddleware` considerably. Sequencing it now buys a merge conflict for an unproven gain. It should follow #2076.
- **L3** (in-memory rate limiting blocks horizontal scaling). Fixing it needs a Redis-backed limiter so a second web replica does not multiply every limit by the replica count. That is a feature, not a fix.
- **The full shared-client refactor.** About 60 sites construct a fresh `AsyncClient` per call. Module-level shared clients need lifecycle management and event-loop care in tests. Only the hazards were taken here.
- **L2** needs nothing. The audit records it as a negative result: no `requests` anywhere, and every `time.sleep` is in a synchronous function.

## Verification

All 9 mutations in `tests/mutations/xproc_lanes.json` caught.

Three escaped on the first run, and the split is worth recording. **Two were bad mutations rather than weak tests** — `continue` inside a `try` still runs the `finally`, so the mutation I wrote to remove the ack never removed it. **One was a genuinely weak test**: equal-duration dispatches started in order also finish in order, so a flat gather looked correctly ordered. It only fails once the durations descend, making the first envelope the slowest.

| suite | result |
|---|---|
| realtime + notifications + audit + new | 245 passed, 6 failed |

The six failures are the same notifications set confirmed pre-existing against a pristine `dev` worktree earlier today. This branch does not touch those routers beyond adding a timeout to one outbound client.