### PR TITLE
feat(studio): tell the user why a generation was refused

### DIFF
--- a/ee/pocketpaw_ee/cloud/studio/fal_errors.py
+++ b/ee/pocketpaw_ee/cloud/studio/fal_errors.py
@@ -1,0 +1,219 @@
+# ee/pocketpaw_ee/cloud/studio/fal_errors.py — turn a fal failure into something
+# a person can act on.
+#
+# Created 2026-09-05 (studio-surface-fal-errors).
+#
+# fal rejects a request with a structured body:
+#
+#   [{"loc": ["body", "image_urls"],
+#     "msg":  "The images or videos provided may contain likenesses of real
+#              people ...",
+#     "type": "content_policy_violation",
+#     "input": {"prompt": "...", "image_urls": ["data:image/jpeg;base64,/9j/4AAQ..."]}}]
+#
+# Every one of those failures used to reach the user as a 502 whose detail was
+# `str(exception)` — the whole list above, base64 payload included. Nobody reads
+# that, so in practice the user saw a generation fail with no reason at all while
+# the actual reason sat in a server log behind a traceback.
+#
+# Two things this module fixes, and they are separate:
+#
+#   1. THE MESSAGE. Take `msg`, drop `input` (that is the base64), and add the
+#      field it was raised against so "which of my three images" is answerable.
+#
+#   2. THE STATUS. A content-policy rejection is not an outage — the user can fix
+#      it by changing the picture. Returning 502 tells them the opposite, and
+#      tells our own monitoring that fal is down when it is working perfectly.
+#      Requests fal REFUSED map to 4xx; requests fal FAILED map to 502.
+#
+# Deliberately dependency-free on fal_client: it is a lazy optional import in
+# every other module here, and an error formatter that cannot be imported during
+# an error is worthless.
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+# fal error `type` values that mean "the caller sent something unacceptable".
+# These are the user's to fix, so they must not be reported as an upstream
+# outage. Anything not listed is treated as a genuine failure — erring toward
+# 502 keeps a real fal incident visible instead of blaming the user for it.
+_CLIENT_FAULT_TYPES: frozenset[str] = frozenset(
+    {
+        "content_policy_violation",
+        "audio_duration_too_short",
+        "audio_duration_too_long",
+        "video_duration_too_short",
+        "video_duration_too_long",
+        "invalid_image",
+        "invalid_audio",
+        "invalid_video",
+        "file_too_large",
+        "too_many_files",
+        "unsupported_format",
+        "value_error",
+        "missing",
+    }
+)
+
+# Friendlier openings for the failures a studio user actually hits. fal's own
+# `msg` still follows — this only adds the context fal cannot know, namely what
+# the person was doing when it happened.
+_PREFIX_BY_TYPE: dict[str, str] = {
+    "content_policy_violation": "The provider rejected this content",
+    "audio_duration_too_short": "That audio track is too short",
+    "audio_duration_too_long": "That audio track is too long",
+    "file_too_large": "That file is too large",
+    "too_many_files": "Too many files attached",
+    "unsupported_format": "Unsupported file format",
+}
+
+# Prefixes above that already name the input they are about. Appending the field
+# label to these reads as a stutter — "That audio track is too short in the music
+# track" — so the label is only added to prefixes that are generic about WHAT
+# was rejected, like the policy one.
+_SELF_DESCRIBING_TYPES: frozenset[str] = frozenset(
+    {
+        "audio_duration_too_short",
+        "audio_duration_too_long",
+        "video_duration_too_short",
+        "video_duration_too_long",
+        "file_too_large",
+        "too_many_files",
+        "unsupported_format",
+    }
+)
+
+# Where a rejection landed → the words the user knows that input by. "body ->
+# image_urls" means nothing to someone who dragged a node onto a canvas.
+_FIELD_LABELS: dict[str, str] = {
+    "image_urls": "the reference image",
+    "image_url": "the reference image",
+    "audio_urls": "the music track",
+    "video_urls": "the reference video",
+    "prompt": "the prompt",
+    "duration": "the clip length",
+    "aspect_ratio": "the aspect ratio",
+    "resolution": "the resolution",
+}
+
+
+@dataclass(frozen=True)
+class FalFailure:
+    """A fal rejection, reduced to what is safe and useful to show.
+
+    ``message`` never contains the request payload. ``client_fault`` decides
+    whether this becomes a 4xx (the user can fix it) or a 502 (fal broke).
+    """
+
+    message: str
+    code: str | None = None
+    field: str | None = None
+    client_fault: bool = False
+
+    @property
+    def log_line(self) -> str:
+        """One line for the server log — no payload, no traceback needed.
+
+        The point of this feature is that the base64 request body stops being
+        written to logs, so this deliberately carries only the classification.
+        """
+        parts = [f"code={self.code or 'unknown'}"]
+        if self.field:
+            parts.append(f"field={self.field}")
+        parts.append(f"msg={self.message}")
+        return " ".join(parts)
+
+
+def _records(exc: BaseException) -> list[dict[str, Any]]:
+    """Pull fal's list-of-records out of an exception, however it is carried.
+
+    The SDK puts the parsed body in ``args[0]`` when it could decode it and the
+    raw text when it could not, so both shapes are handled rather than assumed.
+    """
+    for candidate in (getattr(exc, "args", None) or [None])[:1]:
+        if isinstance(candidate, list):
+            return [r for r in candidate if isinstance(r, dict)]
+        if isinstance(candidate, dict):
+            return [candidate]
+        if isinstance(candidate, str):
+            try:
+                parsed = json.loads(candidate)
+            except (ValueError, TypeError):
+                return []
+            if isinstance(parsed, list):
+                return [r for r in parsed if isinstance(r, dict)]
+            if isinstance(parsed, dict):
+                # FastAPI-style {"detail": [...]} bodies.
+                detail = parsed.get("detail")
+                if isinstance(detail, list):
+                    return [r for r in detail if isinstance(r, dict)]
+                return [parsed]
+    return []
+
+
+def _field_from_loc(loc: Any) -> str | None:
+    """The meaningful field name out of a ``loc`` path like ``["body",
+    "audio_urls", 0]`` — the last string that is not the "body" wrapper."""
+    if not isinstance(loc, (list, tuple)):
+        return None
+    for part in reversed(loc):
+        if isinstance(part, str) and part != "body":
+            return part
+    return None
+
+
+def parse_fal_error(exc: BaseException, *, action: str = "generation") -> FalFailure:
+    """Reduce a fal exception to a showable message + a fault classification.
+
+    ``action`` names what the user was doing ("video generation") so the message
+    reads as a sentence rather than as a bare provider complaint.
+
+    Never raises: this runs inside an exception handler, and a formatter that
+    throws would replace a useful error with a confusing one.
+    """
+    try:
+        records = _records(exc)
+        if not records:
+            # Nothing structured to read — fall back to the exception text, but
+            # cap it. An un-parsed fal body can be an entire base64 payload, and
+            # the whole point is that such a thing never reaches a user or a log.
+            text = str(exc).strip() or "no reason given"
+            if len(text) > 300:
+                text = text[:300].rstrip() + "…"
+            return FalFailure(message=f"{action.capitalize()} failed: {text}")
+
+        first = records[0]
+        code = first.get("type") if isinstance(first.get("type"), str) else None
+        raw_msg = first.get("msg")
+        msg = raw_msg.strip() if isinstance(raw_msg, str) and raw_msg.strip() else ""
+        field = _field_from_loc(first.get("loc"))
+        label = _FIELD_LABELS.get(field or "")
+
+        prefix = _PREFIX_BY_TYPE.get(code or "")
+        if prefix and label and code not in _SELF_DESCRIBING_TYPES:
+            head = f"{prefix} in {label}."
+        elif prefix:
+            head = f"{prefix}."
+        elif label:
+            head = f"{action.capitalize()} was rejected because of {label}."
+        else:
+            head = f"{action.capitalize()} was rejected."
+
+        message = f"{head} {msg}".strip() if msg else head
+        if len(records) > 1:
+            message = f"{message} (+{len(records) - 1} more)"
+
+        return FalFailure(
+            message=message,
+            code=code,
+            field=field,
+            client_fault=bool(code and code in _CLIENT_FAULT_TYPES),
+        )
+    except Exception:  # noqa: BLE001 — an error formatter must never itself fail
+        return FalFailure(message=f"{action.capitalize()} failed.")
+
+
+__all__ = ["FalFailure", "parse_fal_error"]

