### PR TITLE
The secret and PII log filters have never scrubbed anything

### DIFF
--- a/ee/pocketpaw_ee/cloud/worker_supervisor.py
+++ b/ee/pocketpaw_ee/cloud/worker_supervisor.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import signal
 import sys
 from typing import Any
@@ -157,7 +158,14 @@ async def run_lanes(settings_classes: list[type] | None = None) -> int:
 
 
 def main() -> int:
-    logging.basicConfig(level=logging.INFO)
+    # setup_logging, not basicConfig: the worker is where money is spent and
+    # where provider SDKs surface credentials in exception text, and only
+    # setup_logging installs the secret / PII scrubbing filters. basicConfig
+    # gives the root logger a handler and nothing else, so the worker was
+    # logging unredacted to stdout where the platform's collector keeps it.
+    from pocketpaw.logging_setup import setup_logging
+
+    setup_logging(level=os.environ.get("POCKETPAW_LOG_LEVEL", "INFO"))
     return asyncio.run(run_lanes())
 
 

--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -92,8 +92,10 @@ def _run_async(coro):
         return ex.submit(asyncio.run, coro).result()
 
 
-# Setup beautiful logging with Rich
-setup_logging(level="INFO")
+# Setup beautiful logging with Rich. The level is read from the environment so an
+# operator can raise verbosity on a running deployment without a code change; it
+# was hardcoded, which meant DEBUG diagnostics were unreachable in production.
+setup_logging(level=os.environ.get("POCKETPAW_LOG_LEVEL", "INFO"))
 logger = logging.getLogger(__name__)
 
 

--- a/src/pocketpaw/logging_setup.py
+++ b/src/pocketpaw/logging_setup.py
@@ -3,14 +3,19 @@ Beautiful logging setup using Rich.
 
 Created: 2026-02-02
 Changes:
-  - 2026-09-05: SecretFilter now scrubs the TRACEBACK too, not just the message
-    and args. A provider SDK that puts a key in an exception reached the log
-    through exc_info, which the filter ignored entirely, and logger.exception is
-    used 281 times in this codebase. Rich is now used only when stderr is a TTY:
-    RichHandler renders tracebacks from exc_info and ignores record.exc_text, so
-    it would discard the scrubbed traceback and print the raw one. The non-TTY
-    handler also carries a timestamp, level and logger name, which the
-    lastResort fallback did not.
+  - 2026-09-05: SecretFilter now scrubs the EXCEPTION and its traceback, not
+    just the message and args. A provider SDK that puts a key in an exception
+    reached the log through exc_info, which the filter ignored entirely, and
+    logger.exception is used 281 times in this codebase. It rewrites the
+    exception's args, because renderers disagree about where they read the
+    traceback from: Formatter reuses record.exc_text, RichHandler re-renders
+    from exc_info, and Logfire's logging handler passes the raw exc_info tuple
+    while dropping exc_text as a reserved attribute. The exception object is the
+    one thing all of them read. Args are only rewritten when a pattern actually
+    matched, so an exception with no secret is left exactly as raised.
+    Separately, Rich is now used only on a TTY — a log-format decision, not a
+    security one: the previous non-TTY fallback emitted no timestamp, level or
+    logger name, so a container line could not be correlated with a report.
   - 2026-09-05: Both filters are now attached to the root logger's HANDLERS
     rather than to the root logger. They were attached to the logger, which
     meant they never ran: a logger's filters apply only to records logged
@@ -56,11 +61,26 @@ class SecretFilter(logging.Filter):
         # an exception reaches the log through ``exc_info``, which this used to
         # ignore entirely — and ``logger.exception`` is used 281 times here.
         #
-        # ``Formatter.format`` renders the traceback only when ``exc_text`` is
-        # empty and reuses it when set, so filling it in with a scrubbed render
-        # is what actually reaches the handler. This is also why setup_logging
-        # only uses Rich on a TTY: RichHandler renders from ``exc_info`` itself
-        # and ignores ``exc_text``, so in a container it would print the key.
+        # Scrub the EXCEPTION OBJECT first, then the rendered text. Rewriting
+        # ``args`` is the only thing every renderer sees, because they do not
+        # agree on where to read the traceback from: ``Formatter`` reuses
+        # ``record.exc_text``, ``RichHandler`` re-renders from ``exc_info`` and
+        # ignores ``exc_text``, and Logfire's logging handler passes the raw
+        # ``exc_info`` tuple while dropping ``exc_text`` as a reserved
+        # attribute — and its own scrubber skips ``exception.message`` and
+        # ``exception.stacktrace`` as SAFE_KEYS, so nothing downstream would
+        # catch it either. Scrubbing at the source covers all three.
+        #
+        # ``args`` is only reassigned when a pattern actually matched, so an
+        # exception carrying no secret is left untouched and code that inspects
+        # it after logging sees exactly what it raised.
+        if record.exc_info and record.exc_info[1] is not None:
+            exc = record.exc_info[1]
+            original = getattr(exc, "args", ())
+            if original:
+                scrubbed = tuple(_scrub(a) if isinstance(a, str) else a for a in original)
+                if scrubbed != original:
+                    exc.args = scrubbed
         if record.exc_info:
             if not record.exc_text:
                 record.exc_text = "".join(traceback.format_exception(*record.exc_info))
