### PR TITLE
Give site builds their own queue so a publish storm cannot starve chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,15 +172,21 @@
 # Four different ceilings, easy to confuse. In a CLOUD deploy the first one is
 # the only one that bounds how many agent runs execute at once.
 #
-# CLUSTER-WIDE. Concurrent jobs one arq worker will run, shared across every
-# lane it registers: chat runs, workspace jobs, both /ship jobs and both site
-# builds. arq's own default is 10 — so ten concurrent site publishes leave no
-# slot for a chat run, and job 11 is not rejected or retried, it waits in Redis
-# behind a job_timeout of up to 30 minutes. Total concurrency is this value
-# times the number of worker replicas.
+# THE CHAT LANE'S CEILING. Concurrent jobs one arq worker runs on arq's default
+# queue: chat runs, workspace jobs and both /ship jobs. Site builds used to share
+# it and no longer do — ten concurrent publishes left no slot for a chat run, and
+# job 11 was neither rejected nor retried, it waited in Redis behind a job_timeout
+# of up to 30 minutes. Total concurrency is this value times the worker replicas.
 # Raise it WITH the worker container's memory limit: the default
 # claude_agent_sdk backend spawns a Node subprocess per run, so RAM binds first.
 # POCKETPAW_ARQ_MAX_JOBS=10
+#
+# THE SITE-BUILD LANE'S CEILING. Concurrent site builds and draft previews, on
+# their own queue with their own worker settings. Deliberately smaller, and
+# bounded by something different: a build compiles inside a Daytona sandbox, so
+# what runs in this container is an await on a remote exec. Raise it with the
+# sandbox quota you are willing to pay for, not with the memory limit.
+# POCKETPAW_SITES_ARQ_MAX_JOBS=4
 #
 # WORKER ONLY. How often the arq worker refreshes its Redis health key, and so
 # how quickly `arq --check` notices the worker is gone — the key's TTL is this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,11 +225,16 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   env-configurable), marking queued/running `ChatRunDoc`s older than 10 minutes as
   `interrupted` so runs abandoned by a backend restart surface a retry affordance
   instead of leaving clients subscribed forever.