--- a/ee/pocketpaw_ee/cloud/studio/fal_video.py
+++ b/ee/pocketpaw_ee/cloud/studio/fal_video.py
@@ -29,7 +29,7 @@ from typing import Any, NamedTuple
 
 import httpx
 
-from . import fal_edit
+from . import fal_edit, fal_errors
 
 logger = logging.getLogger(__name__)
 
@@ -280,6 +280,18 @@ def _duration_value(endpoint: str, duration_sec: int) -> int | str:
 _CLIENT_TIMEOUT = 600.0
 _START_TIMEOUT = 180.0
 _DOWNLOAD_TIMEOUT = 300.0
+
+
+class FalVideoRejected(Exception):
+    """fal REFUSED the request — a content-policy hit, a file too long, a value
+    out of range. The user can fix these by changing an input, so they must not
+    be reported as an upstream outage: the router maps this to a 4xx and shows
+    the message, while ``FalVideoError`` stays a 502."""
+
+    def __init__(self, message: str, *, code: str | None = None, field: str | None = None):
+        super().__init__(message)
+        self.code = code
+        self.field = field
 
 
 class FalVideoError(Exception):
@@ -945,8 +957,17 @@ async def _run_fal(
             start_timeout=start_timeout,
         )
     except Exception as exc:  # noqa: BLE001 — surface the upstream reason to the user