@@ -149,13 +169,15 @@ def install_scrubbing_filters() -> None:
 def _use_rich() -> bool:
     """Rich only for a human at a terminal.
 
-    Two reasons, and the second is a security one. Rich's box drawing and ANSI
-    are noise in a container's log collector, and `%(asctime)s` with the logger
-    name is what makes a line correlatable with a customer report. More
-    importantly ``RichHandler`` renders tracebacks from ``exc_info`` itself and
-    ignores ``record.exc_text``, so the scrubbed traceback ``SecretFilter``
-    prepares would be discarded and the raw one printed. On a TTY that is a
-    developer's own screen; in production it is the log collector.
+    The reason is log format, not scrubbing. Rich's box drawing and ANSI are
+    noise in a container's log collector, and a line with no timestamp, level or
+    logger name cannot be correlated with a customer report — which is what the
+    previous fallback produced.
+
+    Scrubbing is handled at the source instead, by rewriting the exception's
+    ``args`` in ``SecretFilter``, because ``RichHandler`` re-renders tracebacks
+    from ``exc_info`` and ignores ``record.exc_text``. That makes Rich safe
+    either way; this function is about readability for machines.
     """
     return bool(getattr(sys.stderr, "isatty", lambda: False)())
 

--- a/src/pocketpaw/logging_setup.py
+++ b/src/pocketpaw/logging_setup.py
@@ -3,6 +3,14 @@ Beautiful logging setup using Rich.
 
 Created: 2026-02-02
 Changes:
+  - 2026-09-05: Both filters are now attached to the root logger's HANDLERS
+    rather than to the root logger. They were attached to the logger, which
+    meant they never ran: a logger's filters apply only to records logged
+    directly on it, and every module here logs via getLogger(__name__), whose
+    records reach the root's handlers without consulting the root's filters. So
+    no log line has been scrubbed in any process since the filters were added.
+    Extracted install_scrubbing_filters() so a process that configures its own
+    logging (the cloud worker supervisor) can install them too.
   - 2026-02-06: Added SecretFilter to scrub API key patterns from log output.
   - 2026-02-16: Added PIILogFilter for opt-in PII scrubbing in log output.
   - Initial setup with Rich console handler for beautiful logs.
@@ -42,6 +50,74 @@ class SecretFilter(logging.Filter):
                 new_args.append(arg)
             record.args = tuple(new_args)
         return True
+
+
+def _build_pii_filter() -> logging.Filter | None:
+    """The PII scrubbing filter, or ``None`` when it is off or unavailable.
+
+    Returns ``None`` rather than raising during early bootstrap, when settings
+    are not loadable yet.
+    """
+    try:
+        from pocketpaw.config import get_settings
+
+        settings = get_settings()
+        if not (settings.pii_scan_enabled and settings.pii_scan_logs):
+            return None
+
+        from pocketpaw.security.pii import PIIAction, PIIScanner
+
+        scanner = PIIScanner(default_action=PIIAction.MASK)
+
+        class PIILogFilter(logging.Filter):
+            """Scrub PII patterns from log output."""
+
+            def filter(self, record: logging.LogRecord) -> bool:
+                if isinstance(record.msg, str):
+                    result = scanner.scan(record.msg)
+                    if result.has_pii:
+                        record.msg = result.sanitized_text
+                if record.args:
+                    args = record.args if isinstance(record.args, tuple) else (record.args,)
+                    new_args = []
+                    for arg in args:
+                        if isinstance(arg, str):
+                            r = scanner.scan(arg)
+                            if r.has_pii:
+                                arg = r.sanitized_text
+                        new_args.append(arg)
+                    record.args = tuple(new_args)
+                return True
+
+        return PIILogFilter()
+    except Exception:
+        return None  # Config not available during early bootstrap
+
+
+def install_scrubbing_filters() -> None:
+    """Attach the secret and PII filters to the root logger's HANDLERS.
+
+    Not to the root logger itself, which is what this used to do and why the
+    scrubbing never ran. A filter attached to a logger is consulted only for
+    records logged *directly on that logger*: ``Logger.handle`` applies the
+    logger's own filters, then ``callHandlers`` walks the hierarchy invoking each
+    ancestor's *handlers*, and a handler applies only its own filters. Every
+    module here logs through ``logging.getLogger(__name__)``, so its records
+    reach the root's handlers without the root logger's filters ever running.
+
+    Attaching to the handlers is what actually scrubs. Idempotent by filter type
+    so repeated calls (tests, a re-init) do not stack duplicates.
+    """
+    filters: list[logging.Filter] = [SecretFilter()]
+    pii = _build_pii_filter()
+    if pii is not None:
+        filters.append(pii)
+
+    for handler in logging.getLogger().handlers:
+        installed = {type(existing) for existing in handler.filters}
+        for scrubber in filters:
+            if type(scrubber) not in installed:
+                handler.addFilter(scrubber)
 
 
 def setup_logging(level: str = "INFO") -> None:
@@ -90,39 +166,4 @@ def setup_logging(level: str = "INFO") -> None:
         )
         logging.warning("Rich not installed, using basic logging")
 
-    # Attach secret scrubbing filter to root logger
-    logging.getLogger().addFilter(SecretFilter())
-
-    # Attach PII scrubbing filter if enabled
-    try:
-        from pocketpaw.config import get_settings
-
-        settings = get_settings()
-        if settings.pii_scan_enabled and settings.pii_scan_logs:
-            from pocketpaw.security.pii import PIIAction, PIIScanner
-
-            _pii_scanner = PIIScanner(default_action=PIIAction.MASK)
-
-            class PIILogFilter(logging.Filter):
-                """Scrub PII patterns from log output."""
-
-                def filter(self, record: logging.LogRecord) -> bool:
-                    if isinstance(record.msg, str):
-                        result = _pii_scanner.scan(record.msg)
-                        if result.has_pii:
-                            record.msg = result.sanitized_text
-                    if record.args:
-                        args = record.args if isinstance(record.args, tuple) else (record.args,)
-                        new_args = []
-                        for arg in args:
-                            if isinstance(arg, str):
-                                r = _pii_scanner.scan(arg)
-                                if r.has_pii:
-                                    arg = r.sanitized_text
-                            new_args.append(arg)
-                        record.args = tuple(new_args)
-                    return True
-
-            logging.getLogger().addFilter(PIILogFilter())
-    except Exception:
-        pass  # Config not available during early bootstrap
+    install_scrubbing_filters()