-- **Concurrency / capacity config**: four ceilings that are easy to confuse. In a
-  cloud deploy only the first one bounds how many agent runs execute at once.
-  `POCKETPAW_ARQ_MAX_JOBS` (default `10`, arq's own) — **cluster-wide**: concurrent
-  jobs ONE arq worker runs, shared across every lane it registers (chat runs,
-  workspace jobs, both `/ship` jobs, both site builds). It was unset until
+- **Concurrency / capacity config**: five ceilings that are easy to confuse. In a
+  cloud deploy the first two are the ones that bound how much work executes at once.
+  `POCKETPAW_ARQ_MAX_JOBS` (default `10`, arq's own) — the **chat lane's** ceiling:
+  concurrent jobs ONE arq worker runs on arq's default queue (chat runs,
+  workspace jobs, both `/ship` jobs). Site builds shared it until 2026-09-04 and
+  now have `POCKETPAW_SITES_ARQ_MAX_JOBS` (default `4`) on their own queue,
+  consumed by the same container — `pocketpaw_ee.cloud.worker_supervisor` runs both
+  lanes in one process, so neither can consume the other's slots. Raise the sites
+  one with the Daytona sandbox quota, not with the container's memory limit: a
+  build compiles remotely and what runs here is an await. This was unset until
   2026-09-01, so every earlier deploy ran on arq's default with no way to raise
   it; ten concurrent site publishes left no slot for a chat run, and job 11 was
   neither rejected nor retried (`max_tries = 1`) — it waited in Redis behind a

--- a/docs/internal/2026-05-resumable-runs-deploy.md
+++ b/docs/internal/2026-05-resumable-runs-deploy.md
@@ -28,10 +28,10 @@ backend image and git ref as the web service.
 | Setting | Web service (existing) | Worker service (new) |
 |---------|-----------------------|----------------------|
 | Image / build | unchanged | same as web |
-| Start command | `uv run pocketpaw` (unchanged) | `uv run arq pocketpaw_ee.cloud.chat.runs.worker.WorkerSettings` |
+| Start command | `uv run pocketpaw` (unchanged) | `python -m pocketpaw_ee.cloud.worker_supervisor` (runs both arq lanes; before 2026-09-04 this was `arq pocketpaw_ee.cloud.chat.runs.worker.WorkerSettings`, which ran the chat lane only) |
 | Replicas | unchanged | start with 1; horizontal-scale by replica count |
 | Public port | unchanged | none (worker has no HTTP) |
-| Healthcheck | unchanged | none — arq is a pull worker; healthcheck the queue depth in Redis instead |
+| Healthcheck | unchanged | `arq --check` against BOTH settings classes — each lane writes its own Redis health key, so probing one says nothing about the other |
 
 ### Required env on the worker
 
@@ -60,12 +60,26 @@ will now enqueue an `execute_run_job` instead of spawning an `asyncio.Task`.
 ## Sizing the worker
 
 `max_jobs` was unset until 2026-09-01, so every deploy before that ran on arq's
-default of **10 concurrent jobs per worker** — and that ceiling is shared by all
+default of **10 concurrent jobs per worker** — and that ceiling was shared by all
 six registered functions, not divided among them. Ten concurrent site publishes
-leave no slot for a chat message. The failure mode is invisible from the outside:
+left no slot for a chat message. The failure mode was invisible from the outside:
 job 11 is not rejected and, with `max_tries = 1`, not retried either. It waits in
 Redis behind a `job_timeout` of up to 30 minutes, so the user just sees a reply
 that never starts.
+
+**Site builds moved off that ceiling on 2026-09-04.** They now ride their own arq
+queue (`arq:queue:sites`) with their own settings class
+(`pocketpaw_ee.sites.build_worker.WorkerSettings`) and their own limit,
+`POCKETPAW_SITES_ARQ_MAX_JOBS` (default `4`). Both lanes run in ONE container:
+the compose `command` is `python -m pocketpaw_ee.cloud.worker_supervisor`, which
+starts both arq Workers on one event loop and exits non-zero if either stops. A
+separate service was not an option — Coolify base64s the Dockerfile into a single
+SSH argv per service that declares `build:`, and a third one broke every deploy.
+
+Tune the two ceilings against different limits. The chat lane is bounded by RAM
+(a Node subprocess per run on the default backend); the build lane is bounded by
+how many Daytona sandboxes you are willing to pay for at once, because the build
+itself happens remotely and what occupies a slot here is an await.
 
 Total cluster concurrency is `POCKETPAW_ARQ_MAX_JOBS x worker replicas`. Both
 levers work; they cost different things.
@@ -168,7 +182,8 @@ Env vars (all also documented in `backend/CLAUDE.md` → Key Conventions):
 | Var | Default | Purpose |
 |-----|---------|---------|
 | `POCKETPAW_CLOUD_RUN_EXECUTOR` | `inprocess` | Set to `arq` on the web service to enable Tier 2 |
-| `POCKETPAW_ARQ_MAX_JOBS` | `10` | Concurrent jobs ONE worker runs, shared across every registered lane. Set on the **worker**; the web service ignores it. See "Sizing the worker" below |
+| `POCKETPAW_ARQ_MAX_JOBS` | `10` | Concurrent jobs ONE worker runs on arq's default queue: chat runs, workspace jobs and both `/ship` jobs. Set on the **worker**; the web service ignores it. See "Sizing the worker" below |
+| `POCKETPAW_SITES_ARQ_MAX_JOBS` | `4` | Concurrent site builds and draft previews, on their own queue. Independent of the row above on purpose: raise it with the Daytona sandbox quota, not with the container's memory limit |
 | `POCKETPAW_ARQ_HEALTH_CHECK_INTERVAL` | `30` | How often the worker refreshes its Redis health key. `arq --check` exits 0 while that key lives (TTL = this + 1s), so this is what decides how fast a container healthcheck can notice a dead worker. arq's own default is `3600`, which is far too slow to probe against |
 | `POCKETPAW_AGENT_POOL_MAX_INSTANCES` | `20` | Per-process AgentPool ceiling. Applies to the web process AND each worker |
 | `POCKETPAW_SESSION_WARM_MAX_PER_TENANT` | `8` | Per-process warm session slots one workspace may hold. The per-tenant fairness knob |

--- a/docs/runbooks/2026-07-09-dynamic-sites-real-cf-smoke.md
+++ b/docs/runbooks/2026-07-09-dynamic-sites-real-cf-smoke.md
@@ -28,7 +28,7 @@ A dynamic publish will silently sit in `provisioning` or fail unless every row h
 | 4 | **wrangler creds** (migrate subprocess) | `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` (the standard wrangler env names; the same D1-capable token is fine). Set both pairs. |
 | 5 | **wrangler on the box** | The enterprise image bakes it (#1681) and sets `PAW_CF_WRANGLER_CMD=wrangler`. On a non-baked host, install wrangler and point `PAW_CF_WRANGLER_CMD` at it. Verify: `wrangler --version` runs. |
 | 6 | **Generator toolchain** | Already baked: `paw-sites-gen`, `bun`, the `@ripple-ui/svelte` tarball (`PAW_SITES_RIPPLE_DEP`). Verify: `paw-sites-gen --help` runs. |
-| 7 | **arq worker running** | The `provision_site` job runs on the shared chat/jobs arq worker (`arq pocketpaw_ee.cloud.chat.runs.worker.WorkerSettings`). If it isn't running, the site enqueues and never provisions. Needs `POCKETPAW_REDIS_URL`. |
+| 7 | **arq worker running** | The `provision_site` job runs on the shared chat/jobs arq lane, started by `python -m pocketpaw_ee.cloud.worker_supervisor` along with the separate site-build lane. If it isn't running, the site enqueues and never provisions. Needs `POCKETPAW_REDIS_URL`. |
 | 8 | **Sites domain (for a live URL)** | `PAW_CF_SITES_DOMAIN` so the provisioned site resolves at `https://<site_id>.<domain>`. |
 
 > Quick pre-flight on the box:

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -1,5 +1,17 @@
 """arq worker entry point for Tier 2 run execution.
 
+Updated: 2026-09-04 (fix/queue-lanes, backend-perf C1) — THIS IS NO LONGER THE ONLY
+LANE. Site builds now enqueue onto their own queue and are consumed by
+``pocketpaw_ee.sites.build_worker.WorkerSettings``; both lanes run in one container
+under ``pocketpaw_ee.cloud.worker_supervisor``. The two site functions stay
+registered HERE as well, and deliberately: a deploy cuts over the enqueue side
+instantly, so anything already sitting on the default queue when the old process
+stopped still needs someone willing to claim it. That backlog drains once and is
+then permanently empty.
+
+``max_jobs`` below is therefore no longer the whole cluster's ceiling — it is this
+lane's. The sites lane carries its own, and neither can consume the other's.
+
 Updated: 2026-09-01 (feat/scale-concurrency-knobs) — ``WorkerSettings.max_jobs`` is
 now set, from ``POCKETPAW_ARQ_MAX_JOBS`` (default 10, arq's own). It was previously
 unset, so arq's default applied silently and the whole cluster ran ten concurrent
@@ -81,6 +93,7 @@ can't abort worker startup.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from typing import Any
@@ -143,7 +156,7 @@ async def execute_run_job(ctx: dict[str, Any], spec_dict: dict[str, Any]) -> Non
     await bill_run_now(spec.run_id)
 
 
-async def _startup(ctx: dict[str, Any]) -> None:
+async def _bootstrap(ctx: dict[str, Any]) -> None:
     """Boot the worker: pin role, init the DB + realtime bus, sweep orphans.
 
     ``xproc.set_role("worker")`` must run before any agent code emits, so
@@ -206,8 +219,62 @@ async def _startup(ctx: dict[str, Any]) -> None:
         logger.exception("worker boot: LiteLLM billing-cutover sweep failed")
 
 
+# TWO WorkerSettings classes now share this bootstrap inside ONE process: the chat
+# lane below and the sites lane in ``pocketpaw_ee.sites.build_worker``, started
+# together by ``pocketpaw_ee.cloud.worker_supervisor``. arq calls ``on_startup``
+# once per Worker, so without a guard the second lane would re-run ``init_cloud_db``
+# against a live client and re-run BOTH boot sweeps (compute-cost metering and the
+# LiteLLM billing cutover). Those two are idempotent by ledger key, so a second pass
+# would waste work rather than double-charge — but "probably harmless" is not the
+# standard for a billing path, and a second ``init_cloud_db`` is not something to
+# discover in production.
+#
+# The lock is held ACROSS the bootstrap, not just around the counter. A lane that
+# arrives while the first is still initialising has to wait for the database it is
+# about to run jobs against, and releasing the lock early would let it start empty.
+_bootstrap_lock = asyncio.Lock()
+_bootstrap_lanes = 0
+
+
+async def _startup(ctx: dict[str, Any]) -> None:
+    """Run :func:`_bootstrap` for the FIRST lane in this process only."""
+    global _bootstrap_lanes
+    async with _bootstrap_lock:
+        _bootstrap_lanes += 1
+        if _bootstrap_lanes > 1:
+            logger.info(
+                "worker boot: bootstrap already done in this process (lane %d)",
+                _bootstrap_lanes,
+            )
+            return
+        await _bootstrap(ctx)
+
+
 async def _shutdown(ctx: dict[str, Any]) -> None:
-    await close_cloud_db()
+    """Close the shared database once the LAST lane in this process has stopped."""
+    global _bootstrap_lanes
+    async with _bootstrap_lock:
+        _bootstrap_lanes -= 1
+        if _bootstrap_lanes > 0:
+            return
+        # Clamp rather than trust the count: an unbalanced shutdown (a lane whose
+        # on_startup raised still gets its on_shutdown called) would otherwise drive
+        # this negative and leave the NEXT bootstrap thinking a lane is still up.
+        _bootstrap_lanes = 0
+        await close_cloud_db()
+
+
+def _reset_bootstrap_for_tests() -> None:
+    """Drop the lane count so a test can bootstrap again from scratch."""
+    global _bootstrap_lanes
+    _bootstrap_lanes = 0
+
+
+# Public aliases so the sites lane can share this bootstrap without reaching across
+# modules for a private name. One bootstrap per process is the contract; see the
+# lane counter above for what happens without it.
+worker_startup = _startup
+worker_shutdown = _shutdown
 
 
 def _redis_settings() -> RedisSettings:
@@ -446,3 +513,15 @@ class WorkerSettings:
     health_check_interval = _health_check_interval_seconds()
     # Eager: arq reads __dict__, which bypasses descriptors. See `_redis_settings`.
     redis_settings = _redis_settings()
+
+
+# Shared with the sites lane (``pocketpaw_ee.sites.build_worker``). Aliases rather
+# than a second definition: one copy of the site-build timeout, one copy of the
+# health-key period, one Redis resolver. A duplicated build timeout is precisely the
+# drift that would let arq cancel a build before its in-sandbox ``timeout(1)`` fires,
+# and that destroys the sentinel the lane classifies its verdict from — a healthy
+# but slow build would be recorded as lost infrastructure.
+site_build_fn = _site_build_fn
+site_preview_build_fn = _site_preview_build_fn
+arq_redis_settings = _redis_settings
+arq_health_check_interval_seconds = _health_check_interval_seconds

--- a/ee/pocketpaw_ee/cloud/worker_supervisor.py
+++ b/ee/pocketpaw_ee/cloud/worker_supervisor.py
@@ -1,0 +1,165 @@
+# ee/pocketpaw_ee/cloud/worker_supervisor.py — runs every arq lane in ONE process.
+#
+# Created 2026-09-04 (fix/queue-lanes, backend-perf C1). Splitting site builds onto their
+# own queue is only half the fix; a queue with no consumer is worse than a shared one,
+# because the job waits forever and nothing says so. This module is the consumer side:
+# it starts the chat lane and the site-build lane as two arq Workers on one event loop.
+#
+# WHY ONE PROCESS AND NOT TWO CONTAINERS. Coolify ships the Dockerfile to the deploy host
+# by base64-encoding it into a single SSH command line, ONCE PER COMPOSE SERVICE THAT
+# DECLARES ``build:``. deploy/coolify/Dockerfile is ~24 KB, so each build service adds
+# ~32 KB to one argv. Two services is ~63 KB of a ~128 KB budget; a third one broke every
+# deploy with ``posix_spawn() failed: Argument list too long``, raised by Coolify's PHP
+# before Docker ran at all, naming neither the service nor compose (paw-workspace #193,
+# reverted in #194). So a new lane cannot be a new service, and this is the supported
+# alternative: one container, one command, two lanes with independent ceilings.
+#
+# WHY NOT ``sh -c 'arq A & exec arq B'``. Backgrounding the first lane makes its death
+# invisible: the container stays up and healthy while site builds silently stop being
+# consumed, which is the same class of failure the split was meant to remove. This
+# supervisor treats ANY lane stopping as fatal to the process, so the container exits and
+# the restart policy brings both lanes back together.
+#
+# EXIT CODES. 0 only when a signal asked us to stop. Non-zero when a lane ended on its
+# own, whether it raised or returned — an arq Worker's ``async_run`` is not supposed to
+# return while the process is meant to be serving, so a clean return is just as wrong as
+# an exception and must not be reported as success.
+"""Run every arq lane this deployment needs in a single process."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+from typing import Any
+
+from arq.constants import default_queue_name
+from arq.worker import create_worker
+
+logger = logging.getLogger(__name__)
+
+#: Signals a container runtime uses to ask for a graceful stop. SIGINT is here for the
+#: interactive case; SIGTERM is the one Docker actually sends.
+_STOP_SIGNALS = ("SIGTERM", "SIGINT")
+
+
+def default_lanes() -> list[type]:
+    """The lanes a deployed worker container runs.
+
+    Imported lazily so that importing this module does not drag in the whole cloud
+    package — the settings classes evaluate their Redis config at class-body time and
+    raise when ``POCKETPAW_REDIS_URL`` is unset, which is correct for a worker process
+    and wrong for anything that merely imports the supervisor to inspect it.
+
+    The growth lane (``pocketpaw_ee.cloud.growth.worker``) is deliberately NOT here. It
+    has its own queue already and no consumer in the deployed compose file, so adding it
+    would not be a refactor — it would start executing outbound work that is currently
+    inert. That is a product decision, not a performance one.
+    """
+    from pocketpaw_ee.cloud.chat.runs.worker import WorkerSettings as ChatWorkerSettings
+    from pocketpaw_ee.sites.build_worker import WorkerSettings as SiteBuildWorkerSettings
+
+    return [ChatWorkerSettings, SiteBuildWorkerSettings]
+
+
+def lane_name(settings_cls: type) -> str:
+    """A log-friendly name for a lane: the queue it reads.
+
+    Falls back to arq's own default queue rather than to the class name, because every
+    settings class in this codebase is called ``WorkerSettings`` — a log line naming the
+    class would identify nothing, while the queue is exactly what distinguishes them.
+    """
+    queue = getattr(settings_cls, "queue_name", None)
+    return str(queue) if queue else default_queue_name
+
+
+def _install_stop_handlers(stop: asyncio.Event) -> None:
+    """Ask the loop to set ``stop`` on SIGTERM / SIGINT.
+
+    Best-effort by design. ``add_signal_handler`` is not implemented on Windows, and a
+    supervisor that refused to start there would make the lanes untestable on a developer
+    machine for no production benefit — the deployed container is Linux.
+    """
+    loop = asyncio.get_running_loop()
+    for name in _STOP_SIGNALS:
+        sig = getattr(signal, name, None)
+        if sig is None:
+            continue
+        try:
+            loop.add_signal_handler(sig, stop.set)
+        except (NotImplementedError, RuntimeError, ValueError):
+            logger.debug("supervisor: no loop signal handler for %s on this platform", name)
+
+
+async def _close_quietly(worker: Any, name: str) -> None:
+    """Close a worker without letting shutdown raise.
+
+    ``Worker.close`` calls ``handle_sig(signal.SIGUSR1)`` when it was built with
+    ``handle_signals=False``, and SIGUSR1 does not exist on Windows — so this raises on a
+    developer machine for a reason that has nothing to do with the code under test. It can
+    also raise against a Redis that has already gone away, which is exactly when we are
+    least able to do anything about it.
+    """
+    try:
+        await worker.close()
+    except Exception:
+        logger.warning("supervisor: closing lane %s failed", name, exc_info=True)
+
+
+async def run_lanes(settings_classes: list[type] | None = None) -> int:
+    """Run every lane until one stops or a stop signal arrives. Returns an exit code."""
+    classes = list(default_lanes() if settings_classes is None else settings_classes)
+    if not classes:
+        raise RuntimeError("worker supervisor started with no lanes to run")
+
+    # ``handle_signals=False`` because each arq Worker would otherwise install its OWN
+    # SIGTERM handler on the shared loop, where the last one registered silently replaces
+    # every earlier one. The supervisor owns the signal and stops the lanes itself.
+    workers = [create_worker(cls, handle_signals=False) for cls in classes]
+    names = [lane_name(cls) for cls in classes]
+    logger.info("supervisor: starting %d lane(s): %s", len(names), ", ".join(names))
+
+    stop = asyncio.Event()
+    _install_stop_handlers(stop)
+
+    lane_tasks = [
+        asyncio.create_task(worker.async_run(), name=f"lane:{name}")
+        for worker, name in zip(workers, names, strict=True)
+    ]
+    stop_task = asyncio.create_task(stop.wait(), name="supervisor:stop")
+
+    try:
+        await asyncio.wait([*lane_tasks, stop_task], return_when=asyncio.FIRST_COMPLETED)
+
+        exit_code = 0
+        for task, name in zip(lane_tasks, names, strict=True):
+            if not task.done():
+                continue
+            exit_code = 1
+            exc = task.exception() if not task.cancelled() else None
+            if exc is not None:
+                logger.error("supervisor: lane %s raised; stopping the process", name, exc_info=exc)
+            else:
+                logger.error("supervisor: lane %s returned on its own; stopping the process", name)
+        if exit_code == 0:
+            logger.info("supervisor: stop requested; draining %d lane(s)", len(names))
+        return exit_code
+    finally:
+        stop_task.cancel()
+        for task in lane_tasks:
+            task.cancel()
+        # Gather before closing: a cancelled lane task still has to finish unwinding
+        # before its Worker's own cleanup can run against the same Redis pool.
+        await asyncio.gather(*lane_tasks, stop_task, return_exceptions=True)
+        for worker, name in zip(workers, names, strict=True):
+            await _close_quietly(worker, name)
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    return asyncio.run(run_lanes())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ee/pocketpaw_ee/sites/build_job.py
+++ b/ee/pocketpaw_ee/sites/build_job.py
@@ -164,6 +164,18 @@
 # is served: the compiled server route is absent from the deployable artifact on the
 # svelte track, and react emits no server route at all. If lead capture comes back, the
 # key must be injected at DEPLOY (wrangler ``[vars]``) rather than restored here.
+#
+# Edited 2026-09-04 (fix/queue-lanes, backend-perf C1): BOTH LANES NOW ENQUEUE ONTO
+# THEIR OWN QUEUE, :data:`SITE_BUILD_QUEUE_NAME`, instead of arq's default. Nothing
+# about a build changed; what changed is which ``max_jobs`` ceiling it competes for.
+# Sharing the default queue meant sharing ONE cluster-wide limit of 10 with chat runs,
+# workspace jobs and both /ship jobs, so ten concurrent publishes left chat with no
+# slot at all and the eleventh request hung silently for up to half an hour.
+#
+# Three call sites move together and MUST stay together: both enqueues and the
+# :func:`_preview_job_outcome` status read. arq scopes a job id to a queue, so a read
+# left pointing at the default queue would find nothing, report ``building`` forever,
+# and the client would poll a job that finished minutes ago.
 """SL-2 — the site-build arq job and its enqueue helper."""
 
 from __future__ import annotations
@@ -205,6 +217,29 @@ ARQ_FUNCTION_NAME = "run_site_build"
 #: same reason the function is: a worker that registered one name for both would run a
 #: preview payload through the publish job's signature.
 PREVIEW_ARQ_FUNCTION_NAME = "run_site_preview_build"
+
+#: The dedicated arq queue both site-build lanes ride (backend-perf C1).
+#:
+#: Before this, every lane the cluster runs — chat runs, workspace jobs, both
+#: /ship jobs and both site builds — shared ONE queue and therefore ONE
+#: ``max_jobs`` ceiling, default 10. Ten concurrent publishes left zero slots for
+#: chat, and job 11 did not error: it sat in Redis behind a ``job_timeout`` of up
+#: to 30 minutes while the user watched an SSE stream emit nothing. Builds are the
+#: lane that bursts (a publish storm is one customer pressing Publish on ten sites)
+#: and the lane that is slowest (1020s of budget at today's defaults), so builds are
+#: what starves everything else rather than the other way round.
+#:
+#: A queue is only half a lane; the other half is a consumer. The settings live in
+#: ``pocketpaw_ee.sites.build_worker`` and the process that runs both lanes in one
+#: container is ``pocketpaw_ee.cloud.worker_supervisor``. Enqueueing here with no
+#: consumer running is WORSE than sharing a queue: the job waits forever and
+#: nothing anywhere says so.
+#:
+#: Namespaced, unlike ``GROWTH_QUEUE_NAME`` ("growth"), because arq uses this
+#: string as the Redis key verbatim and this database also holds the realtime
+#: bridge's keys. The growth name is left alone rather than made consistent —
+#: renaming a live queue strands whatever is already sitting in it.
+SITE_BUILD_QUEUE_NAME = "arq:queue:sites"
 
 #: Engines this lane can build. Every one needs a per-site Node build AND emits its
 #: output into a SUBDIRECTORY — ``artifact_tar_command`` refuses an engine whose output
@@ -900,6 +935,7 @@ async def enqueue_site_build(
             normalize_engine(engine),
             timeout,
             _job_id=job_id,
+            _queue_name=SITE_BUILD_QUEUE_NAME,
             # Rides as a kwarg so the positional payload stays exactly what slice 2
             # shipped, and a build queued for verification alone (no deploy) simply omits
             # it. arq forwards any non-underscore kwarg to the function.
@@ -985,7 +1021,7 @@ async def _preview_job_outcome(pool: Any, job_id: str) -> tuple[str, str | None]
       * gone (a result that expired between the enqueue and this read) → ``building``.
         A pure race, and the next poll enqueues cleanly because the id is free again.
     """
-    job = Job(job_id, pool)
+    job = Job(job_id, pool, _queue_name=SITE_BUILD_QUEUE_NAME)
     status = await job.status()
     if status is not JobStatus.complete:
         return "building", None
@@ -1203,6 +1239,7 @@ async def enqueue_preview_build(
         normalize_engine(engine),
         timeout,
         _job_id=job_id,
+        _queue_name=SITE_BUILD_QUEUE_NAME,
     )
     if job is None:
         status, reason = await _preview_job_outcome(pool, job_id)

--- a/ee/pocketpaw_ee/sites/build_worker.py
+++ b/ee/pocketpaw_ee/sites/build_worker.py
@@ -1,0 +1,116 @@
+# ee/pocketpaw_ee/sites/build_worker.py — the site-build lane's OWN arq worker settings.
+#
+# Created 2026-09-04 (fix/queue-lanes, backend-perf C1). Until now every background lane
+# this product runs — chat runs, workspace jobs, both /ship jobs and both site builds —
+# shared arq's default queue, and therefore shared ONE ``max_jobs`` ceiling whose default
+# is 10. That is a cluster-wide number, not a per-lane one, and site builds are the worst
+# possible neighbour to share it with: a publish storm is one customer pressing Publish on
+# ten sites, and a single build's budget is 1020s at today's defaults. Ten of them left
+# chat with zero slots, and the eleventh request did not fail — it sat in Redis until the
+# stale-run sweeper marked it interrupted ten minutes later, while the user watched an SSE
+# stream deliver nothing but heartbeats.
+#
+# Splitting the queue is what fixes that, and a queue without a consumer is worse than no
+# split at all, so this module exists to BE that consumer. It is deliberately thin: every
+# job function, the bootstrap, the Redis resolver and the health-key period are the same
+# objects the chat lane uses, imported rather than redefined. The only thing this lane
+# owns is its own concurrency ceiling.
+#
+# HOW IT RUNS. ``pocketpaw_ee.cloud.worker_supervisor`` starts this lane and the chat lane
+# as two arq Workers in ONE process, because the Coolify compose file cannot take a third
+# service that declares ``build:`` (Coolify base64s the Dockerfile into one SSH argv per
+# build service; a third one blew the argv limit and broke every deploy — paw-workspace
+# #193, reverted in #194). Running it standalone also works and needs no code change::
+#
+#     arq pocketpaw_ee.sites.build_worker.WorkerSettings
+#
+# WHY 4 AND NOT 10. A chat run spawns a Node subprocess per run on the default
+# ``claude_agent_sdk`` backend, so the chat lane's ceiling is bounded by container RAM. A
+# site build is not: the compile happens in a Daytona sandbox and what runs here is an
+# await on a remote exec. So these four slots cost the worker container almost nothing,
+# and the number is about how many sandboxes the account should be paying for at once
+# rather than about memory. Raise it with the Daytona quota, not with the memory limit.
+"""The site-build lane's arq WorkerSettings (backend-perf C1)."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from pocketpaw_ee.cloud.chat.runs.worker import (
+    arq_health_check_interval_seconds,
+    arq_redis_settings,
+    site_build_fn,
+    site_preview_build_fn,
+    worker_shutdown,
+    worker_startup,
+)
+from pocketpaw_ee.sites.build_job import SITE_BUILD_QUEUE_NAME, site_build_job_timeout_seconds
+
+logger = logging.getLogger(__name__)
+
+#: Concurrent site builds per worker process. See the header for why this is small and
+#: what it is actually bounded by.
+_DEFAULT_SITES_MAX_JOBS = 4
+
+_MAX_JOBS_ENV = "POCKETPAW_SITES_ARQ_MAX_JOBS"
+
+
+def _sites_max_jobs() -> int:
+    """Resolve this lane's concurrent-job ceiling from the environment.
+
+    Same fail-soft contract as the chat lane's ``_max_jobs``: an unparseable or
+    non-positive value falls back to the default rather than reaching arq, where ``0``
+    wedges the worker into accepting nothing and a negative crashes ``BoundedSemaphore``.
+
+    It reads its OWN variable rather than ``POCKETPAW_ARQ_MAX_JOBS``. Sharing one would
+    undo the split: raising the chat ceiling to survive a busy morning would raise the
+    build ceiling with it, and the point of the lane is that those two numbers answer to
+    different limits (container RAM here, the sandbox quota there).
+    """
+    raw = os.environ.get(_MAX_JOBS_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_SITES_MAX_JOBS
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an int; using default %d", _MAX_JOBS_ENV, raw, _DEFAULT_SITES_MAX_JOBS
+        )
+        return _DEFAULT_SITES_MAX_JOBS
+    if val <= 0:
+        logger.warning(
+            "%s=%d is not positive; using default %d", _MAX_JOBS_ENV, val, _DEFAULT_SITES_MAX_JOBS
+        )
+        return _DEFAULT_SITES_MAX_JOBS
+    return val
+
+
+class WorkerSettings:
+    """arq worker configuration for the site-build queue."""
+
+    queue_name = SITE_BUILD_QUEUE_NAME
+    # The SAME wrapped function objects the chat lane registers, not copies. Each already
+    # carries its own timeout and ``max_tries=1``; re-wrapping them here would fork the
+    # build timeout, and a build that arq cancels before its in-sandbox timeout fires is
+    # recorded as lost infrastructure rather than as the slow-but-healthy build it was.
+    functions = [site_build_fn, site_preview_build_fn]
+    on_startup = worker_startup
+    on_shutdown = worker_shutdown
+    # No auto-retry, matching every other lane: a build is billed per attempt in a
+    # third-party sandbox, and the retry decision belongs to ``build_state.settle``, which
+    # records WHY it gave up, not to arq silently re-running a job whose row says failed.
+    max_tries = 1
+    # This lane's own ceiling — the whole point of the split. Plain int in ``__dict__``
+    # because arq's ``worker.get_kwargs`` reads ``settings_cls.__dict__`` directly, which
+    # bypasses the descriptor protocol and would hand a property object to the Worker.
+    max_jobs = _sites_max_jobs()
+    # Both wrapped functions carry their own per-function timeout, which is what actually
+    # governs a build. This class-level value exists so the fallback is not arq's 300s
+    # default, which would be under a third of a build's budget.
+    job_timeout = site_build_job_timeout_seconds()
+    # Same health-key period as the chat lane, so ``arq --check`` against THIS settings
+    # class is as truthful as it is against that one. Eager for the __dict__ reason above.
+    health_check_interval = arq_health_check_interval_seconds()
+    # Eager for the __dict__ reason above.
+    redis_settings = arq_redis_settings()

--- a/tests/cloud/runs/conftest.py
+++ b/tests/cloud/runs/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -50,3 +51,24 @@ async def seed_run(mongo_db):  # noqa: ARG001 — forces Beanie init
         intent=None,
     )
     return await run_service.create_run(spec)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_worker_bootstrap():
+    """Reset the worker's lane counter around every test in this directory.
+
+    ``worker._startup`` became refcounted on 2026-09-04 (backend-perf C1): two arq
+    lanes now share one process, so the bootstrap runs for the FIRST lane and the
+    second is a no-op. That makes it PROCESS state, and a test session is one
+    process — so the second test to call ``_startup`` would otherwise be silently
+    skipped, and its assertions about what boot registers would fail for a reason
+    that has nothing to do with what it is testing.
+
+    Autouse rather than per-test because the trap is invisible: nothing about
+    calling ``_startup`` suggests a previous test could have consumed it.
+    """
+    from pocketpaw_ee.cloud.chat.runs import worker as _worker
+
+    _worker._reset_bootstrap_for_tests()
+    yield
+    _worker._reset_bootstrap_for_tests()

--- a/tests/cloud/runs/test_worker_lanes.py
+++ b/tests/cloud/runs/test_worker_lanes.py
@@ -1,0 +1,200 @@
+# tests/cloud/runs/test_worker_lanes.py
+#
+# Created 2026-09-04 (fix/queue-lanes, backend-perf C1). Site builds used to ride arq's
+# default queue alongside chat runs, workspace jobs and both /ship jobs, which meant one
+# ``max_jobs`` ceiling — default 10 — for every lane the product runs. Ten concurrent
+# publishes left chat with zero slots, and the request that lost did not error: it waited
+# in Redis behind a 30-minute ``job_timeout`` while the user watched an SSE stream deliver
+# only heartbeats, until the stale-run sweeper called it interrupted ten minutes later.
+#
+# These tests pin the three things that make the split real rather than cosmetic: the
+# sites lane reads a DIFFERENT queue, its ceiling answers to its OWN variable, and the two
+# lanes share one bootstrap without running it twice.
+"""The site-build lane's separation from the chat lane (backend-perf C1)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from arq.connections import RedisSettings
+from arq.constants import default_queue_name
+from pocketpaw_ee.cloud.chat.runs import worker as chat_worker
+from pocketpaw_ee.sites import build_worker as sites_worker
+from pocketpaw_ee.sites.build_job import SITE_BUILD_QUEUE_NAME
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- the lanes are actually separate ---------------------------------------
+
+
+async def test_the_sites_lane_reads_a_different_queue_than_the_chat_lane():
+    """The whole fix in one assertion.
+
+    ``queue_name`` decides which Redis list a Worker polls, and therefore which
+    ``max_jobs`` semaphore a job competes for. Same queue, same ceiling, and the split is
+    two settings classes describing one lane.
+    """
+    chat_queue = getattr(chat_worker.WorkerSettings, "queue_name", default_queue_name)
+
+    assert sites_worker.WorkerSettings.queue_name == SITE_BUILD_QUEUE_NAME
+    assert sites_worker.WorkerSettings.queue_name != chat_queue
+
+
+async def test_the_sites_ceiling_answers_to_its_own_variable(monkeypatch):
+    """Raising the chat ceiling must not raise the build ceiling with it.
+
+    They are bounded by different things — container RAM for chat, which spawns a Node
+    subprocess per run, and the third-party sandbox quota for builds — so one variable
+    for both would make surviving a busy morning also mean paying for more sandboxes.
+    """
+    monkeypatch.setenv("POCKETPAW_ARQ_MAX_JOBS", "40")
+    monkeypatch.delenv("POCKETPAW_SITES_ARQ_MAX_JOBS", raising=False)
+
+    assert chat_worker._max_jobs() == 40
+    assert sites_worker._sites_max_jobs() == sites_worker._DEFAULT_SITES_MAX_JOBS
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "not-an-int", "0", "-3"])
+async def test_an_unusable_sites_ceiling_falls_back_instead_of_reaching_arq(monkeypatch, raw):
+    """Fail-soft, for the same reason the chat lane is.
+
+    ``0`` wedges the Worker into accepting nothing at all and a negative crashes
+    ``BoundedSemaphore`` on boot, so a typo in a deploy variable would take the lane down
+    rather than mis-tune it.
+    """
+    monkeypatch.setenv("POCKETPAW_SITES_ARQ_MAX_JOBS", raw)
+
+    assert sites_worker._sites_max_jobs() == sites_worker._DEFAULT_SITES_MAX_JOBS
+
+
+async def test_a_usable_sites_ceiling_is_honoured(monkeypatch):
+    monkeypatch.setenv("POCKETPAW_SITES_ARQ_MAX_JOBS", "7")
+
+    assert sites_worker._sites_max_jobs() == 7
+
+
+async def test_the_default_ceilings_leave_room_for_chat():
+    """The build lane must not be able to claim the chat lane's capacity by default.
+
+    This is the number the finding was actually about. A default equal to the chat
+    ceiling would restore the starvation the split removes, just with two queues.
+    """
+    assert 0 < sites_worker._DEFAULT_SITES_MAX_JOBS < chat_worker._DEFAULT_MAX_JOBS
+
+
+# --- one definition of a build, two lanes that can run it -------------------
+
+
+async def test_the_sites_lane_registers_the_chat_lanes_own_wrapped_functions():
+    """Identity, not equality.
+
+    Each site function is wrapped with its own timeout because a build's budget (1020s at
+    today's defaults) is wider than the workspace-jobs timeout it used to share. A second
+    wrapping here would fork that number, and an arq cancellation that lands before the
+    in-sandbox timeout fires destroys the sentinel the lane classifies from — a slow but
+    healthy build gets recorded as lost infrastructure.
+    """
+    assert sites_worker.WorkerSettings.functions == [
+        chat_worker.site_build_fn,
+        chat_worker.site_preview_build_fn,
+    ]
+
+
+async def test_the_chat_lane_still_claims_site_jobs_left_on_the_default_queue():
+    """The cutover has a backlog, and it needs someone willing to claim it.
+
+    A deploy swaps the enqueue side instantly. Anything already sitting on the default
+    queue when the old process stopped would otherwise wait forever with no worker
+    registered for its name — and arq says nothing about a job nobody claims.
+    """
+    names = {
+        getattr(f, "name", getattr(f, "__name__", "")) for f in chat_worker.WorkerSettings.functions
+    }
+
+    assert {"run_site_build", "run_site_preview_build"} <= names
+
+
+async def test_the_sites_settings_survive_arqs_dunder_dict_read():
+    """arq's ``get_kwargs`` reads ``settings_cls.__dict__`` directly.
+
+    That bypasses the descriptor protocol, so anything lazy here is handed to the Worker
+    as-is and crashes when arq tries to use it. Same contract the chat lane already pins.
+    """
+    d = sites_worker.WorkerSettings.__dict__
+
+    assert isinstance(d["redis_settings"], RedisSettings)
+    assert isinstance(d["max_jobs"], int)
+    assert isinstance(d["job_timeout"], int)
+    assert isinstance(d["health_check_interval"], int)
+
+
+# --- one bootstrap, however many lanes share the process --------------------
+
+
+class TestTheSharedBootstrap:
+    """``on_startup`` runs once per Worker; the process only wants it once.
+
+    The lane counter is reset around every test in this directory by an autouse fixture
+    in ``conftest.py`` — it is process state, and a test session is one process.
+    """
+
+    async def test_the_second_lane_does_not_bootstrap_again(self, monkeypatch):
+        """Two lanes, one ``init_cloud_db`` and one pass of the boot sweeps.
+
+        The compute-cost metering sweep and the LiteLLM billing cutover sweep both run in
+        there. They are idempotent by ledger key, so a second pass would waste work rather
+        than double charge — but a billing path is not where "probably harmless" is the
+        standard, and a second ``init_cloud_db`` against a live client is not something to
+        learn about in production.
+        """
+        boot = AsyncMock()
+        monkeypatch.setattr(chat_worker, "_bootstrap", boot)
+
+        await chat_worker._startup({})
+        await chat_worker._startup({})
+
+        assert boot.await_count == 1
+
+    async def test_the_database_closes_only_when_the_last_lane_stops(self, monkeypatch):
+        """A lane stopping is not the process stopping.
+
+        Closing the shared Mongo client on the first ``on_shutdown`` would pull the
+        database out from under every job the other lane still has in flight.
+        """
+        monkeypatch.setattr(chat_worker, "_bootstrap", AsyncMock())
+        close = AsyncMock()
+        monkeypatch.setattr(chat_worker, "close_cloud_db", close)
+
+        await chat_worker._startup({})
+        await chat_worker._startup({})
+        await chat_worker._shutdown({})
+        assert close.await_count == 0
+
+        await chat_worker._shutdown({})
+        assert close.await_count == 1
+
+    async def test_an_unbalanced_shutdown_cannot_break_the_next_bootstrap(self, monkeypatch):
+        """arq calls ``on_shutdown`` even for a lane whose ``on_startup`` raised.
+
+        Without the clamp that drives the counter NEGATIVE, and a negative counter makes
+        the guard under-count: the process comes back up, and because -1 + 1 is still not
+        greater than 1, the SECOND lane bootstraps as well. That is the double
+        ``init_cloud_db`` and the double billing sweep this guard exists to prevent,
+        arrived at from the other direction.
+
+        Two startups is the whole point of the test. One would pass either way, which is
+        how the first version of it let the mutation escape.
+        """
+        boot = AsyncMock()
+        monkeypatch.setattr(chat_worker, "_bootstrap", boot)
+        monkeypatch.setattr(chat_worker, "close_cloud_db", AsyncMock())
+
+        await chat_worker._shutdown({})
+        await chat_worker._shutdown({})
+
+        await chat_worker._startup({})
+        await chat_worker._startup({})
+
+        assert boot.await_count == 1