+        failure = fal_errors.parse_fal_error(exc, action="video generation")
+        if failure.client_fault:
+            # A request fal refused. One log line, NO traceback and NO payload:
+            # the rejected body carries the base64 images and audio, and dumping
+            # it taught nobody anything while making the logs unreadable. The
+            # reason travels to the user instead, which is where it is useful.
+            logger.info("studio: fal video '%s' rejected — %s", endpoint, failure.log_line)
+            raise FalVideoRejected(failure.message, code=failure.code, field=failure.field) from exc
+        # A genuine failure — keep the traceback, that one is ours to debug.
         logger.warning("studio: fal video '%s' failed", endpoint, exc_info=True)
-        raise FalVideoError(f"fal video '{endpoint}' failed: {exc}") from exc
+        raise FalVideoError(failure.message) from exc
     if not isinstance(result, dict):
         raise FalVideoError(f"fal video '{endpoint}' returned an unexpected result")
     return result
@@ -1094,6 +1115,7 @@ __all__ = [
     "SUPPORTED_DURATIONS",
     "CURATED_VIDEO_MODELS",
     "FalVideoError",
+    "FalVideoRejected",
     "resolve_endpoint",
     "resolve_image_to_video_endpoint",
     "build_arguments",

--- a/ee/pocketpaw_ee/cloud/studio/router.py
+++ b/ee/pocketpaw_ee/cloud/studio/router.py
@@ -87,6 +87,12 @@ async def generate(
         raise HTTPException(400, str(exc)) from exc
     except service.StudioNotSupported as exc:
         raise HTTPException(501, str(exc)) from exc
+    except service.StudioRejectedError as exc:
+        # The provider refused this input. NOT a 502: the service is up and the
+        # user can fix it by changing an image, a track or a value. The detail
+        # is already a clean sentence — it carries no request payload — so the
+        # client can show it verbatim.
+        raise HTTPException(422, str(exc)) from exc
     except service.StudioUpstreamError as exc:
         raise HTTPException(502, f"Image generation failed: {exc}") from exc
     except CatalogUpstreamError as exc:

--- a/ee/pocketpaw_ee/cloud/studio/service.py
+++ b/ee/pocketpaw_ee/cloud/studio/service.py
@@ -81,6 +81,24 @@ class StudioUpstreamError(Exception):
     router can surface a typed 502 rather than a bare 500."""
 
 
+class StudioRejectedError(Exception):
+    """The provider REFUSED the request — a content-policy hit, a file out of
+    range, a value it will not accept.
+
+    Distinct from ``StudioUpstreamError`` because the two need opposite
+    handling. An upstream error means "we are broken, retry later" and belongs
+    in a 502; a rejection means "this input cannot be used" and belongs in a
+    4xx the user can act on. Reporting the second as the first told the user
+    the service was down when it was working, and told our monitoring that fal
+    was failing when it was doing its job.
+    """
+
+    def __init__(self, message: str, *, code: str | None = None, field: str | None = None):
+        super().__init__(message)
+        self.code = code
+        self.field = field
+
+
 # ── One-tap styles (mirrors the frontend mock so the pickers match) ──────────
 
 STYLES: list[dict[str, Any]] = [
@@ -1271,6 +1289,8 @@ async def _generate_video(req: schemas.GenerateRequest, *, workspace_id: str) ->
             audio_urls=reference_audio,
             video_urls=reference_video,
         )
+    except fal_video.FalVideoRejected as exc:
+        raise StudioRejectedError(str(exc), code=exc.code, field=exc.field) from exc
     except fal_video.FalVideoError as exc:
         raise StudioUpstreamError(str(exc)) from exc
 

--- a/tests/cloud/studio/test_fal_errors.py
+++ b/tests/cloud/studio/test_fal_errors.py
@@ -1,0 +1,162 @@
+# tests/cloud/studio/test_fal_errors.py — what a fal rejection tells the user.
+#
+# Created 2026-09-05 (studio-surface-fal-errors).
+#
+# A content-policy rejection used to reach the user as a 502 whose detail was
+# `str(exception)` — fal's whole record list, base64 payload and all. Nobody
+# reads that, so the generation appeared to fail for no reason while the reason
+# sat in a log behind a traceback.
+#
+# Two properties are load-bearing and neither is obvious from a passing request:
+#
+#   * The message must NEVER carry the request payload. It is base64 images and
+#     audio; it makes the toast unreadable and the log useless.
+#   * A refusal must NOT be a 502. The user can fix it by changing an input, and
+#     calling it an outage both misleads them and tells our monitoring that fal
+#     is down while it is working correctly.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.studio import fal_errors
+
+
+class _FalErr(Exception):
+    """Stands in for fal_client.FalClientHTTPError, which carries the parsed
+    body as args[0]."""
+
+
+def _policy_error(field: str = "image_urls") -> _FalErr:
+    return _FalErr(
+        [
+            {
+                "loc": ["body", field],
+                "msg": (
+                    "The images or videos provided may contain likenesses of real "
+                    "people or other private information that cannot be processed."
+                ),
+                "type": "content_policy_violation",
+                "ctx": {"extra_info": {"reason": "partner_validation_failed"}},
+                "input": {
+                    "prompt": "@Image1 stands at the cliff edge",
+                    "image_urls": ["data:image/jpeg;base64," + "QUJD" * 2000],
+                },
+            }
+        ]
+    )
+
+
+class TestThePayloadNeverEscapes:
+    def test_the_message_carries_no_base64(self) -> None:
+        """The whole point. Mutation that must break this: include `input`."""
+        failure = fal_errors.parse_fal_error(_policy_error(), action="video generation")
+        assert "base64" not in failure.message
+        assert "QUJD" not in failure.message
+
+    def test_the_log_line_carries_no_base64_either(self) -> None:
+        """The log was the other half of the problem — a traceback with the
+        request body in it, on every rejection."""
+        failure = fal_errors.parse_fal_error(_policy_error(), action="video generation")
+        assert "QUJD" not in failure.log_line
+        assert "base64" not in failure.log_line
+
+    def test_an_unparseable_body_is_truncated_rather_than_dumped(self) -> None:
+        """A body we cannot read can still be a whole base64 payload."""
+        failure = fal_errors.parse_fal_error(_FalErr("x" * 5000), action="video generation")
+        assert len(failure.message) < 400
+        assert failure.message.endswith("…")
+
+
+class TestTheMessageIsActionable:
+    def test_it_names_what_was_rejected(self) -> None:
+        failure = fal_errors.parse_fal_error(_policy_error(), action="video generation")
+        assert "reference image" in failure.message
+
+    def test_it_keeps_fals_own_explanation(self) -> None:
+        """Our framing helps; replacing the provider's reason would not."""
+        failure = fal_errors.parse_fal_error(_policy_error(), action="video generation")
+        assert "likenesses of real people" in failure.message
+
+    def test_the_field_label_is_the_users_word_not_the_wire_name(self) -> None:
+        failure = fal_errors.parse_fal_error(_policy_error("audio_urls"), action="video generation")
+        assert "music track" in failure.message
+        assert "audio_urls" not in failure.message
+
+    def test_a_self_describing_error_does_not_stutter(self) -> None:
+        """ "That audio track is too short in the music track" says it twice."""
+        exc = _FalErr(
+            [
+                {
+                    "loc": ["body", "audio_urls", 0],
+                    "msg": "Audio duration is too short. Minimum is 1.8 seconds.",
+                    "type": "audio_duration_too_short",
+                }
+            ]
+        )
+        failure = fal_errors.parse_fal_error(exc, action="video generation")
+        assert "in the music track" not in failure.message
+        assert "too short" in failure.message
+
+    def test_extra_records_are_counted_not_concatenated(self) -> None:
+        exc = _FalErr(
+            [
+                {"loc": ["body", "image_urls"], "msg": "First problem.", "type": "invalid_image"},
+                {"loc": ["body", "audio_urls"], "msg": "Second problem.", "type": "invalid_audio"},
+            ]
+        )
+        failure = fal_errors.parse_fal_error(exc, action="video generation")
+        assert "First problem." in failure.message
+        assert "+1 more" in failure.message
+
+
+class TestFaultClassification:
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "content_policy_violation",
+            "audio_duration_too_short",
+            "file_too_large",
+            "unsupported_format",
+        ],
+    )
+    def test_a_refusal_is_the_users_to_fix(self, code: str) -> None:
+        """These become a 4xx. Mutation that must break this: drop the code from
+        _CLIENT_FAULT_TYPES, and a policy hit is reported as an outage again."""
+        exc = _FalErr([{"loc": ["body", "image_urls"], "msg": "no", "type": code}])
+        assert fal_errors.parse_fal_error(exc).client_fault is True
+
+    def test_an_unrecognised_failure_stays_an_upstream_error(self) -> None:
+        """Erring toward 502 keeps a real fal incident visible instead of
+        blaming the user for it."""
+        exc = _FalErr([{"loc": ["body"], "msg": "internal", "type": "internal_server_error"}])
+        assert fal_errors.parse_fal_error(exc).client_fault is False
+
+    def test_an_unstructured_exception_is_not_blamed_on_the_user(self) -> None:
+        assert fal_errors.parse_fal_error(_FalErr("connection reset")).client_fault is False
+
+
+class TestItNeverMakesThingsWorse:
+    """This runs inside an exception handler. A formatter that throws would
+    replace a useful error with a confusing one."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            _FalErr(),
+            _FalErr(None),
+            _FalErr([]),
+            _FalErr([{"no": "recognised keys"}]),
+            _FalErr([{"loc": "not-a-list", "msg": None, "type": 42}]),
+            _FalErr('{"detail": [{"msg": "from json", "type": "value_error"}]}'),
+        ],
+    )
+    def test_every_shape_produces_a_message(self, exc: Exception) -> None:
+        failure = fal_errors.parse_fal_error(exc, action="video generation")
+        assert isinstance(failure.message, str)
+        assert failure.message.strip()
+
+    def test_a_json_string_body_is_still_parsed(self) -> None:
+        exc = _FalErr('[{"loc": ["body", "prompt"], "msg": "Too long.", "type": "value_error"}]')
+        failure = fal_errors.parse_fal_error(exc, action="video generation")
+        assert "Too long." in failure.message
+        assert failure.client_fault is True


### PR DESCRIPTION
## Summary

A studio generation refused by fal showed the user nothing useful. The reason existed — fal returns a structured body saying exactly what is wrong — but it reached the client as a **502** whose detail was `str(exception)`: the whole record list, base64 payload included. Nobody reads that, so a generation appeared to fail for no reason while the real explanation sat in a server log behind a traceback that also carried the payload.

Reported from a real run: a character still rejected as `content_policy_violation`, which the user could have fixed immediately had anything told them so.

## The message

Takes fal's own explanation, names the input in the words the user knows it by, and drops `input`:

> The provider rejected this content in **the reference image**. The images or videos provided may contain likenesses of real people or other private information that cannot be processed.

- `body -> image_urls` becomes "the reference image"; `audio_urls` becomes "the music track"
- Self-describing errors don't stutter — "That audio track is too short", not "…too short in the music track"
- An unparseable body is truncated at 300 chars rather than dumped, because that is exactly where a whole base64 blob would otherwise land

## The status

This half matters as much. A content-policy refusal **is not an outage**: the service is up and the user can fix it by changing a picture. Reporting it as 502 told them the opposite, and told our own monitoring that fal was failing while it was working correctly.

- Requests fal **refused** → **422**, detail is the clean sentence, safe to show verbatim
- Requests fal **failed** → 502, unchanged
- An **unrecognised** error type stays 502 deliberately — erring that way keeps a real fal incident visible rather than blaming the user for it

## Logging

A refusal is one `INFO` line with the code and the field: no traceback, no payload. A genuine failure keeps its traceback — that one is ours to debug.

## Notes for review

`fal_errors` deliberately does not import `fal_client`. It is a lazy optional dependency everywhere else in this package, and an error formatter that cannot be imported *during an error* is worthless. The parser also never raises: it runs inside an exception handler, where throwing would replace a useful error with a confusing one — there is a test for every malformed shape.

Pairs with paw-enterprise#872, which surfaces the message as a toast.

## Test plan

`pytest tests/cloud/studio/` → **394 passed** (21 new)

Both load-bearing properties were mutation-checked rather than assumed:

- Re-including `input` in the message → 1 test fails (the payload leak)
- Dropping `content_policy_violation` from the client-fault set → 2 tests fail (a refusal reported as an outage again)
