### PR TITLE
fix(studio): list Seedance reference-to-video so it can actually be picked

### DIFF
--- a/ee/pocketpaw_ee/cloud/studio/fal_video.py
+++ b/ee/pocketpaw_ee/cloud/studio/fal_video.py
@@ -221,6 +221,20 @@ CURATED_VIDEO_MODELS: dict[str, dict[str, Any]] = {
         "durations": (5, 10),
         "duration_as_string": True,
     },
+    "seedance_2_5_ref": {
+        "id": SEEDANCE_REF_TO_VIDEO_MODEL,  # bytedance/seedance-2.5/reference-to-video
+        "name": "Seedance 2.5 (reference)",
+        "vendor": "ByteDance",
+        "kind": "reference-to-video",
+        # The full enum this endpoint accepts — wider than its siblings, which
+        # offer no 21:9 or 4:3.
+        "aspect_ratios": ("16:9", "9:16", "1:1", "21:9", "4:3", "3:4"),
+        # 4..30; the composer offers the three that matter. This is the only
+        # video model that takes an AUDIO input, so it is what a flow lands on
+        # when a Music node is wired into its Video node.
+        "durations": (5, 10, 30),
+        "duration_as_string": True,
+    },
     "seedance_2_5_i2v": {
         "id": SEEDANCE_I2V_MODEL,  # bytedance/seedance-2.5/image-to-video
         "name": "Seedance 2.5 (image)",
@@ -544,10 +558,17 @@ def build_reference_arguments(
     videos = [u.strip() for u in (video_urls or []) if u and u.strip()][: limits.videos]
     audio = [u.strip() for u in (audio_urls or []) if u and u.strip()][: limits.audio]
 
-    if audio and not images and not videos:
-        raise ValueError("reference-to-video needs at least one image or video alongside audio")
+    if not images and not videos:
+        # fal: "At least one reference image or video is required." Now that this
+        # model is selectable in the composer, a user can reach it with nothing
+        # wired — so name the missing piece here rather than return a 422 whose
+        # message says only that the request was invalid.
+        raise ValueError(
+            "Seedance reference-to-video needs at least one reference image or video"
+            + (" — audio alone is not enough" if audio else "")
+        )
 
-    # The overall 12-file cap. Trimmed from the least specific end — extra images
+    # The overall file cap. Trimmed from the least specific end — extra images
     # are the most replaceable, and dropping the audio or the only video would
     # change what the shot IS.
     while len(images) + len(videos) + len(audio) > limits.files and images:

--- a/tests/cloud/studio/test_fal_video_reference.py
+++ b/tests/cloud/studio/test_fal_video_reference.py
@@ -295,3 +295,33 @@ async def test_no_audio_leaves_the_existing_paths_alone(monkeypatch) -> None:
 
     await fal_video.run_fal_video(prompt="a cat", model=fal_video.SEEDANCE_T2V_MODEL, key="k")
     assert seen["endpoint"] == fal_video.SEEDANCE_T2V_MODEL
+
+
+# ── Catalog visibility ──────────────────────────────────────────────────────
+
+
+def test_the_reference_model_is_in_the_curated_catalog() -> None:
+    """It shipped routable but unlisted, so the composer's video picker never
+    offered it — the endpoint worked and nobody could select it.
+
+    Mutation that must break this: remove the seedance_2_5_ref entry.
+    """
+    ids = {cfg["id"] for cfg in fal_video.CURATED_VIDEO_MODELS.values()}
+    assert fal_video.SEEDANCE_REF_TO_VIDEO_MODEL in ids
+
+
+def test_it_advertises_thirty_seconds_and_the_wide_ratios() -> None:
+    """Its enum is wider than its siblings'. Advertising the narrower set would
+    hide options the endpoint accepts."""
+    cfg = fal_video.CURATED_VIDEO_MODELS["seedance_2_5_ref"]
+    assert 30 in cfg["durations"]
+    assert "21:9" in cfg["aspect_ratios"]
+    # Duration is a string enum on this family; sending an int is a 422.
+    assert cfg["duration_as_string"] is True
+
+
+def test_selecting_it_with_nothing_wired_says_what_is_missing() -> None:
+    """fal requires at least one image or video. Now that the model is
+    selectable, a user can reach it with an empty graph."""
+    with pytest.raises(ValueError, match="reference image or video"):
+        fal_video.build_reference_arguments(prompt="a detective", image_urls=[])


### PR DESCRIPTION
## Summary

Seedance 2.5 reference-to-video shipped **routable but unlisted**. It was wired into the dispatcher and reachable whenever a Music node fed a Video node, but it was never added to `CURATED_VIDEO_MODELS` — so `list_models` never emitted it and the composer's video picker never offered it. Working code nobody could select.

## What changed

**The catalog entry**, advertising the endpoint's own enum rather than copying a sibling's:

- **4–30s** — the text-to-video row stops at 10, and this endpoint goes to 30
- **21:9 and 4:3** alongside the usual three, which the other Seedance rows don't carry
- `duration_as_string` — this family declares `duration` as a string enum, and an int is a 422

Advertising the narrower set would have hidden options the endpoint actually accepts.

**A guard for a case that could not happen before.** fal requires at least one reference image or video. Until now this endpoint was only reachable through a flow that had already wired an Image node into the Video node, so there was always an anchor. Being selectable in the composer means a user can reach it with an empty graph — that is caught locally and names the missing piece, rather than returning a 422 whose message says only that the request was invalid.

The previous audio-needs-an-anchor check folds into the same guard: audio alone was always the narrower version of the same requirement.

## Test plan

`pytest tests/cloud/studio/` → **358 passed**

The catalog test was checked by mutation, not assumed: removing the `seedance_2_5_ref` entry fails 2 tests. That matters here specifically, because "the code works but nothing lists it" is the exact failure this PR fixes — and it is invisible to every test that exercises the endpoint directly.
