### PR TITLE
fix(studio): stop labelling generated music as a PNG

### DIFF
--- a/ee/pocketpaw_ee/cloud/studio/service.py
+++ b/ee/pocketpaw_ee/cloud/studio/service.py
@@ -1251,12 +1251,12 @@ async def _generate_video(req: schemas.GenerateRequest, *, workspace_id: str) ->
     reference_audio: list[str] = []
     for url in req.referenceAudioUrls or []:
         if url and url.strip():
-            data_url, _ = await _resolve_source_data_url(url)
+            data_url, _ = await _resolve_source_data_url(url, default_mime="audio/mpeg")
             reference_audio.append(data_url)
     reference_video: list[str] = []
     for url in req.referenceVideoUrls or []:
         if url and url.strip():
-            data_url, _ = await _resolve_source_data_url(url)
+            data_url, _ = await _resolve_source_data_url(url, default_mime="video/mp4")
             reference_video.append(data_url)
 
     try:
@@ -1314,40 +1314,70 @@ async def _generate_video(req: schemas.GenerateRequest, *, workspace_id: str) ->
     return record
 
 
+# Media extensions this surface stores, mapped to the mime a data: URL must
+# declare. AUDIO AND VIDEO ARE HERE FOR A REASON: this table used to hold images
+# only, and every non-image fell through to the "image/png" default — so a
+# generated .mp3 wired into a Video node reached fal as
+# "data:image/png;base64,<mp3 bytes>". fal put it in audio_urls, tried to decode
+# a PNG as sound, and rejected a perfectly good 10-second track as being 0.04
+# seconds long. The bytes were never the problem; the label was.
 _MIME_BY_EXT: dict[str, str] = {
+    # Images
     ".png": "image/png",
     ".jpg": "image/jpeg",
     ".jpeg": "image/jpeg",
     ".webp": "image/webp",
     ".gif": "image/gif",
+    # Audio — what generate_music writes (see _MUSIC_EXT_BY_MIME).
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".m4a": "audio/mp4",
+    ".ogg": "audio/ogg",
+    # Video — what the video paths write (see _video_ext).
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".mov": "video/quicktime",
+    ".m4v": "video/x-m4v",
 }
 
 
