### PR TITLE
Send everything to Logfire, off by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -276,6 +276,13 @@
 # a side effect of turning on observability. Off, you still get model, token
 # counts, latency and tool names -- enough to diagnose a cost or a slowdown.
 # POCKETPAW_LOGFIRE_INCLUDE_CONTENT=false
+#
+# What gets instrumented. Unset means everything: pydantic_ai, claude_agent_sdk,
+# anthropic, openai, mcp, httpx, aiohttp_client, redis, pymongo, system_metrics,
+# plus a span per HTTP request. Set a comma-separated list to narrow it, or
+# "none" to keep the logs and drop every span. Spans are metered per unit, so
+# this is the knob for trimming a bill without a code deploy.
+# POCKETPAW_LOGFIRE_INSTRUMENT=
 
 # -- Console log level -------------------------------------
 # Read from the environment by both entrypoints, so verbosity can be raised on a

--- a/.env.example
+++ b/.env.example
@@ -245,3 +245,39 @@
 #   Dynamic svelte is never routed to the lane whatever this says: its artifact is
 #   worker-rendered and cannot serve from a tar.
 #   Caveat before enabling — docs/internal/2026-05-resumable-runs-deploy.md.
+
+# -- Observability (Pydantic Logfire) ----------------------
+# Master switch. Everything below is inert unless this is truthy ("1", "true",
+# "yes", "on"). With it unset the process logs exactly as it does today and no
+# telemetry leaves the box.
+# POCKETPAW_LOGFIRE_ENABLED=false
+#
+# The project WRITE token, from the Logfire UI under "Add data". Region-bound: a
+# token issued in the EU project sends to the EU account, a US one to the US
+# account, and there is no migration between them. WITHOUT A TOKEN NOTHING IS
+# EXPORTED -- and the spans are still built and thrown away, so turning the
+# switch on with no token is not free and not useful.
+# LOGFIRE_TOKEN=
+#
+# Bring your own backend instead: set an OTLP endpoint and the same spans go to
+# your own collector, with no Logfire account involved. Independent of the token.
+# OTEL_EXPORTER_OTLP_ENDPOINT=
+#
+# Tags every span, so an alert can fire on prod and stay quiet for staging.
+# LOGFIRE_ENVIRONMENT=development
+#
+# Set this PER SERVICE. The backend and the worker run the same image and share
+# this file, so without it they are one indistinguishable service in every query.
+# LOGFIRE_SERVICE_NAME=pocketpaw
+#
+# Whether agent PROMPTS AND COMPLETIONS are sent. Off here, on in Logfire's own
+# default, and this inverts it deliberately: Logfire does not scrub message
+# content at all, so leaving it on ships customer chat text to a hosted store as
+# a side effect of turning on observability. Off, you still get model, token
+# counts, latency and tool names -- enough to diagnose a cost or a slowdown.
+# POCKETPAW_LOGFIRE_INCLUDE_CONTENT=false
+
+# -- Console log level -------------------------------------
+# Read from the environment by both entrypoints, so verbosity can be raised on a
+# running deployment without a code change. DEBUG / INFO / WARNING / ERROR.
+# POCKETPAW_LOG_LEVEL=INFO

--- a/docs/deployment/self-hosting.mdx
+++ b/docs/deployment/self-hosting.mdx
@@ -222,6 +222,34 @@ POCKETPAW_WEB_PORT=8888
 POCKETPAW_TOOL_PROFILE=coding
 ```
 
+### Observability (optional)
+
+PocketPaw can send its logs and its agent traces to [Pydantic Logfire](https://pydantic.dev/docs/logfire/),
+or to any OpenTelemetry collector you already run. It is off unless you turn it on.
+
+```bash
+POCKETPAW_LOGFIRE_ENABLED=true
+LOGFIRE_TOKEN=...              # or OTEL_EXPORTER_OTLP_ENDPOINT for your own collector
+LOGFIRE_SERVICE_NAME=pocketpaw # set this per service if you run web and worker separately
+LOGFIRE_ENVIRONMENT=prod
+```
+
+Two things are worth knowing before you turn it on.
+
+**Nothing is exported without a destination.** With the switch on but no
+`LOGFIRE_TOKEN` and no `OTEL_EXPORTER_OTLP_ENDPOINT`, the spans are still built
+and then dropped. That costs a little and buys nothing, so set one or leave the
+switch off.
+
+**Agent prompts and completions are excluded by default.** Logfire's own default
+is to include them, and it does not scrub message content. PocketPaw inverts that
+default: you get the model, token counts, latency and tool names without the
+customer's text leaving your network. Set `POCKETPAW_LOGFIRE_INCLUDE_CONTENT=true`
+if you want the prompts too, and decide where your data is allowed to live first.
+
+Log messages and tracebacks are scrubbed for credential formats and, when PII
+scanning is on, for personal data, before any of it reaches an exporter.
+
 ### Security Hardening
 
 1. **Run as a dedicated user** -- Don't run as root

--- a/docs/deployment/self-hosting.mdx
+++ b/docs/deployment/self-hosting.mdx
@@ -234,7 +234,12 @@ LOGFIRE_SERVICE_NAME=pocketpaw # set this per service if you run web and worker 
 LOGFIRE_ENVIRONMENT=prod
 ```
 
-Two things are worth knowing before you turn it on.
+With it on you get a span per HTTP request labelled by route, every outbound
+call the process makes, the agent runs with their models and token counts, the
+Redis queues, the Mongo queries, and the container's own CPU, memory and disk.
+That is the point: it is meant to replace reading container logs by hand.
+
+Three things are worth knowing before you turn it on.
 
 **Nothing is exported without a destination.** With the switch on but no
 `LOGFIRE_TOKEN` and no `OTEL_EXPORTER_OTLP_ENDPOINT`, the spans are still built
@@ -247,8 +252,19 @@ default: you get the model, token counts, latency and tool names without the
 customer's text leaving your network. Set `POCKETPAW_LOGFIRE_INCLUDE_CONTENT=true`
 if you want the prompts too, and decide where your data is allowed to live first.
 
+**Spans are metered per unit.** If one integration turns out to dominate the
+bill, `POCKETPAW_LOGFIRE_INSTRUMENT` takes a comma-separated list of the ones to
+keep, or `none` to keep the logs and drop every span. No code change needed.
+
+```bash
+POCKETPAW_LOGFIRE_INSTRUMENT=pydantic_ai,httpx,system_metrics
+```
+
 Log messages and tracebacks are scrubbed for credential formats and, when PII
-scanning is on, for personal data, before any of it reaches an exporter.
+scanning is on, for personal data, before any of it reaches an exporter. Request
+and response headers, HTTP bodies and Redis statements are never captured, since
+those carry bearer tokens and customer content. The health and version routes are
+not traced, so a container probe does not bill for itself.
 
 ### Security Hardening
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,11 +191,32 @@ pydantic-ai = [
     "pydantic-ai-skills==1.3.0",
     # Observability. Pydantic's own OpenTelemetry platform, and the thing that
     # turns "the model feels slow" into a span with a number on it. Optional at
-    # runtime: the Instrumentation capability is only wired when a token is
-    # configured, so an install that never sets one pays nothing. Ranged rather
-    # than pinned because it is a 4.x line on a normal cadence, unlike the
-    # pre-1.0-shaped packages above.
-    "logfire>=4.39.0,<5",
+    # runtime: nothing is configured unless POCKETPAW_LOGFIRE_ENABLED is set, so
+    # an install that never sets it pays nothing. Ranged rather than pinned
+    # because it is a 4.x line on a normal cadence, unlike the pre-1.0-shaped
+    # packages above.
+    #
+    # THE EXTRAS ARE THE INSTRUMENTORS. Each one is a thin
+    # `opentelemetry-instrumentation-*` package that logfire dispatches to;
+    # without it `logfire.instrument_fastapi()` raises at runtime telling you to
+    # install exactly this. They are declared HERE rather than in an extra of
+    # their own so there is one logfire version spec in this file: `[all]`
+    # already self-references `pocketpaw[pydantic-ai]` for the same reason, and
+    # the deployed image builds from `[all]`.
+    #
+    # Which ones and why: fastapi is a span per request with its route and
+    # status; httpx is the whole outbound surface, so a slow model call and a
+    # slow sandbox stop reading identically; redis is the arq queues and the run
+    # stream; pymongo covers Mongo under motor and beanie; system-metrics is the
+    # container's own CPU, memory and disk, which is what answers "was it the
+    # code or the box". Every instrumentor is inert until something calls it, so
+    # an install that never enables Logfire carries a few hundred KB of unused
+    # pure Python and nothing else.
+    #
+    # NOT included: sqlite3 and sqlalchemy. Fabric, Instinct, the audit log and
+    # the ledger all run on SQLite, and a span per statement would dominate the
+    # bill for little over the operation span already wrapping them.
+    "logfire[fastapi,httpx,redis,pymongo,system-metrics]>=4.39.0,<5",
 ]
 pydantic-ai-evals = [
     # Evaluation harness, kept OUT of the runtime extra on purpose: it is a

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -7,6 +7,11 @@ self-hosted LiteLLM proxy.
 
 Design source: ``docs/design/drafts/2026-07-29-pydantic-ai-agent-backend-prd.md``.
 
+Changed 2026-09-05: this file no longer calls ``logfire.configure`` itself. That
+call is process-global and this file is not — see
+``_build_instrumentation_capability``. It now delegates to
+``pocketpaw.observability.configure_observability``, which startup calls first.
+
 Why this exists: ``claude_agent_sdk`` spawns a Claude Code CLI Node subprocess
 per concurrent run (~300-500 MB RSS). At the 300-400 concurrent-user target
 that is ~75 GB of agent RSS before any other cost. This backend runs the agent
@@ -450,10 +455,6 @@ _POCKET_SCOPE_SENTINEL = "<pocket-scope>"
 _SKILLS_CAPABILITY_ID = "pocketpaw-skills"
 
 # Bounds on the per-session transcript cache (see ``_session_messages``).
-# ``logfire.configure`` is process-global and one backend instance exists per
-# agent, so the capability builder would otherwise reconfigure it per agent.
-_LOGFIRE_CONFIGURED = False
-
 _MAX_TRACKED_SESSIONS = 200
 _MAX_SESSION_MESSAGES = 60
 
@@ -1803,11 +1804,13 @@ class PydanticAIBackend:
         is still unrun. Spans are what make that measurable from the inside
         rather than by wrapping a stopwatch around the whole request.
 
-        ``logfire.configure`` is called with ``send_to_logfire='if-token-present'``
-        so this is safe to enable on a deployment with no Logfire account: the
-        spans go to whatever OTel exporter is already configured, or nowhere.
-        Configuration is process-global and guarded by a module flag, because
-        one instance per agent means this method runs many times.
+        Logfire is configured at STARTUP now, by ``setup_logging``, because
+        ``logfire.configure`` is process-global and this method is not: it runs
+        once per agent, and only in a process that actually builds a pydantic-ai
+        agent — which with ``POCKETPAW_CLOUD_RUN_EXECUTOR=arq`` is the worker and
+        never the web process. The call kept here is the fallback for a process
+        that never ran ``setup_logging`` at all (tests, library use, anything
+        embedding the backend), and it is a no-op when startup already did it.
         """
         if not getattr(self.settings, "pydantic_ai_instrumentation", False):
             return None
@@ -1816,21 +1819,11 @@ class PydanticAIBackend:
         except ImportError:  # pragma: no cover - pydantic-ai too old
             return None
 
-        global _LOGFIRE_CONFIGURED
-        if not _LOGFIRE_CONFIGURED:
-            _LOGFIRE_CONFIGURED = True
-            try:
-                import logfire
+        # Never load-bearing: configure_observability swallows its own failures,
+        # so a misconfigured exporter cannot stop a tenant's run.
+        from pocketpaw.observability import configure_observability
 
-                logfire.configure(
-                    send_to_logfire="if-token-present",
-                    service_name="pocketpaw-pydantic-ai",
-                    console=False,
-                )
-            except Exception as exc:  # noqa: BLE001
-                # Instrumentation is observability, never load-bearing: a
-                # misconfigured exporter must not stop a tenant's run.
-                logger.warning("Could not configure logfire, spans stay local: %s", exc)
+        configure_observability()
         return Instrumentation()
 
     def _build_web_capabilities(self) -> list:

--- a/src/pocketpaw/api/serve.py
+++ b/src/pocketpaw/api/serve.py
@@ -1,5 +1,9 @@
 """API server for ``pocketpaw serve``.
 
+Changed 2026-09-05: the app is handed to ``instrument_fastapi_app`` after the
+routers are mounted, so a deployed request has a span with its route, status and
+duration on it. Off unless POCKETPAW_LOGFIRE_ENABLED is set.
+
 Starts the versioned ``/api/v1/`` routers **and** a ``/ws`` WebSocket endpoint
 with auth middleware and CORS — no web dashboard frontend assets.  Ideal for
 external clients (Tauri desktop app, scripts) that provide their own UI.
@@ -164,6 +168,15 @@ def create_api_app():
     ):
         """WebSocket v1 short path — for clients using /v1/ws."""
         await _handle_ws(websocket, token, resume_session)