--- a/tests/cloud/test_worker_supervisor.py
+++ b/tests/cloud/test_worker_supervisor.py
@@ -1,0 +1,262 @@
+# tests/cloud/test_worker_supervisor.py
+#
+# Created 2026-09-04 (fix/queue-lanes, backend-perf C1). Splitting site builds onto their
+# own arq queue is only half a lane; the other half is a consumer, and a queue with no
+# consumer is worse than a shared one because the job waits forever and nothing anywhere
+# says so. The supervisor is that consumer side: it runs the chat lane and the site-build
+# lane as two arq Workers in one process, because the Coolify compose file cannot take a
+# third service that declares ``build:``.
+#
+# The failure this file exists to prevent is the quiet one. ``sh -c 'arq A & exec arq B'``
+# would also run two lanes, and when lane A died the container would stay up and healthy
+# while site builds silently stopped being consumed. So the contract under test is: ANY
+# lane ending is fatal to the process, whether it raised or returned cleanly.
+"""The multi-lane arq supervisor (backend-perf C1)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud import worker_supervisor as sup
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeWorker:
+    """Stands in for an arq ``Worker``: it runs a coroutine and records its close."""
+
+    def __init__(self, run, *, close_error: BaseException | None = None) -> None:
+        self._run = run
+        self._close_error = close_error
+        self.closed = False
+
+    async def async_run(self) -> None:
+        await self._run()
+
+    async def close(self) -> None:
+        self.closed = True
+        if self._close_error is not None:
+            raise self._close_error
+
+
+def _settings(queue: str) -> type:
+    return type("WorkerSettings", (), {"queue_name": queue})
+
+
+def _patch_workers(monkeypatch, workers: list[_FakeWorker]) -> list[dict]:
+    """Hand ``run_lanes`` our fake workers and record how it built them."""
+    made: list[dict] = []
+    it = iter(workers)
+
+    def _create(cls, **kwargs):
+        made.append({"settings": cls, "kwargs": kwargs})
+        return next(it)
+
+    monkeypatch.setattr(sup, "create_worker", _create)
+    return made
+
+
+async def _forever() -> None:
+    await asyncio.Event().wait()
+
+
+#: How long a supervisor gets to return before the test calls it hung.
+#:
+#: Generous, because every lane here is a stub and none of them do real work. The
+#: deadline is not a performance assertion — it exists because "the supervisor never
+#: returns" is a real failure mode, and without a deadline it presents as a test run
+#: that hangs rather than one that goes red. A mutation deleting the stop-handler call
+#: produces exactly that, and a gate that hangs instead of failing is not a gate.
+_DEADLINE_SECONDS = 5.0
+
+
+async def _run(settings_classes: list[type]) -> int:
+    try:
+        return await asyncio.wait_for(sup.run_lanes(settings_classes), _DEADLINE_SECONDS)
+    except TimeoutError:
+        pytest.fail(
+            f"run_lanes did not return within {_DEADLINE_SECONDS}s: nothing stopped the lanes"
+        )
+
+
+# --- a lane ending is fatal -------------------------------------------------
+
+
+async def test_a_lane_that_returns_on_its_own_stops_the_process(monkeypatch):
+    """A clean return is just as wrong as a crash.
+
+    ``Worker.async_run`` is not supposed to return while the process is meant to be
+    serving. Reporting that as success is how a container stays up with a dead lane --
+    exactly the silent half-death the supervisor exists to make impossible.
+    """
+
+    async def _returns() -> None:
+        return None
+
+    workers = [_FakeWorker(_returns), _FakeWorker(_forever)]
+    _patch_workers(monkeypatch, workers)
+
+    code = await _run([_settings("a"), _settings("b")])
+
+    assert code == 1
+
+
+async def test_a_lane_that_raises_stops_the_process(monkeypatch):
+    async def _raises() -> None:
+        raise RuntimeError("redis went away")
+
+    workers = [_FakeWorker(_forever), _FakeWorker(_raises)]
+    _patch_workers(monkeypatch, workers)
+
+    code = await _run([_settings("a"), _settings("b")])
+
+    assert code == 1
+
+
+async def test_the_surviving_lane_is_stopped_and_closed_too(monkeypatch):
+    """One lane down means the process goes down, not that it limps on with one lane.
+
+    Leaving the survivor running would keep the container alive and healthy-looking while
+    half the background work quietly stopped happening.
+    """
+
+    async def _returns() -> None:
+        return None
+
+    survivor = _FakeWorker(_forever)
+    workers = [_FakeWorker(_returns), survivor]
+    _patch_workers(monkeypatch, workers)
+
+    await _run([_settings("a"), _settings("b")])
+
+    assert survivor.closed is True
+
+
+# --- a signal is the only clean stop ----------------------------------------
+
+
+async def test_a_stop_signal_exits_clean(monkeypatch):
+    """SIGTERM from the container runtime is the one ending that is not a failure."""
+
+    def _install(stop: asyncio.Event) -> None:
+        asyncio.get_running_loop().call_soon(stop.set)
+
+    monkeypatch.setattr(sup, "_install_stop_handlers", _install)
+    workers = [_FakeWorker(_forever), _FakeWorker(_forever)]
+    _patch_workers(monkeypatch, workers)
+
+    code = await _run([_settings("a"), _settings("b")])
+
+    assert code == 0
+    assert all(w.closed for w in workers)
+
+
+async def test_the_supervisor_asks_for_the_stop_signal_at_all(monkeypatch):
+    """Without this the deployed container would only ever stop by being killed.
+
+    arq's own handler is switched off deliberately (see below), so if nobody installs a
+    replacement, SIGTERM does nothing and Docker escalates to SIGKILL after its grace
+    period — terminating in-flight jobs instead of draining them.
+    """
+    seen: list[asyncio.Event] = []
+
+    def _install(stop: asyncio.Event) -> None:
+        seen.append(stop)
+        asyncio.get_running_loop().call_soon(stop.set)
+
+    monkeypatch.setattr(sup, "_install_stop_handlers", _install)
+    _patch_workers(monkeypatch, [_FakeWorker(_forever)])
+
+    await _run([_settings("a")])
+
+    assert len(seen) == 1 and isinstance(seen[0], asyncio.Event)
+
+
+# --- how the workers are built ----------------------------------------------
+
+
+async def test_every_lane_is_built_with_arqs_own_signal_handling_off(monkeypatch):
+    """Two arq Workers on one loop would fight over the signal handler.
+
+    ``loop.add_signal_handler`` replaces rather than appends, so the last Worker to
+    register would silently become the only one that ever hears SIGTERM, and the other
+    lane would never drain. The supervisor owns the signal instead.
+    """
+
+    def _install(stop: asyncio.Event) -> None:
+        asyncio.get_running_loop().call_soon(stop.set)
+
+    monkeypatch.setattr(sup, "_install_stop_handlers", _install)
+    workers = [_FakeWorker(_forever), _FakeWorker(_forever)]
+    made = _patch_workers(monkeypatch, workers)
+
+    await _run([_settings("a"), _settings("b")])
+
+    assert [m["kwargs"]["handle_signals"] for m in made] == [False, False]
+
+
+async def test_a_close_that_raises_does_not_take_the_shutdown_with_it(monkeypatch):
+    """Shutdown paths cannot afford to raise.
+
+    ``Worker.close`` calls ``handle_sig(signal.SIGUSR1)`` when signals were handed to us
+    instead, and SIGUSR1 does not exist on Windows — so this raises on a developer
+    machine for a reason unrelated to the code. It can also raise against a Redis that has
+    already gone, which is precisely when there is nothing useful to do about it.
+    """
+
+    def _install(stop: asyncio.Event) -> None:
+        asyncio.get_running_loop().call_soon(stop.set)
+
+    monkeypatch.setattr(sup, "_install_stop_handlers", _install)
+    angry = _FakeWorker(_forever, close_error=AttributeError("SIGUSR1"))
+    calm = _FakeWorker(_forever)
+    _patch_workers(monkeypatch, [angry, calm])
+
+    code = await _run([_settings("a"), _settings("b")])
+
+    assert code == 0
+    assert calm.closed is True
+
+
+async def test_starting_with_no_lanes_is_an_error_not_an_idle_process():
+    """A supervisor with nothing to supervise would sit there looking healthy forever.
+
+    Under the same deadline as every other call here, and for a sharper reason: without
+    the guard this does not raise, it waits on a stop event that no lane will ever cause.
+    That is the failure being asserted, so it has to arrive as a red test rather than as
+    a run that never finishes.
+    """
+    with pytest.raises(RuntimeError):
+        await asyncio.wait_for(sup.run_lanes([]), _DEADLINE_SECONDS)
+
+
+# --- which lanes a deployment actually runs ---------------------------------
+
+
+async def test_the_deployed_lanes_are_chat_and_site_builds(monkeypatch):
+    """Both queues have a consumer, and they are the two that exist.
+
+    The growth lane is deliberately absent: it already has its own queue and no consumer
+    in the deployed compose file, so adding it here would not be a refactor — it would
+    start executing outbound work that is currently inert.
+    """
+    monkeypatch.setenv("POCKETPAW_REDIS_URL", "redis://localhost:6379/0")
+    from arq.constants import default_queue_name
+    from pocketpaw_ee.sites.build_job import SITE_BUILD_QUEUE_NAME
+
+    names = [sup.lane_name(cls) for cls in sup.default_lanes()]
+
+    assert names == [default_queue_name, SITE_BUILD_QUEUE_NAME]
+
+
+async def test_a_lane_without_its_own_queue_is_named_after_arqs_default():
+    """Every settings class in this codebase is called ``WorkerSettings``.
+
+    A log line naming the class would identify nothing; the queue is the only thing that
+    tells two lanes apart in an incident.
+    """
+    from arq.constants import default_queue_name
+
+    assert sup.lane_name(type("WorkerSettings", (), {})) == default_queue_name
+    assert sup.lane_name(_settings("arq:queue:sites")) == "arq:queue:sites"

--- a/tests/ee/sites/test_build_job.py
+++ b/tests/ee/sites/test_build_job.py
@@ -218,6 +218,36 @@ class TestTheCaptureSecretNeverLeavesThisProcess:
         payload = pool.calls[0]["args"]
         assert "site_key_realsecret" not in repr(payload)
 
+    async def test_a_publish_is_queued_on_the_site_build_lane(self, beanie_test_db) -> None:
+        """backend-perf C1 — the publish enqueue names its own queue.
+
+        On arq's default queue this job competed for one cluster-wide ``max_jobs`` of 10
+        with chat runs, workspace jobs and both /ship jobs. Ten concurrent publishes left
+        chat with no slot, and the request that lost did not fail: it sat in Redis behind
+        a 30-minute ``job_timeout`` while its SSE stream delivered heartbeats and nothing
+        else. Dropping the kwarg puts the job back on the shared ceiling silently, so the
+        queue is asserted rather than inferred from the fact that builds still run.
+        """
+        site = await _insert_site()
+        pool = FakePool()
+
+        await bj.enqueue_site_build(
+            site, engine="react", generator_input=_input(), _pool_override=pool
+        )
+
+        assert pool.calls[0]["kwargs"]["_queue_name"] == bj.SITE_BUILD_QUEUE_NAME
+
+    async def test_the_build_lane_is_not_arqs_default_queue(self) -> None:
+        """The constant has to differ from arq's default, or the split is a no-op.
+
+        Asserted on its own because every other test here would pass just as happily with
+        ``SITE_BUILD_QUEUE_NAME = "arq:queue"``: the kwarg would be present, the enqueue
+        would work, and the lane would still be sharing one ceiling with chat.
+        """
+        from arq.constants import default_queue_name
+
+        assert bj.SITE_BUILD_QUEUE_NAME != default_queue_name
+
 
 # ---------------------------------------------------------------------------
 # Reading the scaffold

--- a/tests/ee/sites/test_preview_build_lane.py
+++ b/tests/ee/sites/test_preview_build_lane.py
@@ -400,15 +400,48 @@ class TestOneRenderIsOneSandbox:
         assert result["body_html"] == ""
 
 
+class TestThePreviewLaneQueue:
+    """backend-perf C1 — the preview enqueue rides the site-build queue too."""
+
+    async def test_a_preview_is_queued_on_the_site_build_lane(self) -> None:
+        """Both site lanes move together or the split only half applies.
+
+        A draft preview is the SAME build as a publish — same sandbox, same budget --
+        so leaving it on arq's default queue would keep the exact starvation the split
+        removes, and would keep it on the lane a user hits by typing, not by publishing.
+        """
+        pool = FakePool()
+
+        await bj.enqueue_preview_build(
+            pocket_id="pk1",
+            content_hash="c0ffee",
+            engine="react",
+            generator_input=_preview_input(),
+            _pool_override=pool,
+        )
+
+        assert pool.calls[0]["kwargs"]["_queue_name"] == bj.SITE_BUILD_QUEUE_NAME
+
+
 class TestReadingARefusedEnqueue:
     """``_preview_job_outcome`` against a stand-in for arq's ``Job``."""
 