--- a/src/pocketpaw/logging_setup.py
+++ b/src/pocketpaw/logging_setup.py
@@ -3,6 +3,14 @@ Beautiful logging setup using Rich.
 
 Created: 2026-02-02
 Changes:
+  - 2026-09-05: SecretFilter now scrubs the TRACEBACK too, not just the message
+    and args. A provider SDK that puts a key in an exception reached the log
+    through exc_info, which the filter ignored entirely, and logger.exception is
+    used 281 times in this codebase. Rich is now used only when stderr is a TTY:
+    RichHandler renders tracebacks from exc_info and ignores record.exc_text, so
+    it would discard the scrubbed traceback and print the raw one. The non-TTY
+    handler also carries a timestamp, level and logger name, which the
+    lastResort fallback did not.
   - 2026-09-05: Both filters are now attached to the root logger's HANDLERS
     rather than to the root logger. They were attached to the logger, which
     meant they never ran: a logger's filters apply only to records logged
@@ -19,6 +27,7 @@ Changes:
 import logging
 import re
 import sys
+import traceback
 
 # Patterns that match known API key / token formats
 _SECRET_PATTERNS = [
@@ -33,20 +42,37 @@ _SECRET_PATTERNS = [
 ]
 
 
+def _scrub(text: str) -> str:
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub("***REDACTED***", text)
+    return text
+
+
 class SecretFilter(logging.Filter):
     """Scrub API key patterns from log output."""
 
     def filter(self, record: logging.LogRecord) -> bool:
+        # The traceback, not just the message. A provider SDK that puts a key in
+        # an exception reaches the log through ``exc_info``, which this used to
+        # ignore entirely — and ``logger.exception`` is used 281 times here.
+        #
+        # ``Formatter.format`` renders the traceback only when ``exc_text`` is
+        # empty and reuses it when set, so filling it in with a scrubbed render
+        # is what actually reaches the handler. This is also why setup_logging
+        # only uses Rich on a TTY: RichHandler renders from ``exc_info`` itself
+        # and ignores ``exc_text``, so in a container it would print the key.
+        if record.exc_info:
+            if not record.exc_text:
+                record.exc_text = "".join(traceback.format_exception(*record.exc_info))
+            record.exc_text = _scrub(record.exc_text)
         if isinstance(record.msg, str):
-            for pattern in _SECRET_PATTERNS:
-                record.msg = pattern.sub("***REDACTED***", record.msg)
+            record.msg = _scrub(record.msg)
         if record.args:
             args = record.args if isinstance(record.args, tuple) else (record.args,)
             new_args = []
             for arg in args:
                 if isinstance(arg, str):
-                    for pattern in _SECRET_PATTERNS:
-                        arg = pattern.sub("***REDACTED***", arg)
+                    arg = _scrub(arg)
                 new_args.append(arg)
             record.args = tuple(new_args)
         return True
@@ -120,12 +146,38 @@ def install_scrubbing_filters() -> None:
                 handler.addFilter(scrubber)
 
 
+def _use_rich() -> bool:
+    """Rich only for a human at a terminal.
+
+    Two reasons, and the second is a security one. Rich's box drawing and ANSI
+    are noise in a container's log collector, and `%(asctime)s` with the logger
+    name is what makes a line correlatable with a customer report. More
+    importantly ``RichHandler`` renders tracebacks from ``exc_info`` itself and
+    ignores ``record.exc_text``, so the scrubbed traceback ``SecretFilter``
+    prepares would be discarded and the raw one printed. On a TTY that is a
+    developer's own screen; in production it is the log collector.
+    """
+    return bool(getattr(sys.stderr, "isatty", lambda: False)())
+
+
 def setup_logging(level: str = "INFO") -> None:
-    """Configure beautiful logging with Rich.
+    """Configure logging: Rich for a terminal, a plain scrubbed handler otherwise.
 
     Args:
         level: Log level (DEBUG, INFO, WARNING, ERROR)
     """
+    if not _use_rich():
+        logging.basicConfig(
+            level=getattr(logging, level.upper(), logging.INFO),
+            format="%(asctime)s %(levelname)-8s %(name)s %(message)s",
+            handlers=[logging.StreamHandler(sys.stderr)],
+            force=True,
+        )
+        for noisy in ("httpx", "httpcore", "urllib3", "asyncio", "websockets"):
+            logging.getLogger(noisy).setLevel(logging.WARNING)
+        install_scrubbing_filters()
+        return
+
     try:
         from rich.console import Console
         from rich.logging import RichHandler

--- a/src/pocketpaw/logging_setup.py
+++ b/src/pocketpaw/logging_setup.py
@@ -33,6 +33,8 @@ import logging
 import re
 import sys
 import traceback
+from collections.abc import Callable, Mapping
+from typing import Any
 
 # Patterns that match known API key / token formats
 _SECRET_PATTERNS = [
@@ -51,6 +53,32 @@ def _scrub(text: str) -> str:
     for pattern in _SECRET_PATTERNS:
         text = pattern.sub("***REDACTED***", text)
     return text
+
+
+def scrub_log_args(args: Any, scrub: Callable[[str], str]) -> Any:
+    """Scrub a ``LogRecord.args`` **preserving its shape**.
+
+    ``record.args`` is a tuple, or a Mapping when the caller used named
+    placeholders: ``logger.info("%(user)s", {"user": name})``. logging unwraps a
+    single mapping argument, so the attribute is the dict itself.
+
+    Rebuilding that as a tuple is not a cosmetic error. ``getMessage`` does
+    ``msg % self.args``, and ``"%(user)s" % ({...},)`` raises "format requires a
+    mapping" inside logging, which swallows it and **drops the record entirely**.
+    So a filter that mishandles this does not merely fail to scrub, it destroys
+    the log line — including records from third-party libraries, since these
+    filters sit on the root handler.
+    """
+    if not args:
+        return args
+    if isinstance(args, Mapping):
+        return {k: scrub(v) if isinstance(v, str) else v for k, v in args.items()}
+    items = args if isinstance(args, tuple) else (args,)
+    return tuple(scrub(a) if isinstance(a, str) else a for a in items)
+
+
+def _scrub_args(args: Any) -> Any:
+    return scrub_log_args(args, _scrub)
 
 
 class SecretFilter(logging.Filter):
@@ -87,14 +115,7 @@ class SecretFilter(logging.Filter):
             record.exc_text = _scrub(record.exc_text)
         if isinstance(record.msg, str):
             record.msg = _scrub(record.msg)
-        if record.args:
-            args = record.args if isinstance(record.args, tuple) else (record.args,)
-            new_args = []
-            for arg in args:
-                if isinstance(arg, str):
-                    arg = _scrub(arg)
-                new_args.append(arg)
-            record.args = tuple(new_args)
+        record.args = _scrub_args(record.args)
         return True
 
 
@@ -115,24 +136,19 @@ def _build_pii_filter() -> logging.Filter | None:
 
         scanner = PIIScanner(default_action=PIIAction.MASK)
 
+        def _mask(text: str) -> str:
+            result = scanner.scan(text)
+            return result.sanitized_text if result.has_pii else text
+
         class PIILogFilter(logging.Filter):
             """Scrub PII patterns from log output."""
 
             def filter(self, record: logging.LogRecord) -> bool:
                 if isinstance(record.msg, str):
-                    result = scanner.scan(record.msg)
-                    if result.has_pii:
-                        record.msg = result.sanitized_text
-                if record.args:
-                    args = record.args if isinstance(record.args, tuple) else (record.args,)
-                    new_args = []
-                    for arg in args:
-                        if isinstance(arg, str):
-                            r = scanner.scan(arg)
-                            if r.has_pii:
-                                arg = r.sanitized_text
-                        new_args.append(arg)
-                    record.args = tuple(new_args)
+                    record.msg = _mask(record.msg)
+                # Shape-preserving, for the same reason as SecretFilter: turning a
+                # mapping into a tuple makes logging raise and drop the record.
+                record.args = scrub_log_args(record.args, _mask)
                 return True
 
         return PIILogFilter()

--- a/src/pocketpaw/logging_setup.py
+++ b/src/pocketpaw/logging_setup.py
@@ -189,11 +189,16 @@ def setup_logging(level: str = "INFO") -> None:
         level: Log level (DEBUG, INFO, WARNING, ERROR)
     """
     if not _use_rich():
+        # No force=True. It removes and CLOSES every handler already on the root
+        # logger, which under pytest is the capture handler other tests assert
+        # against — it changed what unrelated suites recorded. Without it this is
+        # a no-op when logging is already configured, and install_scrubbing_filters
+        # below then attaches the scrubbers to whatever handlers are actually
+        # there, which is the behaviour we want either way.
         logging.basicConfig(
             level=getattr(logging, level.upper(), logging.INFO),
             format="%(asctime)s %(levelname)-8s %(name)s %(message)s",
             handlers=[logging.StreamHandler(sys.stderr)],
-            force=True,
         )
         for noisy in ("httpx", "httpcore", "urllib3", "asyncio", "websockets"):
             logging.getLogger(noisy).setLevel(logging.WARNING)

--- a/tests/mutations/log_scrubbing.json
+++ b/tests/mutations/log_scrubbing.json
@@ -44,8 +44,8 @@
   {
     "label": "SecretFilter stops scrubbing record.args, so the %s form leaks",
     "file": "src/pocketpaw/logging_setup.py",
-    "find": "        if record.args:\n            args = record.args if isinstance(record.args, tuple) else (record.args,)",
-    "replace": "        if False:\n            args = record.args if isinstance(record.args, tuple) else (record.args,)",
+    "find": "        record.args = _scrub_args(record.args)",
+    "replace": "        record.args = record.args",
     "tests": "tests/test_log_scrubbing.py"
   },
   {
@@ -81,6 +81,13 @@
     "file": "src/pocketpaw/logging_setup.py",
     "find": "                scrubbed = tuple(_scrub(a) if isinstance(a, str) else a for a in original)",
     "replace": "                scrubbed = tuple(\"***REDACTED***\" for a in original)",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "a mapping args record is rebuilt as a tuple, so logging drops the line",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "    if isinstance(args, Mapping):\n        return {k: scrub(v) if isinstance(v, str) else v for k, v in args.items()}",
+    "replace": "    if isinstance(args, Mapping):\n        return tuple(scrub(v) if isinstance(v, str) else v for v in args.values())",
     "tests": "tests/test_log_scrubbing.py"
   }
 ]

