### PR TITLE
test: retry the loop-freedom measurement instead of flaking on it

### DIFF
--- a/tests/test_blocking_offload.py
+++ b/tests/test_blocking_offload.py
@@ -56,14 +56,41 @@ _MIN_TICKS = 5
 # one ~0.5, so 0.75 has real margin in both directions.
 _MIN_TICK_COVERAGE = 0.75
 
+# Attempts a correct handler gets to clear that bar.
+#
+# The ratio compares two windows measured moments apart, so anything that
+# steals the loop during one but not the other moves it. Measured on Windows:
+# two failures in four runs of this file alongside its neighbours, and none
+# when it ran alone. That is a flaky gate, which is worse than a missing one.
+#
+# Retrying does not weaken it. A handler that still blocks scores ~0.5 on
+# EVERY attempt, because what is being measured is which half of its work sits
+# on the loop, not how busy the machine is. Both retried handlers are
+# read-only reads of a temp jail, so re-running one costs only the sleep.
+_MEASURE_ATTEMPTS = 3
 
-def _assert_loop_stayed_free(during: int, elapsed: float, rate: float, label: str) -> None:
-    """Assert the ticker ran for essentially the whole handler call."""
-    expected = rate * elapsed
-    assert during >= _MIN_TICKS, f"{label}: loop was blocked outright ({during} ticks)"
-    assert during >= expected * _MIN_TICK_COVERAGE, (
-        f"{label}: {during} ticks in {elapsed:.2f}s against an idle baseline of "
-        f"~{expected:.0f} — part of the handler is still on the event loop"
+
+async def _run_until_loop_stays_free(factory, label: str):
+    """Run the handler until one attempt proves the loop stayed free.
+
+    Returns that attempt's ``(result, ticks_during, elapsed)``. Fails at once,
+    without retrying, when the loop was blocked outright: that case is not
+    noise, and no number of retries should be allowed to look past it.
+    """
+    misses: list[str] = []
+    for _ in range(_MEASURE_ATTEMPTS):
+        rate = await _idle_tick_rate()
+        result, during, elapsed = await _run_with_ticker(factory)
+        if during < _MIN_TICKS:
+            pytest.fail(f"{label}: loop was blocked outright ({during} ticks)")
+        expected = rate * elapsed
+        if during >= expected * _MIN_TICK_COVERAGE:
+            return result, during, elapsed
+        misses.append(f"{during} ticks in {elapsed:.2f}s against a baseline of ~{expected:.0f}")
+    pytest.fail(
+        f"{label}: part of the handler is still on the event loop. "
+        f"{_MEASURE_ATTEMPTS} attempts, none reached {_MIN_TICK_COVERAGE:.0%} of the "
+        "idle tick rate: " + "; ".join(misses)
     )
 
 
@@ -140,15 +167,15 @@ def jail(tmp_path):
 
 
 async def test_git_status_keeps_the_loop_running(jail):
-    rate = await _idle_tick_rate()
     with patch.object(subprocess, "run", _blocking_run("main\n")):
-        response, during, elapsed = await _run_with_ticker(lambda: files.git_status(path=str(jail)))
+        response, during, elapsed = await _run_until_loop_stays_free(
+            lambda: files.git_status(path=str(jail)), "git_status"
+        )
 
     # Two git invocations (rev-parse + status), so the stub slept twice — and
     # BOTH have to be offloaded. Asserting only that some ticks landed passes
     # when just one of them is.
     assert elapsed >= _BLOCK_SECONDS * 2
-    _assert_loop_stayed_free(during, elapsed, rate, "git_status")
     assert response.is_git_repo is True
     assert response.branch == "main"
 
@@ -176,14 +203,13 @@ async def test_git_status_still_reports_a_subprocess_timeout(jail):
 
 async def test_git_diff_keeps_the_loop_running(jail):
     target = jail / "tracked.txt"
-    rate = await _idle_tick_rate()
-
     with patch.object(subprocess, "run", _blocking_run("")):
-        response, during, elapsed = await _run_with_ticker(lambda: files.git_diff(path=str(target)))
+        response, during, elapsed = await _run_until_loop_stays_free(
+            lambda: files.git_diff(path=str(target)), "git_diff"
+        )
 
     # Two git invocations (diff + rev-parse) — both must be offloaded.
     assert elapsed >= _BLOCK_SECONDS * 2
-    _assert_loop_stayed_free(during, elapsed, rate, "git_diff")
     assert response.is_git_repo is True
 
 


### PR DESCRIPTION
The two git handler tests in `test_blocking_offload.py` are flaky on Windows. I wrote them, they merged with #2077, and I caught this verifying the seven-PR merge on `dev`.

## What flakes

Both assert that a handler left the event loop free by comparing ticks recorded during the handler against ticks recorded during an idle baseline taken moments earlier. Anything that steals the loop during one window but not the other moves the ratio, and the threshold sits at 75%.

Measured: two failures in four runs of this file alongside its neighbours, and none in four runs of the file alone. So it needs load to show up, which is exactly the condition a full suite provides.

A flaky gate is worse than a missing one. The next person to see it red learns to re-run rather than to look.

## Why not just loosen the threshold

Because the threshold is carrying real weight. Both handlers make two subprocess calls, and offloading only one of them scores about 0.5. A floor of "some ticks landed" is satisfied by that, and both single-call mutations escaped exactly that way before the assertion became proportional. Anything below 0.5 gives that bug back.

## What changed

The measurement gets three attempts and passes on the first that clears the bar.

This does not weaken it. What the assertion measures is which half of the handler's work sits on the loop, not how busy the machine is, so a handler that still blocks one call scores about half the idle rate on every attempt. Retrying cannot rescue it.

A loop blocked outright still fails on the first attempt with no retry, because that case is not noise and nothing should be allowed to look past it.

Both retried handlers are read-only reads of a temp jail, so re-running one costs only the sleep.

## Verified

All 17 mutations in the event-loop plan are still caught, including `git_status runs its subprocess inline again` and `git_diff runs its subprocess inline again`. Those two are the reason the assertion is proportional in the first place, so they are the ones that had to survive this change.

Four more runs of the same five-file group after the fix, all green.