-    def _patch_job(self, monkeypatch, *, status: Any, info: Any) -> None:
+    def _patch_job(self, monkeypatch, *, status: Any, info: Any) -> list[dict[str, Any]]:
+        """Swap arq's ``Job`` for a stand-in and return the ctor calls it recorded.
+
+        ``_queue_name`` is part of the signature here because it is part of arq's, and
+        because it is the argument this read cannot afford to get wrong: arq scopes a job
+        id to a queue, so a status read pointed at the wrong one finds nothing, answers
+        ``building`` forever, and the client polls a job that ended minutes ago.
+        """
         from arq.jobs import JobStatus
 
+        calls: list[dict[str, Any]] = []
+
         class _FakeJob:
-            def __init__(self, job_id: str, pool: Any) -> None:
+            def __init__(self, job_id: str, pool: Any, _queue_name: str | None = None) -> None:
                 self.job_id = job_id
+                calls.append({"job_id": job_id, "queue_name": _queue_name})
 
             async def status(self) -> Any:
                 return status
@@ -418,12 +451,31 @@ class TestReadingARefusedEnqueue:
 
         monkeypatch.setattr(bj, "Job", _FakeJob)
         assert JobStatus.complete is not None  # the enum the production code compares on
+        return calls
 
     async def test_a_running_job_reads_as_building(self, monkeypatch) -> None:
         from arq.jobs import JobStatus
 
         self._patch_job(monkeypatch, status=JobStatus.in_progress, info=None)
         assert await bj._preview_job_outcome(object(), "j1") == ("building", None)
