### PR TITLE
perf: finish the three partials the first pass left half done

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/request_log.py
+++ b/ee/pocketpaw_ee/cloud/_core/request_log.py
@@ -37,6 +37,32 @@ volume and telemetry write volume were 1:1, which made ``request_logs`` a
 strong candidate for the busiest write target in the database. Health probes,
 the CSRF token fetch and static assets carry no audit value and are the bulk
 of that traffic.
+
+Updated 2026-09-04 - the writes are batched.
+
+Skipping the no-audit-value paths reduced the volume; it did not change the
+shape. Every remaining request still opened its own insert, so at 100 req/s
+this collection was still issuing 100 writes a second against the same
+connection pool and the same WiredTiger cache as the traffic it was describing.
+
+Entries now go onto a bounded queue that ONE consumer task drains into
+``insert_many``. Three consequences worth knowing:
+
+  * A burst becomes one round trip instead of hundreds. The consumer takes
+    everything already queued, waits ``_LINGER_SECONDS`` for a trickle to
+    become a batch too, and writes the lot.
+  * Telemetry is visible on /audit up to that linger later than it was. It is
+    telemetry about requests that have already been answered; the delay costs
+    nothing and the batching is the point.
+  * The queue is the backpressure. Past ``_QUEUE_MAX`` queued entries the
+    entry is dropped and counted, exactly as the old in-flight ceiling did:
+    when the database is not keeping up, shedding telemetry is the correct
+    thing to give up, and queueing it without bound is how a Mongo stall
+    became an OOM.
+
+The queue and its consumer are bound to the loop that created them and rebuilt
+if that loop changes, so a test that makes and tears down loops does not
+inherit a consumer parked on a dead one.
 """
 
 from __future__ import annotations
@@ -50,13 +76,25 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 logger = logging.getLogger(__name__)
 
-#: Strong references to in-flight telemetry writes. Without this the loop's
-#: weak reference is the only one and the task may be collected mid-await.
-_pending: set[asyncio.Task] = set()
+#: Ceiling on QUEUED telemetry entries. Past this, drop rather than queue: an
+#: unbounded backlog of pending inserts is how a Mongo stall becomes an OOM.
+#: Higher than the old in-flight ceiling because a queued dict is far cheaper
+#: than a pending task, and the whole point is to absorb a burst.
+_QUEUE_MAX = 4096
 
-#: Ceiling on concurrent telemetry writes. Past this, drop rather than queue:
-#: an unbounded pile of pending inserts is how a Mongo stall becomes an OOM.
-_MAX_PENDING = 256
+#: Most entries in one ``insert_many``. Bounds the BSON of a single write so a
+#: backlog is drained in several round trips rather than one enormous one.
+_BATCH_MAX = 200
+
+#: How long the consumer waits for more entries once it has at least one.
+#: Straight-line request rate is what makes batching worth anything, and at a
+#: steady 100 req/s each insert would otherwise carry exactly one row again.
+_LINGER_SECONDS = 0.25
+
+#: Bound to the loop that created them; rebuilt if the running loop changes.
+_queue: asyncio.Queue[dict] | None = None
+_queue_loop: asyncio.AbstractEventLoop | None = None
+_drain_task: asyncio.Task | None = None
 
 #: Suppressed so a dropped-telemetry incident is reported once, not per request.
 _dropped = 0
@@ -180,57 +218,197 @@ def _log_request(
     user_agent: str,
     ip: str | None,
 ) -> None:
-    """Fire-and-forget write to the dedicated ``request_logs`` collection.
+    """Queue one ``request_logs`` entry for the batching consumer.
 
-    Logs EVERY HTTP request — including non-workspace endpoints like
-    health, login, CSRF, etc. Non-workspace requests are stored with
-    an empty ``workspace`` field so they still appear in the global
-    request-log view on the /audit page.
+    Logs EVERY HTTP request that was not skipped above - including
+    non-workspace endpoints like login - so they still appear in the global
+    request-log view on the /audit page. Non-workspace requests are stored with
+    an empty ``workspace`` field.
 
-    Schedules the MongoDB write and returns; the write itself is deferred so
-    it never blocks the caller. The task is held in ``_pending`` until it
-    completes — see the module docstring for why a bare ``ensure_future`` was
-    not safe — and dropped once the in-flight ceiling is reached.
+    Returns as soon as the entry is queued; the write itself happens on the
+    consumer task, so nothing here is on the caller's critical path. Past the
+    queue ceiling the entry is dropped and counted - see the module docstring.
     """
     global _dropped
 
-    from pocketpaw_ee.cloud.request_log import service as _request_log_service
-
-    if len(_pending) >= _MAX_PENDING:
-        # The database is not keeping up. Shedding telemetry is the right
-        # thing to give up here; queueing it without bound is not.
-        _dropped += 1
-        if _dropped % 1000 == 1:
-            logger.warning(
-                "request-log telemetry dropped: %d writes shed with %d in flight "
-                "(ceiling %d). The request_logs write path is not keeping up.",
-                _dropped,
-                len(_pending),
-                _MAX_PENDING,
-            )
-        return
-
-    try:
-        task = asyncio.create_task(
-            _request_log_service.record(
-                workspace_id=workspace_id,
-                actor_id=actor_id,
-                method=method,
-                path=path,
-                status_code=status_code,
-                duration_ms=round(duration_ms, 1),
-                is_error=is_error,
-                ip=ip,
-                user_agent=user_agent,
-            )
-        )
-    except RuntimeError:
+    queue = _ensure_consumer()
+    if queue is None:
         # No running loop (sync test harness, shutdown). Telemetry is not
         # worth raising over.
         return
 
-    _pending.add(task)
-    task.add_done_callback(_pending.discard)
+    try:
+        queue.put_nowait(
+            {
+                "workspace": workspace_id,
+                "actor_id": actor_id,
+                "method": method,
+                "path": path,
+                "status_code": status_code,
+                "duration_ms": round(duration_ms, 1),
+                "is_error": is_error,
+                "ip": ip,
+                "user_agent": user_agent,
+            }
+        )
+    except asyncio.QueueFull:
+        # The database is not keeping up. Shedding telemetry is the right thing
+        # to give up here; queueing it without bound is not.
+        _dropped += 1
+        if _dropped % 1000 == 1:
+            logger.warning(
+                "request-log telemetry dropped: %d entries shed with %d queued "
+                "(ceiling %d). The request_logs write path is not keeping up.",
+                _dropped,
+                queue.qsize(),
+                _QUEUE_MAX,
+            )
 
 
-__all__ = ["RequestLogMiddleware"]
+def _ensure_consumer() -> asyncio.Queue[dict] | None:
+    """Return the queue for the running loop, starting the consumer if needed.
+
+    ``None`` when there is no running loop at all. The loop identity check is
+    what stops a consumer parked on a torn-down test loop from swallowing the
+    next one's entries: a queue belongs to the loop whose futures it holds, and
+    handing it entries from another loop is not recoverable.
+    """
+    global _queue, _queue_loop, _drain_task
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+
+    if _queue is None or _queue_loop is not loop or _drain_task is None or _drain_task.done():
+        _retire(_drain_task)
+        _queue = asyncio.Queue(maxsize=_QUEUE_MAX)
+        _queue_loop = loop
+        _drain_task = loop.create_task(_drain(_queue))
+    return _queue
+
+
+def _retire(task: asyncio.Task | None) -> None:
+    """Cancel a superseded consumer, but only if its own loop still runs.
+
+    Rebuilding without this leaves the old consumer parked on a queue nobody
+    feeds, and CPython raises out of its finalizer once that loop is gone.
+    ``get_loop()`` rather than the running loop, because the case that gets
+    here is precisely the one where those two differ.
+    """
+    if task is None or task.done():
+        return
+    try:
+        if not task.get_loop().is_closed():
+            task.cancel()
+    except Exception:  # noqa: BLE001
+        logger.debug("could not retire the previous request-log consumer", exc_info=True)
+
+
+async def _collect_batch(queue: asyncio.Queue[dict]) -> list[dict]:
+    """Block for one entry, then gather as many more as the ceiling allows.
+
+    Two stages, and the first is what does the work under load. Everything
+    ALREADY queued joins the batch immediately - which is exactly the backlog
+    a slow write left behind. The linger that follows is for the opposite
+    case: a steady trickle where nothing is waiting yet, and one insert per
+    request is what we are trying to stop doing.
+    """
+    batch = [await queue.get()]
+    while len(batch) < _BATCH_MAX:
+        try:
+            batch.append(queue.get_nowait())
+        except asyncio.QueueEmpty:
+            break
+
+    if len(batch) >= _BATCH_MAX or _LINGER_SECONDS <= 0:
+        return batch
+
+    deadline = time.monotonic() + _LINGER_SECONDS
+    while len(batch) < _BATCH_MAX:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            batch.append(await asyncio.wait_for(queue.get(), remaining))
+        except TimeoutError:
+            break
+    return batch
+
+
+async def _drain(queue: asyncio.Queue[dict]) -> None:
+    """Consume the queue forever, writing each batch in one round trip.
+
+    Never lets a write failure end the loop. A consumer that dies takes every
+    subsequent request log with it and does so silently, which is a worse
+    outcome than any single failed batch - and ``record_many`` already
+    swallows its own errors, so reaching the ``except`` here means something
+    unanticipated.
+    """
+    while True:
+        batch = await _collect_batch(queue)
+        try:
+            # Imported per batch, not once at task start: an import that fails
+            # at start would kill the consumer, and _ensure_consumer would then
+            # respawn a dying task on every single request. Failing here logs
+            # once per batch and keeps draining.
+            from pocketpaw_ee.cloud.request_log import service as _request_log_service
+
+            await _request_log_service.record_many(batch)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("request-log batch of %d failed to write", len(batch), exc_info=True)
+
+
+async def shutdown_request_log(timeout: float = 5.0) -> int:
+    """Flush what is queued and stop the consumer. Returns entries written.
+
+    Called from the cloud app's shutdown hook. Without it the queued tail is
+    simply lost on every deploy, which is a visible gap in /audit right at the
+    moment - a restart - when someone is most likely to be reading it.
+    """
+    global _queue, _queue_loop, _drain_task
+
+    queue, task = _queue, _drain_task
+    _queue, _queue_loop, _drain_task = None, None, None
+
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.debug("request-log consumer raised on shutdown", exc_info=True)
+
+    if queue is None or queue.empty():
+        return 0
+
+    from pocketpaw_ee.cloud.request_log import service as _request_log_service
+
+    written = 0
+    try:
+        async with asyncio.timeout(timeout):
+            while not queue.empty():
+                batch: list[dict] = []
+                while len(batch) < _BATCH_MAX and not queue.empty():
+                    batch.append(queue.get_nowait())
+                written += await _request_log_service.record_many(batch)
+    except TimeoutError:
+        logger.warning(
+            "request-log shutdown flush timed out with %d entries unwritten", queue.qsize()
+        )
+    return written
+
+
+def _reset_for_tests() -> None:
+    """Drop the consumer and the queue without flushing."""
+    global _queue, _queue_loop, _drain_task, _dropped
+
+    _retire(_drain_task)
+    _queue, _queue_loop, _drain_task = None, None, None
+    _dropped = 0
+
+
+__all__ = ["RequestLogMiddleware", "shutdown_request_log"]

