### PR TITLE
fix(worker): make the arq health key expire fast enough to probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,6 +182,14 @@
 # claude_agent_sdk backend spawns a Node subprocess per run, so RAM binds first.
 # POCKETPAW_ARQ_MAX_JOBS=10
 #
+# WORKER ONLY. How often the arq worker refreshes its Redis health key, and so
+# how quickly `arq --check` notices the worker is gone — the key's TTL is this
+# plus one second. arq's own default is 3600, which reports a worker that died
+# a minute ago as healthy for the rest of the hour; the deploy compose polls
+# this every 30s, so the default here is 30. Keep it comfortably below whatever
+# interval is polling it, or the probe flaps.
+# POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL=30
+#
 # PER-PROCESS. Live agent instances one process's AgentPool holds before it
 # refuses to build another. The web process and each worker each get their own.
 # POCKETPAW_AGENT_POOL_MAX_INSTANCES=20

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,13 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   30-minute `job_timeout`. Total concurrency is this value x worker replicas.
   Raise it WITH the container's memory limit: the default `claude_agent_sdk`
   backend spawns a Node subprocess per run, so RAM binds before CPU.
+  `POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL` (default `30`) — **worker only**, and not
+  a capacity knob at all: it is how often the worker refreshes its Redis health
+  key, and therefore how fast `arq --check` can notice the worker is gone (the
+  key's TTL is this plus a second). arq's own default is `3600`, which answers
+  "healthy" for up to an hour after the process died — so a container
+  healthcheck built on it looks like coverage and catches nothing. The deploy
+  compose polls it every 30s; keep this comfortably under whatever polls it.
   `POCKETPAW_AGENT_POOL_MAX_INSTANCES` (default `20`) — **per-process** AgentPool
   ceiling; the web process and each worker each hold their own pool.
   `POCKETPAW_SESSION_WARM_MAX_PER_TENANT` (default `8`) /

--- a/docs/internal/2026-05-resumable-runs-deploy.md
+++ b/docs/internal/2026-05-resumable-runs-deploy.md
@@ -169,6 +169,7 @@ Env vars (all also documented in `backend/CLAUDE.md` → Key Conventions):
 |-----|---------|---------|
 | `POCKETPAW_CLOUD_RUN_EXECUTOR` | `inprocess` | Set to `arq` on the web service to enable Tier 2 |
 | `POCKETPAW_ARQ_MAX_JOBS` | `10` | Concurrent jobs ONE worker runs, shared across every registered lane. Set on the **worker**; the web service ignores it. See "Sizing the worker" below |
+| `POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL` | `30` | How often the worker refreshes its Redis health key. `arq --check` exits 0 while that key lives (TTL = this + 1s), so this is what decides how fast a container healthcheck can notice a dead worker. arq's own default is `3600`, which is far too slow to probe against |
 | `POCKETPAW_AGENT_POOL_MAX_INSTANCES` | `20` | Per-process AgentPool ceiling. Applies to the web process AND each worker |
 | `POCKETPAW_SESSION_WARM_MAX_PER_TENANT` | `8` | Per-process warm session slots one workspace may hold. The per-tenant fairness knob |
 | `POCKETPAW_SESSION_WARM_MAX_GLOBAL` | `64` | Per-process warm session slots across all workspaces |

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -310,6 +310,52 @@ def _max_jobs() -> int:
     return val
 
 
+# arq writes a health-check key to Redis every ``health_check_interval`` seconds
+# with a TTL of interval + 1, and ``arq --check <settings>`` exits 0 while that
+# key is alive. arq's own default interval is 3600, which makes the key a poor
+# liveness signal for anything that polls: a worker that died a minute ago still
+# reports healthy for the rest of the hour. That is worse than no probe, because
+# a container healthcheck built on it looks like coverage while catching nothing.
+#
+# 30 seconds costs one small Redis write every 30 seconds and makes the key mean
+# what a probe assumes it means.
+_DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS = 30
+
+
+def _health_check_interval_seconds() -> int:
+    """Resolve the arq health-key refresh period from the environment.
+
+    Same fail-soft contract as ``_max_jobs`` and ``_job_timeout_seconds``: an
+    unparseable or non-positive value falls back to the default rather than
+    reaching arq, where a non-positive interval turns the health loop into a
+    busy wait.
+
+    Raising this loosens every probe built on the key, because the key's TTL is
+    derived from it. Keep it comfortably below the healthcheck interval of
+    whatever is polling, or the probe flaps.
+    """
+    raw = os.environ.get("POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL", "").strip()
+    if not raw:
+        return _DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.warning(
+            "POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL=%r is not an int; using default %ds",
+            raw,
+            _DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS,
+        )
+        return _DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS
+    if val <= 0:
+        logger.warning(
+            "POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL=%d is not positive; using default %ds",
+            val,
+            _DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS,
+        )
+        return _DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS
+    return val
+
+
 # Workspace jobs (pp#1459) run on this same worker but get their OWN
 # per-function timeout via ``arq.worker.func`` so a long-running job can't be
 # clipped by the chat-run timeout and vice-versa. The dotted name the web
@@ -410,5 +456,11 @@ class WorkerSettings:
     # retried, just queued. Plain int in __dict__ for the arq-reads-__dict__
     # reason documented on `_redis_settings`.
     max_jobs = _max_jobs()
+    # How often the worker refreshes its Redis health key, and therefore how
+    # quickly ``arq --check`` notices it is gone. arq's default of an hour makes
+    # that check answer "healthy" for up to an hour after the process died,
+    # which is exactly the wrong answer to give a container healthcheck. Plain
+    # int in __dict__ for the arq-reads-__dict__ reason above.
+    health_check_interval = _health_check_interval_seconds()
     # Eager: arq reads __dict__, which bypasses descriptors. See `_redis_settings`.
     redis_settings = _redis_settings()

--- a/tests/cloud/runs/test_worker_config_and_pool.py
+++ b/tests/cloud/runs/test_worker_config_and_pool.py
@@ -210,3 +210,64 @@ async def test_max_jobs_helper_invalid_or_nonpositive_falls_back(monkeypatch):
         assert worker_mod._max_jobs() == worker_mod._DEFAULT_MAX_JOBS, (
             f"{bad!r} should fall back to the default"
         )
+
+
+# --- H7: the health key has to expire fast enough to mean anything ---------
+#
+# arq refreshes a Redis key every ``health_check_interval`` with a TTL of
+# interval + 1, and ``arq --check`` exits 0 while it is alive. The container
+# healthcheck in deploy/coolify/docker-compose.yaml is built on that command,
+# so the interval is what decides whether the probe can ever fail.
+
+
+async def test_worker_settings_health_check_interval_is_a_plain_int_in_dict():
+    """Same arq-reads-__dict__ contract as ``max_jobs`` and ``redis_settings``."""
+    raw = worker_mod.WorkerSettings.__dict__.get("health_check_interval")
+    assert isinstance(raw, int), (
+        f"WorkerSettings.health_check_interval in __dict__ is {type(raw).__name__}, "
+        "expected int. arq bypasses the descriptor protocol via __dict__ access."
+    )
+    assert raw > 0
+
+
+async def test_the_health_key_expires_far_faster_than_arq_would_leave_it():
+    """The whole point of the knob, stated as a number.
+
+    arq's own default is an hour. A container healthcheck polling every 30
+    seconds against an hour-old key reports healthy for the rest of the hour
+    after the worker dies, which is worse than having no probe: it looks like
+    coverage. Anything at or above arq's default is that bug.
+    """
+    from arq.worker import Worker
+
+    arq_default = inspect.signature(Worker.__init__).parameters["health_check_interval"].default
+
+    assert worker_mod._DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS < arq_default
+    assert worker_mod._DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS <= 60, (
+        "the compose healthcheck polls on a 30s interval; a refresh period "
+        "above a minute makes the probe flap or lie"
+    )
+
+
+async def test_health_check_interval_helper_default(monkeypatch):
+    monkeypatch.delenv("POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL", raising=False)
+    assert (
+        worker_mod._health_check_interval_seconds()
+        == worker_mod._DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS
+    )
+
+
+async def test_health_check_interval_helper_env_override(monkeypatch):
+    monkeypatch.setenv("POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL", "15")
+    assert worker_mod._health_check_interval_seconds() == 15
+
+
+async def test_health_check_interval_helper_invalid_or_nonpositive_falls_back(monkeypatch):
+    """A non-positive interval turns arq's health loop into a busy wait, so it
+    must never reach arq."""
+    for bad in ("not-a-number", "-5", "0", "", "  "):
+        monkeypatch.setenv("POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL", bad)
+        assert (
+            worker_mod._health_check_interval_seconds()
+            == worker_mod._DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS
+        ), f"{bad!r} should fall back to the default"

--- a/tests/mutations/scale_concurrency_knobs.json
+++ b/tests/mutations/scale_concurrency_knobs.json
@@ -1,6 +1,6 @@
 [
   {
-    "label": "max_jobs is dropped from WorkerSettings, so arq silently falls back to its own default of 10 and the whole knob is dead — the exact bug this change fixes, reintroduced",
+    "label": "max_jobs is dropped from WorkerSettings, so arq silently falls back to its own default of 10 and the whole knob is dead \u2014 the exact bug this change fixes, reintroduced",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
     "find": "    max_jobs = _max_jobs()\n",
     "replace": "",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "label": "max_jobs becomes a property, so arq's __dict__ read hands a descriptor to BoundedSemaphore(max_jobs + 1) and the worker crashes on boot — the _LazyRedisSettings deploy crash, repeated",
+    "label": "max_jobs becomes a property, so arq's __dict__ read hands a descriptor to BoundedSemaphore(max_jobs + 1) and the worker crashes on boot \u2014 the _LazyRedisSettings deploy crash, repeated",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
     "find": "    max_jobs = _max_jobs()",
     "replace": "    max_jobs = property(lambda self: _max_jobs())",
@@ -87,6 +87,33 @@
     "replace": "    session_warm_max_global: int = Field(\n        default=32,",
     "tests": [
       "tests/test_session_supervisor.py"
+    ]
+  },
+  {
+    "label": "the worker keeps arq's hour-long health interval, so arq --check reports a dead worker healthy for the rest of the hour and the container probe never fires",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "_DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS = 30",
+    "replace": "_DEFAULT_HEALTH_CHECK_INTERVAL_SECONDS = 3600",
+    "tests": [
+      "tests/cloud/runs/test_worker_config_and_pool.py"
+    ]
+  },
+  {
+    "label": "health_check_interval is left off WorkerSettings, so the knob exists and reaches nothing",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "    health_check_interval = _health_check_interval_seconds()",
+    "replace": "    _unused_health_check_interval = _health_check_interval_seconds()",
+    "tests": [
+      "tests/cloud/runs/test_worker_config_and_pool.py"
+    ]
+  },
+  {
+    "label": "a non-positive health interval reaches arq, turning its health loop into a busy wait",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "    if val <= 0:\n        logger.warning(\n            \"POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL=%d is not positive; using default %ds\",",
+    "replace": "    if False:\n        logger.warning(\n            \"POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL=%d is not positive; using default %ds\",",
+    "tests": [
+      "tests/cloud/runs/test_worker_config_and_pool.py"
     ]
   }
 ]


### PR DESCRIPTION
H7 in the backend performance audit says neither app container has a healthcheck. Adding one to the worker turns out to need a change here first, and this is it. The compose change that consumes it lands in the workspace repo.

## The problem with the obvious probe

The worker runs `arq`, which has no HTTP surface, so the natural liveness check is `arq --check`. That command exits 0 while the worker's Redis health key is alive, and the key's TTL comes from `health_check_interval`. arq defaults that to an hour.

A container healthcheck polling every thirty seconds against an hour-old key reports a worker that died a minute ago as healthy for the rest of the hour. That is worse than having no probe at all, because the compose file then looks like it has coverage while catching nothing.

## The change

`health_check_interval` is now thirty seconds, read from `POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL`, and set on `WorkerSettings` as a plain int in `__dict__` for the same reason `max_jobs` and `redis_settings` are: arq reads the settings class dictionary directly and bypasses the descriptor protocol.

The helper is fail-soft in exactly the way the two knobs beside it are. An unparseable or non-positive value falls back to the default rather than reaching arq, where a non-positive interval turns the health loop into a busy wait.

The cost is one small Redis write every thirty seconds.

## Ordering

Shipping this before or after the compose change is safe. The existing key never reports a false unhealthy, it only reports healthy for too long, so a probe added first would simply be slow to notice rather than wrong.

## Testing

All 13 mutations in the concurrency-knobs plan are caught, including three new ones. The one worth naming leaves the knob on the module but takes it off `WorkerSettings`, which is the shape where a setting is read, documented and silently ignored. That mutation is the reason the test asserts on `WorkerSettings.__dict__` rather than on the helper's return value.

Documented in `.env.example`, the deploy guide's env table, and the concurrency section of `CLAUDE.md`, which is where the four capacity knobs are already disambiguated. This one is filed there with an explicit note that it is not a capacity knob, because it sits among four that are.