+
+    async def test_the_status_read_looks_in_the_queue_the_enqueue_wrote_to(
+        self, monkeypatch
+    ) -> None:
+        """The read and both enqueues share one queue, or the read is blind.
+
+        backend-perf C1 moved site builds off arq's default queue. arq scopes a job id to
+        a queue, so a read left on the default would never find the job it just refused to
+        enqueue: ``status()`` returns ``not_found``, this function reports ``building``,
+        and the client polls a finished build forever. There is no error anywhere on that
+        path, which is why it is asserted rather than left to the enqueue tests.
+        """
+        from arq.jobs import JobStatus
+
+        calls = self._patch_job(monkeypatch, status=JobStatus.in_progress, info=None)
+        await bj._preview_job_outcome(object(), "j1")
+
+        assert calls == [{"job_id": "j1", "queue_name": bj.SITE_BUILD_QUEUE_NAME}]
 
     async def test_a_completed_job_reports_its_own_settlement(self, monkeypatch) -> None:
         from arq.jobs import JobStatus

--- a/tests/mutations/queue_lanes.json
+++ b/tests/mutations/queue_lanes.json
@@ -1,0 +1,201 @@
+[
+  {
+    "label": "the publish enqueue drops its queue kwarg, so site builds go back onto arq's default queue and compete with chat runs for one cluster-wide ceiling of 10 - the exact starvation this change removes",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "            _queue_name=SITE_BUILD_QUEUE_NAME,\n",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_job.py"
+    ]
+  },
+  {
+    "label": "the preview enqueue drops its queue kwarg, so draft renders - the lane a user hits by typing rather than by publishing - go back onto the chat lane's ceiling",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "        _job_id=job_id,\n        _queue_name=SITE_BUILD_QUEUE_NAME,\n    )\n",
+    "replace": "        _job_id=job_id,\n    )\n",
+    "tests": [
+      "tests/ee/sites/test_preview_build_lane.py"
+    ]
+  },
+  {
+    "label": "the refused-enqueue status read looks in arq's default queue instead of the one the job was written to, so status() answers not_found, the lane reports 'building' forever, and a client polls a build that ended minutes ago",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "    job = Job(job_id, pool, _queue_name=SITE_BUILD_QUEUE_NAME)",
+    "replace": "    job = Job(job_id, pool)",
+    "tests": [
+      "tests/ee/sites/test_preview_build_lane.py"
+    ]
+  },
+  {
+    "label": "the queue constant becomes arq's own default, so every enqueue and read still names a queue and the split is a no-op that reads as done",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "SITE_BUILD_QUEUE_NAME = \"arq:queue:sites\"",
+    "replace": "SITE_BUILD_QUEUE_NAME = \"arq:queue\"",
+    "tests": [
+      "tests/ee/sites/test_build_job.py",
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the sites worker stops declaring its queue, so it polls arq's default and the site-build queue has no consumer at all - jobs wait in Redis forever with nothing reporting it",
+    "file": "ee/pocketpaw_ee/sites/build_worker.py",
+    "find": "    queue_name = SITE_BUILD_QUEUE_NAME\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the sites ceiling reads the chat lane's variable, so tuning chat concurrency silently retunes how many third-party build sandboxes the account pays for",
+    "file": "ee/pocketpaw_ee/sites/build_worker.py",
+    "find": "_MAX_JOBS_ENV = \"POCKETPAW_SITES_ARQ_MAX_JOBS\"",
+    "replace": "_MAX_JOBS_ENV = \"POCKETPAW_ARQ_MAX_JOBS\"",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the sites default ceiling matches the chat lane's, so the build lane can claim as much capacity as chat and the split moves the starvation rather than removing it",
+    "file": "ee/pocketpaw_ee/sites/build_worker.py",
+    "find": "_DEFAULT_SITES_MAX_JOBS = 4",
+    "replace": "_DEFAULT_SITES_MAX_JOBS = 10",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the sites ceiling stops rejecting non-positive values, so POCKETPAW_SITES_ARQ_MAX_JOBS=0 wedges the worker into accepting nothing and a negative crashes BoundedSemaphore on boot",
+    "file": "ee/pocketpaw_ee/sites/build_worker.py",
+    "find": "    if val <= 0:\n",
+    "replace": "    if False:\n",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the sites max_jobs becomes a property, so arq's settings_cls.__dict__ read hands a descriptor straight to BoundedSemaphore - the _LazyRedisSettings deploy crash, on the new lane",
+    "file": "ee/pocketpaw_ee/sites/build_worker.py",
+    "find": "    max_jobs = _sites_max_jobs()",
+    "replace": "    max_jobs = property(lambda self: _sites_max_jobs())",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the sites lane stops registering the preview function, so preview jobs enqueued onto the sites queue have no worker willing to claim them and arq says nothing",
+    "file": "ee/pocketpaw_ee/sites/build_worker.py",
+    "find": "    functions = [site_build_fn, site_preview_build_fn]",
+    "replace": "    functions = [site_build_fn]",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the chat lane stops registering the site functions, so whatever was already sitting on the default queue at cutover is stranded forever - a backlog nobody is willing to claim",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "        _site_build_fn,\n        _site_preview_build_fn,\n    ]",
+    "replace": "    ]",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the shared bootstrap loses its guard, so a second lane in the same process re-runs init_cloud_db against a live client and re-runs both boot sweeps, one of which is a billing path",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "        if _bootstrap_lanes > 1:\n",
+    "replace": "        if False:\n",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the shutdown closes the shared database as soon as ANY lane stops, pulling Mongo out from under every job the other lane still has in flight",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "        if _bootstrap_lanes > 0:\n            return\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the lane counter loses its clamp, so an unbalanced shutdown drives it negative and the guard under-counts on the way back up - the second lane bootstraps too, re-running init_cloud_db and both boot sweeps",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/worker.py",
+    "find": "        _bootstrap_lanes = 0\n        await close_cloud_db()",
+    "replace": "        await close_cloud_db()",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "a lane ending on its own reports success, so the container stays up and healthy with half its background work silently stopped - the exact failure a backgrounded 'arq A & arq B' would have given us",
+    "file": "ee/pocketpaw_ee/cloud/worker_supervisor.py",
+    "find": "            exit_code = 1\n",
+    "replace": "            exit_code = 0\n",
+    "tests": [
+      "tests/cloud/test_worker_supervisor.py"
+    ]
+  },
+  {
+    "label": "the lanes keep arq's own signal handling, so two Workers register SIGTERM handlers on one loop and the last one silently replaces the first - one lane never drains on shutdown",
+    "file": "ee/pocketpaw_ee/cloud/worker_supervisor.py",
+    "find": "    workers = [create_worker(cls, handle_signals=False) for cls in classes]",
+    "replace": "    workers = [create_worker(cls) for cls in classes]",
+    "tests": [
+      "tests/cloud/test_worker_supervisor.py"
+    ]
+  },
+  {
+    "label": "nobody installs a stop handler, so SIGTERM does nothing, Docker escalates to SIGKILL after the grace period, and in-flight jobs are killed instead of drained",
+    "file": "ee/pocketpaw_ee/cloud/worker_supervisor.py",
+    "find": "    _install_stop_handlers(stop)\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/test_worker_supervisor.py"
+    ]
+  },
+  {
+    "label": "the workers are never closed, so a stopping process leaves its arq health keys in Redis and 'arq --check' keeps answering healthy for a worker that is gone",
+    "file": "ee/pocketpaw_ee/cloud/worker_supervisor.py",
+    "find": "        for worker, name in zip(workers, names, strict=True):\n            await _close_quietly(worker, name)\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/test_worker_supervisor.py"
+    ]
+  },
+  {
+    "label": "a failing close is allowed to propagate, so one lane that cannot clean up prevents every later lane from cleaning up at all",
+    "file": "ee/pocketpaw_ee/cloud/worker_supervisor.py",
+    "find": "    except Exception:\n        logger.warning(\"supervisor: closing lane %s failed\", name, exc_info=True)",
+    "replace": "    except Exception:\n        raise",
+    "tests": [
+      "tests/cloud/test_worker_supervisor.py"
+    ]
+  },
+  {
+    "label": "the deployment stops running the sites lane, so every site build and preview enqueued onto the sites queue waits forever with no consumer - worse than the shared queue it replaced",
+    "file": "ee/pocketpaw_ee/cloud/worker_supervisor.py",
+    "find": "    return [ChatWorkerSettings, SiteBuildWorkerSettings]",
+    "replace": "    return [ChatWorkerSettings]",
+    "tests": [
+      "tests/cloud/test_worker_supervisor.py"
+    ]
+  },
+  {
+    "label": "a supervisor started with no lanes sits there idle and healthy instead of failing, so a misconfigured deploy looks like a running worker",
+    "file": "ee/pocketpaw_ee/cloud/worker_supervisor.py",
+    "find": "    if not classes:\n        raise RuntimeError(\"worker supervisor started with no lanes to run\")\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/test_worker_supervisor.py"
+    ]
+  },
+  {
+    "label": "lanes are logged by class name instead of queue, and every settings class in this codebase is called WorkerSettings - so an incident log identifies neither lane",
+    "file": "ee/pocketpaw_ee/cloud/worker_supervisor.py",
+    "find": "    return str(queue) if queue else default_queue_name",
+    "replace": "    return str(queue) if queue else settings_cls.__name__",
+    "tests": [
+      "tests/cloud/test_worker_supervisor.py"
+    ]
+  }
+]