--- a/ee/pocketpaw_ee/cloud/auth/api_keys.py
+++ b/ee/pocketpaw_ee/cloud/auth/api_keys.py
@@ -2,15 +2,47 @@
 
 Issue/list/revoke API keys and resolve ``paw_<prefix><secret>`` bearer
 tokens to ``(user_id, workspace_id, scopes)``.
+
+Updated 2026-09-04 - a short-TTL cache in front of the argon2 verify.
+
+Argon2id at pwdlib's recommended parameters is ~30ms of CPU and a 64 MB
+allocation per verification, by design. Moving it to a thread stopped it
+freezing the event loop, but it did NOT stop it being paid again on every
+single call: a script polling one endpoint once a second re-derives the same
+hash from the same token 3600 times an hour, and each derivation holds a
+worker thread and 64 MB while it runs.
+
+Caching an authentication decision buys that back at the cost of revocation
+lag, so the cache is built so the lag applies to as little as possible:
+
+  * Revocation through this module is NOT lagged at all. ``revoke_api_key``
+    and ``revoke_keys_for_user_in_workspace`` evict the key's entries as they
+    flip the flag, so a revoked key stops working on the next request.
+  * Expiry is NOT lagged either. ``expires_at`` is re-checked against the
+    clock on every cache hit, not just when the entry was stored, so a key
+    that expires part-way through a cached window dies on time.
+  * What IS lagged is a revocation performed OUT OF BAND - flipping
+    ``revoked`` straight in the database, or in another process, since this
+    cache is per-process. That window is ``_DEFAULT_VERIFY_TTL_SECONDS``, and
+    ``POCKETPAW_API_KEY_VERIFY_TTL_SECONDS=0`` turns the cache off entirely
+    for a deployment that will not accept it.
+
+Only successful verifications are cached. Caching failures would buy nothing
+against the attack it looks like it prevents - a brute-force sends a DIFFERENT
+token every time, so it would never hit the cache - while adding a second way
+for a key to stay dead after it should work again.
 """
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
+import os
 import secrets
 import time
 from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 from beanie import PydanticObjectId
@@ -30,14 +62,61 @@ _LAST_USED_WRITE_INTERVAL = 60.0
 _LAST_USED_LRU_MAX = 1000
 _last_used_writes: OrderedDict[str, float] = OrderedDict()
 
+#: How long a successful verification stays good without re-deriving argon2.
+#: This is the ONLY window in which an out-of-band revocation is not honoured
+#: (see the module docstring); revoking through this module evicts immediately.
+_DEFAULT_VERIFY_TTL_SECONDS = 30.0
+_VERIFY_TTL_ENV = "POCKETPAW_API_KEY_VERIFY_TTL_SECONDS"
+_VERIFY_CACHE_MAX = 512
+_verify_ttl_override: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _VerifiedKey:
+    """One cached successful verification.
+
+    ``expires_at`` rides along so a hit can re-check it against the clock -
+    the entry proves the secret matched, not that the key is still in date.
+    """
+
+    key_id: str
+    owner_user_id: str
+    workspace: str
+    scopes: tuple[str, ...]
+    expires_at: datetime | None
+    verified_at: float  # monotonic
+
+
+#: token sha256 -> the verification it produced. Keyed on a digest of the
+#: presented token rather than the token so the plaintext secret is not held
+#: in a long-lived process map.
+_verify_cache: OrderedDict[str, _VerifiedKey] = OrderedDict()
+
 
 def generate_key() -> tuple[str, str, str]:
-    """Mint a key. Returns ``(full_key, prefix, hashed_secret)``."""
+    """Mint a key. Returns ``(full_key, prefix, hashed_secret)``.
+
+    Synchronous, and ``.hash()`` costs the same ~30ms of CPU and 64 MB that
+    ``verify`` does. Anything on an async path wants ``generate_key_async``
+    instead; this stays for sync callers and for the thread to run.
+    """
     secret = secrets.token_hex(_KEY_BYTES)
     prefix = secret[:_PREFIX_LEN]
     full_key = f"paw_{secret}"
     hashed = _password_hash.hash(secret)
     return full_key, prefix, hashed
+
+
+async def generate_key_async() -> tuple[str, str, str]:
+    """``generate_key`` on a worker thread.
+
+    Minting is rare, so this is not about throughput - it is that the hash is
+    the same blocking 30ms burn as the verify, and one process serving every
+    request cannot afford to take it on the loop just because it happens
+    rarely. One admin creating a key should not stall every WebSocket frame
+    and SSE chunk in flight.
+    """
+    return await asyncio.to_thread(generate_key)
 
 
 async def create_api_key(
@@ -49,7 +128,7 @@ async def create_api_key(
     expires_at: datetime | None = None,
 ) -> tuple[APIKey, str]:
     """Insert a new API key. Returns the doc and the plaintext (shown once)."""
-    full_key, prefix, hashed = generate_key()
+    full_key, prefix, hashed = await generate_key_async()
     doc = APIKey(
         workspace=workspace_id,
         owner_user_id=owner_user_id,
@@ -82,6 +161,12 @@ async def revoke_api_key(key_id: str, workspace_id: str) -> APIKey:
     if not doc.revoked:
         doc.revoked = True
         await doc.save()
+    # Evict BEFORE returning, and unconditionally: an already-revoked doc can
+    # still have a live cache entry if the flag was flipped out of band, and a
+    # revoke that leaves the key working for another 30 seconds is not a
+    # revoke. This is what keeps the cache's staleness window off the path
+    # that actually matters.
+    _invalidate_cached_key(str(doc.id))
     return doc
 
 
@@ -100,6 +185,7 @@ async def revoke_keys_for_user_in_workspace(user_id: str, workspace_id: str) -> 
     for doc in rows:
         doc.revoked = True
         await doc.save()
+        _invalidate_cached_key(str(doc.id))
         count += 1
     return count
 
@@ -121,14 +207,109 @@ def _should_write_last_used(key_id: str, now_monotonic: float) -> bool:
     return True
 
 
+def _verify_ttl_seconds() -> float:
+    """Cache lifetime in seconds. ``0`` disables the cache in both directions.
+
+    Read from the environment once and memoised: this is on the hot path for
+    every API-key request, and a deployment does not change its mind about the
+    TTL while running.
+    """
+    global _verify_ttl_override
+    if _verify_ttl_override is None:
+        raw = os.getenv(_VERIFY_TTL_ENV, "").strip()
+        if not raw:
+            _verify_ttl_override = _DEFAULT_VERIFY_TTL_SECONDS
+        else:
+            try:
+                _verify_ttl_override = max(0.0, float(raw))
+            except ValueError:
+                logger.warning(
+                    "%s=%r is not a number; using the %.0fs default",
+                    _VERIFY_TTL_ENV,
+                    raw,
+                    _DEFAULT_VERIFY_TTL_SECONDS,
+                )
+                _verify_ttl_override = _DEFAULT_VERIFY_TTL_SECONDS
+    return _verify_ttl_override
+
+
+def _token_digest(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _cached_verification(digest: str, now_monotonic: float, now: datetime) -> _VerifiedKey | None:
+    """Return a still-valid cached verification, or ``None``.
+
+    Two independent reasons to miss, and they are not the same clock. The TTL
+    is monotonic (how long ago we checked the secret); the expiry is wall time
+    (whether the key is still in date). A long-lived cache entry for a key
+    that expired ten seconds ago must not authenticate anybody, so the expiry
+    is re-checked HERE rather than only at insert.
+    """
+    ttl = _verify_ttl_seconds()
+    if ttl <= 0:
+        return None
+    entry = _verify_cache.get(digest)
+    if entry is None:
+        return None
+    if now_monotonic - entry.verified_at >= ttl:
+        _verify_cache.pop(digest, None)
+        return None
+    if entry.expires_at is not None:
+        exp = entry.expires_at if entry.expires_at.tzinfo else entry.expires_at.replace(tzinfo=UTC)
+        if exp <= now:
+            _verify_cache.pop(digest, None)
+            return None
+    _verify_cache.move_to_end(digest)
+    return entry
+
+
+def _cache_verification(digest: str, doc: APIKey, now_monotonic: float) -> None:
+    """Store a successful verification, evicting the least recently used."""
+    if _verify_ttl_seconds() <= 0:
+        return
+    _verify_cache[digest] = _VerifiedKey(
+        key_id=str(doc.id),
+        owner_user_id=doc.owner_user_id,
+        workspace=doc.workspace,
+        scopes=tuple(doc.scopes),
+        expires_at=doc.expires_at,
+        verified_at=now_monotonic,
+    )
+    _verify_cache.move_to_end(digest)
+    while len(_verify_cache) > _VERIFY_CACHE_MAX:
+        _verify_cache.popitem(last=False)
+
+
+def _invalidate_cached_key(key_id: str) -> int:
+    """Drop every cached verification for one key. Returns how many went.
+
+    Keyed by token digest, so finding a key's entries is a scan. That is the
+    right way round: revocation happens a handful of times a day, verification
+    thousands of times an hour, and the map is capped at a few hundred entries.
+    """
+    stale = [digest for digest, entry in _verify_cache.items() if entry.key_id == key_id]
+    for digest in stale:
+        _verify_cache.pop(digest, None)
+    return len(stale)
+
+
 def _reset_caches_for_tests() -> None:
+    global _verify_ttl_override
     _last_used_writes.clear()
+    _verify_cache.clear()
+    _verify_ttl_override = None
 
 
 async def resolve_bearer(token: str) -> tuple[str, str, list[str]] | None:
     """Resolve ``paw_<prefix><secret>``.
 
     Returns ``(owner_user_id, workspace_id, scopes)`` or ``None``.