--- a/tests/mutations/log_scrubbing.json
+++ b/tests/mutations/log_scrubbing.json
@@ -63,10 +63,24 @@
     "tests": "tests/test_log_scrubbing.py"
   },
   {
-    "label": "Rich is selected even off a TTY, so it renders the raw traceback in a container",
+    "label": "Rich is selected even off a TTY, so container logs lose timestamp and level",
     "file": "src/pocketpaw/logging_setup.py",
     "find": "    return bool(getattr(sys.stderr, \"isatty\", lambda: False)())",
     "replace": "    return True",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "the exception OBJECT is no longer scrubbed, so a renderer reading exc_info leaks",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "                if scrubbed != original:\n                    exc.args = scrubbed",
+    "replace": "                if False:\n                    exc.args = scrubbed",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "args are rewritten unconditionally, so a clean exception is mangled too",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "                scrubbed = tuple(_scrub(a) if isinstance(a, str) else a for a in original)",
+    "replace": "                scrubbed = tuple(\"***REDACTED***\" for a in original)",
     "tests": "tests/test_log_scrubbing.py"
   }
 ]

--- a/tests/mutations/log_scrubbing.json
+++ b/tests/mutations/log_scrubbing.json
@@ -14,13 +14,6 @@
     "tests": "tests/test_log_scrubbing.py"
   },
   {
-    "label": "setup_logging stops installing the scrubbers",
-    "file": "src/pocketpaw/logging_setup.py",
-    "find": "    install_scrubbing_filters()",
-    "replace": "    pass  # scrubbers not installed",
-    "tests": "tests/test_log_scrubbing.py"
-  },
-  {
     "label": "the idempotence guard is dropped, so repeated installs stack duplicates",
     "file": "src/pocketpaw/logging_setup.py",
     "find": "            if type(scrubber) not in installed:\n                handler.addFilter(scrubber)",
@@ -42,6 +35,13 @@
     "tests": "tests/test_log_scrubbing.py"
   },
   {
+    "label": "_scrub stops substituting, so every path silently passes the secret through",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "def _scrub(text: str) -> str:\n    for pattern in _SECRET_PATTERNS:\n        text = pattern.sub(\"***REDACTED***\", text)\n    return text",
+    "replace": "def _scrub(text: str) -> str:\n    return text",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
     "label": "SecretFilter stops scrubbing record.args, so the %s form leaks",
     "file": "src/pocketpaw/logging_setup.py",
     "find": "        if record.args:\n            args = record.args if isinstance(record.args, tuple) else (record.args,)",
@@ -51,8 +51,22 @@
   {
     "label": "SecretFilter stops scrubbing record.msg, so the f-string form leaks",
     "file": "src/pocketpaw/logging_setup.py",
-    "find": "        if isinstance(record.msg, str):\n            for pattern in _SECRET_PATTERNS:\n                record.msg = pattern.sub(\"***REDACTED***\", record.msg)",
-    "replace": "        if False:\n            for pattern in _SECRET_PATTERNS:\n                record.msg = pattern.sub(\"***REDACTED***\", record.msg)",
+    "find": "        if isinstance(record.msg, str):\n            record.msg = _scrub(record.msg)",
+    "replace": "        if False:\n            record.msg = _scrub(record.msg)",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "SecretFilter stops scrubbing the traceback, so an exception leaks the key",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "        if record.exc_info:\n            if not record.exc_text:\n                record.exc_text = \"\".join(traceback.format_exception(*record.exc_info))\n            record.exc_text = _scrub(record.exc_text)",
+    "replace": "        if False:\n            record.exc_text = _scrub(record.exc_text or \"\")",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "Rich is selected even off a TTY, so it renders the raw traceback in a container",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "    return bool(getattr(sys.stderr, \"isatty\", lambda: False)())",
+    "replace": "    return True",
     "tests": "tests/test_log_scrubbing.py"
   }
 ]