### PR DESCRIPTION
Every background job this product runs shared one arq queue, and therefore one
`max_jobs` ceiling whose default is 10. That number is cluster-wide, not
per-lane, and site builds were the worst possible neighbour to share it with: a
publish storm is one customer pressing Publish on ten sites, and one build's
budget is 1020s. Ten of them left chat with zero slots.

The eleventh request did not fail. It got a run id and a 200, opened its SSE
stream, and sat on heartbeats until the stale-run sweeper marked it interrupted
ten minutes later. A silent ten-minute hang, then a failure.

## What this does

Site builds and draft previews now enqueue onto `arq:queue:sites` and are
consumed by their own settings class with its own ceiling, default 4. The chat
lane keeps its own 10 for chat runs, workspace jobs and both `/ship` jobs.
Neither can take the other's slots.

The two ceilings answer to different limits, which is why they are two numbers.
Chat is bounded by container memory, because the default backend spawns a Node
subprocess per run. A build compiles inside a Daytona sandbox, so what occupies
a slot here is an await on a remote exec. Raise that one with the sandbox quota.

## Both lanes run in one container

`python -m pocketpaw_ee.cloud.worker_supervisor` starts both arq Workers on one
event loop. A separate compose service was not available: Coolify base64s the
whole Dockerfile into a single SSH argv once per service that declares `build:`,
and a third one blew the argv limit and broke every deploy in paw-workspace #193.

