### PR TITLE
A captured brief now reaches the agent that builds from it

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -186,6 +186,14 @@ class SurfaceMeta:
     # / unset refines (edits) the site. Consulted only on the refine branch (pocket_id
     # present); the sites handler reads ``meta.mode`` there. Absent on create/gallery.
     mode: str | None = None
+    # Sites import-create hint — the id of a captured ``SiteDesignBrief``. Present
+    # only on a REBUILD import: the user gave a URL, the crawl distilled it into a
+    # design brief, and the create run authors a native site FROM that brief rather
+    # than from a typed description. Paired with ``engine`` and NO ``pocket_id``,
+    # because a pocket_id would route the run to refine and the pocket is the
+    # agent's own to mint. The handler fetches the brief server-side; only the id
+    # rides the wire.
+    brief_id: str | None = None
     # Belt console hints — set by the /belt page once the user has bound a repo
     # + branch for the run. ``repo`` is the absolute repo path; ``base_branch``
     # is the branch to base the change off. The belt handler injects both into

--- a/ee/pocketpaw_ee/cloud/surface/dto.py
+++ b/ee/pocketpaw_ee/cloud/surface/dto.py
@@ -57,6 +57,7 @@ class SurfaceMetaRequest(BaseModel):
     # "Use Svelte pages" toggle: "ripple" (default) | "svelte". Selects which
     # create-site authoring skill the preamble prefers. Optional.
     engine: str | None = None
+    brief_id: str | None = None
     # Sites refine hint — mirror SurfaceMeta. The Build/Chat toggle in the
     # /sites/[siteId] refine chat: "chat" answers with no mutation, "build" (the
     # default, preserving today's behavior) refines the site. Optional.

--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -571,6 +571,30 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
                 text=refine_text,
                 cache_key=content_key("sites", refine_text),
             )
+    elif meta.brief_id:
+        # IMPORT-CREATE. The user gave a URL, the crawl distilled it into the
+        # crew's DesignBrief, and this run authors a native site FROM that brief
+        # instead of from a typed description. It reaches ``_frontend_preamble``,
+        # the brief-driven twin of ``_create_preamble`` that has existed unwired
+        # since 2026-07-06 waiting for exactly this: it walks the sitemap, injects
+        # the copy and asset manifest, threads the design-system tokens, and
+        # routes on ``brief.engine``.
+        #
+        # It reads live state, so it answers ``content_key`` for the same reason
+        # refine does. And like refine, its failure mode is a DIFFERENT preamble,
+        # never a failed turn: an unreadable or missing brief falls back to the
+        # ordinary create preamble, which asks the user what to build. That is a
+        # worse experience than the rebuild they asked for and a much better one
+        # than an error, and it is what happens if a brief is deleted between the
+        # capture and the send.
+        brief = await _import_brief(meta.brief_id, workspace_id)
+        if brief is not None:
+            brief_text = _frontend_preamble(meta, brief)
+            return SurfacePreamble(
+                text=brief_text,
+                cache_key=content_key("sites", brief_text),
+            )
+        text = _create_preamble(meta)
     else:
         text = _create_preamble(meta)
     # The five inputs the two meta-only sub-preambles read, all off ``meta``.
@@ -582,6 +606,42 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
             "sites", meta.route_path, meta.pocket_id, meta.site_id, meta.engine, meta.mode
         ),
     )
+
+
+async def _import_brief(brief_id: str, workspace_id: str) -> DesignBrief | None:
+    """Load a captured design brief for an import-create run, or ``None``.
+
+    Never raises. Every failure — an id that is not an ObjectId, a brief from
+    another workspace, a capture that has not finished or failed, a payload this
+    build's version cannot read — is the same answer here, because the caller's
+    only two options are "build from this brief" and "ask the user what to
+    build". Which particular thing went wrong belongs in the log and on the
+    import panel, not in a preamble.
+    """
+    try:
+        from bson import ObjectId
+        from bson.errors import InvalidId
+
+        from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+        from pocketpaw_ee.sites.design_brief import load_brief
+
+        try:
+            oid = ObjectId(brief_id)
+        except (InvalidId, TypeError):
+            logger.warning("sites import-create: %r is not a brief id", brief_id)
+            return None
+        doc = await SiteDesignBrief.find_one({"_id": oid, "workspace": workspace_id})
+        if doc is None or doc.status != "ready" or not doc.brief:
+            logger.warning(
+                "sites import-create: brief %s is not ready (%s)",
+                brief_id,
+                getattr(doc, "status", "missing"),
+            )
+            return None
+        return load_brief(doc.brief)
+    except Exception:  # noqa: BLE001 — a preamble read never fails a turn
+        logger.warning("sites import-create: could not load brief %s", brief_id, exc_info=True)
+        return None
 
 
 def _create_preamble(meta: SurfaceMeta) -> str:

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -320,6 +320,7 @@ def _meta_from_request(req: SurfaceMetaRequest) -> SurfaceMeta:
         site_id=req.site_id,
         engine=req.engine,
         mode=req.mode,