+
+    # --- Request tracing (last) ------------------------------------------
+    # After every router is mounted, because the instrumentor reads the route
+    # table to label a span by route TEMPLATE. Instrument before mounting and
+    # /api/v1/pockets/{id} becomes one span name per pocket id. No-op unless
+    # POCKETPAW_LOGFIRE_ENABLED is set.
+    from pocketpaw.observability import instrument_fastapi_app
+
+    instrument_fastapi_app(app)
 
     return app
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -760,11 +760,14 @@ class Settings(BaseSettings):
         default=False,
         description=(
             "Emit OpenTelemetry spans for Pydantic AI agent runs (model "
-            "requests, tool calls, token usage, time to first chunk). Calls "
-            "``logfire.configure`` once per process with "
-            "``send_to_logfire='if-token-present'``, so without a LOGFIRE_TOKEN "
-            "the spans stay local and reach whatever OTel exporter is already "
-            "configured. Off by default. Cheap since pydantic-ai 2.17.0, which "
+            "requests, tool calls, token usage, time to first chunk). Logfire "
+            "is configured at startup with ``send_to_logfire='if-token-present'``, "
+            "so this is safe to enable on a deployment with no Logfire account. "
+            "Be clear about where the spans then go: NOWHERE. Without a "
+            "LOGFIRE_TOKEN or an OTEL_EXPORTER_OTLP_ENDPOINT the span processor "
+            "list is empty, and the spans are still built and serialized before "
+            "being dropped, so this is not free. Off by default. Cheap since "
+            "pydantic-ai 2.17.0, which "
             "caches per-message span serialization — before that it was O(n^2) "
             "over a run's history and a long tool loop paid for it."
         ),

--- a/src/pocketpaw/dashboard.py
+++ b/src/pocketpaw/dashboard.py
@@ -1734,6 +1734,15 @@ def run_dashboard(
     """
     global _uvicorn_server, _restart_requested
 
+    # Request tracing, here rather than beside the app object: this module keeps
+    # registering routes with decorators all the way to the bottom of the file, and
+    # the instrumentor reads the route table to name spans by route TEMPLATE. By
+    # the time run_dashboard is called the whole module has been imported and every
+    # decorator has run. No-op unless POCKETPAW_LOGFIRE_ENABLED is set.
+    from pocketpaw.observability import instrument_fastapi_app
+
+    instrument_fastapi_app(app)
+
     _MAX_RESTARTS = 5
     _restart_count = 0
     first_run = True

--- a/src/pocketpaw/logging_setup.py
+++ b/src/pocketpaw/logging_setup.py
@@ -3,6 +3,18 @@ Beautiful logging setup using Rich.
 
 Created: 2026-02-02
 Changes:
+  - 2026-09-05: setup_logging can now also send the same records to Pydantic
+    Logfire, behind POCKETPAW_LOGFIRE_ENABLED and off by default. The bridge
+    handler is ADDED to the root's handler list, never installed via
+    basicConfig(handlers=[...]) as Logfire's own docs suggest — that replaces the
+    list and deletes the console handler the scrubbers are attached to. The order
+    is load-bearing and is the reason _install_observability exists: the bridge
+    goes on first, then install_scrubbing_filters() walks the handlers, so the
+    bridge carries the scrubbers too. It is the handler where an unscrubbed line
+    stops being a local stdout leak and becomes an exfiltrated one, because
+    Logfire never scrubs a log message itself (``logfire.msg`` is the first entry
+    in its SAFE_KEYS allowlist) and its default patterns match credential
+    KEYWORDS, not credential formats.
   - 2026-09-05: SecretFilter now scrubs the EXCEPTION and its traceback, not
     just the message and args. A provider SDK that puts a key in an exception
     reached the log through exc_info, which the filter ignored entirely, and
@@ -53,6 +65,17 @@ def _scrub(text: str) -> str:
     for pattern in _SECRET_PATTERNS:
         text = pattern.sub("***REDACTED***", text)
     return text
+
+
+def secret_pattern_strings() -> list[str]:
+    """The credential regexes as plain strings.
+
+    ``logfire.ScrubbingOptions(extra_patterns=...)`` takes a ``Sequence[str]``,
+    not compiled patterns, and passing the compiled objects raises inside
+    logfire — where our own try/except would swallow it and leave Logfire
+    silently unconfigured in production while every mocked test stayed green.
+    """
+    return [pattern.pattern for pattern in _SECRET_PATTERNS]
 
 
 def scrub_log_args(args: Any, scrub: Callable[[str], str]) -> Any:
@@ -182,6 +205,31 @@ def install_scrubbing_filters() -> None:
                 handler.addFilter(scrubber)
 
 
+def _install_observability(level: str) -> None:
+    """Wire Logfire (when enabled), then the scrubbers. THE ORDER IS THE POINT.
+
+    ``install_scrubbing_filters()`` walks the root logger's handler list, so any
+    handler added after it runs carries no scrubbers. The Logfire bridge is
+    precisely the handler that must not be missed: Logfire's own scrubber never
+    looks at a log message (``logfire.msg`` is a SAFE_KEY) and never looks at an
+    exception (``exception.message`` / ``exception.stacktrace`` are SAFE_KEYS
+    too), so our filters are the only thing standing in front of it.
+
+    Imported lazily so this module keeps no import-time dependency on logfire,
+    which lives in the ``pydantic-ai`` extra rather than the base requirements.
+    """
+    from pocketpaw.observability import (
+        configure_observability,
+        install_logfire_bridge,
+        logfire_enabled,
+    )
+
+    if logfire_enabled():
+        configure_observability()
+        install_logfire_bridge(level)
+    install_scrubbing_filters()
+
+
 def _use_rich() -> bool:
     """Rich only for a human at a terminal.
 
@@ -218,7 +266,7 @@ def setup_logging(level: str = "INFO") -> None:
         )
         for noisy in ("httpx", "httpcore", "urllib3", "asyncio", "websockets"):
             logging.getLogger(noisy).setLevel(logging.WARNING)
-        install_scrubbing_filters()
+        _install_observability(level)
         return
 
     try:
@@ -261,4 +309,4 @@ def setup_logging(level: str = "INFO") -> None:
         )
         logging.warning("Rich not installed, using basic logging")
 
-    install_scrubbing_filters()
+    _install_observability(level)