`sh -c 'arq A & exec arq B'` was the other option and is worse. Backgrounding
makes a lane's death invisible, so the container stays up and healthy while site
builds silently stop being consumed. That is the same class of failure the split
was meant to remove. The supervisor treats any lane ending as fatal, including a
clean return, so the restart policy brings both lanes back together.

## Details worth a second look

- **Three call sites move together**: both enqueues and the refused-enqueue
  status read. arq scopes a job id to a queue, so a read left pointing at the
  default queue finds nothing, reports `building` forever, and the client polls a
  job that ended minutes ago. There is no error on that path, so it is asserted.
- **The chat lane still registers both site functions.** A deploy cuts the
  enqueue side over instantly, and anything already sitting on the default queue
  needs someone willing to claim it. That backlog drains once.
- **One bootstrap, two lanes.** arq calls `on_startup` per Worker, so it is now
  refcounted. Without the guard the second lane would re-run `init_cloud_db`
  against a live client and re-run both boot sweeps, one of which is a billing
  path. An autouse fixture resets that counter around every test in
  `tests/cloud/runs/`, because it is process state and a test session is one
  process.
- **The functions are shared by identity, not re-wrapped.** A second copy of the
  build timeout is exactly the drift that lets arq cancel a build before its
  in-sandbox timeout fires, which destroys the sentinel the lane classifies from
  and records a slow-but-healthy build as lost infrastructure.

## Tested

29 new tests across the two lanes and the supervisor. 22 mutations in
`tests/mutations/queue_lanes.json`, all caught. Each is a way the split could
look done and not be: the queue constant set back to arq's default, a dropped
`_queue_name`, a lane that reports success when it dies, a healthcheck that only
probes one lane.

Two of them originally hung instead of failing, because they deleted the only
thing that could end the supervisor's wait. The supervisor tests now run under a
deadline, so that failure mode arrives red rather than as a run that never ends.

Blast radius run clean: `tests/cloud/runs`, `tests/cloud/test_worker_supervisor.py`
and all of `tests/ee/sites`. Six failures remain and all six reproduce
identically on a pristine `origin/dev` checkout with the same selection and
ordering.

## Deploy ordering

The compose change is paw-workspace#197 and must not merge before this
one. It sets the worker command to the supervisor module, which does not exist in
an image built from an older ref.