+
+    Backed by the short-TTL verification cache described in the module
+    docstring. A repeat call with the same token inside the window costs one
+    dict lookup instead of a Mongo read plus a 30ms argon2 derivation, and is
+    still refused once the key expires or is revoked through this module.
     """
     if not token.startswith("paw_"):
         return None
@@ -137,6 +318,18 @@ async def resolve_bearer(token: str) -> tuple[str, str, list[str]] | None:
         return None
     prefix = body[:_PREFIX_LEN]
     secret = body
+
+    now = datetime.now(UTC)
+    now_monotonic = time.monotonic()
+
+    # Cache hit: no Mongo round trip and no argon2 derivation. The entry only
+    # ever records that THIS token verified against THIS key, so everything
+    # that can change without the token changing - revocation, expiry - is
+    # still enforced: expiry inside _cached_verification against the clock,
+    # revocation by eviction at the point of revoke.
+    cached = _cached_verification(_token_digest(token), now_monotonic, now)
+    if cached is not None:
+        return cached.owner_user_id, cached.workspace, list(cached.scopes)
 
     doc = await APIKey.find_one(
         APIKey.prefix == prefix,
@@ -147,7 +340,6 @@ async def resolve_bearer(token: str) -> tuple[str, str, list[str]] | None:
 
     # Cheap expiry check first — skips the ~30ms argon2 verify when the
     # key is already dead.
-    now = datetime.now(UTC)
     if doc.expires_at is not None:
         exp = doc.expires_at if doc.expires_at.tzinfo else doc.expires_at.replace(tzinfo=UTC)
         if exp <= now:
@@ -174,7 +366,9 @@ async def resolve_bearer(token: str) -> tuple[str, str, list[str]] | None:
     if not valid:
         return None
 
-    if _should_write_last_used(str(doc.id), time.monotonic()):
+    _cache_verification(_token_digest(token), doc, now_monotonic)
+
+    if _should_write_last_used(str(doc.id), now_monotonic):
         try:
             doc.last_used_at = now
             await doc.save()
@@ -187,6 +381,7 @@ async def resolve_bearer(token: str) -> tuple[str, str, list[str]] | None:
 __all__ = [
     "create_api_key",
     "generate_key",
+    "generate_key_async",
     "list_api_keys",
     "resolve_bearer",
     "revoke_api_key",

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -1952,7 +1952,36 @@ async def list_pockets(
                 continue
         if oids:
             query["_id"] = {"$nin": oids}
-    docs = await _PocketDoc.find(query).to_list()
+    # ``source`` is EXCLUDED from the read. It is the svelte track's content
+    # envelope: the full text of every file in the site, which for a real
+    # generated site runs to hundreds of kilobytes on a single pocket. A
+    # gallery of a hundred pockets was pulling all of it across the wire and
+    # through pydantic on one event loop, to render cards showing a name and
+    # an icon.
+    #
+    # Nothing reads it from THIS response. Every in-tree caller of
+    # ``list_pockets`` uses ``_id``, ``name`` and the widget count
+    # (mission_control, kb, the pockets surface handler), and the desktop
+    # gallery renders cards plus the canvas from ``rippleSpec`` - which is why
+    # rippleSpec and widgets are NOT dropped, despite being the same kind of
+    # weight. The single-pocket ``get`` is unprojected and is where the site
+    # generator and every other source consumer reads it.
+    #
+    # The key stays on the wire as ``None`` (the model default), so a consumer
+    # that looks for it sees a pocket with no source rather than a KeyError.
+    # If one ever needs the real value in a LIST, that is a paginated endpoint,
+    # not a wider projection here.
+    #
+    # ``get_pymongo_collection``, NOT ``get_motor_collection`` - the latter is
+    # beanie 1.x and this is on 2.1.0. Same trap documented at
+    # _resolve_pocket_id_tail below and in ripple_sources.
+    #
+    # Re-validating through the Beanie model (rather than reading raw BSON as
+    # the projected helpers do) is what keeps every OTHER field's default
+    # applying: a document written before ``engine`` existed still reads back
+    # ``"ripple"``, exactly as an unprojected find gives it.
+    cursor = _PocketDoc.get_pymongo_collection().find(query, {"source": 0})
+    docs = [_PocketDoc.model_validate(row) async for row in cursor]
     # Resolve concurrently. Each _resolved_wire_dict awaits its own spec
     # resolution and a team-id lookup, so the old list comprehension paid
     # every pocket's round trips end to end, one after another — N sequential
@@ -3466,10 +3495,23 @@ async def agent_list(workspace_id: str, user_id: str) -> list[dict]:
     "have we already got one of these?" check, so the payload stays
     cheap. Visibility rules mirror ``list_pockets``: owned by the user,
     explicitly shared, or workspace-visible.
+
+    "Cheap" used to describe the RESPONSE only. The read behind it hydrated
+    every whole document to keep seven small fields, so a workspace with a few
+    generated sites paid megabytes off the wire on every creation flow to
+    answer a question about names. The query is projected now, which is what
+    the docstring above always claimed.
     """
     if not workspace_id or not user_id:
         return []