--- a/src/pocketpaw/observability.py
+++ b/src/pocketpaw/observability.py
@@ -1,0 +1,217 @@
+# src/pocketpaw/observability.py — Logfire configuration for the whole process.
+#
+# Created 2026-09-05. Two jobs, both of them process-wide:
+#
+#   1. configure_observability() — call ``logfire.configure`` ONCE, at startup.
+#      It used to live inside PydanticAIBackend._build_instrumentation_capability,
+#      which is wrong in four ways: it is gated on a pydantic-ai feature flag, so
+#      the logging bridge could not be turned on independently; it only fires in a
+#      process that actually constructs a pydantic-ai agent, and with
+#      POCKETPAW_CLOUD_RUN_EXECUTOR=arq the web process enqueues and never builds
+#      one, so on the deployed stack it ran in the worker and never in the backend;
+#      its service_name was the literal "pocketpaw-pydantic-ai", and both
+#      containers run the SAME image, so the two would be one indistinguishable
+#      service; and it ran late, as a side effect of construction, after the
+#      process was already serving. Here it is called from setup_logging(), which
+#      is the one function both entrypoints already run first.
+#
+#      configure_observability() also instruments pydantic-ai globally, via
+#      logfire.instrument_pydantic_ai(), so an agent run emits spans wherever it is
+#      built rather than only where a capability was wired. That is safe alongside
+#      the per-agent Instrumentation capability the pydantic-ai backend can add:
+#      pydantic-ai 2.18 injects the global one only when the run's capability list
+#      does not already carry an InstrumentationCap (agent/__init__.py:1368), so
+#      the two cannot double up.
+#
+#   2. install_logfire_bridge() — add Logfire's stdlib logging handler to the root
+#      ADDITIVELY. Not via basicConfig(handlers=[...]), which the Logfire docs
+#      suggest and which would delete the console handler — and with it the
+#      handler that install_scrubbing_filters() attaches the scrubbers to.
+#
+# BOTH ARE INERT UNLESS POCKETPAW_LOGFIRE_ENABLED IS TRUTHY. Turning it on with no
+# LOGFIRE_TOKEN and no OTEL_EXPORTER_OTLP_ENDPOINT is not free and not useful:
+# logfire builds a real TracerProvider with zero span processors, so spans are
+# constructed, serialized and dropped. There is no short-circuit for traces the way
+# there is for metrics.
+"""Process-wide observability wiring (Pydantic Logfire)."""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+#: Values that count as "on" for POCKETPAW_LOGFIRE_ENABLED. Spelled out because
+#: ``bool(os.environ.get(...))`` makes the string "false" truthy, which is the
+#: classic way an off switch turns out to be a decoration.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+# ``logfire.configure`` is process-global. The guard is module state rather than a
+# parameter because two independent callers reach it — setup_logging() at startup,
+# and the pydantic-ai backend as a fallback for a process that never ran
+# setup_logging (tests, library use, anything embedding the backend).
+_CONFIGURED = False
+
+
+def _env_flag(name: str, default: str = "") -> bool:
+    return os.environ.get(name, default).strip().lower() in _TRUTHY
+
+
+def logfire_enabled() -> bool:
+    """The master switch, read straight from the environment.
+
+    Not a pydantic setting. ``setup_logging`` runs before settings are reliably
+    loadable, and this follows the same precedent as ``POCKETPAW_LOG_LEVEL``,
+    which both entrypoints read from ``os.environ`` for exactly that reason.
+    """
+    return _env_flag("POCKETPAW_LOGFIRE_ENABLED")
+
+
+def logfire_include_content() -> bool:
+    """Whether agent PROMPTS AND COMPLETIONS are sent to Logfire. Off by default.
+
+    Logfire's own default is on, and this deliberately inverts it. Logfire does
+    not scrub message content at all — every ``gen_ai.*`` message key is in its
+    SAFE_KEYS allowlist, on the reasoning that an LLM prompt is the thing you most
+    want to read when a run goes wrong. That is right for a debugging session and
+    it is a data-residency decision for a product: with it on, customer chat text
+    leaves the network and lands in a hosted store.
+
+    Off, the spans still carry model, token counts, latency and tool names, which
+    is what makes a cost or a slowdown diagnosable. On, they also carry what the
+    customer typed.
+    """
+    return _env_flag("POCKETPAW_LOGFIRE_INCLUDE_CONTENT")
+
+
+def logfire_extra_scrub_patterns() -> list[str]:
+    """Our credential regexes, in the form ``ScrubbingOptions`` wants.
+
+    Logfire's own ``DEFAULT_PATTERNS`` are KEYWORD patterns — "password", "secret",
+    "api[._ -]?key" — so they match an attribute *named* like a credential and
+    match none of the credential FORMATS this codebase actually handles.
+    ``sk-ant-``, ``xoxb-`` and ``pp_`` hit nothing in that list.
+
+    This closes the attribute side. The message side is closed by ``SecretFilter``
+    running as a logging filter before emit, because the formatted message lands in
+    ``logfire.msg``, which is the first entry in Logfire's SAFE_KEYS allowlist and
+    is never scrubbed by Logfire itself.
+    """
+    from pocketpaw.logging_setup import secret_pattern_strings
+
+    return secret_pattern_strings()
+
+
+def configure_observability() -> bool:
+    """Configure Logfire once per process. True when it is configured.
+
+    Never raises. Observability is not load-bearing: a bad token or an unreachable
+    exporter must not stop a tenant's run or a container's boot.
+    """
+    global _CONFIGURED
+    if _CONFIGURED:
+        return True
+    try:
+        import logfire
+    except ImportError:
+        # logfire lives in the ``pydantic-ai`` EXTRA, not the base dependency
+        # list, so a bare ``pip install pocketpaw`` does not have it.
+        return False
+
+    _CONFIGURED = True
+    try:
+        logfire.configure(
+            # From the environment because the backend and the worker run the
+            # SAME image. A literal here makes them one service in every query.
+            service_name=os.environ.get("LOGFIRE_SERVICE_NAME", "pocketpaw"),
+            environment=os.environ.get("LOGFIRE_ENVIRONMENT", "development"),
+            # Safe with no account: with no token and no OTEL_EXPORTER_OTLP_*
+            # endpoint, nothing is exported.
+            send_to_logfire="if-token-present",
+            # Logfire's OWN console span exporter, which would print an indented
+            # span tree to stderr next to every log line. Nothing to do with the
+            # Rich handler, which is a stdlib logging handler Logfire never touches.
+            console=False,
+            # The default EXTRACTS an incoming traceparent header. On an
+            # internet-facing API that lets any caller graft spans onto our traces.
+            distributed_tracing=False,
+            scrubbing=logfire.ScrubbingOptions(extra_patterns=logfire_extra_scrub_patterns()),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not configure logfire: %s", exc)
+        return False
+
+    instrument_pydantic_ai()
+    return True
+
+
+def instrument_pydantic_ai() -> bool:
+    """Instrument every pydantic-ai agent in this process. True when it happened.
+
+    ``Agent.instrument_all`` under the hood, so an agent built anywhere emits run,
+    model-request and tool-call spans — not only one built through a code path that
+    remembered to pass the capability.
+
+    No double-instrumentation: pydantic-ai resolves the global settings into an
+    ``InstrumentationCap`` at run time and inserts it only when the run's capability
+    list does not already have one, so an agent carrying the backend's explicit
+    ``Instrumentation()`` capability is instrumented once, by its own.
+
+    Content is excluded unless ``POCKETPAW_LOGFIRE_INCLUDE_CONTENT`` says otherwise
+    — see ``logfire_include_content``.
+    """
+    try:
+        import logfire
+    except ImportError:
+        return False
+    # find_spec rather than ``import pydantic_ai``: an existence check should not
+    # execute a heavy package, and pydantic-ai is an extra too — a deployment on
+    # another agent backend has no agents to instrument.
+    if importlib.util.find_spec("pydantic_ai") is None:
+        return False
+    include_content = logfire_include_content()
+    try:
+        logfire.instrument_pydantic_ai(
+            include_content=include_content,
+            include_binary_content=include_content,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not instrument pydantic-ai: %s", exc)
+        return False
+    return True
+
+
+def install_logfire_bridge(level: str = "INFO") -> bool:
+    """Add Logfire's logging handler to the root logger, alongside the existing ones.
+
+    The caller must run ``install_scrubbing_filters()`` AFTER this. That function
+    walks the root's handler list, so a handler added later carries no scrubbers —
+    and this is the handler where an unscrubbed line stops being a local stdout
+    leak and becomes an exfiltrated one.
+
+    ``fallback=NullHandler()`` because the default is a ``StreamHandler`` on
+    stderr, used while instrumentation is suppressed — which is exactly during
+    Logfire's own export request. With the console handler already on stderr that
+    shows up as occasional duplicated lines.
+    """
+    try:
+        from logfire.integrations.logging import LogfireLoggingHandler
+    except ImportError:
+        return False
+
+    root = logging.getLogger()
+    if any(isinstance(handler, LogfireLoggingHandler) for handler in root.handlers):
+        return True
+    try:
+        root.addHandler(
+            LogfireLoggingHandler(
+                level=getattr(logging, level.upper(), logging.INFO),
+                fallback=logging.NullHandler(),
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Could not install the logfire logging bridge: %s", exc)
+        return False
+    return True

--- a/src/pocketpaw/observability.py
+++ b/src/pocketpaw/observability.py
@@ -1,6 +1,6 @@
 # src/pocketpaw/observability.py — Logfire configuration for the whole process.
 #
-# Created 2026-09-05. Two jobs, both of them process-wide:
+# Created 2026-09-05. Three jobs, all of them process-wide:
 #
 #   1. configure_observability() — call ``logfire.configure`` ONCE, at startup.
 #      It used to live inside PydanticAIBackend._build_instrumentation_capability,
@@ -15,21 +15,23 @@
 #      process was already serving. Here it is called from setup_logging(), which
 #      is the one function both entrypoints already run first.
 #
-#      configure_observability() also instruments pydantic-ai globally, via
-#      logfire.instrument_pydantic_ai(), so an agent run emits spans wherever it is
-#      built rather than only where a capability was wired. That is safe alongside
-#      the per-agent Instrumentation capability the pydantic-ai backend can add:
-#      pydantic-ai 2.18 injects the global one only when the run's capability list
-#      does not already carry an InstrumentationCap (agent/__init__.py:1368), so
-#      the two cannot double up.
+#   2. instrument_everything() — attach every integration in _instrumentations():
+#      the agent backends, the HTTP clients, Redis, Mongo, MCP, and host metrics.
+#      FastAPI is the exception, because it needs the app object, so it has its own
+#      entry point in instrument_fastapi_app().
 #
-#   2. install_logfire_bridge() — add Logfire's stdlib logging handler to the root
+#      Global pydantic-ai instrumentation is safe alongside the per-agent
+#      Instrumentation capability the backend can add: pydantic-ai 2.18 injects the
+#      global one only when the run's capability list does not already carry an
+#      InstrumentationCap (agent/__init__.py:1368), so the two cannot double up.
+#
+#   3. install_logfire_bridge() — add Logfire's stdlib logging handler to the root
 #      ADDITIVELY. Not via basicConfig(handlers=[...]), which the Logfire docs
 #      suggest and which would delete the console handler — and with it the
 #      handler that install_scrubbing_filters() attaches the scrubbers to.
 #
-# BOTH ARE INERT UNLESS POCKETPAW_LOGFIRE_ENABLED IS TRUTHY. Turning it on with no
-# LOGFIRE_TOKEN and no OTEL_EXPORTER_OTLP_ENDPOINT is not free and not useful:
+# ALL OF IT IS INERT UNLESS POCKETPAW_LOGFIRE_ENABLED IS TRUTHY. Turning it on with
+# no LOGFIRE_TOKEN and no OTEL_EXPORTER_OTLP_ENDPOINT is not free and not useful:
 # logfire builds a real TracerProvider with zero span processors, so spans are
 # constructed, serialized and dropped. There is no short-circuit for traces the way
 # there is for metrics.
@@ -40,6 +42,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +50,11 @@ logger = logging.getLogger(__name__)
 #: ``bool(os.environ.get(...))`` makes the string "false" truthy, which is the
 #: classic way an off switch turns out to be a decoration.
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+#: Routes excluded from FastAPI request spans. The compose healthcheck curls
+#: ``/api/v1/version`` every 30 seconds in both containers, which is thousands of
+#: metered spans a day saying nothing a container status does not already say.
+_UNTRACED_ROUTES = r"/api/v1/version,/api/v1/health"
 
 # ``logfire.configure`` is process-global. The guard is module state rather than a
 # parameter because two independent callers reach it — setup_logging() at startup,
@@ -104,6 +112,179 @@ def logfire_extra_scrub_patterns() -> list[str]:
     return secret_pattern_strings()
 
 
+def _pydantic_ai_instrumentation() -> None:
+    """Instrument every pydantic-ai agent in this process.
+
+    ``Agent.instrument_all`` under the hood, so an agent built anywhere emits run,
+    model-request and tool-call spans — not only one built through a code path that
+    remembered to pass the capability.
+
+    No double-instrumentation: pydantic-ai resolves the global settings into an
+    ``InstrumentationCap`` at run time and inserts it only when the run's capability
+    list does not already have one, so an agent carrying the backend's explicit
+    ``Instrumentation()`` capability is instrumented once, by its own.
+
+    Content is excluded unless ``POCKETPAW_LOGFIRE_INCLUDE_CONTENT`` says otherwise
+    — see ``logfire_include_content``.
+
+    Raises rather than returning a flag; ``_instrument`` is what swallows it.
+    """
+    import logfire
+
+    # find_spec rather than ``import pydantic_ai``: an existence check should not
+    # execute a heavy package, and pydantic-ai is an extra too — a deployment on
+    # another agent backend has no agents to instrument.
+    if importlib.util.find_spec("pydantic_ai") is None:
+        raise RuntimeError("pydantic-ai is not installed")
+    include_content = logfire_include_content()
+    logfire.instrument_pydantic_ai(
+        include_content=include_content,
+        include_binary_content=include_content,
+    )
+
+
+def _instrumentations() -> dict[str, Any]:
+    """Everything instrumented at startup, by name.
+
+    Built lazily because every value closes over ``logfire``, and importing it at
+    module scope would put a ``pydantic-ai``-extra dependency in the import path of
+    a base install.
+
+    The keyword arguments are data decisions, not taste ones:
+
+    * ``capture_headers=False`` everywhere. Headers carry ``Authorization``, our
+      own API keys and session cookies, and Logfire's scrubber matches attribute
+      NAMES against a keyword list, so a bearer token under a header name it does
+      not recognise would go straight through.
+    * ``capture_request_body`` / ``capture_response_body`` stay off on httpx.
+      Those bodies are the customer's prompts and the model's completions.
+    * ``capture_statement=False`` on Redis. The statement carries the job payload,
+      which for the chat lane is the conversation.
+
+    Not here: sqlite3 and sqlalchemy. Fabric, Instinct, the audit log and the
+    ledger all run on SQLite and would emit a span per statement, which adds little
+    over the operation span already wrapping them and would dominate the bill.
+    ``POCKETPAW_LOGFIRE_INSTRUMENT`` can name them back in.
+    """
+    import logfire
+
+    return {
+        # --- Agent backends. The reason any of this exists. ---
+        "pydantic_ai": _pydantic_ai_instrumentation,
+        "claude_agent_sdk": logfire.instrument_claude_agent_sdk,
+        "anthropic": logfire.instrument_anthropic,
+        "openai": logfire.instrument_openai,
+        # Tool calls out to MCP servers, which is where an agent's side effects
+        # actually happen.
+        "mcp": logfire.instrument_mcp,
+        # --- Everything the process talks to. ---
+        # httpx is the whole outbound surface: the LiteLLM proxy, provider APIs,
+        # Daytona, webhooks. A slow model request and a slow sandbox read
+        # identically in a log line and are one attribute apart in a span.
+        "httpx": lambda: logfire.instrument_httpx(capture_headers=False),
+        "aiohttp_client": logfire.instrument_aiohttp_client,
+        # The arq queues and the run stream transport.
+        "redis": lambda: logfire.instrument_redis(capture_statement=False),
+        # Mongo, under both motor and beanie.
+        "pymongo": logfire.instrument_pymongo,
+        # --- The host. Metrics rather than spans, so close to free. ---
+        # CPU, memory, disk and network for the container itself, which answers
+        # "was it the code or was it the box" without an SSH session.
+        "system_metrics": logfire.instrument_system_metrics,
+    }
+
+
+def _instrument(name: str, call: Any) -> bool:
+    """Run one instrumentation, and never let it take the process down.
+
+    A missing optional package is the expected case, not a fault: the OTel
+    instrumentors ride on the ``pydantic-ai`` extra's logfire spec, and an install
+    without them should lose spans, never fail to boot. So a
+    per-integration failure is DEBUG while the summary of what attached is INFO.
+    One line naming real coverage beats eight naming absence.
+    """
+    try:
+        call()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("logfire: %s not instrumented (%s)", name, exc)
+        return False
+    return True
+
+
+def _selected_instrumentations() -> list[str]:
+    """Which integrations to attach. Everything, unless told otherwise.
+
+    ``POCKETPAW_LOGFIRE_INSTRUMENT`` replaces the default set with an explicit
+    comma-separated list, and ``none`` disables all of them. It exists because
+    spans are metered per unit: if one integration turns out to dominate the bill,
+    dropping it should not need a deploy of new code.
+    """
+    raw = os.environ.get("POCKETPAW_LOGFIRE_INSTRUMENT", "").strip()
+    known = _instrumentations()
+    if not raw:
+        return list(known)
+    if raw.lower() == "none":
+        return []
+    wanted = [part.strip() for part in raw.split(",") if part.strip()]
+    unknown = [name for name in wanted if name not in known]
+    if unknown:
+        logger.warning(
+            "POCKETPAW_LOGFIRE_INSTRUMENT names unknown integrations %s; known are %s",
+            unknown,
+            sorted(known),
+        )
+    return [name for name in wanted if name in known]
+
+
+def instrument_everything() -> list[str]:
+    """Attach every selected instrumentation. Returns the ones that took.
+
+    Called by ``configure_observability``, and separate from it so a caller can
+    re-run it after importing a library that was not present at startup.
+    """
+    try:
+        registry = _instrumentations()
+    except Exception as exc:  # noqa: BLE001
+        # Not just ImportError. Building the registry touches every
+        # ``logfire.instrument_*`` attribute, so a name that a future logfire
+        # renames raises AttributeError HERE, before the per-integration guard in
+        # ``_instrument`` can contain it — and this runs inside setup_logging, at
+        # module scope in __main__, where an exception stops the process booting.
+        logger.debug("logfire: no instrumentation (%s)", exc)
+        return []
+    attached = [name for name in _selected_instrumentations() if _instrument(name, registry[name])]
+    if attached:
+        logger.info("logfire: instrumented %s", ", ".join(attached))
+    return attached
+
+
+def instrument_fastapi_app(app: Any) -> bool:
+    """Instrument one FastAPI app: a span per request, with route and status.
+
+    Separate from the rest because it needs the app object, so it cannot run at
+    configure time. Call it once the routers are mounted — the instrumentor reads
+    the route table to label spans by route TEMPLATE rather than by path, which is
+    what keeps ``/api/v1/pockets/{id}`` one row instead of one row per pocket.
+    """
+    if not logfire_enabled():
+        return False
+    try:
+        import logfire
+    except ImportError:
+        return False
+    try:
+        logfire.instrument_fastapi(
+            app,
+            # Headers carry Authorization and session cookies.
+            capture_headers=False,
+            excluded_urls=_UNTRACED_ROUTES,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("logfire: fastapi not instrumented (%s)", exc)
+        return False
+    return True
+
+
 def configure_observability() -> bool:
     """Configure Logfire once per process. True when it is configured.
 
@@ -143,43 +324,7 @@ def configure_observability() -> bool:
         logger.warning("Could not configure logfire: %s", exc)
         return False
 
-    instrument_pydantic_ai()
-    return True
-
-
-def instrument_pydantic_ai() -> bool:
-    """Instrument every pydantic-ai agent in this process. True when it happened.
-
-    ``Agent.instrument_all`` under the hood, so an agent built anywhere emits run,
-    model-request and tool-call spans — not only one built through a code path that
-    remembered to pass the capability.
-
-    No double-instrumentation: pydantic-ai resolves the global settings into an
-    ``InstrumentationCap`` at run time and inserts it only when the run's capability
-    list does not already have one, so an agent carrying the backend's explicit
-    ``Instrumentation()`` capability is instrumented once, by its own.
-
-    Content is excluded unless ``POCKETPAW_LOGFIRE_INCLUDE_CONTENT`` says otherwise
-    — see ``logfire_include_content``.
-    """
-    try:
-        import logfire
-    except ImportError:
-        return False
-    # find_spec rather than ``import pydantic_ai``: an existence check should not
-    # execute a heavy package, and pydantic-ai is an extra too — a deployment on
-    # another agent backend has no agents to instrument.
-    if importlib.util.find_spec("pydantic_ai") is None:
-        return False
-    include_content = logfire_include_content()
-    try:
-        logfire.instrument_pydantic_ai(
-            include_content=include_content,
-            include_binary_content=include_content,
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("Could not instrument pydantic-ai: %s", exc)
-        return False
+    instrument_everything()
     return True
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,53 @@ from pocketpaw.security.audit import AuditLogger
 # strict behaviour monkeypatch POCKETPAW_ALLOW_INTERNAL_URLS=false themselves.
 os.environ.setdefault("POCKETPAW_ALLOW_INTERNAL_URLS", "true")
 
+# A test run must NEVER configure Logfire. Same class of dev-machine leak as the
+# line above, and a worse blast radius, because it leaves the machine.
+#
+# ``security/url_validators.py`` calls ``load_dotenv()`` at import, and
+# python-dotenv walks UP from the calling FILE when the frame is not
+# interactive. From a git worktree that walk reaches the PARENT checkout's
+# ``.env``, so an operator's real project token arrives in a test process that
+# never asked for one. (``python -c`` counts as interactive and searches the cwd
+# instead, which is why this does not reproduce from a one-liner.)
+#
+# It has to be popped here, at import, rather than in a fixture:
+# ``logfire.configure`` is process-global and there is no un-configure, so one
+# test reaching ``setup_logging`` before the fixture ran would arm exporting for
+# the whole session. With POCKETPAW_LOGFIRE_INCLUDE_CONTENT also set, what ships
+# is fixture text.
+#
+# SET to a safe value, not popped -- popping does not hold, and that was the
+# first thing tried here. The pop runs at conftest import; ``load_dotenv`` runs
+# whenever the module that calls it is first imported, which for
+# ``url_validators`` is later, and for ``dashboard_lifecycle`` and
+# ``uploads/factory`` is inside a function at run time. Any of those re-adds
+# what was popped.
+#
+# Every one of those calls uses ``override=False`` (the default), so a value
+# already present in the environment WINS. Setting a safe one is therefore the
+# only form of this that survives a later load. Checked: no call in src/ or ee/
+# passes override=True.
+#
+# The token is emptied rather than removed for the same reason -- an empty string
+# is present, so it cannot be replaced, and it is falsy, so
+# ``send_to_logfire="if-token-present"`` exports nothing even if something did
+# manage to configure.
+#
+# A test that wants the ON path uses ``monkeypatch.setenv``, which restores the
+# safe value afterwards.
+#
+# POCKETPAW_LOGFIRE_INSTRUMENT is deliberately NOT pinned here. It only selects
+# which integrations attach, and nothing attaches unless configure ran, which the
+# master switch already gates -- so pinning it would buy no safety and would
+# fight the tests that exercise the selection.
+for _var, _safe in (
+    ("POCKETPAW_LOGFIRE_ENABLED", "false"),
+    ("POCKETPAW_LOGFIRE_INCLUDE_CONTENT", "false"),
+    ("LOGFIRE_TOKEN", ""),
+):
+    os.environ[_var] = _safe
+
 
 def pytest_report_header() -> str | None:
     """Say so, loudly, when a mutation sweep is running in this worktree.

--- a/tests/mutations/logfire_bridge.json
+++ b/tests/mutations/logfire_bridge.json
@@ -37,15 +37,15 @@
   {
     "label": "agent prompts and completions are sent, which is Logfire's default and not ours",
     "file": "src/pocketpaw/observability.py",
-    "find": "        logfire.instrument_pydantic_ai(\n            include_content=include_content,\n            include_binary_content=include_content,\n        )",
-    "replace": "        logfire.instrument_pydantic_ai(\n            include_content=True,\n            include_binary_content=True,\n        )",
+    "find": "    logfire.instrument_pydantic_ai(\n        include_content=include_content,\n        include_binary_content=include_content,\n    )",
+    "replace": "    logfire.instrument_pydantic_ai(\n        include_content=True,\n        include_binary_content=True,\n    )",
     "tests": "tests/test_logfire_bridge.py"
   },
   {
-    "label": "pydantic-ai is never instrumented, so there are logs but no agent spans",
+    "label": "pydantic-ai drops out of the registry, so there are logs but no agent spans",
     "file": "src/pocketpaw/observability.py",
-    "find": "    instrument_pydantic_ai()\n    return True",
-    "replace": "    return True",
+    "find": "        \"pydantic_ai\": _pydantic_ai_instrumentation,",
+    "replace": "",
     "tests": "tests/test_logfire_bridge.py"
   },
   {
@@ -82,5 +82,82 @@
     "find": "        from pocketpaw.observability import configure_observability\n\n        configure_observability()\n        return Instrumentation()",
     "replace": "        return Instrumentation()",
     "tests": "tests/test_pydantic_ai_backend.py::test_instrumentation_is_off_by_default_and_configures_logfire_once"
+  },
+  {
+    "label": "httpx captures headers, so every Authorization bearer is exported",
+    "file": "src/pocketpaw/observability.py",
+    "find": "\"httpx\": lambda: logfire.instrument_httpx(capture_headers=False),",
+    "replace": "\"httpx\": lambda: logfire.instrument_httpx(capture_headers=True),",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "redis captures the statement, which is the arq job payload and the conversation",
+    "file": "src/pocketpaw/observability.py",
+    "find": "\"redis\": lambda: logfire.instrument_redis(capture_statement=False),",
+    "replace": "\"redis\": lambda: logfire.instrument_redis(capture_statement=True),",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the outbound HTTP surface drops out of the registry, so provider latency is invisible",
+    "file": "src/pocketpaw/observability.py",
+    "find": "        \"aiohttp_client\": logfire.instrument_aiohttp_client,",
+    "replace": "",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "host metrics drop out, so an OOM still needs the container console",
+    "file": "src/pocketpaw/observability.py",
+    "find": "        \"system_metrics\": logfire.instrument_system_metrics,",
+    "replace": "",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "POCKETPAW_LOGFIRE_INSTRUMENT is ignored, so the bill cannot be trimmed without a deploy",
+    "file": "src/pocketpaw/observability.py",
+    "find": "    raw = os.environ.get(\"POCKETPAW_LOGFIRE_INSTRUMENT\", \"\").strip()\n    known = _instrumentations()\n    if not raw:\n        return list(known)",
+    "replace": "    raw = \"\"\n    known = _instrumentations()\n    if not raw:\n        return list(known)",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "a misspelled integration name is dropped silently instead of reported",
+    "file": "src/pocketpaw/observability.py",
+    "find": "    if unknown:\n        logger.warning(",
+    "replace": "    if False:\n        logger.warning(",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "one failing instrumentation is re-raised, so a missing package stops the boot",
+    "file": "src/pocketpaw/observability.py",
+    "find": "    try:\n        call()\n    except Exception as exc:  # noqa: BLE001\n        logger.debug(\"logfire: %s not instrumented (%s)\", name, exc)\n        return False\n    return True",
+    "replace": "    call()\n    return True",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the healthcheck route is traced, so the compose probe bills thousands of spans a day",
+    "file": "src/pocketpaw/observability.py",
+    "find": "            excluded_urls=_UNTRACED_ROUTES,",
+    "replace": "            excluded_urls=None,",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "FastAPI is instrumented even with the master switch off",
+    "file": "src/pocketpaw/observability.py",
+    "find": "    if not logfire_enabled():\n        return False\n    try:\n        import logfire\n    except ImportError:\n        return False\n    try:\n        logfire.instrument_fastapi(",
+    "replace": "    try:\n        import logfire\n    except ImportError:\n        return False\n    try:\n        logfire.instrument_fastapi(",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the API app is instrumented BEFORE the routers, so spans are named by path not route",
+    "file": "src/pocketpaw/api/serve.py",
+    "find": "    from pocketpaw.observability import instrument_fastapi_app\n\n    instrument_fastapi_app(app)\n\n    return app",
+    "replace": "    return app",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "nothing is instrumented at all, so Logfire receives logs and no spans",
+    "file": "src/pocketpaw/observability.py",
+    "find": "    instrument_everything()\n    return True",
+    "replace": "    return True",
+    "tests": "tests/test_logfire_bridge.py"
   }
 ]

--- a/tests/mutations/logfire_bridge.json
+++ b/tests/mutations/logfire_bridge.json
@@ -159,5 +159,19 @@
     "find": "    instrument_everything()\n    return True",
     "replace": "    return True",
     "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the test run inherits the operator's real Logfire config and exports to it",
+    "file": "tests/conftest.py",
+    "find": "for _var, _safe in (\n    (\"POCKETPAW_LOGFIRE_ENABLED\", \"false\"),\n    (\"POCKETPAW_LOGFIRE_INCLUDE_CONTENT\", \"false\"),\n    (\"LOGFIRE_TOKEN\", \"\"),\n):\n    os.environ[_var] = _safe",
+    "replace": "for _var, _safe in ():\n    os.environ[_var] = _safe",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the safe values are POPPED instead of set, so a later load_dotenv puts them back",
+    "file": "tests/conftest.py",
+    "find": "    os.environ[_var] = _safe",
+    "replace": "    os.environ.pop(_var, None)",
+    "tests": "tests/test_logfire_bridge.py"
   }
 ]

--- a/tests/mutations/logfire_bridge.json
+++ b/tests/mutations/logfire_bridge.json
@@ -1,0 +1,86 @@
+[
+  {
+    "label": "the scrubbers are installed BEFORE the bridge, so the bridge carries none (the order gate)",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "    if logfire_enabled():\n        configure_observability()\n        install_logfire_bridge(level)\n    install_scrubbing_filters()",
+    "replace": "    install_scrubbing_filters()\n    if logfire_enabled():\n        configure_observability()\n        install_logfire_bridge(level)",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the master switch is ignored, so telemetry leaves the box with the flag off",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "    if logfire_enabled():\n        configure_observability()",
+    "replace": "    if True:\n        configure_observability()",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the off switch is a decoration: the string \"false\" turns Logfire on",
+    "file": "src/pocketpaw/observability.py",
+    "find": "    return _env_flag(\"POCKETPAW_LOGFIRE_ENABLED\")",
+    "replace": "    return bool(os.environ.get(\"POCKETPAW_LOGFIRE_ENABLED\"))",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the bridge REPLACES the root's handlers, as Logfire's own docs show",
+    "file": "src/pocketpaw/observability.py",
+    "find": "    if any(isinstance(handler, LogfireLoggingHandler) for handler in root.handlers):\n        return True\n    try:",
+    "replace": "    if any(isinstance(handler, LogfireLoggingHandler) for handler in root.handlers):\n        return True\n    root.handlers = []\n    try:",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "compiled patterns are handed to ScrubbingOptions, which wants strings",
+    "file": "src/pocketpaw/logging_setup.py",
+    "find": "    return [pattern.pattern for pattern in _SECRET_PATTERNS]",
+    "replace": "    return list(_SECRET_PATTERNS)",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "agent prompts and completions are sent, which is Logfire's default and not ours",
+    "file": "src/pocketpaw/observability.py",
+    "find": "        logfire.instrument_pydantic_ai(\n            include_content=include_content,\n            include_binary_content=include_content,\n        )",
+    "replace": "        logfire.instrument_pydantic_ai(\n            include_content=True,\n            include_binary_content=True,\n        )",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "pydantic-ai is never instrumented, so there are logs but no agent spans",
+    "file": "src/pocketpaw/observability.py",
+    "find": "    instrument_pydantic_ai()\n    return True",
+    "replace": "    return True",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the once-per-process guard is dropped, so every caller reconfigures the process",
+    "file": "src/pocketpaw/observability.py",
+    "find": "    global _CONFIGURED\n    if _CONFIGURED:\n        return True",
+    "replace": "    global _CONFIGURED",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "distributed tracing is left at its default, so a caller can graft spans onto our traces",
+    "file": "src/pocketpaw/observability.py",
+    "find": "            distributed_tracing=False,",
+    "replace": "            distributed_tracing=True,",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "Logfire's own console exporter is left on, so every line prints twice",
+    "file": "src/pocketpaw/observability.py",
+    "find": "            console=False,",
+    "replace": "            console=True,",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the service name goes back to a literal, so backend and worker are one service",
+    "file": "src/pocketpaw/observability.py",
+    "find": "            service_name=os.environ.get(\"LOGFIRE_SERVICE_NAME\", \"pocketpaw\"),",
+    "replace": "            service_name=\"pocketpaw-pydantic-ai\",",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "the backend stops configuring at all, so a process that never ran setup_logging has no exporter",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        from pocketpaw.observability import configure_observability\n\n        configure_observability()\n        return Instrumentation()",
+    "replace": "        return Instrumentation()",
+    "tests": "tests/test_pydantic_ai_backend.py::test_instrumentation_is_off_by_default_and_configures_logfire_once"
+  }
+]

--- a/tests/test_logfire_bridge.py
+++ b/tests/test_logfire_bridge.py
@@ -671,3 +671,60 @@ def test_the_api_app_is_instrumented_after_every_router_is_mounted() -> None:
     assert called.index("instrument_fastapi_app") > called.index("mount_v1_routers"), (
         "instrumented before the routers were mounted; spans would be named by path"
     )
+
+
+# ---------------------------------------------------------------------------
+# The test process must not inherit a real Logfire configuration.
+# ---------------------------------------------------------------------------
+
+
+def test_a_developers_own_logfire_config_never_reaches_a_test_run() -> None:
+    """A real project token must not be live while the suite runs.
+
+    ``security/url_validators.py`` calls ``load_dotenv()`` at import, and
+    python-dotenv walks UP from the calling file, so from a git worktree it
+    reaches the PARENT checkout's ``.env``. That is how an operator's real token
+    arrives in a process that never asked for one. Measured, not theorised: it
+    reproduced on this machine the moment a token was put in that file.
+
+    ``logfire.configure`` is process-global with no un-configure, so a single
+    test that reached ``setup_logging`` before any fixture ran would arm
+    exporting for the entire session, and with content capture on what ships is
+    fixture text. ``tests/conftest.py`` pops these at import for that reason.
+    """
+    import os
+
+    from pocketpaw.observability import logfire_enabled, logfire_include_content
+
+    assert not logfire_enabled(), (
+        "the master switch is on during the test run, so this suite can "
+        "configure Logfire and export to a real project. See tests/conftest.py."
+    )
+    assert not logfire_include_content(), "content capture is on during the test run"
+    assert not os.environ.get("LOGFIRE_TOKEN"), (
+        "a Logfire token is live during the test run, so anything that does "
+        "configure will export to a real project"
+    )
+
+
+def test_setup_logging_is_inert_when_the_environment_is_clean() -> None:
+    """The consequence of the guard above, asserted end to end.
+
+    Not a restatement: this drives the real ``setup_logging`` and checks that no
+    bridge handler appears. It is what would actually have shipped test noise.
+    """
+    import logging
+
+    from pocketpaw.logging_setup import setup_logging
+
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    try:
+        setup_logging(level="INFO")
+        assert not any(
+            type(h).__name__ == "LogfireLoggingHandler" for h in logging.getLogger().handlers
+        ), "a test run installed the Logfire bridge on the root logger"
+    finally:
+        root.handlers = saved_handlers
+        root.level = saved_level

--- a/tests/test_logfire_bridge.py
+++ b/tests/test_logfire_bridge.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import io
 import logging
 from collections.abc import Iterator
@@ -26,6 +27,15 @@ import pytest
 from pocketpaw.logging_setup import SecretFilter, install_scrubbing_filters
 
 _FAKE_KEY = "sk-ant-" + "A" * 40
+
+#: pydantic-ai is an EXTRA. CI runs an OSS-only install where it is absent by
+#: design, and there ``_pydantic_ai_instrumentation`` raises and the integration
+#: drops out — correctly. Tests that assert on what it passed have nothing to say
+#: on that install.
+_HAS_PYDANTIC_AI = importlib.util.find_spec("pydantic_ai") is not None
+_needs_pydantic_ai = pytest.mark.skipif(
+    not _HAS_PYDANTIC_AI, reason="pydantic-ai not installed (OSS-only install)"
+)
 
 
 class _FakeLogfireInstance:
@@ -307,6 +317,7 @@ def test_configure_passes_only_kwargs_real_logfire_accepts() -> None:
     assert not unknown, f"logfire.configure does not accept {unknown}"
 
 
+@_needs_pydantic_ai
 def test_agent_content_is_excluded_unless_it_is_asked_for(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -332,6 +343,7 @@ def test_agent_content_is_excluded_unless_it_is_asked_for(
     assert instrumented[0]["include_binary_content"] is False
 
 
+@_needs_pydantic_ai
 def test_agent_content_can_be_turned_on_deliberately(monkeypatch: pytest.MonkeyPatch) -> None:
     """Opting in is one env var, because debugging a bad run needs the prompt."""
     import sys
@@ -425,13 +437,20 @@ def test_every_integration_in_the_default_set_attaches(monkeypatch: pytest.Monke
     A registry entry naming a function logfire does not have would be a silent
     hole: ``_instrument`` swallows the AttributeError and that integration is
     just quietly absent.
+
+    ``_pydantic_ai_instrumentation`` is stubbed rather than run, because this
+    asserts what the REGISTRY covers and pydantic-ai is an extra — otherwise the
+    expected set would change with the install shape, and the OSS-only CI job
+    would read a correct absence as a coverage regression.
     """
     import sys
 
+    from pocketpaw import observability
     from pocketpaw.observability import instrument_everything
 
     calls: dict[str, Any] = {}
     monkeypatch.setitem(sys.modules, "logfire", _recording_logfire(calls))
+    monkeypatch.setattr(observability, "_pydantic_ai_instrumentation", lambda: None)
     monkeypatch.delenv("POCKETPAW_LOGFIRE_INSTRUMENT", raising=False)
 
     attached = instrument_everything()
@@ -489,8 +508,10 @@ def test_the_instrument_list_can_be_trimmed_and_emptied(
     calls: dict[str, Any] = {}
     monkeypatch.setitem(sys.modules, "logfire", _recording_logfire(calls))
 
-    monkeypatch.setenv("POCKETPAW_LOGFIRE_INSTRUMENT", "httpx, pydantic_ai")
-    assert set(instrument_everything()) == {"httpx", "pydantic_ai"}
+    # Two integrations that need no extra, so this measures the SELECTION and not
+    # which optional packages the install happens to carry.
+    monkeypatch.setenv("POCKETPAW_LOGFIRE_INSTRUMENT", "httpx, redis")
+    assert set(instrument_everything()) == {"httpx", "redis"}
 
     calls.clear()
     monkeypatch.setenv("POCKETPAW_LOGFIRE_INSTRUMENT", "none")

--- a/tests/test_logfire_bridge.py
+++ b/tests/test_logfire_bridge.py
@@ -82,13 +82,14 @@ def _fake_logfire_module(calls: list[dict[str, Any]], instrumented: list[dict[st
     Deliberately not a bare ``SimpleNamespace(configure=...)``: a fake missing
     ``ScrubbingOptions`` would make the real call raise inside our own try/except,
     which warns and returns False — leaving Logfire silently unconfigured in
-    production while the test stayed green.
+    production while the test stayed green. Same reason it carries every
+    ``instrument_*`` name: the registry reads them all when it is built.
     """
-    return SimpleNamespace(
-        configure=lambda **kw: calls.append(kw),
-        ScrubbingOptions=lambda **kw: SimpleNamespace(**kw),
-        instrument_pydantic_ai=lambda **kw: instrumented.append(kw),
-    )
+    fake = _recording_logfire({})
+    fake.configure = lambda **kw: calls.append(kw)
+    fake.ScrubbingOptions = lambda **kw: SimpleNamespace(**kw)
+    fake.instrument_pydantic_ai = lambda **kw: instrumented.append(kw)
+    return fake
 
 
 def test_nothing_is_wired_unless_the_flag_is_set(
@@ -387,3 +388,265 @@ def test_a_broken_bridge_does_not_stop_startup(
 
     assert install_logfire_bridge("INFO") is False
     assert logging.getLogger().handlers, "the console handler was lost"
+
+
+# ---------------------------------------------------------------------------
+# Coverage: which integrations attach, and what they are allowed to capture.
+# ---------------------------------------------------------------------------
+
+
+def _recording_logfire(calls: dict[str, Any]):
+    """A logfire stand-in whose every instrument_* records the kwargs it got."""
+    names = (
+        "instrument_pydantic_ai",
+        "instrument_claude_agent_sdk",
+        "instrument_anthropic",
+        "instrument_openai",
+        "instrument_mcp",
+        "instrument_httpx",
+        "instrument_aiohttp_client",
+        "instrument_redis",
+        "instrument_pymongo",
+        "instrument_system_metrics",
+    )
+
+    def recorder(name: str):
+        def _call(**kwargs: Any) -> None:
+            calls[name] = kwargs
+
+        return _call
+
+    return SimpleNamespace(**{name: recorder(name) for name in names})
+
+
+def test_every_integration_in_the_default_set_attaches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default is everything, and every entry has to actually be callable.
+
+    A registry entry naming a function logfire does not have would be a silent
+    hole: ``_instrument`` swallows the AttributeError and that integration is
+    just quietly absent.
+    """
+    import sys
+
+    from pocketpaw.observability import instrument_everything
+
+    calls: dict[str, Any] = {}
+    monkeypatch.setitem(sys.modules, "logfire", _recording_logfire(calls))
+    monkeypatch.delenv("POCKETPAW_LOGFIRE_INSTRUMENT", raising=False)
+
+    attached = instrument_everything()
+
+    assert set(attached) == {
+        "pydantic_ai",
+        "claude_agent_sdk",
+        "anthropic",
+        "openai",
+        "mcp",
+        "httpx",
+        "aiohttp_client",
+        "redis",
+        "pymongo",
+        "system_metrics",
+    }, f"the default coverage changed: {attached}"
+
+
+def test_the_capture_flags_that_would_export_customer_data_are_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headers carry Authorization; httpx bodies are prompts; redis holds the job.
+
+    Logfire's scrubber matches attribute NAMES against a keyword list, so a
+    bearer token under a header name it does not recognise goes through
+    untouched. These flags decide whether it ever gets the chance.
+    """
+    import sys
+
+    from pocketpaw.observability import instrument_everything
+
+    calls: dict[str, Any] = {}
+    monkeypatch.setitem(sys.modules, "logfire", _recording_logfire(calls))
+    monkeypatch.delenv("POCKETPAW_LOGFIRE_INSTRUMENT", raising=False)
+
+    instrument_everything()
+
+    assert calls["instrument_httpx"]["capture_headers"] is False
+    assert "capture_request_body" not in calls["instrument_httpx"], (
+        "leave it at logfire's own default of False rather than setting it here"
+    )
+    assert calls["instrument_redis"]["capture_statement"] is False, (
+        "the redis statement carries the arq job payload, which is the conversation"
+    )
+
+
+def test_the_instrument_list_can_be_trimmed_and_emptied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spans are metered, so dropping one integration must not need a code deploy."""
+    import sys
+
+    from pocketpaw.observability import instrument_everything
+
+    calls: dict[str, Any] = {}
+    monkeypatch.setitem(sys.modules, "logfire", _recording_logfire(calls))
+
+    monkeypatch.setenv("POCKETPAW_LOGFIRE_INSTRUMENT", "httpx, pydantic_ai")
+    assert set(instrument_everything()) == {"httpx", "pydantic_ai"}
+
+    calls.clear()
+    monkeypatch.setenv("POCKETPAW_LOGFIRE_INSTRUMENT", "none")
+    assert instrument_everything() == []
+    assert not calls
+
+
+def test_an_unknown_integration_name_is_reported_not_swallowed(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A typo in the env var must not read as "that integration is off"."""
+    import sys
+
+    from pocketpaw.observability import instrument_everything
+
+    calls: dict[str, Any] = {}
+    monkeypatch.setitem(sys.modules, "logfire", _recording_logfire(calls))
+    monkeypatch.setenv("POCKETPAW_LOGFIRE_INSTRUMENT", "htpx,redis")
+
+    with caplog.at_level(logging.WARNING, logger="pocketpaw.observability"):
+        attached = instrument_everything()
+
+    assert attached == ["redis"]
+    assert any("htpx" in record.getMessage() for record in caplog.records), (
+        "a misspelled integration was skipped silently"
+    )
+
+
+def test_one_broken_integration_does_not_stop_the_others(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The instrumentors are optional packages, so a missing one is expected.
+
+    An install without them should lose spans, never fail to boot.
+    """
+    import sys
+
+    from pocketpaw.observability import instrument_everything
+
+    calls: dict[str, Any] = {}
+    fake = _recording_logfire(calls)
+
+    def _boom(**_: Any) -> None:
+        raise RuntimeError("requires the opentelemetry-instrumentation-httpx package")
+
+    fake.instrument_httpx = _boom
+    monkeypatch.setitem(sys.modules, "logfire", fake)
+    monkeypatch.delenv("POCKETPAW_LOGFIRE_INSTRUMENT", raising=False)
+
+    attached = instrument_everything()
+
+    assert "httpx" not in attached
+    assert "redis" in attached, "a missing optional package took the rest down with it"
+
+
+def test_fastapi_is_not_instrumented_with_the_switch_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both app builders call this unconditionally, so the gate lives here."""
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+
+    from pocketpaw.observability import instrument_fastapi_app
+
+    monkeypatch.delenv("POCKETPAW_LOGFIRE_ENABLED", raising=False)
+
+    assert instrument_fastapi_app(FastAPI()) is False
+
+
+def test_a_request_becomes_a_span_named_by_route_not_by_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The end-to-end one, against real logfire and a real request.
+
+    Two properties, and both fail quietly rather than loudly:
+
+    * The span is named by route TEMPLATE. Instrument before the routers are
+      mounted and there is no route table to match against, so every pocket id
+      becomes its own span name and the dashboard is unusable.
+    * ``/api/v1/version`` produces NO span. The compose healthcheck curls it
+      every 30 seconds in both containers, which is thousands of metered spans a
+      day that say nothing a container status does not.
+    """
+    logfire = pytest.importorskip("logfire")
+    pytest.importorskip("opentelemetry.instrumentation.fastapi")
+    testing = pytest.importorskip("logfire.testing")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    from pocketpaw.observability import instrument_fastapi_app
+
+    exporter = testing.TestExporter()
+    logfire.configure(
+        send_to_logfire=False,
+        console=False,
+        additional_span_processors=[SimpleSpanProcessor(exporter)],
+    )
+    monkeypatch.setenv("POCKETPAW_LOGFIRE_ENABLED", "true")
+
+    app = FastAPI()
+
+    @app.get("/api/v1/pockets/{pocket_id}")
+    def read_pocket(pocket_id: str) -> dict[str, str]:
+        return {"id": pocket_id}
+
+    @app.get("/api/v1/version")
+    def version() -> dict[str, str]:
+        return {"version": "1.0.0"}
+
+    assert instrument_fastapi_app(app) is True
+
+    client = TestClient(app)
+    client.get("/api/v1/pockets/abc123")
+    client.get("/api/v1/version")
+
+    names = [span.name for span in exporter.exported_spans]
+    assert names, "the request produced no span at all"
+    assert all("{pocket_id}" in name for name in names), (
+        f"spans are named by path, not by route template: {names}"
+    )
+    assert not any("version" in name for name in names), (
+        f"the healthcheck route was traced: {names}"
+    )
+
+
+def test_the_api_app_is_instrumented_after_every_router_is_mounted() -> None:
+    """Ordering inside ``create_api_app``, checked structurally.
+
+    The route-template test above proves the instrumentor uses templates when it
+    has a route table. This proves it is given one: instrument before
+    ``mount_v1_routers`` and there are no routes to match, so every pocket id
+    becomes its own span name. That failure produces spans, so nothing else
+    catches it — it just makes the dashboard useless.
+
+    By AST over the function body rather than by substring, because the file
+    mentions both names in prose.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from pocketpaw.api import serve
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(serve.create_api_app)))
+    called: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name in {"instrument_fastapi_app", "mount_v1_routers", "install_cors"}:
+                called.append(name)
+
+    assert "instrument_fastapi_app" in called, (
+        "the deployed API app is never instrumented, so requests produce no spans"
+    )
+    assert called.index("instrument_fastapi_app") > called.index("mount_v1_routers"), (
+        "instrumented before the routers were mounted; spans would be named by path"
+    )

--- a/tests/test_logfire_bridge.py
+++ b/tests/test_logfire_bridge.py
@@ -1,0 +1,389 @@
+# test_logfire_bridge.py — the Logfire wiring is off by default, and scrubbed when on.
+# Created: 2026-09-05. Two properties, and the second is the reason the first can be
+#   shipped before anyone decides on data residency:
+#     1. With POCKETPAW_LOGFIRE_ENABLED unset, nothing is configured and no handler is
+#        added. The process logs exactly as it did.
+#     2. With it set, the Logfire handler carries the scrubbers. Logfire never scrubs a
+#        log message itself — the formatted message lands in ``logfire.msg``, the first
+#        entry in its SAFE_KEYS allowlist, and an exception lands in
+#        ``exception.message`` / ``exception.stacktrace``, also SAFE_KEYS. So our
+#        filters are the only thing in front of it, and a handler added AFTER
+#        install_scrubbing_filters() would carry none.
+#   The discriminating tests drive the REAL LogfireLoggingHandler with a fake Logfire
+#   instance, so they assert on what Logfire would actually receive rather than on what
+#   a StreamHandler prints.
+
+from __future__ import annotations
+
+import io
+import logging
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from pocketpaw.logging_setup import SecretFilter, install_scrubbing_filters
+
+_FAKE_KEY = "sk-ant-" + "A" * 40
+
+
+class _FakeLogfireInstance:
+    """Stands in for the Logfire instance the handler emits to."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def with_settings(self, **_: Any) -> _FakeLogfireInstance:
+        return self
+
+    def log(self, **kwargs: Any) -> None:
+        self.calls.append(kwargs)
+
+
+@pytest.fixture
+def captured_root() -> Iterator[io.StringIO]:
+    """Root logger with one readable handler, fully restored afterwards."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    saved_filters = root.filters[:]
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root.handlers = [handler]
+    root.setLevel(logging.INFO)
+    root.filters = []
+    try:
+        yield stream
+    finally:
+        root.handlers = saved_handlers
+        root.level = saved_level
+        root.filters = saved_filters
+
+
+@pytest.fixture(autouse=True)
+def reset_configured_flag() -> Iterator[None]:
+    """``_CONFIGURED`` is process state; a leaked True makes later tests lie."""
+    from pocketpaw import observability
+
+    saved = observability._CONFIGURED
+    observability._CONFIGURED = False
+    try:
+        yield
+    finally:
+        observability._CONFIGURED = saved
+
+
+def _fake_logfire_module(calls: list[dict[str, Any]], instrumented: list[dict[str, Any]]):
+    """A stand-in logfire module with the full surface we call.
+
+    Deliberately not a bare ``SimpleNamespace(configure=...)``: a fake missing
+    ``ScrubbingOptions`` would make the real call raise inside our own try/except,
+    which warns and returns False — leaving Logfire silently unconfigured in
+    production while the test stayed green.
+    """
+    return SimpleNamespace(
+        configure=lambda **kw: calls.append(kw),
+        ScrubbingOptions=lambda **kw: SimpleNamespace(**kw),
+        instrument_pydantic_ai=lambda **kw: instrumented.append(kw),
+    )
+
+
+def test_nothing_is_wired_unless_the_flag_is_set(
+    captured_root: io.StringIO, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Off by default is what makes this shippable before the residency decision.
+
+    No configure, no handler, no telemetry. The process logs exactly as it did.
+    """
+    from pocketpaw import observability
+    from pocketpaw.logging_setup import setup_logging
+
+    monkeypatch.delenv("POCKETPAW_LOGFIRE_ENABLED", raising=False)
+    configured: list[bool] = []
+    monkeypatch.setattr(
+        observability, "configure_observability", lambda: configured.append(True) or True
+    )
+
+    setup_logging(level="INFO")
+
+    assert not configured, "logfire was configured with the master switch off"
+    assert not any(
+        type(h).__name__ == "LogfireLoggingHandler" for h in logging.getLogger().handlers
+    ), "the bridge went on with the master switch off"
+
+
+def test_the_off_switch_is_not_a_decoration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``bool(os.environ.get(...))`` makes the string "false" truthy.
+
+    That is how an off switch turns out to be a label, so the parse is spelled out
+    and tested rather than assumed.
+    """
+    from pocketpaw.observability import logfire_enabled
+
+    for value in ("1", "true", "TRUE", "yes", "on"):
+        monkeypatch.setenv("POCKETPAW_LOGFIRE_ENABLED", value)
+        assert logfire_enabled() is True, f"{value!r} should be on"
+    for value in ("", "0", "false", "False", "no", "off", "maybe"):
+        monkeypatch.setenv("POCKETPAW_LOGFIRE_ENABLED", value)
+        assert logfire_enabled() is False, f"{value!r} should be off"
+
+
+def test_the_bridge_is_added_alongside_the_console_handler(
+    captured_root: io.StringIO, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Additive, not a replacement.
+
+    Logfire's own docs say ``basicConfig(handlers=[LogfireLoggingHandler()])``,
+    which REPLACES the root's handler list. That would delete the console handler
+    and, more to the point, the handler the scrubbers are attached to.
+    """
+    pytest.importorskip("logfire")
+    from pocketpaw import observability
+    from pocketpaw.logging_setup import setup_logging
+
+    monkeypatch.setenv("POCKETPAW_LOGFIRE_ENABLED", "true")
+    monkeypatch.setattr(observability, "configure_observability", lambda: True)
+
+    setup_logging(level="INFO")
+
+    kinds = [type(h).__name__ for h in logging.getLogger().handlers]
+    assert "LogfireLoggingHandler" in kinds, "the bridge was not installed"
+    assert any(k != "LogfireLoggingHandler" for k in kinds), (
+        "the bridge replaced the console handler instead of joining it"
+    )
+
+
+def test_the_bridge_handler_carries_the_scrubbers(
+    captured_root: io.StringIO, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE ORDER GATE. The bridge goes on first, then the scrubbers are installed.
+
+    ``install_scrubbing_filters()`` walks the root's handler list, so a handler
+    added after it carries no filters. Reversing the two lines in
+    ``_install_observability`` leaves the Logfire handler unscrubbed while every
+    other test still passes, because the console handler's filter mutates the
+    record in place before the bridge ever sees it.
+    """
+    pytest.importorskip("logfire")
+    from pocketpaw import observability
+    from pocketpaw.logging_setup import setup_logging
+
+    monkeypatch.setenv("POCKETPAW_LOGFIRE_ENABLED", "true")
+    monkeypatch.setattr(observability, "configure_observability", lambda: True)
+
+    setup_logging(level="INFO")
+
+    bridges = [
+        h for h in logging.getLogger().handlers if type(h).__name__ == "LogfireLoggingHandler"
+    ]
+    assert bridges, "the bridge was not installed"
+    assert any(isinstance(f, SecretFilter) for f in bridges[0].filters), (
+        "the Logfire handler carries no scrubber, so it exports credentials in clear"
+    )
+
+
+def test_a_secret_in_args_reaches_logfire_redacted(captured_root: io.StringIO) -> None:
+    """Driven through the REAL handler, asserting on what Logfire receives."""
+    logging_integration = pytest.importorskip("logfire.integrations.logging")
+
+    fake = _FakeLogfireInstance()
+    handler = logging_integration.LogfireLoggingHandler(
+        logfire_instance=fake, fallback=logging.NullHandler()
+    )
+    logging.getLogger().handlers = [handler]
+    install_scrubbing_filters()
+
+    logging.getLogger("pocketpaw.agents.provider").info("provider rejected %s", _FAKE_KEY)
+
+    assert fake.calls, "the bridge emitted nothing"
+    emitted = repr(fake.calls[0])
+    assert _FAKE_KEY not in emitted, "the key reached Logfire in clear"
+    assert "***REDACTED***" in emitted
+
+
+def test_a_secret_in_a_traceback_reaches_logfire_redacted(captured_root: io.StringIO) -> None:
+    """The bridge passes the RAW ``exc_info`` tuple and drops ``exc_text``.
+
+    ``exc_text`` is in Logfire's RESERVED_ATTRS, so the scrubbed rendering never
+    arrives; Logfire re-renders from the exception objects. Then
+    ``exception.message`` and ``exception.stacktrace`` are SAFE_KEYS, so its own
+    scrubber skips them. Scrubbing the exception OBJECT is what covers this, and
+    this test is the only one that sees it from Logfire's side.
+    """
+    logging_integration = pytest.importorskip("logfire.integrations.logging")
+
+    fake = _FakeLogfireInstance()
+    handler = logging_integration.LogfireLoggingHandler(
+        logfire_instance=fake, fallback=logging.NullHandler()
+    )
+    logging.getLogger().handlers = [handler]
+    install_scrubbing_filters()
+
+    log = logging.getLogger("pocketpaw.agents.provider")
+    try:
+        raise RuntimeError(f"upstream rejected token {_FAKE_KEY}")
+    except RuntimeError:
+        log.exception("provider call failed")
+
+    assert fake.calls, "the bridge emitted nothing"
+    exc_info = fake.calls[0]["exc_info"]
+    assert exc_info is not None, "no exception reached Logfire; the test proves nothing"
+    assert _FAKE_KEY not in str(exc_info[1]), "Logfire got the raw exception with the key in it"
+    assert "***REDACTED***" in str(exc_info[1])
+
+
+def test_configure_is_called_once_and_with_the_settings_that_matter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Four kwargs each close a specific hole; none is decoration."""
+    import sys
+
+    from pocketpaw.observability import configure_observability
+
+    calls: list[dict[str, Any]] = []
+    instrumented: list[dict[str, Any]] = []
+    monkeypatch.setitem(sys.modules, "logfire", _fake_logfire_module(calls, instrumented))
+    monkeypatch.setenv("LOGFIRE_SERVICE_NAME", "pocketpaw-worker")
+    monkeypatch.setenv("LOGFIRE_ENVIRONMENT", "prod")
+
+    for _ in range(3):
+        assert configure_observability() is True
+
+    assert len(calls) == 1, f"logfire configured {len(calls)} times"
+    kwargs = calls[0]
+    assert kwargs["send_to_logfire"] == "if-token-present", "must be safe with no account"
+    assert kwargs["console"] is False, "Logfire's console exporter would double every line"
+    assert kwargs["distributed_tracing"] is False, (
+        "the default EXTRACTS an incoming traceparent, so any caller could graft "
+        "spans onto our traces on an internet-facing API"
+    )
+    assert kwargs["service_name"] == "pocketpaw-worker", (
+        "backend and worker run the same image; a literal makes them one service"
+    )
+    assert kwargs["environment"] == "prod"
+
+
+def test_the_extra_scrub_patterns_are_what_logfire_accepts() -> None:
+    """``ScrubbingOptions.extra_patterns`` is ``Sequence[str]``, not compiled patterns.
+
+    Passing the compiled objects raises inside logfire, where our own try/except
+    swallows it and warns — leaving Logfire unconfigured in production while every
+    mocked test stays green. So this one runs against the real class.
+    """
+    logfire = pytest.importorskip("logfire")
+
+    from pocketpaw.observability import logfire_extra_scrub_patterns
+
+    patterns = logfire_extra_scrub_patterns()
+    assert patterns, "no credential patterns were exported to Logfire"
+    assert all(isinstance(p, str) for p in patterns)
+    logfire.ScrubbingOptions(extra_patterns=patterns)
+
+
+def test_configure_passes_only_kwargs_real_logfire_accepts() -> None:
+    """A typo'd kwarg is invisible against a mock that accepts ``**kw``."""
+    logfire = pytest.importorskip("logfire")
+
+    import inspect
+    import sys
+
+    from pocketpaw.observability import configure_observability
+
+    calls: list[dict[str, Any]] = []
+    instrumented: list[dict[str, Any]] = []
+    saved = sys.modules["logfire"]
+    sys.modules["logfire"] = _fake_logfire_module(calls, instrumented)
+    try:
+        configure_observability()
+    finally:
+        sys.modules["logfire"] = saved
+
+    accepted = inspect.signature(logfire.configure).parameters
+    unknown = [name for name in calls[0] if name not in accepted]
+    assert not unknown, f"logfire.configure does not accept {unknown}"
+
+
+def test_agent_content_is_excluded_unless_it_is_asked_for(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Logfire's default is to send prompts and completions. This inverts it.
+
+    Logfire does not scrub message content at all — every ``gen_ai.*`` message key
+    is a SAFE_KEY — so leaving the default on would ship customer chat text to a
+    hosted store as a side effect of turning on observability.
+    """
+    import sys
+
+    from pocketpaw.observability import configure_observability
+
+    calls: list[dict[str, Any]] = []
+    instrumented: list[dict[str, Any]] = []
+    monkeypatch.setitem(sys.modules, "logfire", _fake_logfire_module(calls, instrumented))
+    monkeypatch.delenv("POCKETPAW_LOGFIRE_INCLUDE_CONTENT", raising=False)
+
+    configure_observability()
+
+    assert instrumented, "pydantic-ai was never instrumented"
+    assert instrumented[0]["include_content"] is False, "customer prompts would leave the network"
+    assert instrumented[0]["include_binary_content"] is False
+
+
+def test_agent_content_can_be_turned_on_deliberately(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Opting in is one env var, because debugging a bad run needs the prompt."""
+    import sys
+
+    from pocketpaw.observability import configure_observability
+
+    calls: list[dict[str, Any]] = []
+    instrumented: list[dict[str, Any]] = []
+    monkeypatch.setitem(sys.modules, "logfire", _fake_logfire_module(calls, instrumented))
+    monkeypatch.setenv("POCKETPAW_LOGFIRE_INCLUDE_CONTENT", "true")
+
+    configure_observability()
+
+    assert instrumented[0]["include_content"] is True
+
+
+def test_a_broken_logfire_does_not_stop_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Observability is never load-bearing.
+
+    ``setup_logging`` runs at module scope in ``__main__``, so an exception here
+    would stop the process booting rather than degrade its telemetry.
+    """
+    import sys
+
+    from pocketpaw.observability import configure_observability
+
+    def _boom(**_: Any) -> None:
+        raise RuntimeError("no exporter")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "logfire",
+        SimpleNamespace(configure=_boom, ScrubbingOptions=lambda **kw: SimpleNamespace(**kw)),
+    )
+
+    assert configure_observability() is False
+
+
+def test_a_broken_bridge_does_not_stop_startup(
+    captured_root: io.StringIO, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same rule for the handler: a failure leaves the console logging intact."""
+    import sys
+
+    from pocketpaw.observability import install_logfire_bridge
+
+    class _Boom:
+        def __init__(self, **_: Any) -> None:
+            raise RuntimeError("handler unavailable")
+
+    monkeypatch.setitem(
+        sys.modules, "logfire.integrations.logging", SimpleNamespace(LogfireLoggingHandler=_Boom)
+    )
+
+    assert install_logfire_bridge("INFO") is False
+    assert logging.getLogger().handlers, "the console handler was lost"

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -3115,18 +3115,31 @@ def test_a_withheld_web_tool_is_not_granted_back_by_the_native_capability():
 def test_instrumentation_is_off_by_default_and_configures_logfire_once():
     """One backend instance exists per agent, so a per-instance
     ``logfire.configure`` would reconfigure the process on every agent built."""
-    import pocketpaw.agents.pydantic_ai as mod
+    # The configure call moved to ``pocketpaw.observability`` so that STARTUP owns
+    # it: this method runs once per agent, and only in a process that builds a
+    # pydantic-ai agent, which under POCKETPAW_CLOUD_RUN_EXECUTOR=arq is the worker
+    # and never the web process. The idempotence this test names is unchanged, it
+    # is just guarded one module further out.
+    import pocketpaw.observability as mod
 
     assert "Instrumentation" not in {
         type(c).__name__ for c in PydanticAIBackend(_settings())._build_capabilities()
     }
 
     calls: list = []
-    original_flag = mod._LOGFIRE_CONFIGURED
-    mod._LOGFIRE_CONFIGURED = False
+    original_flag = mod._CONFIGURED
+    mod._CONFIGURED = False
     import sys
 
-    fake = SimpleNamespace(configure=lambda **kw: calls.append(kw))
+    # A fuller stub than ``configure`` alone: a fake missing ``ScrubbingOptions``
+    # makes the real call raise inside our own try/except, which warns and moves
+    # on — so the assertion below would fail for a reason that has nothing to do
+    # with what it is testing.
+    fake = SimpleNamespace(
+        configure=lambda **kw: calls.append(kw),
+        ScrubbingOptions=lambda **kw: SimpleNamespace(**kw),
+        instrument_pydantic_ai=lambda **kw: None,
+    )
     saved, sys.modules["logfire"] = sys.modules.get("logfire"), fake
     try:
         for _ in range(3):
@@ -3142,7 +3155,7 @@ def test_instrumentation_is_off_by_default_and_configures_logfire_once():
             sys.modules["logfire"] = saved
         else:
             sys.modules.pop("logfire", None)
-        mod._LOGFIRE_CONFIGURED = original_flag
+        mod._CONFIGURED = original_flag
 
     assert len(calls) == 1, f"logfire configured {len(calls)} times across 3 backends"
     assert calls[0]["send_to_logfire"] == "if-token-present", (
@@ -3154,15 +3167,17 @@ def test_a_broken_logfire_does_not_break_the_run():
     """Observability is never load-bearing."""
     import sys
 
-    import pocketpaw.agents.pydantic_ai as mod
+    import pocketpaw.observability as mod
 
     def _boom(**kw):
         raise RuntimeError("no exporter")
 
-    original_flag = mod._LOGFIRE_CONFIGURED
-    mod._LOGFIRE_CONFIGURED = False
+    original_flag = mod._CONFIGURED
+    mod._CONFIGURED = False
     saved = sys.modules.get("logfire")
-    sys.modules["logfire"] = SimpleNamespace(configure=_boom)
+    sys.modules["logfire"] = SimpleNamespace(
+        configure=_boom, ScrubbingOptions=lambda **kw: SimpleNamespace(**kw)
+    )
     try:
         caps = {
             type(c).__name__
@@ -3175,6 +3190,6 @@ def test_a_broken_logfire_does_not_break_the_run():
             sys.modules["logfire"] = saved
         else:
             sys.modules.pop("logfire", None)
-        mod._LOGFIRE_CONFIGURED = original_flag
+        mod._CONFIGURED = original_flag
 
     assert "Instrumentation" in caps, "a dead exporter must not drop instrumentation"

--- a/uv.lock
+++ b/uv.lock
@@ -321,6 +321,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
 name = "astor"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3629,6 +3638,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/57/b40307cdfd81d07433ad5ae38de70fe6e543f3fb7e764bdf6944695a386b/logfire-4.39.0-py3-none-any.whl", hash = "sha256:e6046e03ce45098c15a9dbf42ced8b95dfcb60cc1f3600a6250c8f515755be5f", size = 405126, upload-time = "2026-07-24T18:31:30.844Z" },
 ]
 
+[package.optional-dependencies]
+fastapi = [
+    { name = "opentelemetry-instrumentation-fastapi" },
+]
+httpx = [
+    { name = "opentelemetry-instrumentation-httpx" },
+]
+pymongo = [
+    { name = "opentelemetry-instrumentation-pymongo" },
+]
+redis = [
+    { name = "opentelemetry-instrumentation-redis" },
+]
+system-metrics = [
+    { name = "opentelemetry-instrumentation-system-metrics" },
+]
+
 [[package]]
 name = "logfire-api"
 version = "4.39.0"
@@ -4789,6 +4815,97 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/db/851fa88db7441da82d50bd80f2de5ee55213782e25dc858e04d0c9961d60/opentelemetry_instrumentation_asgi-0.60b1.tar.gz", hash = "sha256:16bfbe595cd24cda309a957456d0fc2523f41bc7b076d1f2d7e98a1ad9876d6f", size = 26107, upload-time = "2025-12-11T13:36:47.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/76/1fb94367cef64420d2171157a6b9509582873bd09a6afe08a78a8d1f59d9/opentelemetry_instrumentation_asgi-0.60b1-py3-none-any.whl", hash = "sha256:d48def2dbed10294c99cfcf41ebbd0c414d390a11773a41f472d20000fcddc25", size = 16933, upload-time = "2025-12-11T13:35:40.462Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/e7/e7e5e50218cf488377209d85666b182fa2d4928bf52389411ceeee1b2b60/opentelemetry_instrumentation_fastapi-0.60b1.tar.gz", hash = "sha256:de608955f7ff8eecf35d056578346a5365015fd7d8623df9b1f08d1c74769c01", size = 24958, upload-time = "2025-12-11T13:36:59.35Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/cc/6e808328ba54662e50babdcab21138eae4250bc0fddf67d55526a615a2ca/opentelemetry_instrumentation_fastapi-0.60b1-py3-none-any.whl", hash = "sha256:af94b7a239ad1085fc3a820ecf069f67f579d7faf4c085aaa7bd9b64eafc8eaf", size = 13478, upload-time = "2025-12-11T13:36:00.811Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/08/11208bcfcab4fc2023252c3f322aa397fd9ad948355fea60f5fc98648603/opentelemetry_instrumentation_httpx-0.60b1.tar.gz", hash = "sha256:a506ebaf28c60112cbe70ad4f0338f8603f148938cb7b6794ce1051cd2b270ae", size = 20611, upload-time = "2025-12-11T13:37:01.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/59/b98e84eebf745ffc75397eaad4763795bff8a30cbf2373a50ed4e70646c5/opentelemetry_instrumentation_httpx-0.60b1-py3-none-any.whl", hash = "sha256:f37636dd742ad2af83d896ba69601ed28da51fa4e25d1ab62fde89ce413e275b", size = 15701, upload-time = "2025-12-11T13:36:04.56Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-pymongo"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/af/42bbe99fbcc88e8d86c5ed87f7b02628e0cdf4bddb7b29bd6b1a3a4bef01/opentelemetry_instrumentation_pymongo-0.60b1.tar.gz", hash = "sha256:448f895b981b356dbcce2af0311a1efe9c5a6a65ea3590d85623febea0776aa8", size = 10337, upload-time = "2025-12-11T13:37:08.693Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/9d/9fe3ccbec82c20d7ae8d14af47f630fdc6066afda5b18743ceb13f4be997/opentelemetry_instrumentation_pymongo-0.60b1-py3-none-any.whl", hash = "sha256:179cff51e4b018fa92f6acb7aea1dfc5440364e66561db9d5ca0dc0227e0a6dc", size = 11419, upload-time = "2025-12-11T13:36:17.073Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-redis"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1e/225364fab4db793f6f5024ed9f3dd53774fd7c7c21fa242460234dcdf8d9/opentelemetry_instrumentation_redis-0.60b1.tar.gz", hash = "sha256:ecafa8f81c88917b59f0d842fb3d157f3a8edc71fb4b85bebca3bc19432ce7b8", size = 14774, upload-time = "2025-12-11T13:37:11.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/bd/d55d3b34fd49df08d9d9fa3701dff0051b216e2c7e9adaaa4ff6aa1de8d7/opentelemetry_instrumentation_redis-0.60b1-py3-none-any.whl", hash = "sha256:33bef0ff9af6f2d88de90c1cd7e25675c10a16d4f9ee5ae7592b28bb08b78139", size = 15502, upload-time = "2025-12-11T13:36:21.481Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-system-metrics"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "psutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/68/55e946130c4630fda3cce8ceccb9d6ccd9967278cd082af66243c5228145/opentelemetry_instrumentation_system_metrics-0.60b1.tar.gz", hash = "sha256:b9c3a40f31f20c694c386bd28fa0eed5268532bb78f545bbd8e23bbe99d81e09", size = 15868, upload-time = "2025-12-11T13:37:15.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/a1/fef3de5fba4f80012af7be501e8d216048aa710929d9818e1d2cd3ddc854/opentelemetry_instrumentation_system_metrics-0.60b1-py3-none-any.whl", hash = "sha256:21fb040ed6cfabc8ca97c63548fd01689f7ec92c64bbc6cfd08f30489a336fc6", size = 13516, upload-time = "2025-12-11T13:36:27.579Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5218,7 +5335,7 @@ all = [
     { name = "langchain-mcp-adapters" },
     { name = "langchain-ollama" },
     { name = "langchain-openai" },
-    { name = "logfire" },
+    { name = "logfire", extra = ["fastapi", "httpx", "pymongo", "redis", "system-metrics"] },
     { name = "matrix-nio" },
     { name = "mcp" },
     { name = "mem0ai" },
@@ -5246,7 +5363,7 @@ all-backends = [
     { name = "langchain-ollama" },
     { name = "langchain-openai" },
     { name = "litellm" },
-    { name = "logfire" },
+    { name = "logfire", extra = ["fastapi", "httpx", "pymongo", "redis", "system-metrics"] },
     { name = "openai-agents" },
     { name = "pydantic-ai-harness" },
     { name = "pydantic-ai-skills" },
@@ -5407,7 +5524,7 @@ postgresql = [
     { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 pydantic-ai = [
-    { name = "logfire" },
+    { name = "logfire", extra = ["fastapi", "httpx", "pymongo", "redis", "system-metrics"] },
     { name = "pydantic-ai-harness" },
     { name = "pydantic-ai-skills" },
     { name = "pydantic-ai-slim", extra = ["mcp", "openai"] },
@@ -5581,7 +5698,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'deep-agents'", specifier = ">=1.2.0,<2.0.0" },
     { name = "langchain-openai", marker = "extra == 'dev'", specifier = ">=1.2.0,<2.0.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.40.0" },
-    { name = "logfire", marker = "extra == 'pydantic-ai'", specifier = ">=4.39.0,<5" },
+    { name = "logfire", extras = ["fastapi", "httpx", "redis", "pymongo", "system-metrics"], marker = "extra == 'pydantic-ai'", specifier = ">=4.39.0,<5" },
     { name = "matrix-nio", marker = "extra == 'all'", specifier = ">=0.24.0" },
     { name = "matrix-nio", marker = "extra == 'all-channels'", specifier = ">=0.24.0" },
     { name = "matrix-nio", marker = "extra == 'dev'", specifier = ">=0.24.0" },


### PR DESCRIPTION
Stacked on #2092. That branch is a prerequisite, not a coincidence of timing. See "Why this is stacked" below.

logfire was already a dependency and already half-wired, so this finishes something rather than starting it. `pyproject.toml` pins `logfire>=4.39.0,<5` in the `pydantic-ai` extra, the deployed image installs `.[all]`, and `PydanticAIBackend._build_instrumentation_capability` already called `logfire.configure`.

## What was wrong with where it lived

The configure call sat inside the pydantic-ai backend's capability builder. Four problems, and the second is the one that matters.

1. It was gated on `pydantic_ai_instrumentation`, a backend feature flag. The logging bridge has nothing to do with pydantic-ai and could not be turned on independently.
2. It only fired in a process that actually builds a pydantic-ai agent. With `POCKETPAW_CLOUD_RUN_EXECUTOR=arq` the web process enqueues and never constructs one, so on the deployed stack it ran in the worker and never in the backend.
3. `service_name` was the literal `"pocketpaw-pydantic-ai"`. Both containers run the same image, so if both had configured they would have been one indistinguishable service in every query and every alert.
4. It ran late, as a side effect of construction, after the process was already serving.

## Where it lives now

`src/pocketpaw/observability.py`, called from `setup_logging()`. That is the one function both entrypoints already run first, and one that `tests/test_log_scrubbing.py` already AST-pins for the worker, so this needs no new call site in either entrypoint.

It does three things: configures Logfire once per process, attaches every instrumentation, and adds Logfire's stdlib logging handler to the root.

The backend keeps a `configure_observability()` call as the fallback for a process that never ran `setup_logging` at all. Tests, library use, anything embedding the backend. It is a no-op when startup already did it.

## What is actually instrumented

Ten integrations at startup, plus a span per HTTP request wired in by both app builders. The point is that reading container logs by hand stops being the way you find things.

| | |
|---|---|
| Requests | FastAPI, labelled by route template |
| Agents | pydantic-ai, Claude Agent SDK, Anthropic, OpenAI, MCP tool calls |
| Outbound | httpx and aiohttp, which is the LiteLLM proxy, provider APIs, Daytona and webhooks |
| Stores | Redis for the arq queues and the run stream, Mongo under motor and beanie |
| Host | CPU, memory, disk and network, as metrics rather than spans |

Four of the keyword arguments are data decisions rather than taste ones, and each has a mutation.

- **Headers are never captured.** They carry `Authorization`, our own API keys and session cookies, and Logfire's scrubber matches attribute names against a keyword list, so a bearer token under a header name it does not recognise goes straight through.
- **httpx bodies stay off.** They are the customer's prompts and the model's completions.
- **The Redis statement stays off.** It is the arq job payload, which for the chat lane is the conversation.
- **Health and version are not traced.** The compose healthcheck curls version every 30 seconds in both containers, which is thousands of metered spans a day saying nothing a container status does not.

Deliberately not in the default set: sqlite3 and sqlalchemy. Fabric, Instinct, the audit log and the ledger all run on SQLite, so a span per statement would dominate the bill for little over the operation span already wrapping them.

Spans are metered per unit, so `POCKETPAW_LOGFIRE_INSTRUMENT` narrows the set by name, or takes `none` to keep the logs and drop every span. Trimming a bill should not need a deploy of new code.

The instrumentors ride on the `pydantic-ai` extra's existing logfire spec rather than a new extra, so there is one version to bump and the deployed image, which builds from `[all]`, gets them. Locked at `0.60b1`, resolved under the repo's own supply-chain floor.

One known cosmetic wart, worth naming so nobody chases it twice. logfire prints a `UserWarning` at startup saying `httpx2` will not be instrumented because it wants `opentelemetry-instrumentation-httpx>=0.65b0`. `httpx` itself is instrumented; only `httpx2`, which is installed transitively and which nothing in this tree imports, is not. Moving to `0.65b0` needs `opentelemetry-api` 1.44, and `livekit-agents` pins the SDK to `~=1.39.0`, so this cannot be fixed from here. It is one line, once per process.

## The handler is added, not installed

Logfire's own docs say `basicConfig(handlers=[logfire.LogfireLoggingHandler()])`. That replaces the root's handler list, which deletes the console handler and, more to the point, deletes the handler `install_scrubbing_filters()` attaches the scrubbers to.

The ordering is load-bearing. The bridge goes on first, then the scrubbers, because that function walks the handler list. Reverse those two lines and the Logfire handler carries nothing while every other test still passes, since the console handler's filter mutates the record in place before the bridge ever sees it. That is the first mutation in the plan.

## Why this is stacked

Logfire does not scrub a log message. The formatted message lands in `logfire.msg`, the first entry in its `SAFE_KEYS` allowlist, commented "Formatted field values are scrubbed separately". An exception lands in `exception.message` and `exception.stacktrace`, also `SAFE_KEYS`, and a scrubbing callback cannot help because `SAFE_KEYS` are matched before the callback runs.

So our filters are the only thing standing in front of it, and until #2092 they had never scrubbed a line in any process. The exception-object scrub in that branch's third commit is specifically what covers the bridge. `LogfireLoggingHandler.emit` passes the raw `exc_info` tuple, and `exc_text` is in its `RESERVED_ATTRS`, so the scrubbed rendering never arrives and Logfire re-renders from the exception objects.

Turning this on without that branch converts a local stdout leak into an exfiltrated one, at 281 `logger.exception` call sites.

Logfire's `DEFAULT_PATTERNS` are keyword patterns: "password", "secret", `api[._ -]?key`. They match an attribute *named* like a credential and none of the credential formats this codebase handles. `sk-ant-`, `xoxb-` and `pp_` hit nothing in that list. `logfire_extra_scrub_patterns()` mirrors ours across, which closes the attribute side.

## Two defaults that are deliberately not Logfire's

Agent content is excluded. `include_content` defaults to on in Logfire and this inverts it, because Logfire does not scrub message content at all. Leaving the default would ship customer chat text to a hosted store as a side effect of turning on observability. Off, the spans still carry model, token counts, latency and tool names, which is what makes a cost or a slowdown diagnosable. `POCKETPAW_LOGFIRE_INCLUDE_CONTENT=true` opts in.

Distributed tracing is off. The default extracts an incoming `traceparent` header, and on an internet-facing API that lets any caller graft spans onto our traces.

## Off by default, and honest about what "on with no token" means

Everything is inert unless `POCKETPAW_LOGFIRE_ENABLED` is truthy, parsed against a real set so the string "false" does not turn it on.

With the switch on but no `LOGFIRE_TOKEN` and no `OTEL_EXPORTER_OTLP_ENDPOINT`, the span processor list is empty and the spans are still built and serialized before being dropped. Metrics get a `NoOpMeterProvider` when there are no readers. Traces are not treated the same way. So it is not free and not useful, and the setting description and the deploy docs now say that rather than "the spans stay local".

The OTLP endpoint is the bring-your-own-backend path and needs no code change. It sits outside the `send_to_logfire` branch in logfire's exporter setup, so the two are independent.

## Gate

`tests/mutations/logfire_bridge.json`, twenty-three mutations, all observed to fail the tests. Repo-wide anchor validation is green at 1114 anchors across 84 plans. Two anchors had rotted against my own refactor between the two commits and were repointed, which is the failure mode this repo has been bitten by before.

Three are worth naming. The ordering mutation is invisible to every other test in the tree. The one that hands compiled patterns to `ScrubbingOptions` covers a failure that would otherwise be silent in production: it raises inside logfire, our own try/except warns and moves on, and Logfire sits unconfigured while every mocked test stays green. And instrumenting the API app before the routers are mounted still produces spans, so nothing else would catch it. It just names them by path instead of by route, and one span name per pocket id makes the dashboard useless.

The discriminating tests drive the real `LogfireLoggingHandler` with a fake Logfire instance, so they assert on what Logfire receives rather than on what a `StreamHandler` prints.

## Verified against the installed 4.39.0, not the docs

The handler source, `RESERVED_ATTRS`, `SAFE_KEYS`, `DEFAULT_PATTERNS`, the exporter conditions in `_internal/config.py`, and pydantic-ai 2.18's `agent/__init__.py:1368`. That last one is what makes global instrumentation safe alongside the backend's explicit `Instrumentation()` capability: it inserts the global one only when the run's capability list does not already carry an `InstrumentationCap`, so the two cannot double up.

No dependency change and no version bump. 4.39.0 was published 43 days ago, ahead of both the seven-day floor and the repo's `exclude-newer = 2026-08-10`.

## CI does not run here yet

`.github/workflows/ci.yml` triggers on PRs targeting `dev`, `main` or `feat/*-integration`. This one targets its stack base, so only `check-quality` and `security-scan` fire and the test matrix never does. Retarget it at `dev` once #2092 merges. Until then the numbers below are local, on a full `--group ee` install.

#2092 itself is green on every check.

## Test status

Twenty-one tests in `tests/test_logfire_bridge.py`, all passing. 191 passing across the four affected suites. Ruff and the import-linter contract are clean.

Writing the coverage tests found a real gap in my own first commit: building the registry touches every `logfire.instrument_*` attribute, so a name a future logfire renames raises `AttributeError` before the per-integration guard can contain it, inside `setup_logging`, at module scope in `__main__`. That would have stopped the process booting. Now caught, with a test that would have failed.

The third commit fixes a second one. Three of the coverage tests assumed pydantic-ai was installed, and the OSS-only CI job installs without it by design, so they read a correct absence as a regression. Proved by running the suite with `pydantic_ai` hidden from `find_spec`, which is how that install looks from inside this code: nineteen pass and two skip.

`tests/test_pydantic_ai_backend.py` needed its two logfire tests repointed at the moved guard. Their assertions are unchanged.

Two failures in `tests/test_credentials.py` are pre-existing and unrelated. They assert `agent_backend == "claude_agent_sdk"`, the core default, while the enterprise package sets `pydantic_ai` and overrides it at import, so they fail on any full `--group ee` install and pass on an OSS-only one.

## What still needs a decision

The deploy half is paw-workspace#204, which names the two containers separately. It is two lines of YAML and does nothing until this merges.

Turning this on in production sends log text to a hosted service. The token is region-bound with no migration between regions, and self-hosting is Enterprise-gated. That is a data-residency call, and nothing here makes it. The switch stays off until someone sets it.