+        brief_id=req.brief_id,
         repo=req.repo,
         base_branch=req.base_branch,
         current_dir=req.current_dir,

--- a/ee/pocketpaw_ee/sites/design_brief.py
+++ b/ee/pocketpaw_ee/sites/design_brief.py
@@ -1,48 +1,56 @@
-# ee/pocketpaw_ee/sites/design_brief.py — the typed, versioned description of a
-# source page that the SITE REGENERATION path hands to the generator, instead of
-# re-hosting the source's own bytes the way the html mirror does.
+# ee/pocketpaw_ee/sites/design_brief.py — build the site-authoring crew's
+# ``DesignBrief`` from a crawled URL, so a rebuild-mode import feeds the SAME
+# baton the crew's Frontend stage already knows how to build from.
 #
-# Created 2026-09-04 (IR-2a, feat/sites-import-design-brief). Only ``meta`` is
-# filled at capture time; ``tokens`` (IR-4), ``sections`` (IR-3), ``forms`` (IR-9)
-# and ``assets`` (IR-5) are each filled by a later slice and land empty here. They
-# exist now so the persisted shape does not change under a stored brief every time
-# one of those slices lands.
+# REWRITTEN 2026-09-04 (feat/sites-import-regenerate). The first version of this
+# module declared its own ``DesignBrief``, which was a duplicate: the codebase
+# already had one at ``sites_crew/models.py``, threaded Designer → Branding →
+# Frontend, and ``cloud/surface/handlers/sites.py::_frontend_preamble`` already
+# renders build instructions from it and routes to ``create_svelte_site``. That
+# preamble has been written and unwired since 2026-07-06, waiting on an
+# orchestration slice that never landed. Regenerating from a URL is that slice.
 #
-# WHY A VERSION FIELD, CHECKED ON READ: a brief outlives the capture that made it
-# — the whole point of persisting one is that a regenerate does not re-crawl. So a
-# brief written by an older build will be read by a newer one. ``load_brief``
-# refuses a mismatch loudly (recapture, or a build that is too old to read this)
-# rather than letting pydantic quietly default away fields whose meaning changed.
-# A silently misread brief regenerates a site that looks nothing like its source
-# and reports no error, which is the failure mode this file exists to prevent.
-"""Typed design brief for regenerating a site from a URL."""
+# So there is no second brief type. This module only knows how to FILL the crew's
+# brief from a harvest, and how to version the persisted copy — the crew model
+# carries no version of its own because, until now, it never outlived a request.
+#
+# Created 2026-09-04 (IR-2a).
+"""Build the crew's DesignBrief from a crawled source page."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime
 from typing import Any
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from pocketpaw_ee.sites_crew.models import (
+    AssetRef,
+    Branding,
+    DesignBrief,
+    DesignDirection,
+    DesignSystem,
+)
 
-# Bump on ANY change to the shape below that an older reader would misinterpret.
-# Adding a field with a default that reads correctly as "absent" does not need a
-# bump; renaming, re-typing, or changing what a field MEANS does.
+# Bump on any change to how a brief is PERSISTED that an older reader would
+# misinterpret. This lives here rather than on the crew model because the crew
+# model is a request-scoped baton; only the import path stores one and has to
+# read it back later.
 BRIEF_VERSION = 1
 
-# The closed section vocabulary. Deliberately the set the design-taste skill
-# already authors, so a brief never asks the generator for a section kind it has
-# no idiom for. Anything unrecognised becomes ``content`` plus a warning — see
-# IR-3 — because dropping a section silently loses a whole band of the page.
-SECTION_KINDS = (
+# The section roles the crew's ``Section.role`` already names, which are also
+# what the design-taste skill authors. IR-3 classifies into this set; anything it
+# cannot place becomes "custom" plus an open question, never a dropped band.
+SECTION_ROLES = (
+    "nav",
     "hero",
-    "features",
+    "services",
+    "proof",
     "pricing",
-    "testimonial",
-    "faq",
     "cta",
+    "lead_form",
+    "faq",
     "footer",
-    "content",
+    "custom",
 )
 
 
@@ -50,76 +58,73 @@ class BriefVersionError(ValueError):
     """A stored brief cannot be read by this build. Recapture, or upgrade."""
 
 
-class BriefMeta(BaseModel):
-    """What the source page says it is. The only family filled at capture time."""
+def build_brief_from_source(
+    *,
+    source_url: str,
+    title: str = "",
+    description: str = "",
+    favicon_url: str | None = None,
+    warnings: list[str] | None = None,
+) -> DesignBrief:
+    """Fill the crew brief from what a capture learned about a source page.
 