-    docs = await _PocketDoc.find(
+    # Projected to exactly the fields returned below. Safe to read as raw BSON
+    # because this response is hand-built rather than serialized from the
+    # model - but the model's defaults do not apply to raw BSON, so each
+    # fallback below has to stand in for one (models/pocket.py: type="custom",
+    # icon="", color="", description=""). A document written before a field
+    # existed must come back as its default, not as None: callers put these
+    # straight into prompt rows and call string methods on them.
+    cursor = _PocketDoc.get_pymongo_collection().find(
         {
             "workspace": workspace_id,
             "$or": [
@@ -3477,22 +3519,21 @@ async def agent_list(workspace_id: str, user_id: str) -> list[dict]:
                 {"shared_with": user_id},
                 {"visibility": "workspace"},
             ],
+        },
+        {"_id": 1, "name": 1, "description": 1, "type": 1, "icon": 1, "color": 1, "owner": 1},
+    )
+    return [
+        {
+            "id": str(row["_id"]),
+            "name": row.get("name") or "",
+            "description": row.get("description") or "",
+            "type": row.get("type") or "",
+            "icon": row.get("icon") or "",
+            "color": row.get("color") or "",
+            "owner": row.get("owner") or "",
         }
-    ).to_list()
-    out: list[dict] = []
-    for d in docs:
-        out.append(
-            {
-                "id": str(d.id),
-                "name": d.name,
-                "description": d.description or "",
-                "type": d.type or "",
-                "icon": d.icon or "",
-                "color": d.color or "",
-                "owner": d.owner,
-            }
-        )
-    return out
+        async for row in cursor
+    ]
 
 
 async def agent_update(

--- a/ee/pocketpaw_ee/cloud/request_log/service.py
+++ b/ee/pocketpaw_ee/cloud/request_log/service.py
@@ -104,6 +104,38 @@ async def record(
         logger.warning("request_log.record failed for %s %s", method, path, exc_info=True)
 
 
+async def record_many(entries: list[dict[str, Any]]) -> int:
+    """Persist a batch of request log entries in ONE round trip.
+
+    Returns how many were written. Fire-and-forget like ``record``: a write
+    failure is logged and swallowed, because losing telemetry is always
+    preferable to failing or delaying the traffic it describes.
+
+    ``ordered=False`` so a single malformed document does not discard the rest
+    of the batch - Mongo attempts every insert and reports the failures rather
+    than stopping at the first. That is the same tradeoff the whole write path
+    already makes, applied to the batch instead of the request.
+    """
+    if not entries:
+        return 0
+    docs: list[_RequestLogDoc] = []
+    for entry in entries:
+        try:
+            docs.append(_RequestLogDoc(**entry))
+        except Exception:
+            # One unbuildable entry must not cost the batch. This is telemetry
+            # about a request that has already been served.
+            logger.warning("request_log.record_many skipped a bad entry", exc_info=True)
+    if not docs:
+        return 0
+    try:
+        await _RequestLogDoc.insert_many(docs, ordered=False)
+    except Exception:
+        logger.warning("request_log.record_many failed for %d entries", len(docs), exc_info=True)
+        return 0
+    return len(docs)
+
+
 # ---------------------------------------------------------------------------
 # Read
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -656,6 +656,11 @@ ignore_imports = [
     # dashboard_lifecycle drains the EE InProcessExecutor on shutdown via a
     # try/except runtime import; the OSS core never imports EE statically.
     "pocketpaw.dashboard_lifecycle -> pocketpaw_ee.cloud.chat.runs.executor",
+    # Same seam, same reason: request-log telemetry is batched behind a queue
+    # in EE, and this is the only shutdown hook that fires under
+    # FastAPI(lifespan=...), so the queued tail is flushed from here or not at
+    # all. Guarded by try/except; an OSS-only install has nothing to flush.
+    "pocketpaw.dashboard_lifecycle -> pocketpaw_ee.cloud._core.request_log",
     "pocketpaw.api.v1.cloud_projects -> pocketpaw_ee.cloud.daytona.client",
     "pocketpaw.api.v1.cloud_projects -> pocketpaw_ee.cloud.daytona.store",
     # atlas resolves optional EE introspection (Fabric schema) and the

--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -654,6 +654,18 @@ async def shutdown_event(*, _stop_channel_adapter_fn=None):
     except Exception as exc:
         logger.debug("Cloud run drain skipped: %s", exc)
 
+    # Flush the batched request-log queue. Telemetry writes are batched behind
+    # a queue now, so on any restart the queued tail is simply lost unless
+    # something drains it — and a restart is exactly when someone is reading
+    # /audit. Same guarded-import shape and same reason as the run drain above:
+    # this is the only shutdown hook that fires.
+    try:
+        from pocketpaw_ee.cloud._core.request_log import shutdown_request_log
+
+        await _bounded("request_log_flush", shutdown_request_log(), timeout=8.0)
+    except Exception as exc:
+        logger.debug("Request-log flush skipped: %s", exc)
+
     # Stop all channel adapters
     if _stop_channel_adapter_fn:
         for channel in list(_channel_adapters):

--- a/tests/cloud/_core/test_request_log_backpressure.py
+++ b/tests/cloud/_core/test_request_log_backpressure.py
@@ -1,17 +1,22 @@
-# Tests for the request-log write path's task handling and path skipping.
+# Tests for the request-log write path's backpressure and path skipping.
 #
-# Created 2026-09-04 alongside the fix. Two behaviours are pinned here because
-# both failed silently in production shape and neither is visible from a
-# response:
+# Created 2026-09-04 alongside the fix that made telemetry writes safe.
+# Rewritten the same day, when the write path changed shape: it no longer
+# spawns one task per request, it queues one entry per request for a single
+# consumer to batch. The properties being pinned did not change, but where
+# they live did.
 #
-#   * A telemetry write task must be strongly referenced. The old code used
+#   * The write must be strongly referenced. The original code used
 #     asyncio.ensure_future and kept no reference, so the loop's weak
 #     reference was the only one and a pending write could be collected
-#     mid-await. Nothing surfaces when that happens — the row is simply
-#     missing, sometimes.
-#   * The number of in-flight writes must be bounded. Unbounded, a Mongo stall
-#     turns into unbounded memory growth in the web process instead of
-#     backpressure.
+#     mid-await, silently. Now there is exactly one long-lived consumer, and
+#     it is the module that holds it.
+#   * The backlog must be bounded. Unbounded, a Mongo stall turns into
+#     unbounded memory growth in the web process instead of backpressure.
+#     The ceiling moved from in-flight tasks to queued entries.
+#   * The high-volume, no-audit-value paths must never reach any of this.
+#
+# The batching itself is covered in tests/cloud/test_request_log_batching.py.
 #
 # NOTE: this file lives under tests/cloud/, which the CI lanes exclude, so it
 # does not run on a pull request today. That exclusion is a known pre-existing
@@ -27,12 +32,22 @@ from pocketpaw_ee.cloud._core import request_log
 
 @pytest.fixture(autouse=True)
 def _clean_module_state():
-    """Each test starts with an empty pending set and drop counter."""
-    request_log._pending.clear()
-    request_log._dropped = 0
+    """Each test starts with no consumer, no queue and no drop count."""
+    request_log._reset_for_tests()
     yield
-    request_log._pending.clear()
-    request_log._dropped = 0
+    request_log._reset_for_tests()
+
+
+async def _stop_consumer() -> None:
+    """Reset while a loop is still running, then let the cancel land.
+
+    The autouse fixture is synchronous, so its reset happens after the loop is
+    gone and the cancelled consumer is finalized by the garbage collector
+    instead - which CPython reports as an unraisable "Event loop is closed"
+    against whichever test happens to run next.
+    """
+    request_log._reset_for_tests()
+    await asyncio.sleep(0)
 
 
 def _log_once(**overrides):
@@ -86,99 +101,100 @@ class TestSkippedPaths:
         assert request_log._is_skipped(path) is False
 
 
-class TestTaskLifetime:
+class TestConsumerLifetime:
     @pytest.mark.asyncio
-    async def test_pending_task_is_strongly_referenced_until_it_finishes(self, monkeypatch):
-        """The write task must be held, not left to the loop's weak reference."""
+    async def test_the_consumer_is_strongly_referenced(self, monkeypatch):
+        """The module holds the consumer, not the loop's weak reference."""
         started = asyncio.Event()
         release = asyncio.Event()
 
-        async def _slow_record(**_kwargs):
+        async def _slow_record_many(entries):  # noqa: ARG001
             started.set()
             await release.wait()
+            return len(entries)
 
         monkeypatch.setattr(
-            "pocketpaw_ee.cloud.request_log.service.record", _slow_record, raising=False
+            "pocketpaw_ee.cloud.request_log.service.record_many",
+            _slow_record_many,
+            raising=False,
         )
+        monkeypatch.setattr(request_log, "_LINGER_SECONDS", 0.0)
 
         _log_once()
         await started.wait()
 
-        assert len(request_log._pending) == 1, "in-flight write is not referenced"
+        assert request_log._drain_task is not None, "the consumer is not referenced"
+        assert not request_log._drain_task.done()
 
         release.set()
-        # Let the task finish and its done-callback run.
         await asyncio.sleep(0)
         await asyncio.sleep(0)
 
-        assert request_log._pending == set(), "completed write was not released"
+        # Still referenced and still running: one consumer serves every
+        # request for the lifetime of the loop.
+        assert request_log._drain_task is not None
+        assert not request_log._drain_task.done()
+
+        await _stop_consumer()
 
     @pytest.mark.asyncio
-    async def test_writes_are_dropped_once_the_ceiling_is_reached(self, monkeypatch):
-        """Past the ceiling, shed telemetry rather than queue without bound."""
-        release = asyncio.Event()
+    async def test_entries_are_dropped_once_the_queue_is_full(self, monkeypatch):
+        """Past the ceiling, shed telemetry rather than queue without bound.
 
-        async def _blocked_record(**_kwargs):
-            await release.wait()
+        Nothing awaits inside the loop, so the consumer never gets a turn and
+        the queue genuinely fills - the same shape as a Mongo stall.
+        """
+        monkeypatch.setattr(request_log, "_QUEUE_MAX", 8)
+        request_log._reset_for_tests()
 
-        monkeypatch.setattr(
-            "pocketpaw_ee.cloud.request_log.service.record", _blocked_record, raising=False
-        )
-
-        for _ in range(request_log._MAX_PENDING):
+        for _ in range(request_log._QUEUE_MAX):
             _log_once()
-        await asyncio.sleep(0)
 
-        assert len(request_log._pending) == request_log._MAX_PENDING
+        assert request_log._queue is not None
+        assert request_log._queue.qsize() == request_log._QUEUE_MAX
         assert request_log._dropped == 0
 
         # One more must be shed, not queued.
         _log_once()
-        assert len(request_log._pending) == request_log._MAX_PENDING
+
+        assert request_log._queue.qsize() == request_log._QUEUE_MAX
         assert request_log._dropped == 1
 
-        release.set()
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        await _stop_consumer()
 
     @pytest.mark.asyncio
-    async def test_capacity_recovers_after_writes_drain(self, monkeypatch):
+    async def test_capacity_recovers_after_the_queue_drains(self, monkeypatch):
         """Shedding is transient: once the backlog clears, logging resumes."""
-        release = asyncio.Event()
+        written: list[int] = []
 
-        async def _blocked_record(**_kwargs):
-            await release.wait()
+        async def _record_many(entries):  # noqa: ANN001
+            written.append(len(entries))
+            return len(entries)
 
         monkeypatch.setattr(
-            "pocketpaw_ee.cloud.request_log.service.record", _blocked_record, raising=False
+            "pocketpaw_ee.cloud.request_log.service.record_many", _record_many, raising=False
         )
+        monkeypatch.setattr(request_log, "_LINGER_SECONDS", 0.0)
+        monkeypatch.setattr(request_log, "_QUEUE_MAX", 8)
+        request_log._reset_for_tests()
 
-        for _ in range(request_log._MAX_PENDING):
+        for _ in range(request_log._QUEUE_MAX + 1):
             _log_once()
-        await asyncio.sleep(0)
-        _log_once()
         assert request_log._dropped == 1
 
-        release.set()
-        for _ in range(5):
+        for _ in range(10):
             await asyncio.sleep(0)
 
-        assert request_log._pending == set()
+        assert sum(written) == request_log._QUEUE_MAX
+        assert request_log._queue is not None
+        assert request_log._queue.qsize() == 0
 
-        # A fresh write is accepted again rather than shed.
-        release_2 = asyncio.Event()
-
-        async def _record_2(**_kwargs):
-            await release_2.wait()
-
-        monkeypatch.setattr(
-            "pocketpaw_ee.cloud.request_log.service.record", _record_2, raising=False
-        )
+        # A fresh entry is accepted again rather than shed.
         _log_once()
-        await asyncio.sleep(0)
-        assert len(request_log._pending) == 1
-        assert request_log._dropped == 1, "drop counter must not rise on an accepted write"
+        assert request_log._dropped == 1, "drop counter must not rise on an accepted entry"
 
-        release_2.set()
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert sum(written) == request_log._QUEUE_MAX + 1
+
+        await _stop_consumer()

--- a/tests/cloud/auth/test_api_key_verify_cache.py
+++ b/tests/cloud/auth/test_api_key_verify_cache.py
@@ -1,0 +1,291 @@
+"""Gates on the short-TTL cache in front of the argon2 API-key verify.
+
+The cache trades a small window of staleness for not re-deriving a 30ms hash
+on every call, so what needs guarding is not that it caches - it is everything
+it must still refuse while it does. Each test below names the mutation in
+``tests/mutations/partials.json`` that breaks it.
+
+Clocks are injected by swapping ``api_keys.time`` and ``api_keys.datetime``,
+which are module attributes of that module alone. The TTL is monotonic and the
+expiry is wall time, and the whole point of several of these tests is that
+moving one does not move the other.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+
+import asyncio
+import threading
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud.auth import api_keys as api_keys_service
+
+_WORKSPACE = "ws_cache_1"
+_OWNER = "u_cache_1"
+
+
+class _FakeTime:
+    """Stands in for the ``time`` module inside api_keys."""
+
+    def __init__(self) -> None:
+        self._now = 1000.0
+
+    def monotonic(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
+class _FakeDatetime:
+    """Stands in for the ``datetime`` CLASS inside api_keys.
+
+    Returns real datetimes so every comparison downstream is a real one.
+    """
+
+    _offset = timedelta(0)
+
+    @classmethod
+    def now(cls, tz=None):  # noqa: ANN001
+        return datetime.now(tz or UTC) + cls._offset
+
+
+class _StubDoc:
+    """Minimal stand-in for an APIKey doc, for the pure-cache unit tests."""
+
+    def __init__(self, key_id: str) -> None:
+        self.id = key_id
+        self.owner_user_id = _OWNER
+        self.workspace = _WORKSPACE
+        self.scopes = ["chat.send"]
+        self.expires_at: datetime | None = None
+
+
+@pytest_asyncio.fixture
+async def clocks(mongo_db, monkeypatch):  # noqa: ARG001
+    api_keys_service._reset_caches_for_tests()
+    monkeypatch.delenv("POCKETPAW_API_KEY_VERIFY_TTL_SECONDS", raising=False)
+    fake_time = _FakeTime()
+
+    class _Dt(_FakeDatetime):
+        _offset = timedelta(0)
+
+    monkeypatch.setattr(api_keys_service, "time", fake_time)
+    monkeypatch.setattr(api_keys_service, "datetime", _Dt)
+    yield fake_time, _Dt
+    api_keys_service._reset_caches_for_tests()
+
+
+def _count_verifies(monkeypatch) -> list[int]:
+    """Wrap the argon2 verify so tests can count derivations."""
+    calls = [0]
+    real = api_keys_service._password_hash.verify
+
+    def _counting(secret, hashed):  # noqa: ANN001
+        calls[0] += 1
+        return real(secret, hashed)
+
+    monkeypatch.setattr(api_keys_service._password_hash, "verify", _counting)
+    return calls
+
+
+async def _mint(*, expires_at: datetime | None = None, scopes: list[str] | None = None):
+    doc, token = await api_keys_service.create_api_key(
+        workspace_id=_WORKSPACE,
+        owner_user_id=_OWNER,
+        name="k",
+        scopes=scopes if scopes is not None else ["chat.send"],
+        expires_at=expires_at,
+    )
+    return doc, token
+
+
+async def test_a_repeat_resolve_does_not_re_derive_argon2(clocks, monkeypatch):
+    """Mutation: drop the cache lookup from resolve_bearer."""
+    _doc, token = await _mint()
+    calls = _count_verifies(monkeypatch)
+
+    first = await api_keys_service.resolve_bearer(token)
+    second = await api_keys_service.resolve_bearer(token)
+
+    assert first == second == (_OWNER, _WORKSPACE, ["chat.send"])
+    assert calls[0] == 1, "the second resolve re-derived the hash"
+
+
+async def test_the_cache_expires_and_the_hash_is_derived_again(clocks, monkeypatch):
+    """Mutation: never expire the entry (drop the TTL comparison)."""
+    fake_time, _ = clocks
+    _doc, token = await _mint()
+    calls = _count_verifies(monkeypatch)
+
+    await api_keys_service.resolve_bearer(token)
+    fake_time.advance(api_keys_service._DEFAULT_VERIFY_TTL_SECONDS + 1.0)
+    assert await api_keys_service.resolve_bearer(token) is not None
+
+    assert calls[0] == 2, "a stale entry was served past its TTL"
+
+
+async def test_a_zero_ttl_turns_the_cache_off(clocks, monkeypatch):
+    """Mutation: ignore the 0 setting and cache anyway."""
+    monkeypatch.setenv("POCKETPAW_API_KEY_VERIFY_TTL_SECONDS", "0")
+    api_keys_service._reset_caches_for_tests()
+    _doc, token = await _mint()
+    calls = _count_verifies(monkeypatch)
+
+    await api_keys_service.resolve_bearer(token)
+    await api_keys_service.resolve_bearer(token)
+    await api_keys_service.resolve_bearer(token)
+
+    assert calls[0] == 3
+    assert not api_keys_service._verify_cache
+
+
+async def test_revoking_a_key_stops_it_working_immediately(clocks):
+    """Mutation: drop the eviction from revoke_api_key.
+
+    This is the finding's whole risk. Without the eviction the revoked key
+    keeps authenticating for the rest of the TTL, and the cheap expiry check
+    below it does not save you: the key has no expiry, only a revoked flag,
+    and a cache hit never re-reads the flag.
+    """
+    doc, token = await _mint()
+    assert await api_keys_service.resolve_bearer(token) is not None
+
+    await api_keys_service.revoke_api_key(str(doc.id), _WORKSPACE)
+
+    assert await api_keys_service.resolve_bearer(token) is None
+
+
+async def test_the_member_removal_cascade_also_evicts(clocks):
+    """Mutation: drop the eviction from revoke_keys_for_user_in_workspace."""
+    _doc, token = await _mint()
+    assert await api_keys_service.resolve_bearer(token) is not None
+
+    flipped = await api_keys_service.revoke_keys_for_user_in_workspace(_OWNER, _WORKSPACE)
+
+    assert flipped == 1
+    assert await api_keys_service.resolve_bearer(token) is None
+
+
+async def test_expiry_is_re_checked_on_every_hit_not_just_at_insert(clocks, monkeypatch):
+    """Mutation: trust the entry once stored (drop the expiry re-check).
+
+    The key is cached while in date, then time passes it. The TTL has NOT
+    elapsed, so the entry is still there; only the wall clock moved. A cache
+    that checked expiry once, at insert, authenticates an expired key here.
+
+    The verify count is asserted too: it proves the refusal came from the
+    cache path re-checking, not from a fresh database read doing the work.
+    """
+    fake_time, fake_dt = clocks
+    _doc, token = await _mint(expires_at=datetime.now(UTC) + timedelta(seconds=5))
+    calls = _count_verifies(monkeypatch)
+
+    assert await api_keys_service.resolve_bearer(token) is not None
+    assert calls[0] == 1
+
+    fake_dt._offset = timedelta(seconds=30)  # past the key's expiry
+    fake_time.advance(1.0)  # but well inside the 30s cache TTL
+
+    assert await api_keys_service.resolve_bearer(token) is None
+    assert calls[0] == 1, "it fell through to a fresh verify instead of refusing on the hit"
+
+
+async def test_the_cache_is_bounded(clocks, monkeypatch):
+    """Mutation: drop the LRU eviction loop.
+
+    An unbounded map keyed on presented tokens is a memory leak any caller
+    can drive, which is the same class of bug this PR's sibling fixes.
+    """
+    monkeypatch.setattr(api_keys_service, "_VERIFY_CACHE_MAX", 4)
+    for index in range(12):
+        api_keys_service._cache_verification(
+            f"digest-{index}",
+            _StubDoc(f"key-{index}"),
+            now_monotonic=1000.0,
+        )
+    assert len(api_keys_service._verify_cache) == 4
+
+
+async def test_scopes_handed_out_cannot_be_mutated_through_the_cache(clocks):
+    """Mutation: hand back the stored scopes instead of a fresh list.
+
+    Every caller receives the same object otherwise, and one of them appending
+    to it rewrites what the next request is authorized to do. The type is
+    asserted first because the entry stores a tuple: returning that directly
+    would fail on the append rather than on the leak, which is a confusing
+    way to learn about a privilege escalation.
+    """
+    _doc, token = await _mint(scopes=["chat.send", "files.read"])
+
+    first = await api_keys_service.resolve_bearer(token)
+    assert first is not None
+    assert isinstance(first[2], list)
+    first[2].append("admin.everything")
+
+    second = await api_keys_service.resolve_bearer(token)
+    assert second is not None
+    assert second[2] == ["chat.send", "files.read"]
+
+
+async def test_minting_a_key_hashes_off_the_event_loop(clocks, monkeypatch):
+    """Mutation: call generate_key directly instead of generate_key_async.
+
+    argon2's hash costs the same blocking 30ms as its verify. Asserting the
+    thread identity is what distinguishes "ran in a worker" from "ran inline
+    and happened to be fast".
+    """
+    loop_thread = threading.get_ident()
+    seen: list[int] = []
+    real = api_keys_service._password_hash.hash
+
+    def _recording(secret):  # noqa: ANN001
+        seen.append(threading.get_ident())
+        return real(secret)
+
+    monkeypatch.setattr(api_keys_service._password_hash, "hash", _recording)
+
+    await _mint()
+
+    assert seen and all(tid != loop_thread for tid in seen)
+
+
+async def test_generate_key_async_leaves_the_loop_free(clocks):
+    """The other direction: the loop keeps running while the hash derives."""
+    ticks = 0
+
+    async def _tick() -> None:
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0)
+            ticks += 1
+
+    ticker = asyncio.create_task(_tick())
+    try:
+        await api_keys_service.generate_key_async()
+    finally:
+        ticker.cancel()
+    assert ticks > 0
+
+
+@pytest.mark.parametrize("naive", [True, False])
+async def test_a_naive_expiry_is_still_compared_in_utc(clocks, naive):
+    """Mutation: compare expires_at without normalizing the tzinfo.
+
+    Mongo hands datetimes back naive. Comparing a naive to an aware datetime
+    raises TypeError, which resolve_bearer would surface as a 500 rather than
+    a refusal - so the normalization is load-bearing on the real read path.
+    """
+    expired = datetime.now(UTC) - timedelta(hours=1)
+    doc = _StubDoc("k1")
+    doc.expires_at = expired.replace(tzinfo=None) if naive else expired
+    api_keys_service._cache_verification("digest-x", doc, now_monotonic=1000.0)
+
+    got = api_keys_service._cached_verification("digest-x", 1000.0, datetime.now(UTC))
+
+    assert got is None

--- a/tests/cloud/pockets/test_list_projection.py
+++ b/tests/cloud/pockets/test_list_projection.py
@@ -1,0 +1,245 @@
+"""Gates on the two pocket LIST reads being projected.
+
+Both used to hydrate whole documents. A Pocket carries ``rippleSpec``, every
+widget's ``spec``, and - on the svelte track - a ``source`` map holding the
+full text of every file in the generated site. A gallery of a hundred pockets
+pulled all of it across the wire on one event loop to render cards.
+
+``list_pockets`` drops ``source`` and keeps everything the desktop canvas
+renders from. ``agent_list`` already returned only seven small fields, so its
+projection is the seven; the gap there was that the read never matched the
+response, and nothing in the RESPONSE can show that - which is why these tests
+watch the query as well as the result.
+
+Mutations live in ``tests/mutations/partials.json``.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+
+import pytest_asyncio
+from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+_WORKSPACE = "ws_proj_1"
+_OWNER = "u_proj_1"
+
+#: Stands in for a generated SvelteKit site. The real ones run to hundreds of
+#: kilobytes across dozens of files; the size is not what the test asserts, the
+#: presence is.
+_SOURCE = {
+    "src/routes/+page.svelte": "<script>let x = 1;</script>\n<h1>hi</h1>\n" * 40,
+    "src/app.css": "body { margin: 0 }\n" * 40,
+}
+
+_SPEC = {"ui": {"kind": "grid", "children": []}, "state": {}}
+
+
+async def _seed(**overrides) -> _PocketDoc:
+    fields = {
+        "workspace": _WORKSPACE,
+        "name": "Marketing site",
+        "description": "the landing page",
+        "owner": _OWNER,
+        "type": "site",
+        "icon": "rocket",
+        "color": "#ff0000",
+        "engine": "svelte",
+        "source": dict(_SOURCE),
+        "rippleSpec": dict(_SPEC),
+        "visibility": "workspace",
+    }
+    fields.update(overrides)
+    doc = _PocketDoc(**fields)
+    await doc.insert()
+    return doc
+
+
+class _ProjectionSpy:
+    """Wraps the real pymongo collection, recording every ``find`` projection.
+
+    Watching the query is the only way to see ``agent_list``'s fix: it never
+    returned ``source``, so a revert to an unprojected read is invisible in
+    the response and completely visible here.
+    """
+
+    def __init__(self, inner) -> None:  # noqa: ANN001
+        self._inner = inner
+        self.projections: list[object] = []
+
+    def find(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        # Copied, not referenced: the driver normalizes the projection dict in
+        # place (adding an explicit ``_id``), so holding the caller's object
+        # would record what the driver made of it rather than what was asked.
+        given = args[1] if len(args) > 1 else kwargs.get("projection")
+        self.projections.append(dict(given) if isinstance(given, dict) else given)
+        return self._inner.find(*args, **kwargs)
+
+    def __getattr__(self, name: str):
+        return getattr(self._inner, name)
+
+
+@pytest_asyncio.fixture
+async def spy(mongo_db, monkeypatch):  # noqa: ARG001
+    inner = _PocketDoc.get_pymongo_collection()
+    watcher = _ProjectionSpy(inner)
+    monkeypatch.setattr(
+        _PocketDoc,
+        "get_pymongo_collection",
+        classmethod(lambda cls: watcher),  # noqa: ARG005
+    )
+    return watcher
+
+
+async def test_the_gallery_does_not_carry_the_site_source(spy):
+    """Mutation: revert list_pockets to an unprojected find.
+
+    ``source`` is the single biggest field on the document and no consumer of
+    THIS response reads it. It must come back as the model default rather than
+    the stored map.
+    """
+    await _seed()
+
+    rows = await pockets_service.list_pockets(_WORKSPACE, _OWNER)
+
+    assert len(rows) == 1
+    assert rows[0]["source"] is None
+
+
+async def test_the_gallery_still_carries_what_the_canvas_renders(spy):
+    """The other direction, and the reason this is a projection not a rewrite.
+
+    Dropping ``rippleSpec`` or ``widgets`` would be a bigger saving and would
+    break the desktop client, which renders the canvas straight off this list.
+    """
+    await _seed()
+
+    rows = await pockets_service.list_pockets(_WORKSPACE, _OWNER)
+
+    # Compared on the ``ui`` subtree, not the whole spec: the wire dict runs
+    # the spec through the normalizer and the $source resolver, both of which
+    # legitimately add keys. The subtree is the part the canvas draws.
+    assert rows[0]["rippleSpec"]["ui"] == _SPEC["ui"]
+    assert rows[0]["name"] == "Marketing site"
+    assert rows[0]["engine"] == "svelte"
+    assert rows[0]["icon"] == "rocket"
+    assert "widgets" in rows[0]
+
+
+async def test_the_gallery_read_asks_mongo_to_exclude_source(spy):
+    """Mutation: widen the projection to include source.
+
+    Asserted on the query, not the response: a projection that still fetched
+    the field and dropped it afterwards would pass the test above and save
+    nothing at all, which is the entire cost this finding is about.
+    """
+    await _seed()
+
+    await pockets_service.list_pockets(_WORKSPACE, _OWNER)
+
+    assert spy.projections, "list_pockets did not go through a projected read"
+    assert {"source": 0} in spy.projections, spy.projections
+
+
+async def test_a_legacy_document_still_reads_back_its_model_defaults(spy):
+    """No mutation: this pins behaviour rather than guarding a line.
+
+    The regression it describes - hand-building the wire dict from raw BSON,
+    the way the two projected helpers in this codebase already do - is a
+    rewrite, not an edit, so no find-and-replace expresses it and it is not
+    in the mutation plan. It is here as the reason the projected read still
+    goes through the model at all.
+
+    The projected read must still go through pydantic. A pocket written before
+    ``engine`` existed has no such key in Mongo, and skipping validation hands
+    back None where an unprojected find gives "ripple" - which downstream code
+    treats as a track it does not know. The id is asserted for the same
+    reason: ``_id`` only becomes ``id`` through the model's alias.
+    """
+    doc = await _seed()
+    await _PocketDoc.get_pymongo_collection().update_one(
+        {"_id": doc.id}, {"$unset": {"engine": "", "icon": "", "color": ""}}
+    )
+
+    rows = await pockets_service.list_pockets(_WORKSPACE, _OWNER)
+
+    assert rows[0]["_id"] == str(doc.id)
+    assert rows[0]["engine"] == "ripple"
+    assert rows[0]["icon"] == ""
+    assert rows[0]["color"] == ""
+
+
+async def test_the_agent_list_read_is_projected_to_what_it_returns(spy):
+    """Mutation: revert agent_list to an unprojected find.
+
+    This one runs on every creation flow as the "have we already got one of
+    these?" check, so it is the hottest of the two.
+    """
+    await _seed()
+
+    rows = await pockets_service.agent_list(_WORKSPACE, _OWNER)
+
+    assert spy.projections, "agent_list did not go through a projected read"
+    projection = spy.projections[-1]
+    assert isinstance(projection, dict)
+    assert "source" not in projection
+    assert "rippleSpec" not in projection
+    assert "widgets" not in projection
+    assert set(projection) == {"_id", "name", "description", "type", "icon", "color", "owner"}
+    assert rows == [
+        {
+            "id": str((await _PocketDoc.find_one({"workspace": _WORKSPACE})).id),
+            "name": "Marketing site",
+            "description": "the landing page",
+            "type": "site",
+            "icon": "rocket",
+            "color": "#ff0000",
+            "owner": _OWNER,
+        }
+    ]
+
+
+async def test_agent_list_substitutes_a_default_for_a_missing_field(spy):
+    """Mutation: drop the ``or ""`` fallbacks.
+
+    Raw BSON does not get the model's defaults, and these values go straight
+    into prompt rows where callers call string methods on them. A None here is
+    an AttributeError in the surface handler, a long way from this file.
+    """
+    doc = await _seed()
+    await _PocketDoc.get_pymongo_collection().update_one(
+        {"_id": doc.id}, {"$unset": {"description": "", "icon": "", "color": ""}}
+    )
+
+    rows = await pockets_service.agent_list(_WORKSPACE, _OWNER)
+
+    assert rows[0]["description"] == ""
+    assert rows[0]["icon"] == ""
+    assert rows[0]["color"] == ""
+
+
+async def test_both_reads_stay_scoped_to_the_workspace(spy):
+    """A projection must not quietly widen the tenancy filter."""
+    await _seed()
+    await _seed(workspace="ws_other", name="Someone else's")
+
+    listed = await pockets_service.list_pockets(_WORKSPACE, _OWNER)
+    agent_rows = await pockets_service.agent_list(_WORKSPACE, _OWNER)
+
+    assert [r["name"] for r in listed] == ["Marketing site"]
+    assert [r["name"] for r in agent_rows] == ["Marketing site"]
+
+
+async def test_a_private_pocket_owned_by_someone_else_stays_hidden(spy):
+    """The $or visibility union survives the rewrite."""
+    await _seed(owner="someone_else", visibility="private", name="Private")
+    await _seed(name="Mine")
+
+    listed = await pockets_service.list_pockets(_WORKSPACE, _OWNER)
+    agent_rows = await pockets_service.agent_list(_WORKSPACE, _OWNER)
+
+    assert [r["name"] for r in listed] == ["Mine"]
+    assert [r["name"] for r in agent_rows] == ["Mine"]

--- a/tests/cloud/test_request_log_batching.py
+++ b/tests/cloud/test_request_log_batching.py
@@ -1,0 +1,347 @@
+"""Gates on request-log telemetry being batched instead of one insert each.
+
+Request volume and telemetry write volume used to be 1:1, which made
+``request_logs`` a strong candidate for the busiest write target in the
+database - competing with the traffic it exists to describe, for the same
+connection pool and the same cache.
+
+Entries now go onto a bounded queue drained by one consumer into
+``insert_many``. The gates below are the three properties that make that safe:
+a burst really does become one write, a database that stops keeping up sheds
+telemetry rather than growing without bound, and the consumer survives a failed
+batch instead of silently taking every later request log with it.
+
+``_LINGER_SECONDS`` is set to 0 throughout so batching is driven by what is
+already queued rather than by wall-clock timing. Mutations live in
+``tests/mutations/partials.json``.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+
+import asyncio
+
+import pytest_asyncio
+from pocketpaw_ee.cloud._core import request_log as middleware
+from pocketpaw_ee.cloud.request_log import service as request_log_service
+
+
+def _entry(path: str = "/api/v1/thing", status_code: int = 200) -> dict:
+    return {
+        "method": "GET",
+        "path": path,
+        "status_code": status_code,
+        "duration_ms": 1.25,
+        "actor_id": "u1",
+        "workspace_id": "ws1",
+        "is_error": status_code >= 400,
+        "user_agent": "pytest",
+        "ip": "127.0.0.1",
+    }
+
+
+@pytest_asyncio.fixture
+async def batches(monkeypatch):
+    """Capture what reaches the write layer, with the linger disabled."""
+    middleware._reset_for_tests()
+    monkeypatch.setattr(middleware, "_LINGER_SECONDS", 0.0)
+    seen: list[list[dict]] = []
+
+    async def _record_many(entries):  # noqa: ANN001
+        seen.append(list(entries))
+        return len(entries)
+
+    monkeypatch.setattr(request_log_service, "record_many", _record_many)
+    yield seen
+    await _teardown()
+
+
+async def _settle(times: int = 5) -> None:
+    for _ in range(times):
+        await asyncio.sleep(0)
+
+
+async def _teardown() -> None:
+    """Reset, then give the cancelled consumer a tick to actually finish.
+
+    Without the tick the task is still pending when the loop closes and
+    CPython raises "Event loop is closed" out of its finalizer, which surfaces
+    as an unraisable-exception warning attached to whichever test runs next.
+    """
+    middleware._reset_for_tests()
+    await asyncio.sleep(0)
+
+
+async def test_a_burst_of_requests_becomes_one_write(batches):
+    """Mutation: write each entry on its own instead of collecting a batch.
+
+    Nothing awaits between the five calls, so all five are queued before the
+    consumer gets a turn. That is the shape of a real burst on one event loop,
+    and it must cost one round trip.
+    """
+    for index in range(5):
+        middleware._log_request(**_entry(path=f"/p/{index}"))
+
+    await _settle()
+
+    assert len(batches) == 1
+    assert len(batches[0]) == 5
+    assert [e["path"] for e in batches[0]] == [f"/p/{i}" for i in range(5)]
+
+
+async def test_a_batch_is_bounded(batches, monkeypatch):
+    """Mutation: drop the _BATCH_MAX ceiling from the collect loop.
+
+    One unbounded ``insert_many`` of a whole backlog is its own stall. The
+    backlog should be drained in several bounded writes.
+    """
+    monkeypatch.setattr(middleware, "_BATCH_MAX", 3)
+    for index in range(7):
+        middleware._log_request(**_entry(path=f"/p/{index}"))
+
+    await _settle(20)
+
+    assert [len(b) for b in batches] == [3, 3, 1]
+
+
+async def test_the_entry_carries_the_fields_the_document_needs(batches):
+    """The middleware's kwargs and the document's fields must line up.
+
+    ``workspace_id`` becomes ``workspace``, and the duration is rounded here
+    rather than at the write. Getting either wrong makes every insert fail at
+    a layer that swallows its own errors.
+    """
+    middleware._log_request(**_entry())
+    await _settle()
+
+    entry = batches[0][0]
+    assert entry["workspace"] == "ws1"
+    assert "workspace_id" not in entry
+    assert entry["duration_ms"] == 1.2
+    assert set(entry) == {
+        "workspace",
+        "actor_id",
+        "method",
+        "path",
+        "status_code",
+        "duration_ms",
+        "is_error",
+        "ip",
+        "user_agent",
+    }
+
+
+async def test_a_full_queue_sheds_telemetry_instead_of_growing(batches, monkeypatch):
+    """Mutation: drop the ceiling and let the queue grow.
+
+    An unbounded backlog is how a Mongo stall becomes an OOM. Nothing awaits
+    in this loop, so the consumer never runs and the queue really does fill.
+    """
+    monkeypatch.setattr(middleware, "_QUEUE_MAX", 4)
+    middleware._reset_for_tests()
+
+    for index in range(30):
+        middleware._log_request(**_entry(path=f"/p/{index}"))
+
+    assert middleware._dropped == 26
+    assert middleware._queue is not None
+    assert middleware._queue.qsize() == 4
+
+
+async def test_shedding_telemetry_never_raises_into_the_request(monkeypatch):
+    """A dropped log must not become a 500 on a request that already worked."""
+    middleware._reset_for_tests()
+    monkeypatch.setattr(middleware, "_QUEUE_MAX", 1)
+    middleware._log_request(**_entry())
+    middleware._log_request(**_entry())  # would raise QueueFull if unguarded
+    await _teardown()
+
+
+async def test_the_consumer_survives_a_failed_batch(monkeypatch):
+    """Mutation: let the write exception escape the drain loop.
+
+    Asserted on the TASK, not on the second batch landing. The second batch
+    lands either way, because a dead consumer is replaced on the next request
+    (the test below covers that). What a dying consumer actually costs is the
+    backlog it was holding, which no later write reveals - so the identity of
+    the task is the only thing that separates "survived" from "was replaced".
+    """
+    middleware._reset_for_tests()
+    monkeypatch.setattr(middleware, "_LINGER_SECONDS", 0.0)
+    seen: list[list[dict]] = []
+
+    async def _flaky(entries):  # noqa: ANN001
+        seen.append(list(entries))
+        if len(seen) == 1:
+            raise RuntimeError("mongo said no")
+        return len(entries)
+
+    monkeypatch.setattr(request_log_service, "record_many", _flaky)
+
+    middleware._log_request(**_entry(path="/first"))
+    consumer = middleware._drain_task
+    await _settle()
+
+    assert consumer is not None and not consumer.done(), "the consumer died on a failed batch"
+
+    middleware._log_request(**_entry(path="/second"))
+    await _settle()
+
+    assert middleware._drain_task is consumer
+    assert [b[0]["path"] for b in seen] == ["/first", "/second"]
+    await _teardown()
+
+
+async def test_a_consumer_that_does_die_is_replaced(monkeypatch):
+    """Mutation: keep a finished consumer instead of rebuilding.
+
+    The belt to the previous test's braces. If something does kill the
+    consumer, the next request must get a live one rather than queueing into
+    a backlog nobody drains - which would look exactly like telemetry quietly
+    switching itself off.
+    """
+    middleware._reset_for_tests()
+    monkeypatch.setattr(middleware, "_LINGER_SECONDS", 0.0)
+    seen: list[list[dict]] = []
+
+    async def _record_many(entries):  # noqa: ANN001
+        seen.append(list(entries))
+        return len(entries)
+
+    monkeypatch.setattr(request_log_service, "record_many", _record_many)
+
+    middleware._log_request(**_entry(path="/first"))
+    await _settle()
+    dead = middleware._drain_task
+    assert dead is not None
+    dead.cancel()
+    await _settle()
+    assert dead.done()
+
+    middleware._log_request(**_entry(path="/second"))
+    await _settle()
+
+    assert middleware._drain_task is not dead
+    assert [b[0]["path"] for b in seen] == ["/first", "/second"]
+    await _teardown()
+
+
+async def test_shutdown_flushes_the_queued_tail(monkeypatch):
+    """Mutation: return from shutdown without draining the queue.
+
+    A restart is exactly when someone is reading /audit, and the queued tail
+    is otherwise lost on every deploy.
+    """
+    middleware._reset_for_tests()
+    monkeypatch.setattr(middleware, "_LINGER_SECONDS", 0.0)
+    written: list[list[dict]] = []
+
+    async def _record_many(entries):  # noqa: ANN001
+        written.append(list(entries))
+        return len(entries)
+
+    monkeypatch.setattr(request_log_service, "record_many", _record_many)
+
+    for index in range(3):
+        middleware._log_request(**_entry(path=f"/p/{index}"))
+    # No await: the consumer has not run, so everything is still queued.
+    count = await middleware.shutdown_request_log()
+
+    assert count == 3
+    assert [e["path"] for e in written[0]] == ["/p/0", "/p/1", "/p/2"]
+
+
+async def test_shutdown_stops_the_consumer(monkeypatch):
+    """After a flush, nothing is left running or holding a queue."""
+    middleware._reset_for_tests()
+    monkeypatch.setattr(middleware, "_LINGER_SECONDS", 0.0)
+    middleware._log_request(**_entry())
+    task = middleware._drain_task
+    await middleware.shutdown_request_log()
+
+    assert task is not None and task.done()
+    assert middleware._queue is None
+    assert middleware._drain_task is None
+
+
+def test_logging_with_no_running_loop_is_a_no_op():
+    """Mutation: drop the no-running-loop guard.
+
+    Sync test harnesses and interpreter shutdown both reach this with no loop.
+    Telemetry about a request that has already been answered is never worth
+    raising over, so it has to return rather than throw.
+    """
+    middleware._reset_for_tests()
+    middleware._log_request(**_entry())
+    assert middleware._queue is None
+
+
+async def test_the_consumer_is_rebuilt_when_the_loop_changes(monkeypatch):
+    """Mutation: keep the queue across loops (drop the loop identity check).
+
+    A queue belongs to the loop whose futures it holds. Handing it entries
+    from another loop is not recoverable, and in a test session that means one
+    module's torn-down loop swallowing the next module's telemetry.
+    """
+    middleware._reset_for_tests()
+    real_loop = asyncio.get_running_loop()
+    first = middleware._ensure_consumer()
+    assert first is not None
+
+    class _OtherLoop:
+        """A different loop object, so the identity check has to notice."""
+
+        def create_task(self, coro):  # noqa: ANN001
+            coro.close()
+            return real_loop.create_future()
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: _OtherLoop())
+    second = middleware._ensure_consumer()
+    monkeypatch.undo()
+
+    assert second is not first
+    await _teardown()
+
+
+# ---------------------------------------------------------------------------
+# The write layer itself, against a real collection.
+# ---------------------------------------------------------------------------
+
+
+async def test_record_many_writes_every_entry(mongo_db):  # noqa: ARG001
+    from pocketpaw_ee.cloud.models.request_log import RequestLog
+
+    entries = [
+        {k: v for k, v in _entry(path=f"/p/{i}").items() if k != "workspace_id"}
+        | {"workspace": "ws1"}
+        for i in range(4)
+    ]
+
+    written = await request_log_service.record_many(entries)
+
+    assert written == 4
+    assert await RequestLog.find({"workspace": "ws1"}).count() == 4
+
+
+async def test_one_bad_entry_does_not_cost_the_batch(mongo_db):  # noqa: ARG001
+    """Mutation: build the documents in one comprehension with no guard.
+
+    Telemetry describing requests that have already been served must not be
+    discarded wholesale because one row would not build.
+    """
+    from pocketpaw_ee.cloud.models.request_log import RequestLog
+
+    good = {k: v for k, v in _entry().items() if k != "workspace_id"} | {"workspace": "ws1"}
+    bad = {"workspace": "ws1"}  # missing every required field
+
+    written = await request_log_service.record_many([good, bad, dict(good)])
+
+    assert written == 2
+    assert await RequestLog.find({"workspace": "ws1"}).count() == 2
+
+
+async def test_an_empty_batch_writes_nothing(mongo_db):  # noqa: ARG001
+    assert await request_log_service.record_many([]) == 0

--- a/tests/mutations/entity_rows.json
+++ b/tests/mutations/entity_rows.json
@@ -230,8 +230,8 @@
   {
     "label": "wiring: the beanie 1.x collection API comes back",
     "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
-    "find": "_PocketDoc.get_pymongo_collection().find(",
-    "replace": "_PocketDoc.get_motor_collection().find(",
+    "find": "_PocketDoc.get_pymongo_collection().find({\"workspace\": workspace_id}, {\"_id\": 1})",
+    "replace": "_PocketDoc.get_motor_collection().find({\"workspace\": workspace_id}, {\"_id\": 1})",
     "tests": [
       "tests/cloud/pockets/test_short_id_tool_wiring.py"
     ]

--- a/tests/mutations/partials.json
+++ b/tests/mutations/partials.json
@@ -1,0 +1,228 @@
+[
+  {
+    "label": "resolve_bearer never consults the cache",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "    cached = _cached_verification(_token_digest(token), now_monotonic, now)",
+    "replace": "    cached = None",
+    "tests": [
+      "tests/cloud/auth/test_api_key_verify_cache.py::test_a_repeat_resolve_does_not_re_derive_argon2"
+    ]
+  },
+  {
+    "label": "a cached verification never expires",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "    if now_monotonic - entry.verified_at >= ttl:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/auth/test_api_key_verify_cache.py::test_the_cache_expires_and_the_hash_is_derived_again"
+    ]
+  },
+  {
+    "label": "store entries even when the TTL says the cache is off",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "    \"\"\"Store a successful verification, evicting the least recently used.\"\"\"\n    if _verify_ttl_seconds() <= 0:\n        return\n",
+    "replace": "    \"\"\"Store a successful verification, evicting the least recently used.\"\"\"\n",
+    "tests": [
+      "tests/cloud/auth/test_api_key_verify_cache.py::test_a_zero_ttl_turns_the_cache_off"
+    ]
+  },
+  {
+    "label": "revoking a key leaves its cached verification in place",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "    _invalidate_cached_key(str(doc.id))\n    return doc",
+    "replace": "    return doc",
+    "tests": [
+      "tests/cloud/auth/test_api_key_verify_cache.py::test_revoking_a_key_stops_it_working_immediately"
+    ]
+  },
+  {
+    "label": "the member-removal cascade leaves cached verifications in place",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "        _invalidate_cached_key(str(doc.id))\n        count += 1",
+    "replace": "        count += 1",
+    "tests": [
+      "tests/cloud/auth/test_api_key_verify_cache.py::test_the_member_removal_cascade_also_evicts"
+    ]
+  },
+  {
+    "label": "expiry is checked at insert but not on a hit",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "    if entry.expires_at is not None:\n        exp = entry.expires_at if entry.expires_at.tzinfo else entry.expires_at.replace(tzinfo=UTC)\n        if exp <= now:\n            _verify_cache.pop(digest, None)\n            return None\n",
+    "replace": "    if entry.expires_at is not None:\n        pass\n",
+    "tests": [
+      "tests/cloud/auth/test_api_key_verify_cache.py::test_expiry_is_re_checked_on_every_hit_not_just_at_insert"
+    ]
+  },
+  {
+    "label": "a naive stored expiry is compared without normalizing to UTC",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "        exp = entry.expires_at if entry.expires_at.tzinfo else entry.expires_at.replace(tzinfo=UTC)",
+    "replace": "        exp = entry.expires_at",
+    "tests": [
+      "tests/cloud/auth/test_api_key_verify_cache.py::test_a_naive_expiry_is_still_compared_in_utc"
+    ]
+  },
+  {
+    "label": "the verification cache grows without bound",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "    while len(_verify_cache) > _VERIFY_CACHE_MAX:\n        _verify_cache.popitem(last=False)",
+    "replace": "    pass",
+    "tests": [
+      "tests/cloud/auth/test_api_key_verify_cache.py::test_the_cache_is_bounded"
+    ]
+  },
+  {
+    "label": "hand callers the cached scopes themselves",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "        return cached.owner_user_id, cached.workspace, list(cached.scopes)",
+    "replace": "        return cached.owner_user_id, cached.workspace, cached.scopes",
+    "tests": [
+      "tests/cloud/auth/test_api_key_verify_cache.py::test_scopes_handed_out_cannot_be_mutated_through_the_cache"
+    ]
+  },
+  {
+    "label": "mint the key hash inline on the event loop",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "    full_key, prefix, hashed = await generate_key_async()",
+    "replace": "    full_key, prefix, hashed = generate_key()",
+    "tests": [
+      "tests/cloud/auth/test_api_key_verify_cache.py::test_minting_a_key_hashes_off_the_event_loop"
+    ]
+  },
+  {
+    "label": "the gallery read hydrates whole pocket documents again",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    cursor = _PocketDoc.get_pymongo_collection().find(query, {\"source\": 0})\n    docs = [_PocketDoc.model_validate(row) async for row in cursor]",
+    "replace": "    docs = await _PocketDoc.find(query).to_list()",
+    "tests": [
+      "tests/cloud/pockets/test_list_projection.py::test_the_gallery_does_not_carry_the_site_source",
+      "tests/cloud/pockets/test_list_projection.py::test_the_gallery_read_asks_mongo_to_exclude_source"
+    ]
+  },
+  {
+    "label": "the gallery projection stops excluding source",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": ".find(query, {\"source\": 0})",
+    "replace": ".find(query, {})",
+    "tests": [
+      "tests/cloud/pockets/test_list_projection.py::test_the_gallery_does_not_carry_the_site_source"
+    ]
+  },
+  {
+    "label": "agent_list reads every field again",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "        {\"_id\": 1, \"name\": 1, \"description\": 1, \"type\": 1, \"icon\": 1, \"color\": 1, \"owner\": 1},",
+    "replace": "        {},",
+    "tests": [
+      "tests/cloud/pockets/test_list_projection.py::test_the_agent_list_read_is_projected_to_what_it_returns"
+    ]
+  },
+  {
+    "label": "agent_list drops the model-default fallbacks raw BSON needs",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "            \"description\": row.get(\"description\") or \"\",",
+    "replace": "            \"description\": row.get(\"description\"),",
+    "tests": [
+      "tests/cloud/pockets/test_list_projection.py::test_agent_list_substitutes_a_default_for_a_missing_field"
+    ]
+  },
+  {
+    "label": "telemetry goes back to one write per request",
+    "file": "ee/pocketpaw_ee/cloud/_core/request_log.py",
+    "find": "    batch = [await queue.get()]\n    while len(batch) < _BATCH_MAX:\n        try:\n            batch.append(queue.get_nowait())\n        except asyncio.QueueEmpty:\n            break\n",
+    "replace": "    batch = [await queue.get()]\n",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_a_burst_of_requests_becomes_one_write"
+    ]
+  },
+  {
+    "label": "one batch can be the whole backlog",
+    "file": "ee/pocketpaw_ee/cloud/_core/request_log.py",
+    "find": "    batch = [await queue.get()]\n    while len(batch) < _BATCH_MAX:",
+    "replace": "    batch = [await queue.get()]\n    while True:",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_a_batch_is_bounded"
+    ]
+  },
+  {
+    "label": "the telemetry queue grows without bound",
+    "file": "ee/pocketpaw_ee/cloud/_core/request_log.py",
+    "find": "        _queue = asyncio.Queue(maxsize=_QUEUE_MAX)",
+    "replace": "        _queue = asyncio.Queue()",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_a_full_queue_sheds_telemetry_instead_of_growing"
+    ]
+  },
+  {
+    "label": "a full queue raises into the request that was already served",
+    "file": "ee/pocketpaw_ee/cloud/_core/request_log.py",
+    "find": "    except asyncio.QueueFull:",
+    "replace": "    except asyncio.CancelledError:",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_shedding_telemetry_never_raises_into_the_request"
+    ]
+  },
+  {
+    "label": "a failed batch kills the consumer",
+    "file": "ee/pocketpaw_ee/cloud/_core/request_log.py",
+    "find": "        except Exception:\n            logger.warning(\"request-log batch of %d failed to write\", len(batch), exc_info=True)",
+    "replace": "        except Exception:\n            raise",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_the_consumer_survives_a_failed_batch"
+    ]
+  },
+  {
+    "label": "shutdown drops the queued tail instead of flushing it",
+    "file": "ee/pocketpaw_ee/cloud/_core/request_log.py",
+    "find": "    if queue is None or queue.empty():\n        return 0",
+    "replace": "    if True:\n        return 0",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_shutdown_flushes_the_queued_tail"
+    ]
+  },
+  {
+    "label": "logging with no running loop raises",
+    "file": "ee/pocketpaw_ee/cloud/_core/request_log.py",
+    "find": "    try:\n        loop = asyncio.get_running_loop()\n    except RuntimeError:\n        return None",
+    "replace": "    loop = asyncio.get_running_loop()",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_logging_with_no_running_loop_is_a_no_op"
+    ]
+  },
+  {
+    "label": "the consumer is kept across a change of event loop",
+    "file": "ee/pocketpaw_ee/cloud/_core/request_log.py",
+    "find": "    if _queue is None or _queue_loop is not loop or _drain_task is None or _drain_task.done():",
+    "replace": "    if _queue is None or _drain_task is None or _drain_task.done():",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_the_consumer_is_rebuilt_when_the_loop_changes"
+    ]
+  },
+  {
+    "label": "a finished consumer is kept instead of rebuilt",
+    "file": "ee/pocketpaw_ee/cloud/_core/request_log.py",
+    "find": "    if _queue is None or _queue_loop is not loop or _drain_task is None or _drain_task.done():",
+    "replace": "    if _queue is None or _queue_loop is not loop or _drain_task is None:",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_a_consumer_that_does_die_is_replaced"
+    ]
+  },
+  {
+    "label": "the queued entry keeps the middleware's field name",
+    "file": "ee/pocketpaw_ee/cloud/_core/request_log.py",
+    "find": "                \"workspace\": workspace_id,",
+    "replace": "                \"workspace_id\": workspace_id,",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_the_entry_carries_the_fields_the_document_needs"
+    ]
+  },
+  {
+    "label": "one unbuildable entry discards the whole batch",
+    "file": "ee/pocketpaw_ee/cloud/request_log/service.py",
+    "find": "    docs: list[_RequestLogDoc] = []\n    for entry in entries:\n        try:\n            docs.append(_RequestLogDoc(**entry))\n        except Exception:\n            # One unbuildable entry must not cost the batch. This is telemetry\n            # about a request that has already been served.\n            logger.warning(\"request_log.record_many skipped a bad entry\", exc_info=True)",
+    "replace": "    docs = [_RequestLogDoc(**entry) for entry in entries]",
+    "tests": [
+      "tests/cloud/test_request_log_batching.py::test_one_bad_entry_does_not_cost_the_batch"
+    ]
+  }
+]


### PR DESCRIPTION
Three findings from the backend performance audit were fixed in halves in #2074. This is the other half of each. With this the module has nothing left that is both open and owned by this repo.

## The pocket gallery stops carrying site source

`list_pockets` hydrated whole documents. A pocket carries `rippleSpec`, every widget's `spec`, and on the svelte track a `source` map holding the full text of every file in the generated site. That last one runs to hundreds of kilobytes per pocket, and a gallery of a hundred pockets pulled all of it across the wire, on one event loop, to render cards showing a name and an icon.

The read now excludes `source`. Before dropping it I checked every consumer: `mission_control`, `kb` and the pockets surface handler use the id, the name and the widget count, and the desktop client has no `source` reference anywhere on the list path. The key stays on the wire as `null` so nothing sees a `KeyError`.

`rippleSpec` and `widgets` are deliberately kept even though they are the same kind of weight. The desktop client renders the canvas straight off this list response, and dropping them would show empty widgets. Pagination is the audit's other recommendation and is still not done, because it changes the response shape and that belongs in a change the frontend reviews. The bytes it was going to buy back are bought without it.

**A second instance the finding did not name.** `agent_list` had exactly the same shape, and its docstring said the opposite. "The full `rippleSpec` is intentionally excluded" describes what it returns; the read behind it hydrated whole documents to keep seven small fields. It is the "have we already got one of these?" check on every pocket-creation flow, so it was the hotter of the two. Because that projection is invisible in the response, its test watches the query rather than the result.

## API-key verification gets a short-lived cache

Argon2id at pwdlib's recommended parameters is about thirty milliseconds of CPU and a 64 MB allocation, by design. #2074 moved it to a thread, which stopped it freezing the loop. It did not stop it being paid again on every call: a script polling once a second re-derives the same hash from the same token 3600 times an hour.

The cache was skipped the first time on purpose. Caching an authentication decision buys latency at the cost of revocation lag, and that deserved its own review rather than a ride-along in a perf commit. Reviewed now, and built so the lag applies to as little as possible.

- **Revocation through this module is not lagged.** Both revoke paths evict the key's entries as they flip the flag.
- **Expiry is not lagged.** `expires_at` is re-checked against the clock on every hit, not only when the entry was stored, so a key that expires part-way through a cached window dies on time.
- **What is lagged** is a revocation done out of band: flipping `revoked` straight in the database, or from another process, since the cache is per-process. That window is thirty seconds, and `POCKETPAW_API_KEY_VERIFY_TTL_SECONDS=0` turns the cache off entirely.

Only successful verifications are cached. A negative cache would buy nothing against the attack it looks like it prevents, since a brute force sends a different token every time and would never hit it, while giving a key a second way to stay dead after it should work again.

Minting moves off the loop in the same change. `.hash()` costs the same blocking thirty milliseconds as `verify`, and one admin creating a key should not stall every WebSocket frame in flight.

## Request telemetry is batched

#2074 stopped telemetry writes vanishing and put a ceiling on them, and skipped the paths with no audit value. That reduced the volume without changing the shape: every remaining request still opened its own insert, so at 100 requests a second this collection was still issuing 100 writes a second against the same connection pool and the same cache as the traffic it exists to describe.

Entries now go onto a bounded queue drained by one consumer into `insert_many`. Everything already queued joins a batch immediately, then a 250ms linger lets a steady trickle become a batch too. The queue is the backpressure the in-flight ceiling used to be: past 4096 queued entries the entry is dropped and counted, on the same reasoning as before.

Telemetry reaches the audit page up to the linger later than it did. It describes requests that have already been answered, so the delay costs nothing and the batching is the point.

The queued tail would otherwise be lost on every restart, which is exactly when someone is reading that page. The flush is wired into `dashboard_lifecycle.shutdown_event`, not into an `on_event("shutdown")` handler in `mount_cloud`, because under a lifespan context manager those never fire. That function's own comment already says so, next to the identical guarded import for the chat-run drain.

## Testing

All 25 mutations in the new plan are caught. Two escaped on the first run and both were real weaknesses rather than bad mutations.

The interesting one: making a failed batch kill the consumer did not fail the test, because a dead consumer is replaced on the next request, so the second batch landed either way. What a dying consumer actually costs is the backlog it was holding, which no later write reveals. The test now watches the task identity, and the self-healing it exposed got a test of its own.

The other was a mutation that did not remove the behaviour it claimed to. `model_construct` honours field aliases and fills defaults just like `model_validate`, so swapping them changed nothing. The regression that test describes is a rewrite rather than an edit, so it is out of the plan and says so.

The existing backpressure suite is rewritten rather than deleted. It pinned the in-flight set and its ceiling, both of which are gone; the properties it guarded are unchanged and now live on the queue.

Ran the auth and pockets suites in full. Thirteen failures there, all reproduced on a clean `dev` checkout, none related to this change.