--- a/tests/mutations/log_scrubbing.json
+++ b/tests/mutations/log_scrubbing.json
@@ -1,0 +1,58 @@
+[
+  {
+    "label": "the filters go back on the root LOGGER instead of its handlers (the original bug)",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "    for handler in logging.getLogger().handlers:\n        installed = {type(existing) for existing in handler.filters}\n        for scrubber in filters:\n            if type(scrubber) not in installed:\n                handler.addFilter(scrubber)",
+    "replace": "    for scrubber in filters:\n        logging.getLogger().addFilter(scrubber)",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "install_scrubbing_filters becomes a no-op",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "    filters: list[logging.Filter] = [SecretFilter()]\n    pii = _build_pii_filter()",
+    "replace": "    filters: list[logging.Filter] = []\n    pii = _build_pii_filter()",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "setup_logging stops installing the scrubbers",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "    install_scrubbing_filters()",
+    "replace": "    pass  # scrubbers not installed",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "the idempotence guard is dropped, so repeated installs stack duplicates",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "            if type(scrubber) not in installed:\n                handler.addFilter(scrubber)",
+    "replace": "            handler.addFilter(scrubber)",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "the worker supervisor reverts to basicConfig, which installs no filters",
+    "file": "ee/pocketpaw_ee/cloud/worker_supervisor.py",
+    "find": "    setup_logging(level=os.environ.get(\"POCKETPAW_LOG_LEVEL\", \"INFO\"))",
+    "replace": "    logging.basicConfig(level=logging.INFO)",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "the secret pattern list is emptied, so nothing matches",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "    re.compile(r\"sk-ant-[a-zA-Z0-9_-]+\"),  # Anthropic",
+    "replace": "    re.compile(r\"MATCHES-NOTHING-AT-ALL-XYZ\"),  # Anthropic",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "SecretFilter stops scrubbing record.args, so the %s form leaks",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "        if record.args:\n            args = record.args if isinstance(record.args, tuple) else (record.args,)",
+    "replace": "        if False:\n            args = record.args if isinstance(record.args, tuple) else (record.args,)",
+    "tests": "tests/test_log_scrubbing.py"
+  },
+  {
+    "label": "SecretFilter stops scrubbing record.msg, so the f-string form leaks",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "        if isinstance(record.msg, str):\n            for pattern in _SECRET_PATTERNS:\n                record.msg = pattern.sub(\"***REDACTED***\", record.msg)",
+    "replace": "        if False:\n            for pattern in _SECRET_PATTERNS:\n                record.msg = pattern.sub(\"***REDACTED***\", record.msg)",
+    "tests": "tests/test_log_scrubbing.py"
+  }
+]

