### PR TITLE
Log a rejected titling key as one line instead of a traceback

### DIFF
--- a/src/pocketpaw/memory/titler.py
+++ b/src/pocketpaw/memory/titler.py
@@ -76,6 +76,22 @@ def fallback_title(first_message: str) -> str | None:
     return one_line
 
 
+def _is_auth_failure(exc: Exception) -> bool:
+    """True when ``exc`` is the API refusing the credential rather than a real fault.
+
+    Matched on the SDK's exception classes when they import, and on the status code
+    otherwise, so a titling call never depends on the anthropic package being present.
+    """
+    try:
+        from anthropic import AuthenticationError, PermissionDeniedError
+
+        if isinstance(exc, (AuthenticationError, PermissionDeniedError)):
+            return True
+    except ImportError:
+        pass
+    return getattr(exc, "status_code", None) in (401, 403)
+
+
 async def generate_title(
     first_message: str, *, model: str, api_key: str | None = None
 ) -> str | None:
@@ -114,8 +130,21 @@ async def generate_title(
             max_tokens=_MAX_TOKENS,
             messages=[{"role": "user", "content": _PROMPT.format(message=text)}],
         )
-    except Exception:
-        logger.warning("Haiku title generation call failed; using fallback", exc_info=True)
+    except Exception as exc:
+        # An auth/permission refusal is an EXPECTED outcome here, not a crash: the key
+        # may be absent, expired, or meant for a gateway rather than api.anthropic.com
+        # (ANTHROPIC_BASE_URL, which the Anthropic SDK reads on its own). Titling is
+        # best-effort and already falls back, so a refusal is one line. A full traceback
+        # reads as a failed run and has sent people debugging the agent, which was fine.
+        # Anything else is genuinely unexpected and keeps its traceback.
+        if _is_auth_failure(exc):
+            logger.info(
+                "chat titling skipped: the Anthropic API rejected the configured key "
+                "(%s); using the first-message fallback",
+                type(exc).__name__,
+            )
+        else:
+            logger.warning("Haiku title generation call failed; using fallback", exc_info=True)
         return fallback_title(first_message)
 
     try:

--- a/tests/test_titler_context_preamble.py
+++ b/tests/test_titler_context_preamble.py
@@ -123,3 +123,27 @@ class TestGenerateTitle:
         assert "how do I add a chart to my home?" in seen["prompt"]
         assert "Home page snapshot" not in seen["prompt"]
         assert "pinned widgets" not in seen["prompt"]
+
+
+class _Refused(Exception):
+    """Stands in for the SDK's AuthenticationError without importing it."""
+
+    status_code = 401
+
+
+class _Broken(Exception):
+    status_code = 500
+
+
+def test_an_auth_refusal_is_logged_without_a_traceback(caplog):
+    """A rejected key is an expected outcome, not a crash.
+
+    The titler already falls back, but it used to log the refusal with exc_info, and
+    the resulting traceback reads as a failed agent run. It sent someone debugging the
+    agent after a chat title quietly fell back, which was the only thing that happened.
+    """
+    from pocketpaw.memory.titler import _is_auth_failure
+
+    assert _is_auth_failure(_Refused()) is True
+    assert _is_auth_failure(_Broken()) is False
+    assert _is_auth_failure(ValueError("not an API failure at all")) is False


### PR DESCRIPTION
Chat titling is best-effort. It already falls back to a trimmed first-message excerpt whenever the call fails, so a rejected key changes nothing a user sees.

It still logged the refusal with `exc_info=True`. A working agent run therefore printed a full `AuthenticationError` traceback in the middle of otherwise healthy output, and it reads as the run failing. That is exactly what happened this week: someone hit it, read the traceback as the agent being broken, and went looking for a bug in the agent path. The only thing that had happened was a chat title falling back to its excerpt.

A 401 or 403 is an expected outcome here. The key can be missing, expired, or meant for a gateway rather than `api.anthropic.com` — the Anthropic SDK reads `ANTHROPIC_BASE_URL` on its own, so a process pointed at a gateway sends this same call there and gets a different verdict. None of those are faults worth a stack trace.

Refusals now log one INFO line naming the exception type. Everything else keeps its traceback, since anything that is not the API declining the credential is genuinely unexpected.

Detection matches the SDK's `AuthenticationError` / `PermissionDeniedError` when the package imports, and falls back to the status code otherwise, so titling never gains a hard dependency on the anthropic package being installed.

Tests: 13 pass in the titler file including the new case; 278 pass across the titler and memory selection. `ruff check` and `ruff format` clean. Both import-linter configs pass.