-def _mime_for_filename(name: str) -> str:
-    """Best-effort mime from a media filename's extension (defaults to png)."""
-    return _MIME_BY_EXT.get(Path(name).suffix.lower(), "image/png")
+def _mime_for_filename(name: str, default: str = "image/png") -> str:
+    """Best-effort mime from a media filename's extension.
+
+    ``default`` is what an unknown or absent extension falls back to. Callers
+    resolving a reference they KNOW is audio or video pass their own, so an
+    extensionless file cannot be mislabelled as an image the way every non-image
+    silently was before this table grew."""
+    return _MIME_BY_EXT.get(Path(name).suffix.lower(), default)
 
 
-async def _resolve_source_data_url(source_url: str) -> tuple[str, str]:
-    """Resolve an EditRequest ``sourceUrl`` into ``(data_url, mime)`` fal accepts
-    as an ``image_url`` input.
+async def _resolve_source_data_url(
+    source_url: str, *, default_mime: str = "image/png"
+) -> tuple[str, str]:
+    """Resolve a media reference into ``(data_url, mime)`` fal accepts as input.
 
     Handles three shapes the frontend can send:
       * ``data:`` URL             — pass through as-is (mime parsed from header).
       * ``http(s)://`` URL        — fetch the bytes, encode as a data URL.
       * ``/api/v1/media/<name>``  — read the stored bytes via the media adapter
                                     and encode as a data URL (the common case:
-                                    editing a previously generated asset).
+                                    referencing a previously generated asset).
+
+    ``default_mime`` is what an unrecognised extension or a missing content-type
+    falls back to. It exists because this resolver serves audio and video
+    references as well as images now, and assuming "image/png" for all of them
+    put a PNG header on generated music — which fal then failed to decode as
+    sound. A caller that knows the KIND it is resolving should say so.
     """
     s = source_url.strip()
     if s.startswith("data:"):
-        mime = s[5:].split(";", 1)[0] or "image/png"
+        mime = s[5:].split(";", 1)[0] or default_mime
         return s, mime
     if s.startswith(("http://", "https://")):
         async with httpx.AsyncClient(timeout=60.0) as client:
             resp = await client.get(s)
             resp.raise_for_status()
-        mime = resp.headers.get("content-type", "image/png").split(";")[0].strip() or "image/png"
+        mime = resp.headers.get("content-type", default_mime).split(";")[0].strip() or default_mime
         return fal_edit.encode_bytes(resp.content, mime), mime
     name = s.rsplit("/", 1)[-1]
     if not name or ".." in name or name != Path(name).name:
@@ -1358,7 +1388,7 @@ async def _resolve_source_data_url(source_url: str) -> tuple[str, str]:
         raise ValueError(f"source media '{name}' not found")
     chunks = [c async for c in adapter.open(key)]
     data = b"".join(chunks)
-    mime = _mime_for_filename(name)
+    mime = _mime_for_filename(name, default_mime)
     return fal_edit.encode_bytes(data, mime), mime
 
 

--- a/tests/cloud/studio/test_reference_mime.py
+++ b/tests/cloud/studio/test_reference_mime.py
@@ -1,0 +1,110 @@
+# tests/cloud/studio/test_reference_mime.py — the mime a reference is labelled with.
+#
+# Created 2026-09-05 (fix/studio-audio-mime-in-references).
+#
+# A generated music track wired into a Video node reached fal as
+# "data:image/png;base64,<mp3 bytes>", because `_MIME_BY_EXT` held image
+# extensions only and everything else fell through to an "image/png" default.
+# fal put it in audio_urls, tried to decode a PNG as sound, and rejected a
+# perfectly good 10-second track as 0.04 seconds long.
+#
+# The bytes were never wrong — only the label — which is exactly why this needs a
+# test that reads the data URI HEADER. Every assertion that only checked "an
+# audio url was forwarded" passed throughout.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.studio import service
+
+
+class TestMimeForFilename:
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("track.mp3", "audio/mpeg"),
+            ("bed.wav", "audio/wav"),
+            ("voice.m4a", "audio/mp4"),
+            ("amb.ogg", "audio/ogg"),
+        ],
+    )
+    def test_audio_extensions_resolve_to_audio(self, name: str, expected: str) -> None:
+        """Mutation that must break this: drop the audio rows from _MIME_BY_EXT."""
+        assert service._mime_for_filename(name) == expected
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("clip.mp4", "video/mp4"),
+            ("take.mov", "video/quicktime"),
+            ("web.webm", "video/webm"),
+        ],
+    )
+    def test_video_extensions_resolve_to_video(self, name: str, expected: str) -> None:
+        assert service._mime_for_filename(name) == expected
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [("still.png", "image/png"), ("shot.jpg", "image/jpeg"), ("art.webp", "image/webp")],
+    )
+    def test_images_are_unchanged(self, name: str, expected: str) -> None:
+        """The image paths are the majority caller and must not move."""
+        assert service._mime_for_filename(name) == expected
+
+    def test_no_media_extension_is_ever_labelled_as_an_image(self) -> None:
+        """The specific defect: an extension the table does not know silently
+        became a PNG, whatever it actually was."""
+        for name in ("track.mp3", "clip.mp4", "bed.wav"):
+            assert not service._mime_for_filename(name).startswith("image/")
+
+    def test_an_unknown_extension_falls_back_to_the_callers_expectation(self) -> None:
+        """A caller resolving audio should not get an image default for a file
+        whose extension it cannot read."""
+        assert service._mime_for_filename("mystery", "audio/mpeg") == "audio/mpeg"
+        assert service._mime_for_filename("mystery.xyz", "video/mp4") == "video/mp4"
+        # Unchanged for callers that pass nothing.
+        assert service._mime_for_filename("mystery") == "image/png"
+
+
+class TestResolveSourceDataUrl:
+    async def test_a_stored_mp3_is_encoded_as_audio_not_as_a_png(self, monkeypatch) -> None:
+        """The end-to-end shape of the bug: the header on the data URI is what
+        fal reads, and it said image/png over MP3 bytes.
+
+        Mutation that must break this: hardcode the image default again.
+        """
+        data_url, mime = await _resolve_stored(monkeypatch, "track.mp3", b"ID3fake-mp3-bytes")
+        assert mime == "audio/mpeg"
+        assert data_url.startswith("data:audio/mpeg;base64,")
+        assert "image/png" not in data_url
+
+    async def test_a_stored_png_still_encodes_as_an_image(self, monkeypatch) -> None:
+        data_url, mime = await _resolve_stored(monkeypatch, "still.png", b"\x89PNG-fake")
+        assert mime == "image/png"
+        assert data_url.startswith("data:image/png;base64,")
+
+    async def test_an_extensionless_audio_reference_honours_the_default(self, monkeypatch) -> None:
+        data_url, mime = await _resolve_stored(
+            monkeypatch, "noext", b"bytes", default_mime="audio/mpeg"
+        )
+        assert mime == "audio/mpeg"
+        assert data_url.startswith("data:audio/mpeg;base64,")
+
+
+async def _resolve_stored(
+    monkeypatch, name: str, data: bytes, default_mime: str = "image/png"
+) -> tuple[str, str]:
+    """Resolve a media-path reference with the storage adapter stubbed out."""
+
+    class _Adapter:
+        async def exists(self, key):  # noqa: ANN001, ANN202
+            return True
+
+        async def open(self, key):  # noqa: ANN001, ANN202
+            yield data
+
+    monkeypatch.setattr(service.media_storage, "get_adapter", lambda: _Adapter())
+    monkeypatch.setattr(service.media_storage, "media_key", lambda n: n)
+    return await service._resolve_source_data_url(
+        f"/api/v1/media/{name}", default_mime=default_mime
+    )


### PR DESCRIPTION
## Summary

A music node wired into a Video node failed with:

```
Audio duration is too short. Minimum is 1.8 seconds. Found 0.04 seconds.
```

…on a track that was ten seconds long. The duration was never the problem. The rejected input says what fal actually received:

```
'loc': ['body', 'audio_urls', 0]
'input': 'data:image/png;base64,<truncated>'
```

The MP3 was being sent with a **PNG header**. fal put it in `audio_urls`, decoded a PNG as sound, and measured 0.04 seconds of noise.

## Cause

`_MIME_BY_EXT` held image extensions only, and `_mime_for_filename` defaulted everything else to `image/png`. So a stored `.mp3` resolved to `data:image/png;base64,<mp3 bytes>`. The bytes were intact throughout — only the label was wrong.

Video references had the same defect: an `.mp4` was equally a PNG to that function.

This is mine. The audio path reused a resolver written for images without checking the mime table underneath it.

## Fix

- The table carries the audio and video types this surface actually writes. `_MUSIC_EXT_BY_MIME` and `_video_ext` have known about `.mp3` / `.wav` / `.mp4` all along — the resolver was the only place that didn't.
- `_resolve_source_data_url` takes the caller's expected kind, so an extensionless audio reference falls back to audio rather than to an image. Passing nothing keeps the image default, which is what every existing image caller wants.

## Notes for review

The tests assert the **data URI header**, not just that a URL was forwarded. That distinction is the whole bug: every existing assertion checked that an audio url reached the request, and all of them passed while the header said PNG. Reverting the table to images-only fails 9 tests.

## Test plan

`pytest tests/cloud/studio/` → **373 passed** (15 new)

Verified by mutation: restoring the images-only table reproduces the original failure in the suite.