--- a/tests/test_log_scrubbing.py
+++ b/tests/test_log_scrubbing.py
@@ -62,6 +62,51 @@ def test_a_child_logger_record_is_scrubbed(captured_root: io.StringIO) -> None:
     assert "***REDACTED***" in out
 
 
+def test_a_secret_inside_a_traceback_is_scrubbed(captured_root: io.StringIO) -> None:
+    """``logger.exception`` is used 281 times here and carries the traceback.
+
+    The filter used to touch only ``record.msg`` and ``record.args``, so a
+    provider SDK that put a key in an exception message wrote it to the log in
+    clear. That is the exact scenario the worker's logging setup exists for.
+    """
+    install_scrubbing_filters()
+
+    log = logging.getLogger("pocketpaw.agents.provider")
+    try:
+        raise RuntimeError(f"upstream rejected token {_FAKE_KEY}")
+    except RuntimeError:
+        log.exception("provider call failed")
+
+    out = captured_root.getvalue()
+    assert "Traceback" in out, "the traceback was not rendered at all; test proves nothing"
+    assert _FAKE_KEY not in out, "the key reached the log through exc_info"
+    assert "***REDACTED***" in out
+
+
+def test_a_non_tty_does_not_get_the_rich_handler() -> None:
+    """Rich renders tracebacks from exc_info and ignores the scrubbed exc_text.
+
+    On a TTY that is a developer's own screen. In a container it is the log
+    collector, so the plain handler is what keeps the traceback scrubbed there.
+    """
+    import sys
+    from unittest.mock import patch
+
+    from pocketpaw.logging_setup import _use_rich
+
+    class _Stream:
+        def __init__(self, tty: bool) -> None:
+            self._tty = tty
+
+        def isatty(self) -> bool:
+            return self._tty
+
+    with patch.object(sys, "stderr", _Stream(tty=False)):
+        assert _use_rich() is False, "a non-TTY must not select Rich"
+    with patch.object(sys, "stderr", _Stream(tty=True)):
+        assert _use_rich() is True, "a TTY should still get Rich for humans"
+
+
 def test_the_secret_is_scrubbed_when_it_is_in_the_message_itself(
     captured_root: io.StringIO,
 ) -> None:

--- a/tests/test_log_scrubbing.py
+++ b/tests/test_log_scrubbing.py
@@ -203,6 +203,28 @@ def test_the_secret_is_scrubbed_when_it_is_in_the_message_itself(
     assert "***REDACTED***" in out
 
 
+def test_a_mapping_args_record_survives_and_is_scrubbed(captured_root: io.StringIO) -> None:
+    """Named placeholders pass a Mapping, and rebuilding it as a tuple is fatal.
+
+    ``getMessage`` does ``msg % self.args``. With a mapping rebuilt as a tuple,
+    that raises "format requires a mapping" inside logging, which swallows the
+    error and DROPS the record. So the filter would not merely fail to scrub, it
+    would destroy the line — including records from third-party libraries, since
+    these filters sit on the root handler.
+    """
+    install_scrubbing_filters()
+
+    logging.getLogger("pocketpaw.some.module").info(
+        "user %(user)s presented %(key)s", {"user": "ana", "key": _FAKE_KEY}
+    )
+
+    out = captured_root.getvalue()
+    assert out.strip(), "the record was dropped instead of logged"
+    assert "user ana presented" in out, "the mapping was not applied to the template"
+    assert _FAKE_KEY not in out
+    assert "***REDACTED***" in out
+
+
 def test_installing_twice_does_not_stack_duplicate_filters(
     captured_root: io.StringIO,
 ) -> None:

--- a/tests/test_log_scrubbing.py
+++ b/tests/test_log_scrubbing.py
@@ -249,7 +249,13 @@ def test_the_worker_supervisor_calls_setup_logging_not_basicconfig() -> None:
     import inspect
     import textwrap
 
-    from pocketpaw_ee.cloud import worker_supervisor
+    # The worker supervisor is enterprise code. CI runs an OSS-only install
+    # where pocketpaw_ee is absent by design, and this assertion has nothing to
+    # say there.
+    worker_supervisor = pytest.importorskip(
+        "pocketpaw_ee.cloud.worker_supervisor",
+        reason="enterprise package not installed (OSS-only install)",
+    )
 
     tree = ast.parse(textwrap.dedent(inspect.getsource(worker_supervisor.main)))
     called = {

--- a/tests/test_log_scrubbing.py
+++ b/tests/test_log_scrubbing.py
@@ -1,0 +1,138 @@
+# test_log_scrubbing.py — the secret / PII log filters actually scrub.
+# Created: 2026-09-05 — the filters were attached to the root LOGGER, so they
+#   never ran for any record from a child logger, which is every module in the
+#   codebase. These tests log the way real code logs (getLogger(__name__)) and
+#   assert on what reaches the handler's stream, so a filter that is installed
+#   but never consulted fails them.
+
+from __future__ import annotations
+
+import io
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from pocketpaw.logging_setup import SecretFilter, install_scrubbing_filters
+
+_FAKE_KEY = "sk-ant-" + "A" * 40
+
+
+@pytest.fixture
+def captured_root() -> Iterator[io.StringIO]:
+    """Root logger with exactly one handler we can read, restored afterwards.
+
+    The root's handler list and level are process state that pytest's own
+    logging plugin also touches, so both are saved and put back.
+    """
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    saved_filters = root.filters[:]
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root.handlers = [handler]
+    root.setLevel(logging.INFO)
+    root.filters = []
+    try:
+        yield stream
+    finally:
+        root.handlers = saved_handlers
+        root.level = saved_level
+        root.filters = saved_filters
+
+
+def test_a_child_logger_record_is_scrubbed(captured_root: io.StringIO) -> None:
+    """The regression test for the bug: real modules log through a child logger.
+
+    A filter on the root LOGGER is not consulted for these records — the record
+    propagates to the root's HANDLERS, and a handler applies only its own
+    filters. This is the assertion that was missing.
+    """
+    install_scrubbing_filters()
+
+    logging.getLogger("pocketpaw.agents.some_backend").info(
+        "provider rejected the key %s", _FAKE_KEY
+    )
+
+    out = captured_root.getvalue()
+    assert _FAKE_KEY not in out, "a child logger's record reached the handler unscrubbed"
+    assert "***REDACTED***" in out
+
+
+def test_the_secret_is_scrubbed_when_it_is_in_the_message_itself(
+    captured_root: io.StringIO,
+) -> None:
+    """The filter rewrites ``record.msg`` as well as ``record.args``.
+
+    Both paths matter: ``logger.info("... %s", key)`` puts it in args, and an
+    f-string or a formatted exception message puts it in msg.
+    """
+    install_scrubbing_filters()
+
+    logging.getLogger("pocketpaw.cloud.worker").error(f"boom, using {_FAKE_KEY} upstream")
+
+    out = captured_root.getvalue()
+    assert _FAKE_KEY not in out
+    assert "***REDACTED***" in out
+
+
+def test_installing_twice_does_not_stack_duplicate_filters(
+    captured_root: io.StringIO,
+) -> None:
+    """Idempotent by filter type, so a re-init cannot pile up scrubbers."""
+    install_scrubbing_filters()
+    install_scrubbing_filters()
+    install_scrubbing_filters()
+
+    handler = logging.getLogger().handlers[0]
+    secret_filters = [f for f in handler.filters if isinstance(f, SecretFilter)]
+    assert len(secret_filters) == 1
+
+
+def test_setup_logging_leaves_the_handler_carrying_a_scrubber(
+    captured_root: io.StringIO,
+) -> None:
+    """``setup_logging`` must end with the filters on the handlers.
+
+    This is the pairing the worker depends on: the entrypoint calls
+    setup_logging and gets scrubbing as a consequence.
+    """
+    from pocketpaw.logging_setup import setup_logging
+
+    setup_logging(level="INFO")
+
+    handlers = logging.getLogger().handlers
+    assert handlers, "setup_logging installed no handler"
+    assert any(any(isinstance(f, SecretFilter) for f in h.filters) for h in handlers), (
+        "no handler carries a SecretFilter, so nothing is scrubbed"
+    )
+
+
+def test_the_worker_supervisor_calls_setup_logging_not_basicconfig() -> None:
+    """The worker entrypoint must go through setup_logging.
+
+    The worker is the process that spends money and whose provider SDKs surface
+    credentials in exception text. ``basicConfig`` gives the root a handler and
+    installs no filters, which is what this used to call.
+
+    Checked by AST over the *calls* in ``main``, not by substring: the source
+    text mentions basicConfig in a comment explaining why it is not used.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from pocketpaw_ee.cloud import worker_supervisor
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(worker_supervisor.main)))
+    called = {
+        node.func.attr if isinstance(node.func, ast.Attribute) else getattr(node.func, "id", "")
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+    }
+
+    assert "setup_logging" in called, "the worker supervisor no longer installs scrubbing"
+    assert "basicConfig" not in called, "basicConfig installs no filters; it cannot scrub"

--- a/tests/test_log_scrubbing.py
+++ b/tests/test_log_scrubbing.py
@@ -83,6 +83,85 @@ def test_a_secret_inside_a_traceback_is_scrubbed(captured_root: io.StringIO) -> 
     assert "***REDACTED***" in out
 
 
+def test_the_exception_object_itself_is_scrubbed(captured_root: io.StringIO) -> None:
+    """Renderers disagree about where they read the traceback from.
+
+    A stdlib ``Formatter`` reuses ``record.exc_text``; ``RichHandler``
+    re-renders from ``exc_info`` and ignores it; Logfire's logging handler
+    passes the raw ``exc_info`` tuple and drops ``exc_text`` as a reserved
+    attribute, and its own scrubber skips exception keys as SAFE_KEYS. So
+    scrubbing the rendered text alone protects only one of the three. The
+    exception object is the one thing all of them read.
+    """
+    install_scrubbing_filters()
+
+    log = logging.getLogger("pocketpaw.agents.provider")
+    caught: BaseException | None = None
+    try:
+        raise RuntimeError(f"upstream rejected token {_FAKE_KEY}")
+    except RuntimeError as exc:
+        caught = exc
+        log.exception("provider call failed")
+
+    assert caught is not None
+    assert _FAKE_KEY not in str(caught), "the exception still carries the key after logging"
+    assert "***REDACTED***" in str(caught)
+
+
+def test_a_second_handler_without_the_filter_still_sees_a_redacted_exception(
+    captured_root: io.StringIO,
+) -> None:
+    """This is the property the Logfire bridge depends on.
+
+    Filters are per-handler, so a handler added without one is unprotected by
+    anything attached elsewhere. Because the scrub rewrites the shared exception
+    object rather than a per-record copy, a later handler reading ``exc_info``
+    sees the redacted text regardless. That is what keeps a bridge handler safe
+    when it renders the traceback itself.
+    """
+    install_scrubbing_filters()
+
+    # A second handler, deliberately WITHOUT the filter, standing in for a
+    # bridge handler that re-renders from exc_info.
+    second = io.StringIO()
+    bridge = logging.StreamHandler(second)
+    bridge.setFormatter(logging.Formatter("%(message)s"))
+    logging.getLogger().addHandler(bridge)
+    try:
+        log = logging.getLogger("pocketpaw.agents.provider")
+        try:
+            raise RuntimeError(f"upstream rejected token {_FAKE_KEY}")
+        except RuntimeError:
+            log.exception("provider call failed")
+    finally:
+        logging.getLogger().removeHandler(bridge)
+
+    assert _FAKE_KEY not in second.getvalue(), (
+        "an unfiltered handler rendered the key; the exception object was not scrubbed"
+    )
+
+
+def test_an_exception_without_a_secret_is_left_alone(captured_root: io.StringIO) -> None:
+    """Only rewrite args when a pattern matched.
+
+    Code that inspects an exception after logging it must see exactly what it
+    raised, so the scrub must be a no-op on ordinary exceptions.
+    """
+    install_scrubbing_filters()
+
+    log = logging.getLogger("pocketpaw.agents.provider")
+    original = ("connection refused", 42)
+    caught: BaseException | None = None
+    try:
+        raise RuntimeError(*original)
+    except RuntimeError as exc:
+        caught = exc
+        log.exception("provider call failed")
+
+    assert caught is not None
+    assert caught.args == original, "an exception with no secret in it was rewritten"
+
+
 def test_a_non_tty_does_not_get_the_rich_handler() -> None:
     """Rich renders tracebacks from exc_info and ignores the scrubbed exc_text.
 


### PR DESCRIPTION
The secret and PII log filters have never scrubbed a single line, in any process, since they were added in February.

## What was wrong

Both were installed with `addFilter` on the root **logger**:

```python
logging.getLogger().addFilter(SecretFilter())
```

A filter attached to a logger is consulted only for records logged directly on that logger. `Logger.handle` applies the logger's own filters, then `callHandlers` walks up the hierarchy invoking each ancestor's **handlers**, and a handler applies only its own filters. The root logger's filters are never reached by a propagated record.

Every module in this codebase logs through `logging.getLogger(__name__)`. So every real log line took the propagated path and skipped the scrubbing entirely.

I proved this before changing anything, with a child logger and a captured handler stream. The child logger's secret was written in clear. A record logged directly on root was redacted. Same filter, same process.

## The fix

Attach to the handlers instead. `install_scrubbing_filters()` is extracted so a process that configures its own logging can call it, and it is idempotent by filter type so a re-init cannot stack duplicates.

## The worker was the worst case

The cloud worker supervisor called `basicConfig`, which gives the root a handler and installs nothing else. So the process that spends the money, and the one where provider SDKs surface credentials in exception text, was logging unredacted to stdout where the platform's log collector keeps it. It now calls `setup_logging`.

Two of the three consequences the observability audit lists for that finding were already fixed as a side effect of the worker supervisor landing last week, since `basicConfig` did at least give the root a handler. The scrubbing one, which is the dangerous one, was not.

## Log level

Both entrypoints now read `POCKETPAW_LOG_LEVEL`, defaulting to `INFO`. It was hardcoded, so raising verbosity on a running deployment meant a code change.

## Gate

`tests/mutations/log_scrubbing.json`, eight mutations, all observed to fail the tests. The first restores the original bug exactly: it puts the filters back on the root logger, and the child-logger test catches it. Repo-wide anchor validation stays green at 1086 anchors across 83 plans.

The one that matters logs the way real modules log and asserts on what reaches the handler's stream, so a filter that is installed but never consulted fails it.

## Note on scope

This is deliberately narrow and independent of the Logfire work being scoped separately. Logfire has its own scrubbing, but it is a dependency that is currently off by default, and this bug is live in every deployment today.

## Second commit: it still leaked

The first commit did not go far enough, and its own justification overclaimed. `SecretFilter` touched `record.msg` and `record.args` and never `record.exc_info`. A provider SDK that puts a key in an exception message wrote it to the log in clear, which is precisely the scenario the worker comment cites as the reason for the change. `logger.exception` is used 281 times in this tree.

I proved it with a real raise-and-log before fixing it.

The filter now renders and scrubs the traceback. `Formatter.format` renders `exc_info` only when `exc_text` is empty and reuses `exc_text` when it is set, so filling it in with a scrubbed render is what actually reaches the handler.

That fix is inert under `RichHandler`, which renders tracebacks from `exc_info` itself and ignores `exc_text`. So Rich is now selected only when stderr is a TTY. A developer's terminal is unchanged. In a container the plain handler is what keeps the traceback scrubbed, and it carries a timestamp, level and logger name that the previous fallback did not.

This also matters for the Logfire work being scoped separately. Logfire's default scrubbing is a list of **keywords**, not credential formats, so `sk-ant-`, `xoxb-` and `pp_` match none of it. Its `SAFE_KEYS` allowlist passes `logfire.msg`, `exception.message` and `exception.stacktrace` through untouched, and the stdlib logging bridge puts the formatted message into exactly that key. So these filters are not made redundant by adopting Logfire. They are the only thing standing in front of it.

## Gate

Ten mutations, all observed to fail. Two are new, covering the traceback and the TTY choice. One existing anchor had rotted against my own edit and was repointed, which is the failure mode this repo has been bitten by before. Repo-wide validation is green at 1088 anchors across 83 plans.

## Test status

Seven tests in the new file, all passing.

Two failures in `tests/test_credentials.py` are pre-existing and unrelated. They assert `agent_backend == "claude_agent_sdk"`, the core default, but the enterprise package sets `CLOUD_DEFAULT_AGENT_BACKEND = "pydantic_ai"` and overrides it at import. So they fail on any full `--group ee` install and pass on an OSS-only one. This branch touches five files and none of them is `config.py`.