-    title: str = ""
-    description: str = ""
-    favicon_url: str | None = None
-    og_image_url: str | None = None
+    IR-2a fills the identity layer only. The sitemap (IR-3), the design system
+    (IR-4) and the asset manifest (IR-5) are each a later slice and land empty,
+    which the crew model already tolerates — every one of those fields has a
+    default, because the crew fills them stage by stage too.
 
-
-class BriefTokens(BaseModel):
-    """The source's design language. Filled by IR-4 from its stylesheets.
-
-    ``palette`` is ORDERED most-referenced first, which is the whole reason it is
-    a list rather than a set: a real site declares dozens to hundreds of colour
-    tokens and a brief needs a handful, so the order is the selection.
+    ``engine`` is svelte because that is the track with the native edit lane, and
+    being able to restructure the result is the entire reason a rebuild exists
+    rather than a mirror.
     """
+    host = urlparse(source_url).netloc or source_url
+    subject = title.strip() or host
+    # The TITLE leads, because it is the site's name and the host is only its
+    # address. A goal that says "rebuild rohitk06.in" tells the agent where the
+    # reference lives; one that says "rebuild Rohit Kushwaha (rohitk06.in)" tells
+    # it what it is building.
+    named = f"{subject} ({host})" if subject != host else host
+    goal = (
+        f"Rebuild {named} as a native Paw site. Match the source's structure, "
+        f"layout and design language; do not copy its markup."
+    )
+    if description.strip():
+        goal += f" The source describes itself as: {description.strip()}"
 
-    palette: list[str] = Field(default_factory=list)
-    # {"heading": <family>, "body": <family>, "mono": <family>} — resolved
-    # families, never a raw ``var(--x)`` reference and never a bare fallback stack.
-    fonts: dict[str, str] = Field(default_factory=dict)
-    type_scale: list[str] = Field(default_factory=list)
-    spacing: list[str] = Field(default_factory=list)
-    radii: list[str] = Field(default_factory=list)
-    shadows: list[str] = Field(default_factory=list)
+    # AssetRef REJECTS anything that is not an http(s) URL, which is the right
+    # rule and also why this is guarded rather than passed straight through: a
+    # page can declare a data: favicon, and a source that declares none is
+    # ordinary. Neither is worth failing a capture over.
+    favicon = None
+    if favicon_url and favicon_url.startswith(("http://", "https://")):
+        favicon = AssetRef(url=favicon_url, kind="favicon", alt=f"{subject} favicon")
+    elif favicon_url:
+        (warnings := list(warnings or [])).append(
+            "the source's favicon is not a fetchable http(s) URL and was not carried over"
+        )
+
+    brand = Branding(
+        design_system=DesignSystem(name=f"{subject} (from {host})"),
+        favicon_asset=favicon,
+    )
+    return DesignBrief(
+        goal=goal,
+        engine="svelte",
+        pattern="landing",
+        # The source URL is a visual REFERENCE, which is exactly what this field
+        # is for. It is not an asset and not a page we are hosting.
+        design_direction=DesignDirection(
+            references=[source_url],
+            layout_notes="Match the source page's section order and proportions.",
+        ),
+        branding=brand,
+        open_questions=list(warnings or []),
+    )
 
 
-class BriefSection(BaseModel):
-    """One band of the source page, in document order. Filled by IR-3."""
-
-    kind: str = "content"
-    order: int = 0
-    heading: str = ""
-    subcopy: str = ""
-    items: list[str] = Field(default_factory=list)
-    image_refs: list[str] = Field(default_factory=list)
-    # top / left / width / height as the rendered page reported them. Kept because
-    # the ORDER and relative size of bands is most of what "same layout" means.
-    geometry: dict[str, float] = Field(default_factory=dict)
-
-
-class BriefForm(BaseModel):
-    """A form the source page carried. Filled by IR-9.
-
-    ``fields`` carries the original NAMES because downstream lead handling keys on
-    them: a regenerated form with prettier field names captures leads that no
-    existing mapping recognises.
-    """
-
-    purpose: str = ""
-    fields: list[str] = Field(default_factory=list)
-    original_action: str = ""
-    method: str = "post"
-
-
-class DesignBrief(BaseModel):
-    """Everything the generator needs to author a native site that reads as the
-    source's, without ever taking ownership of the source's own tree."""
-
-    version: int = BRIEF_VERSION
-    source_url: str
-    captured_at: datetime
-    meta: BriefMeta = Field(default_factory=BriefMeta)
-    tokens: BriefTokens = Field(default_factory=BriefTokens)
-    sections: list[BriefSection] = Field(default_factory=list)
-    forms: list[BriefForm] = Field(default_factory=list)
-    # path -> the URL it was stored at in OUR blob storage, so a generated section
-    # never points at the original host. Filled by IR-5.
-    assets: dict[str, str] = Field(default_factory=dict)
-    warnings: list[str] = Field(default_factory=list)
+def dump_brief(brief: DesignBrief) -> dict[str, Any]:
+    """The persisted envelope: the crew brief plus the version that wrote it."""
+    return {"version": BRIEF_VERSION, "brief": brief.model_dump(mode="json")}
 
 
 def load_brief(payload: Mapping[str, Any]) -> DesignBrief:
@@ -136,14 +141,16 @@ def load_brief(payload: Mapping[str, Any]) -> DesignBrief:
         raise BriefVersionError(
             f"design brief has no readable version (got {stored!r}); recapture the source"
         ) from None
-    if version > BRIEF_VERSION:
-        raise BriefVersionError(
-            f"design brief is version {version}, newer than this build reads "
-            f"({BRIEF_VERSION}); upgrade rather than reading it"
+    if version != BRIEF_VERSION:
+        direction = "newer than" if version > BRIEF_VERSION else "older than"
+        remedy = (
+            "upgrade rather than reading it" if version > BRIEF_VERSION else "recapture the source"
         )
-    if version < BRIEF_VERSION:
         raise BriefVersionError(
-            f"design brief is version {version}, older than this build reads "
-            f"({BRIEF_VERSION}); recapture the source"
+            f"design brief is version {version}, {direction} this build reads "
+            f"({BRIEF_VERSION}); {remedy}"
         )
-    return DesignBrief.model_validate(dict(payload))
+    body = payload.get("brief")
+    if not isinstance(body, Mapping):
+        raise BriefVersionError("design brief envelope carries no brief")
+    return DesignBrief.model_validate(dict(body))

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -744,6 +744,29 @@ class ImportFromUrlResponse(BaseModel):
     brief_id: str | None = None
 
 
+class ImportBriefStatusResponse(BaseModel):
+    """GET /sites/import/brief/{id} — where a rebuild capture has got to.
+
+    Four states, and they are deliberately distinguishable: ``queued`` (nothing
+    has run), ``capturing`` (the crawl is in flight), ``ready`` (there is a brief
+    to generate from) and ``failed`` (it ended, and ``error`` says why in safe,
+    user-facing words). A client that cannot tell ``queued`` from ``failed``
+    shows a spinner forever on a dead capture, which is the bug the import panel
+    already had once.
+
+    ``goal`` and ``open_questions`` are the readable half of the brief itself, so
+    the panel can show what was understood without shipping the whole baton to
+    the browser.
+    """
+
+    brief_id: str
+    status: str  # queued | capturing | ready | failed
+    source_url: str
+    error: str = ""
+    goal: str = ""
+    open_questions: list[str] = []
+
+
 class SiteInvoiceOut(BaseModel):
     """One manual receipt on the site's client record. ``amount_cents`` is integer
     MINOR units — the wire never carries a float for money, so the reading client

--- a/ee/pocketpaw_ee/sites/import_service.py
+++ b/ee/pocketpaw_ee/sites/import_service.py
@@ -845,9 +845,17 @@ def _seed_page_file(url: str, files: dict[str, bytes]) -> tuple[str, bytes]:
 
 
 def _brief_from_crawl(url: str, crawl: Any) -> Any:
-    """Turn a harvest into a versioned brief. IR-2a fills ``meta`` only; sections,
-    tokens, forms and assets are each a later slice and land empty."""
-    from pocketpaw_ee.sites.design_brief import BriefMeta, DesignBrief
+    """Turn a harvest into the site-authoring crew's ``DesignBrief``.
+
+    Deliberately the crew's own baton rather than a second brief type: the crew
+    threads it Designer → Branding → Frontend, and
+    ``surface/handlers/sites.py::_frontend_preamble`` already renders build
+    instructions from one and routes to ``create_svelte_site``. IR-2a fills the
+    identity layer; the sitemap, design system and asset manifest are each a
+    later slice and land empty, which the crew model already tolerates because
+    its own stages fill them one at a time too.
+    """
+    from pocketpaw_ee.sites.design_brief import build_brief_from_source
 
     warnings = list(crawl.warnings)
     path, blob = _seed_page_file(url, crawl.files)
@@ -860,17 +868,14 @@ def _brief_from_crawl(url: str, crawl: Any) -> Any:
     title = scan.title or scan.og_title
     if not title:
         warnings.append("the source page declares no title")
-    return DesignBrief(
+    return build_brief_from_source(
         source_url=url,
-        captured_at=datetime.now(UTC),
-        meta=BriefMeta(
-            title=title,
-            description=scan.description,
-            # Resolved against the SOURCE url so a stored brief carries an
-            # absolute address; the crawl's own rewrite made these site-relative.
-            favicon_url=urljoin(url, scan.favicon) if scan.favicon else None,
-            og_image_url=urljoin(url, scan.og_image) if scan.og_image else None,
-        ),
+        title=title,
+        description=scan.description,
+        # Resolved against the SOURCE url so a stored brief carries an absolute
+        # address; the crawl's own rewrite made these site-relative, and
+        # ``AssetRef`` refuses anything that is not fetchable.
+        favicon_url=urljoin(url, scan.favicon) if scan.favicon else None,
         warnings=warnings,
     )
 
@@ -936,7 +941,9 @@ async def capture_design_brief(
         await _mark_brief_failed(doc, message=_safe_crawl_failure(exc))
         return doc
 
-    doc.brief = brief.model_dump(mode="json")
+    from pocketpaw_ee.sites.design_brief import dump_brief
+
+    doc.brief = dump_brief(brief)
     doc.error = ""
     doc.status = "ready"
     await doc.save()
@@ -950,7 +957,7 @@ async def capture_design_brief(
             "kind": "rebuild",
             "url": url,
             "brief_id": brief_id,
-            "warnings": len(brief.warnings),
+            "open_questions": len(brief.open_questions),
         },
     )
     return doc
@@ -995,3 +1002,60 @@ async def regenerate_from_url(*, workspace_id: str, user_id: str, url: str) -> d
         _run_design_capture(brief_id=brief_id, workspace_id=workspace_id, url=candidate)
     )
     return {"brief_id": brief_id, "status": "queued", "mode": "rebuild"}
+
+
+async def read_design_brief(*, workspace_id: str, brief_id: str) -> Any:
+    """Read a captured brief's state for the import panel (IR-2b).
+
+    Returns the four states as themselves rather than collapsing any pair: a
+    client that cannot tell ``queued`` from ``failed`` shows a spinner forever on
+    a capture that already died, which is the same class of bug the import report
+    panel shipped with. ``error`` is already safe text (``_safe_crawl_failure``
+    wrote it), so it goes straight to a reader.
+
+    The brief BODY is not returned. Only the goal and the open questions, which
+    are the readable half — the baton itself is for the generation run, and
+    shipping it to a browser would be sending the whole design system to render
+    one status line.
+    """
+    from bson import ObjectId
+    from bson.errors import InvalidId
+
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+    from pocketpaw_ee.sites.design_brief import BriefVersionError, load_brief
+    from pocketpaw_ee.sites.dto import ImportBriefStatusResponse
+
+    try:
+        oid = ObjectId(brief_id)
+    except (InvalidId, TypeError):
+        raise ValidationError("sites.brief_missing", "Unknown design brief id.") from None
+    doc = await SiteDesignBrief.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise ValidationError("sites.brief_missing", "Unknown design brief id.")
+
+    goal, questions = "", []
+    if doc.status == "ready" and doc.brief:
+        try:
+            brief = load_brief(doc.brief)
+            goal, questions = brief.goal, list(brief.open_questions)
+        except BriefVersionError as exc:
+            # A stored brief this build cannot read is a FAILED capture from the
+            # reader's point of view: there is nothing here to generate from, and
+            # saying "ready" would start a run against a brief the preamble will
+            # also refuse. Recapturing is the fix, so say so.
+            logger.warning("sites rebuild: brief %s is unreadable: %s", brief_id, exc)
+            return ImportBriefStatusResponse(
+                brief_id=brief_id,
+                status="failed",
+                source_url=doc.source_url,
+                error="that capture was saved by a different version — import the URL again",
+            )
+
+    return ImportBriefStatusResponse(
+        brief_id=brief_id,
+        status=doc.status,
+        source_url=doc.source_url,
+        error=doc.error,
+        goal=goal,
+        open_questions=questions,
+    )

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -257,6 +257,7 @@ from pocketpaw_ee.sites.dto import (
     DevPreviewResponse,
     DomainRequest,
     DomainStatusResponse,
+    ImportBriefStatusResponse,
     ImportFromUrlRequest,
     ImportFromUrlResponse,
     LeafEditsRequest,
@@ -1183,3 +1184,21 @@ async def delete_site_asset(
         await store.delete(workspace_id=ctx.workspace_id, pocket_id=pocket_id, key=body.key)
     except PublicAssetError as exc:
         raise HTTPException(403, str(exc)) from exc
+
+
+@router.get("/sites/import/brief/{brief_id}", response_model=ImportBriefStatusResponse)
+async def get_import_brief(
+    brief_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> ImportBriefStatusResponse:
+    """Where a rebuild capture has got to (IR-2b).
+
+    The rebuild 202 returns immediately with a ``brief_id`` and the crawl runs in
+    the background, so the client polls this to learn when there is a brief to
+    generate from. Four distinguishable states, because a client that cannot tell
+    ``queued`` from ``failed`` spins forever on a dead capture.
+
+    Tenant-scoped on ctx: a brief id from another workspace is not found here, not
+    readable. A read, so no ``fabric.write`` — same shape as the sibling listings.
+    """
+    return await import_service.read_design_brief(workspace_id=ctx.workspace_id, brief_id=brief_id)

--- a/tests/ee/sites/test_import_design_brief.py
+++ b/tests/ee/sites/test_import_design_brief.py
@@ -78,20 +78,38 @@ def test_brief_round_trips_and_refuses_a_version_it_cannot_read():
     from pocketpaw_ee.sites.design_brief import (
         BRIEF_VERSION,
         BriefVersionError,
-        DesignBrief,
+        build_brief_from_source,
+        dump_brief,
         load_brief,
     )
 
-    brief = DesignBrief(source_url="https://example.test", captured_at=datetime.now(UTC))
-    dumped = brief.model_dump(mode="json")
-    assert load_brief(dumped).source_url == "https://example.test"
+    brief = build_brief_from_source(source_url="https://example.test/", title="Example")
+    envelope = dump_brief(brief)
+    assert load_brief(envelope).goal == brief.goal
 
-    # A brief outlives the capture that made it, so a mismatched version must fail
-    # loudly. Defaulting a renamed field away produces a plausible site that is
-    # wrong about its source and reports nothing.
+    # A brief outlives the capture that made it, so a mismatched version must
+    # fail loudly. Defaulting a renamed field away produces a plausible site that
+    # is wrong about its source and reports nothing.
     for bad in (BRIEF_VERSION + 1, BRIEF_VERSION - 1, "not-a-number", None):
         with pytest.raises(BriefVersionError):
-            load_brief({**dumped, "version": bad})
+            load_brief({**envelope, "version": bad})
+    # An envelope with a version but no brief is refused too, rather than
+    # validating into an empty brief that would generate a site about nothing.
+    with pytest.raises(BriefVersionError):
+        load_brief({"version": BRIEF_VERSION})
+
+
+def test_the_brief_is_the_crews_own_baton():
+    """Not a second brief type. The crew threads this one Designer to Frontend,
+    and _frontend_preamble already builds from it."""
+    from pocketpaw_ee.sites.design_brief import build_brief_from_source
+    from pocketpaw_ee.sites_crew.models import DesignBrief as CrewBrief
+
+    brief = build_brief_from_source(source_url="https://example.test/")
+    assert isinstance(brief, CrewBrief)
+    # svelte because that is the track with the native edit lane, which is the
+    # entire reason a rebuild exists rather than a mirror.
+    assert brief.engine == "svelte"
 
 
 def test_metadata_is_read_from_minified_markup():
@@ -123,22 +141,27 @@ def test_brief_from_crawl_carries_the_sources_own_words():
     crawl = _FakeCrawl({"index.html": _PAGE.encode()}, warnings=["one crawl warning"])
     brief = import_service._brief_from_crawl("https://rohitk06.test/", crawl)
 
-    assert brief.meta.title == "Rohit Kushwaha"
-    assert brief.meta.description == "Full-Stack Engineer"
-    # Resolved against the SOURCE url — a stored brief carries absolute addresses,
-    # because the crawl's own rewrite made these site-relative.
-    assert brief.meta.favicon_url == "https://rohitk06.test/favicon.ico"
-    assert brief.meta.og_image_url == "https://rohitk06.test/og.png"
-    assert "one crawl warning" in brief.warnings
-    # Every other family is a later slice and lands empty rather than guessed.
-    assert brief.sections == [] and brief.forms == [] and brief.assets == {}
+    # The source's own title and description reach the goal the agent builds to.
+    assert "rohitk06.test" in brief.goal
+    assert "Full-Stack Engineer" in brief.goal
+    # The URL is a visual REFERENCE, which is the field that means that. It is
+    # not an asset and not a page we are hosting.
+    assert brief.design_direction.references == ["https://rohitk06.test/"]
+    # Resolved against the SOURCE url — AssetRef refuses anything unfetchable,
+    # and the crawl's own rewrite had made this site-relative.
+    assert brief.branding.favicon_asset is not None
+    assert brief.branding.favicon_asset.url == "https://rohitk06.test/favicon.ico"
+    assert "one crawl warning" in brief.open_questions
+    # Every other layer is a later slice and lands empty rather than guessed.
+    assert brief.sitemap == [] and brief.copy == {} and brief.asset_manifest == []
 
 
 def test_a_page_with_no_title_warns_rather_than_failing():
     crawl = _FakeCrawl({"index.html": b"<html><body><p>no head</p></body></html>"})
     brief = import_service._brief_from_crawl("https://x.test/", crawl)
-    assert brief.meta.title == ""
-    assert any("no title" in w for w in brief.warnings)
+    # With no title the goal falls back to the host rather than inventing one.
+    assert "x.test" in brief.goal
+    assert any("no title" in q for q in brief.open_questions)
 
 
 # --------------------------------------------------------------------------- #
@@ -257,8 +280,9 @@ async def test_capture_persists_a_ready_brief(beanie_test_db, monkeypatch):
     assert stored.status == "ready"
     assert stored.error == ""
     brief = load_brief(stored.brief)
-    assert brief.meta.title == "Rohit Kushwaha"
-    assert brief.source_url == "https://rohitk06.test/"
+    assert "Rohit Kushwaha" in brief.goal
+    assert brief.design_direction.references == ["https://rohitk06.test/"]
+    assert brief.engine == "svelte"
 
 
 @pytest.mark.asyncio
@@ -333,3 +357,129 @@ async def test_capture_is_tenant_scoped(beanie_test_db, monkeypatch):
         )
     stored = await SiteDesignBrief.find_one({"_id": doc.id})
     assert stored is not None and stored.status == "queued"
+
+
+# --------------------------------------------------------------------------- #
+# IR-2b — the brief reaches the agent, and a missing one never fails a turn
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_ready_brief_routes_to_the_brief_driven_preamble(beanie_test_db, monkeypatch):
+    """The whole point of a rebuild. With a brief and no pocket, the create run
+    gets _frontend_preamble — which walks the brief and routes to the svelte
+    create tool — instead of the preamble that asks the user what to build."""
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+    from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+    from pocketpaw_ee.cloud.surface.handlers.sites import build_preamble
+
+    doc = SiteDesignBrief(workspace="ws_owner", owner="u", source_url="https://rohitk06.test/")
+    await doc.insert()
+    _patch_crawl(monkeypatch, _FakeCrawl({"index.html": _PAGE.encode()}))
+    await import_service.capture_design_brief(
+        brief_id=str(doc.id), workspace_id="ws_owner", url="https://rohitk06.test/"
+    )
+
+    pre = await build_preamble("ws_owner", "u", SurfaceMeta(engine="svelte", brief_id=str(doc.id)))
+    assert "rohitk06.test" in pre.text
+    assert "Rohit Kushwaha" in pre.text
+    assert "create_svelte_site" in pre.text
+    # It read live state, so it answers a content key, exactly as refine does.
+    assert pre.cache_key
+
+
+@pytest.mark.asyncio
+async def test_a_brief_that_is_not_ready_falls_back_rather_than_failing(
+    beanie_test_db, monkeypatch
+):
+    """A capture still running, one that failed, an id from another workspace and
+    an id that is not an id all land the same way: the ordinary create preamble.
+    The turn must never fail — the user is mid-conversation."""
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+    from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+    from pocketpaw_ee.cloud.surface.handlers.sites import build_preamble
+
+    plain = await build_preamble("ws_owner", "u", SurfaceMeta(engine="svelte"))
+
+    queued = SiteDesignBrief(workspace="ws_owner", owner="u", source_url="https://x.test/")
+    await queued.insert()
+    failed = SiteDesignBrief(
+        workspace="ws_owner", owner="u", source_url="https://y.test/", status="failed"
+    )
+    await failed.insert()
+    other = SiteDesignBrief(workspace="ws_other", owner="u", source_url="https://z.test/")
+    await other.insert()
+
+    for brief_id in (str(queued.id), str(failed.id), str(other.id), "not-an-id", ""):
+        pre = await build_preamble("ws_owner", "u", SurfaceMeta(engine="svelte", brief_id=brief_id))
+        assert pre.text == plain.text, f"{brief_id!r} did not fall back"
+
+
+# --------------------------------------------------------------------------- #
+# The status read the panel polls
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_the_status_read_tells_the_four_states_apart(beanie_test_db, monkeypatch):
+    """queued, capturing, failed and ready are each themselves. A client that
+    cannot tell queued from failed spins forever on a capture that already died."""
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+
+    doc = SiteDesignBrief(workspace="ws_owner", owner="u", source_url="https://x.test/")
+    await doc.insert()
+
+    got = await import_service.read_design_brief(workspace_id="ws_owner", brief_id=str(doc.id))
+    assert got.status == "queued"
+    assert got.source_url == "https://x.test/"
+    assert got.error == "" and got.goal == ""
+
+    doc.status = "failed"
+    doc.error = "crawl exceeded the 120s wall-clock cap"
+    await doc.save()
+    got = await import_service.read_design_brief(workspace_id="ws_owner", brief_id=str(doc.id))
+    assert got.status == "failed"
+    assert "120s" in got.error
+
+    _patch_crawl(monkeypatch, _FakeCrawl({"index.html": _PAGE.encode()}))
+    await import_service.capture_design_brief(
+        brief_id=str(doc.id), workspace_id="ws_owner", url="https://rohitk06.test/"
+    )
+    got = await import_service.read_design_brief(workspace_id="ws_owner", brief_id=str(doc.id))
+    assert got.status == "ready"
+    assert "Rohit Kushwaha" in got.goal
+    # A successful recapture clears the old failure rather than leaving it to be
+    # read alongside a ready status.
+    assert got.error == ""
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_stored_brief_reads_as_failed(beanie_test_db):
+    """A brief saved by another version is nothing to generate from. Reporting
+    ready would start a run the preamble then refuses, so it reads as failed with
+    a remedy the user can act on."""
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+
+    doc = SiteDesignBrief(
+        workspace="ws_owner",
+        owner="u",
+        source_url="https://x.test/",
+        status="ready",
+        brief={"version": 99, "brief": {"goal": "from the future"}},
+    )
+    await doc.insert()
+
+    got = await import_service.read_design_brief(workspace_id="ws_owner", brief_id=str(doc.id))
+    assert got.status == "failed"
+    assert "again" in got.error
+
+
+@pytest.mark.asyncio
+async def test_the_status_read_is_tenant_scoped(beanie_test_db):
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+    from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+
+    doc = SiteDesignBrief(workspace="ws_other", owner="u", source_url="https://x.test/")
+    await doc.insert()
+    with pytest.raises(ValidationError):
+        await import_service.read_design_brief(workspace_id="ws_owner", brief_id=str(doc.id))

--- a/tests/ee/sites/test_import_design_brief.py
+++ b/tests/ee/sites/test_import_design_brief.py
@@ -19,7 +19,6 @@
 #   * The seed page is found by its own PATH, not by assuming "index.html".
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Any
 
 import pytest


### PR DESCRIPTION
Capturing a design brief did nothing on its own. This wires it to the generator, so a rebuild import actually produces a native Svelte site. Backend half; the modal that offers the choice is a paw-enterprise PR.

## Most of this already existed

`_frontend_preamble` in the sites surface handler describes itself in its own header as "the ADDITIVE brief-driven twin of `_create_preamble`". It walks a `DesignBrief`'s sitemap, injects the matching copy blocks and real asset imagery, threads the branding design-system tokens, and routes on `brief.engine` to `create_svelte_site`. It has been written and unwired since 2026-07-06, waiting on an orchestration slice that never landed. Regenerating from a URL is that slice.

Which means the brief added in #2079 was a duplicate. `sites_crew.models.DesignBrief` already existed as the baton the site-authoring crew threads Designer to Branding to Frontend, and it is a superset of what was added: `sitemap` for sections, a full `DesignSystem` for tokens, an `asset_manifest` whose `AssetRef` refuses anything that is not a fetchable http(s) URL, plus `goal`, `engine`, `pattern` and `copy`.

So there is no second brief type any more. `sites/design_brief.py` now only knows how to fill the crew's brief and how to version the persisted copy, which the crew model has never needed because until now a brief never outlived a request.

## The wiring

`surface_meta` gains a `brief_id`. A create run carrying one with no `pocket_id` renders the brief-driven preamble instead of the one that asks the user what to build. It reads live state, so it answers a content key, the same as refine.

The failure mode is deliberate. An unreadable brief, a capture still running, one that failed, an id from another workspace, and a string that is not an id all fall back to the ordinary create preamble. That is worse than the rebuild the user asked for and far better than a failed turn mid-conversation. A test asserts all five land byte-identical to a plain create.

## The status read

Added so the import panel can poll. The four states stay distinguishable, because a client that cannot tell `queued` from `failed` shows a spinner forever on a capture that already died. A brief stored by a version this build cannot read reports failed with a remedy, rather than ready for a run the preamble would then refuse.

The brief body is not returned, only the goal and the open questions. The baton is for the generation run; shipping it to a browser would send a whole design system to render one status line.

## One thing a test caught

The goal was built from the host alone, so the agent was told to rebuild `rohitk06.in` without being told the site is called Rohit Kushwaha. The title leads now, and the host is the address in brackets.

## Tests

23 in the brief file, up from 17. Mutation-checked by removing the import-create branch, which failed the routing test and left the fallback test passing, as it should.

`tests/ee/sites` and `tests/cloud/surface` together are 1888 passed, 3 failed. Those three fail identically on a clean checkout of dev, in the Paw Bar autoembed and a custom-domain plan limit. Nothing here touches them.
