### PR TITLE
Sixteen background loops were registered and never ran

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -153,7 +153,82 @@ Each has router.py (thin), service.py (logic), schemas.py (validation).
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
+
 from fastapi import Depends, FastAPI
+
+_logger = logging.getLogger(__name__)
+
+
+def _install_cloud_lifespan(
+    app: FastAPI,
+    startup_hooks: list[Callable[[], Awaitable[None]]],
+    shutdown_hooks: list[Callable[[], Awaitable[None]]],
+) -> None:
+    """Run the cloud's startup/shutdown hooks from the app's lifespan.
+
+    These used to be ``@app.on_event(...)`` handlers, and none of them ever ran.
+    ``Router.startup()`` / ``Router.shutdown()`` are the only readers of
+    ``on_startup`` / ``on_shutdown``, and only ``_DefaultLifespan`` calls them --
+    which Starlette installs only when the app was built with no ``lifespan=``.
+    Both host factories DO pass one (``src/pocketpaw/dashboard.py`` and
+    ``src/pocketpaw/api/serve.py``), so every handler registered that way was
+    collected into a list nothing reads. Sixteen background loops sat in that
+    list, including the Daytona sandbox reaper, which is why the bug cost money
+    for as long as it lasted.
+
+    ``app.router.lifespan_context`` is whatever the host passed, or Starlette's
+    ``_DefaultLifespan`` when it passed nothing. Wrapping it composes with either
+    shape, so the OSS core needs no change and no knowledge of the cloud.
+
+    ORDERING IS LOAD-BEARING. The cloud hooks run INSIDE the host's lifespan:
+    after host startup, before host shutdown. Every one of these loops reads
+    Mongo, and Mongo is opened by ``CloudLifecycleHook.on_startup``, which the
+    host lifespan runs. Starting them first would give each loop a first tick
+    against an uninitialised Beanie.
+
+    A hook that raises is logged and skipped. A background sweep that cannot
+    start must not take the web process down with it -- that is the difference
+    between a degraded box and a restart loop.
+    """
+    if getattr(app.state, "_cloud_lifespan_installed", False):
+        return
+    app.state._cloud_lifespan_installed = True
+
+    host_lifespan = app.router.lifespan_context
+
+    @asynccontextmanager
+    async def _cloud_lifespan(scoped_app: FastAPI):
+        from pocketpaw_ee.cloud._core import sweep_runtime
+
+        async with host_lifespan(scoped_app) as maybe_state:
+            for hook in startup_hooks:
+                name = getattr(hook, "__name__", repr(hook))
+                try:
+                    await hook()
+                except Exception:
+                    _logger.exception("Cloud startup hook %s failed", name)
+                else:
+                    # Marked only on success, and only here. That is what makes
+                    # /api/v1/automations/status unable to report a sweep as
+                    # running when its hook was dropped, raised, or never
+                    # existed -- the failure mode that let this bug survive.
+                    sweep_runtime.mark_started(name)
+            try:
+                yield maybe_state
+            finally:
+                for hook in reversed(shutdown_hooks):
+                    name = getattr(hook, "__name__", repr(hook))
+                    try:
+                        await hook()
+                    except Exception:
+                        _logger.exception("Cloud shutdown hook %s failed", name)
+                    finally:
+                        sweep_runtime.mark_stopped(name.replace("_stop_", "_start_", 1))
+
+    app.router.lifespan_context = _cloud_lifespan
 
 
 def init_realtime() -> None:
@@ -851,15 +926,16 @@ def mount_cloud(app: FastAPI) -> None:
     # path to fetch Composio tools using the official provider package for
     # that SDK. No cloud-bootstrap registration is needed.
 
-    # Initialise the realtime EventBus eagerly.
+    # Initialise the realtime EventBus eagerly, at MOUNT time rather than at
+    # startup. It only sets module-level singletons (bus + resolver) with no
+    # async work, and doing it here means a service that calls ``emit(...)``
+    # between mount and startup does not fail with "EventBus not initialized".
     #
-    # The host app (src/pocketpaw/dashboard.py) uses a FastAPI ``lifespan``
-    # context manager, which supersedes ``@app.on_event("startup")`` —
-    # startup handlers registered here never fire. ``init_realtime()`` only
-    # sets module-level singletons (bus + resolver) with no async work, so
-    # it's safe to call synchronously at mount time. Without this, the
-    # first service that calls ``emit(...)`` fails with "EventBus not
-    # initialized".
+    # This used to be the workaround for the bug ``_install_cloud_lifespan`` now
+    # fixes: startup handlers registered here never fired, so anything that had
+    # to happen at boot had to happen at mount instead. The hooks below DO run
+    # now, but this stays eager because "before any request" is a stronger
+    # guarantee than "at startup" and costs nothing.
     init_realtime()
 
     # Register built-in workspace jobs (pp#1459) into the process-wide job
@@ -922,6 +998,22 @@ def mount_cloud(app: FastAPI) -> None:
 
     init_decisions_projection(rebuild_from_journal=True)
 
+    # ---- Lifespan hooks -------------------------------------------------
+    # Collected here and run from the composed lifespan installed at the end of
+    # this function. They used to be ``@app.on_event("startup"/"shutdown")``,
+    # which Starlette drops on the floor for any app built with ``lifespan=`` --
+    # which is both of ours. See ``_install_cloud_lifespan``.
+    _startup_hooks: list[Callable[[], Awaitable[None]]] = []
+    _shutdown_hooks: list[Callable[[], Awaitable[None]]] = []
+
+    def on_startup(fn: Callable[[], Awaitable[None]]) -> Callable[[], Awaitable[None]]:
+        _startup_hooks.append(fn)
+        return fn
+
+    def on_shutdown(fn: Callable[[], Awaitable[None]]) -> Callable[[], Awaitable[None]]:
+        _shutdown_hooks.append(fn)
+        return fn
+
     # Decision-graph reconciler + abandon-path sweeper (RFC 09 Slice 4).
     #
     # The reconciler is a 60s background loop that drains the journal
@@ -945,19 +1037,19 @@ def mount_cloud(app: FastAPI) -> None:
             stop_reconciler,
         )
 
-        @app.on_event("startup")
+        @on_startup
         async def _start_decisions_reconciler() -> None:
             await start_reconciler(app)
 
-        @app.on_event("shutdown")
+        @on_shutdown
         async def _stop_decisions_reconciler() -> None:
             await stop_reconciler(app)
 
-        @app.on_event("startup")
+        @on_startup
         async def _start_decisions_sweeper() -> None:
             await start_action_sweeper(app)
 
-        @app.on_event("shutdown")
+        @on_shutdown
         async def _stop_decisions_sweeper() -> None:
             await stop_action_sweeper(app)
 
@@ -1039,11 +1131,11 @@ def mount_cloud(app: FastAPI) -> None:
     if _os.environ.get("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "").lower() == "true":
         from pocketpaw_ee.cloud.cycles.scheduler import start_in_process_scheduler
 
-        @app.on_event("startup")
+        @on_startup
         async def _start_cycle_scheduler() -> None:
             await start_in_process_scheduler(app)
 
-        @app.on_event("shutdown")
+        @on_shutdown
         async def _stop_cycle_scheduler() -> None:
             from pocketpaw_ee.cloud.cycles.scheduler import stop_in_process_scheduler
 
@@ -1061,11 +1153,11 @@ def mount_cloud(app: FastAPI) -> None:
             stop_member_ingest,
         )
 
-        @app.on_event("startup")
+        @on_startup
         async def _start_member_ingest() -> None:
             await start_member_ingest(app)
 
-        @app.on_event("shutdown")
+        @on_shutdown
         async def _stop_member_ingest() -> None:
             await stop_member_ingest(app)
 
@@ -1083,11 +1175,11 @@ def mount_cloud(app: FastAPI) -> None:
             stop_fabric_ingest,
         )
 
-        @app.on_event("startup")
+        @on_startup
         async def _start_fabric_ingest() -> None:
             await start_fabric_ingest(app)
 
-        @app.on_event("shutdown")
+        @on_shutdown
         async def _stop_fabric_ingest() -> None:
             await stop_fabric_ingest(app)
 
@@ -1107,11 +1199,11 @@ def mount_cloud(app: FastAPI) -> None:
             stop_websandbox_reaper,
         )
 
-        @app.on_event("startup")
+        @on_startup
         async def _start_websandbox_reaper() -> None:
             await start_websandbox_reaper(app)
 
-        @app.on_event("shutdown")
+        @on_shutdown
         async def _stop_websandbox_reaper() -> None:
             await stop_websandbox_reaper(app)
 
@@ -1130,11 +1222,11 @@ def mount_cloud(app: FastAPI) -> None:
             shutdown_all_autopilot_tasks,
         )
 
-        @app.on_event("startup")
+        @on_startup
         async def _start_mandate_autopilot() -> None:
             await reconcile_autopilot_tasks()
 
-        @app.on_event("shutdown")
+        @on_shutdown
         async def _stop_mandate_autopilot() -> None:
             await shutdown_all_autopilot_tasks()
 
@@ -1154,11 +1246,11 @@ def mount_cloud(app: FastAPI) -> None:
             shutdown_scheduler,
         )
 
-        @app.on_event("startup")
+        @on_startup
         async def _start_mandate_scheduler() -> None:
             await reconcile_scheduler()
 
-        @app.on_event("shutdown")
+        @on_shutdown
         async def _stop_mandate_scheduler() -> None:
             await shutdown_scheduler()
 
@@ -1179,26 +1271,30 @@ def mount_cloud(app: FastAPI) -> None:
     # ``InboundMessage.metadata["attachments"]``. The old
     # ``ee.cloud.shared.chat_persistence`` bus subscriber was removed because
     # it dual-wrote every turn.
-    @app.on_event("startup")
+    @on_startup
     async def _start_agent_pool():
         from pocketpaw.agents.pool import get_agent_pool
 
         await get_agent_pool().start()
 
-    @app.on_event("shutdown")
+    @on_shutdown
     async def _stop_agent_pool():
         from pocketpaw.agents.pool import get_agent_pool
 
         await get_agent_pool().stop()
 
-    # Defence-in-depth drain. Under ``FastAPI(lifespan=...)`` (the host's
-    # default in ``src/pocketpaw/dashboard.py``) this hook is silently dropped
-    # — the real drain runs in ``dashboard_lifecycle.shutdown_event``. Kept
-    # here so a host that doesn't pass ``lifespan=`` still drains in-flight runs.
-    @app.on_event("shutdown")
+    # Defence-in-depth drain. ``dashboard_lifecycle.shutdown_event`` also
+    # drains, with a bound; this one covers a host that mounts the cloud without
+    # going through that lifecycle. ``drain()`` is idempotent, so a second call
+    # on an already-drained executor returns immediately.
+    @on_shutdown
     async def _drain_chat_runs() -> None:
         from pocketpaw_ee.cloud.chat.runs.executor import InProcessExecutor, get_executor
 
         executor = get_executor()
         if isinstance(executor, InProcessExecutor):
             await executor.drain()
+
+    # Install LAST: the closure captures the lists, so every hook above has to
+    # be in them before this runs.
+    _install_cloud_lifespan(app, _startup_hooks, _shutdown_hooks)

--- a/ee/pocketpaw_ee/cloud/_core/sweep_runtime.py
+++ b/ee/pocketpaw_ee/cloud/_core/sweep_runtime.py
@@ -1,0 +1,48 @@
+# ee/pocketpaw_ee/cloud/_core/sweep_runtime.py — which background sweeps actually started.
+#
+# Created 2026-09-05. GET /api/v1/automations/status used to answer "are the
+# sweeps on" by reading an environment variable and nothing else. For the whole
+# period the mount_cloud hooks were being dropped, that endpoint reported every
+# sweep as on while none of them existed, which is most of the reason the bug
+# survived: the place you would look to check reported a confident yes.
+#
+# This is the smallest thing that cannot lie in that direction. A name lands here
+# only when the hook that starts the sweep has actually run to completion, so a
+# dropped hook, an import error, or a raise inside the hook all leave it absent.
+# It is process-local on purpose: the question the endpoint answers is "is this
+# process running the sweep", and with more than one replica each answers for
+# itself.
+"""Process-local record of which cloud background sweeps started."""
+
+from __future__ import annotations
+
+_STARTED: set[str] = set()
+
+
+def mark_started(name: str) -> None:
+    """Record that the hook named ``name`` completed without raising."""
+    _STARTED.add(name)
+
+
+def mark_stopped(name: str) -> None:
+    """Record that the sweep started by ``name`` has been torn down."""
+    _STARTED.discard(name)
+
+
+def is_running(name: str | None) -> bool:
+    """Whether ``name`` started in this process and has not been torn down.
+
+    ``None`` means the caller has no hook to point at, which is itself an
+    answer: nothing claims to have started it, so it is not running.
+    """
+    return bool(name) and name in _STARTED
+
+
+def started_names() -> frozenset[str]:
+    """Everything currently marked started. For diagnostics and tests."""
+    return frozenset(_STARTED)
+
+
+def reset() -> None:
+    """Clear the record. Tests only — a leaked entry makes a later test lie."""
+    _STARTED.clear()

--- a/ee/pocketpaw_ee/cloud/automations_status/domain.py
+++ b/ee/pocketpaw_ee/cloud/automations_status/domain.py
@@ -28,6 +28,18 @@ class SweepDescriptor:
     sweep's loop-spawn at app boot; ``env_flag_on`` is that flag's current value
     in THIS process (resolved at read time). ``interval_env`` names the optional
     override for the sweep's cadence, when it has one.
+
+    ``running`` is the field that was missing, and its absence is most of why the
+    dropped-hook bug survived: this row used to carry ``env_flag_on`` alone, so
+    the endpoint that exists to answer "are the sweeps on" answered from a
+    variable that had never been connected to anything. It reported all of them
+    on for the whole period none of them existed. ``running`` is set from a
+    record written only when the start hook completes, so it cannot say yes for a
+    sweep that never started.
+
+    The two are not redundant. ``env_flag_on and not running`` is the exact
+    signature of "configured but broken", which is the state this codebase was
+    in, and which no single field can express.
     """
 
     key: str
@@ -35,6 +47,7 @@ class SweepDescriptor:
     kind: SweepKind
     env_flag: str
     env_flag_on: bool
+    running: bool = False
     interval_env: str | None = None
     description: str = ""
 

--- a/ee/pocketpaw_ee/cloud/automations_status/dto.py
+++ b/ee/pocketpaw_ee/cloud/automations_status/dto.py
@@ -40,6 +40,10 @@ class SweepDescriptorOut(BaseModel):
     kind: str
     env_flag: str
     env_flag_on: bool
+    #: Whether the sweep's start hook actually ran in THIS process. Distinct
+    #: from ``env_flag_on``: the pair "flag on, not running" is what a broken
+    #: wiring looks like, and it is what this deployment looked like for months.
+    running: bool = False
     interval_env: str | None = None
     description: str = ""
 

--- a/ee/pocketpaw_ee/cloud/automations_status/service.py
+++ b/ee/pocketpaw_ee/cloud/automations_status/service.py
@@ -51,6 +51,11 @@ logger = logging.getLogger(__name__)
 _CLOUD_SCHEDULER_FLAG = "POCKETPAW_CLOUD_SCHEDULER_ENABLED"
 # The pocket-interval refresh sweep carries its own gate.
 _REFRESH_SCHEDULER_FLAG = "POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED"
+#: The temporal sweeps have their OWN gate. They are started from
+#: ``CloudLifecycleHook.on_startup`` (ee/pocketpaw_ee/extensions.py), not from
+#: mount_cloud, and this table used to list them under the cloud-scheduler flag
+#: -- so the one row whose sweep was actually running named the wrong variable.
+_TEMPORAL_SWEEP_FLAG = "POCKETPAW_TEMPORAL_SWEEP_ENABLED"
 
 
 def _env_flag_on(name: str) -> bool:
@@ -70,15 +75,24 @@ def scheduler_enabled() -> bool:
 # the single place that enumerates them, kept in sync with the app-factory
 # wiring by the C4 touch-time rule (add a sweep → add a row here). The env-flag
 # on/off value is resolved at read time so the status reflects THIS process.
+#
+# The sixth column is the name of the START HOOK, and it is what makes the
+# ``running`` field trustworthy. ``_install_cloud_lifespan`` records a hook name
+# only after that hook has run without raising, so a row can report running only
+# if its loop was actually spawned in this process. Before that existed, this
+# table reported every sweep as on for the entire period all of them were
+# silently dropped. A row with ``None`` here is started somewhere other than
+# mount_cloud and says so rather than guessing.
 # ---------------------------------------------------------------------------
 
-_SWEEP_TABLE: tuple[tuple[str, str, str, str, str | None, str], ...] = (
+_SWEEP_TABLE: tuple[tuple[str, str, str, str, str | None, str | None, str], ...] = (
     (
         "cycles_snapshot",
         "Cycle daily snapshot",
         "snapshot",
         _CLOUD_SCHEDULER_FLAG,
         None,
+        "_start_cycle_scheduler",
         "Once per UTC midnight, snapshots every active cycle in each active workspace.",
     ),
     (
@@ -87,6 +101,7 @@ _SWEEP_TABLE: tuple[tuple[str, str, str, str, str | None, str], ...] = (
         "decisions",
         _CLOUD_SCHEDULER_FLAG,
         None,
+        "_start_decisions_reconciler",
         "60s reconciler drains chain events the hot path missed; hourly sweeper "
         "closes chains for parked Actions past the TTL.",
     ),
@@ -96,6 +111,7 @@ _SWEEP_TABLE: tuple[tuple[str, str, str, str, str | None, str], ...] = (
         "ingest",
         _CLOUD_SCHEDULER_FLAG,
         "POCKETPAW_MEMBER_INGEST_INTERVAL_SECONDS",
+        "_start_member_ingest",
         "Backfills/incrementally syncs each consented member's Gmail + Calendar "
         "into their private KB scope.",
     ),
@@ -105,6 +121,7 @@ _SWEEP_TABLE: tuple[tuple[str, str, str, str, str | None, str], ...] = (
         "ingest",
         _CLOUD_SCHEDULER_FLAG,
         "POCKETPAW_FABRIC_INGEST_INTERVAL_SECONDS",
+        "_start_fabric_ingest",
         "Mirrors each workspace's configured Firestore collections into Fabric "
         "objects (backfill then incremental).",
     ),
@@ -112,8 +129,9 @@ _SWEEP_TABLE: tuple[tuple[str, str, str, str, str | None, str], ...] = (
         "temporal_sweeps",
         "Pocket temporal sweeps",
         "temporal",
-        _CLOUD_SCHEDULER_FLAG,
+        _TEMPORAL_SWEEP_FLAG,
         None,
+        "_start_temporal_sweeps",
         "Fires per-pocket temporal triggers across the workspace × pocket "
         "cross-product for pockets that declare interval sources.",
     ),
@@ -123,13 +141,24 @@ _SWEEP_TABLE: tuple[tuple[str, str, str, str, str | None, str], ...] = (
         "refresh",
         _REFRESH_SCHEDULER_FLAG,
         None,
+        "_start_pocket_refresh",
         "Re-pulls each pocket's interval data sources on its declared cadence.",
     ),
 )
 
 
 def build_sweep_registry() -> list[SweepDescriptor]:
-    """Return the constructed cloud sweep registry with live env-flag state."""
+    """The cloud sweep registry, with both the env flag AND whether it is running.
+
+    Reporting the flag alone is what made the dropped-hook bug expensive: this
+    function answered "are the sweeps on" from a variable that had never been
+    connected to a running loop, and said yes for months while every one of them
+    was dead. ``running`` comes from ``sweep_runtime``, which is written only
+    after a start hook completes, so the pair can now express "configured but not
+    running" -- the state this deployment was actually in.
+    """
+    from pocketpaw_ee.cloud._core import sweep_runtime
+
     return [
         SweepDescriptor(
             key=key,
@@ -137,10 +166,19 @@ def build_sweep_registry() -> list[SweepDescriptor]:
             kind=kind,  # type: ignore[arg-type]
             env_flag=env_flag,
             env_flag_on=_env_flag_on(env_flag),
+            running=sweep_runtime.is_running(start_hook),
             interval_env=interval_env,
             description=description,
         )
-        for (key, label, kind, env_flag, interval_env, description) in _SWEEP_TABLE
+        for (
+            key,
+            label,
+            kind,
+            env_flag,
+            interval_env,
+            start_hook,
+            description,
+        ) in _SWEEP_TABLE
     ]
 
 

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -441,9 +441,15 @@ class CloudLifecycleHook:
         # exactly one replica). The task lives at module scope inside the
         # scheduler so this no-`app` lifecycle hook can still own it.
         try:
+            from pocketpaw_ee.cloud._core import sweep_runtime
             from pocketpaw_ee.cloud.pockets.refresh_scheduler import start_scheduler
 
             await start_scheduler()
+            # These two sweeps start HERE, not in mount_cloud, so the lifespan
+            # that records the rest never sees them. Marked by hand under the
+            # name /api/v1/automations/status looks them up by, so that endpoint
+            # cannot report them running when this call raised above.
+            sweep_runtime.mark_started("_start_pocket_refresh")
         except Exception as exc:  # noqa: BLE001
             logger.warning("Pocket interval-refresh scheduler start failed: %s", exc)
 
@@ -457,11 +463,13 @@ class CloudLifecycleHook:
         # scope inside the scheduler so this no-``app`` lifecycle hook
         # can still own it.
         try:
+            from pocketpaw_ee.cloud._core import sweep_runtime
             from pocketpaw_ee.cloud._core.temporal_scheduler import (
                 start_scheduler as start_temporal_scheduler,
             )
 
             await start_temporal_scheduler()
+            sweep_runtime.mark_started("_start_temporal_sweeps")
         except Exception as exc:  # noqa: BLE001
             logger.warning("Temporal sweep scheduler start failed: %s", exc)
 
@@ -532,17 +540,26 @@ class CloudLifecycleHook:
         except Exception as exc:  # noqa: BLE001
             logger.warning("Meeting scheduler shutdown error: %s", exc)
 
-        # Most cloud teardown is handled inside mount_cloud's own shutdown
-        # hook. The interval-refresh scheduler is owned by this lifecycle
-        # hook (it was started in on_startup), so it is cancelled here so
-        # the background task does not outlive the process.
+        # NOTE: this method runs only because the host lifecycle calls it --
+        # see dashboard_lifecycle.shutdown_event. It was called by nothing at
+        # all until 2026-09-05, and the comment that used to sit here said
+        # "most cloud teardown is handled inside mount_cloud's own shutdown
+        # hook", which was wrong twice over: mount_cloud's shutdown hooks were
+        # themselves dropped, and a reader checking whether teardown was
+        # covered found a sentence saying yes.
+        #
+        # mount_cloud now owns its own teardown through the composed lifespan
+        # (_install_cloud_lifespan). What is cancelled below is what THIS hook
+        # started in on_startup.
         import logging
 
         logger = logging.getLogger(__name__)
         try:
+            from pocketpaw_ee.cloud._core import sweep_runtime
             from pocketpaw_ee.cloud.pockets.refresh_scheduler import stop_scheduler
 
             await stop_scheduler()
+            sweep_runtime.mark_stopped("_start_pocket_refresh")
         except Exception as exc:  # noqa: BLE001
             logger.warning("Pocket interval-refresh scheduler stop failed: %s", exc)
 

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -339,7 +339,16 @@ class AgentPool:
         self._build_lock = asyncio.Lock()
 
     async def start(self) -> None:
-        """Start the GC background task."""
+        """Start the GC background task. Idempotent.
+
+        Two callers reach this on a cloud boot: ``dashboard_lifecycle``'s
+        startup and the cloud lifespan hook, which only began running again when
+        the dropped-``on_event`` bug was fixed. Without this guard the second
+        call overwrites ``_gc_task`` and orphans the first loop, which then runs
+        forever with nothing holding a handle to cancel it.
+        """
+        if self._gc_task is not None and not self._gc_task.done():
+            return
         self._gc_task = asyncio.create_task(self._gc_loop())
         logger.info(
             "AgentPool started (max_idle=%ds, max_instances=%d)",

--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -699,6 +699,23 @@ async def shutdown_event(*, _stop_channel_adapter_fn=None):
     except Exception as exc:
         logger.debug("Request-log flush skipped: %s", exc)
 
+    # Run the enterprise lifecycle shutdown hooks. The mirror of the startup
+    # loop above, which existed on its own for months: ``on_shutdown`` was
+    # declared in the protocol (src/pocketpaw/extensions.py), implemented by
+    # CloudLifecycleHook, and called by nothing. Everything that hook started --
+    # the meeting scheduler, the pocket interval refresh, the temporal sweeps,
+    # the run sweeper -- outlived the process it belonged to.
+    #
+    # Placed after the run drain and the request-log flush so cloud teardown
+    # happens before the channel adapters and the daemon go down under it.
+    try:
+        from pocketpaw._registry import providers as _ext_providers
+
+        for _hook in _ext_providers("pocketpaw.lifecycle"):
+            await _bounded("lifecycle_shutdown", _hook.on_shutdown(), timeout=10.0)
+    except Exception as exc:
+        logger.debug("Lifecycle shutdown hooks skipped: %s", exc)
+
     # Stop all channel adapters
     if _stop_channel_adapter_fn:
         for channel in list(_channel_adapters):

--- a/tests/cloud/test_cloud_lifespan_hooks.py
+++ b/tests/cloud/test_cloud_lifespan_hooks.py
@@ -1,0 +1,381 @@
+# test_cloud_lifespan_hooks.py — mount_cloud's startup/shutdown hooks actually run.
+# Created: 2026-09-05. Sixteen background loops were registered inside mount_cloud
+#   with @app.on_event and never ran once, because both host app factories build
+#   their FastAPI app with lifespan=. Starlette reads the on_event lists only
+#   through _DefaultLifespan, which it installs only when no lifespan was passed.
+#   The dead loops include the Daytona sandbox reaper, so the bug spends money
+#   continuously, and the mandate cadence scheduler, a shipped feature that had
+#   never fired for anyone.
+#
+#   The first test here pins the FRAMEWORK MECHANISM rather than our code: it is
+#   what makes the rest of this file necessary, and if a future Starlette changed
+#   it, that test is where the news arrives.
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import FastAPI
+
+pytest.importorskip("pocketpaw_ee", reason="enterprise package not installed")
+
+
+async def _run_lifespan(app: FastAPI) -> None:
+    """Drive the app's lifespan exactly as an ASGI server does."""
+    async with app.router.lifespan_context(app):
+        pass
+
+
+async def test_on_event_never_runs_when_the_app_has_a_lifespan() -> None:
+    """The framework behaviour the whole bug rests on.
+
+    ``Router.startup()`` and ``Router.shutdown()`` are the only readers of
+    ``on_startup`` / ``on_shutdown``, and only ``_DefaultLifespan`` calls them.
+    Starlette installs that only when the app was built with no ``lifespan=``.
+    Both of our app factories pass one, so every ``@app.on_event`` handler
+    registered against them was collected into a list nothing reads.
+
+    Asserted here, against the installed Starlette, so this is a measurement and
+    not a claim repeated from a design document.
+    """
+    ran: list[str] = []
+
+    @asynccontextmanager
+    async def host_lifespan(_app: FastAPI):
+        ran.append("host-startup")
+        yield
+        ran.append("host-shutdown")
+
+    app = FastAPI(lifespan=host_lifespan)
+
+    @app.on_event("startup")
+    async def _never() -> None:  # pragma: no cover - the point is that it does not run
+        ran.append("on_event-startup")
+
+    await _run_lifespan(app)
+
+    assert ran == ["host-startup", "host-shutdown"], (
+        "on_event ran after all; the mechanism this fix is built on has changed"
+    )
+
+
+async def test_the_composed_lifespan_runs_hooks_inside_the_host_lifespan() -> None:
+    """Ordering is the whole design, not a detail.
+
+    Every one of these loops reads Mongo, and Mongo is opened by the host's
+    lifespan through CloudLifecycleHook.on_startup. A cloud hook that ran before
+    the host started would take its first tick against an uninitialised Beanie.
+    Shutdown mirrors it: cloud teardown before the host tears down under it.
+    """
+    from pocketpaw_ee.cloud import _install_cloud_lifespan
+
+    order: list[str] = []
+
+    @asynccontextmanager
+    async def host_lifespan(_app: FastAPI):
+        order.append("host-start")
+        yield
+        order.append("host-stop")
+
+    app = FastAPI(lifespan=host_lifespan)
+
+    async def start_a() -> None:
+        order.append("start-a")
+
+    async def start_b() -> None:
+        order.append("start-b")
+
+    async def stop_a() -> None:
+        order.append("stop-a")
+
+    async def stop_b() -> None:
+        order.append("stop-b")
+
+    _install_cloud_lifespan(app, [start_a, start_b], [stop_a, stop_b])
+    await _run_lifespan(app)
+
+    assert order == [
+        "host-start",
+        "start-a",
+        "start-b",
+        "stop-b",
+        "stop-a",
+        "host-stop",
+    ], f"hooks ran in the wrong order: {order}"
+
+
+async def test_a_failing_startup_hook_does_not_take_the_process_down() -> None:
+    """A background sweep that cannot start must degrade, not restart-loop.
+
+    The web process serves traffic. Letting one sweep's import error propagate
+    out of the lifespan would fail startup and hand the container a crash loop,
+    which is strictly worse than the sweep being absent.
+    """
+    from pocketpaw_ee.cloud import _install_cloud_lifespan
+
+    ran: list[str] = []
+
+    async def boom() -> None:
+        raise RuntimeError("redis unreachable at boot")
+
+    async def after() -> None:
+        ran.append("after")
+
+    async def stop_boom() -> None:
+        raise RuntimeError("teardown also failed")
+
+    async def stop_after() -> None:
+        ran.append("stop-after")
+
+    app = FastAPI()
+    _install_cloud_lifespan(app, [boom, after], [stop_boom, stop_after])
+
+    await _run_lifespan(app)
+
+    assert "after" in ran, "one failing startup hook stopped the hooks behind it"
+    assert "stop-after" in ran, "one failing shutdown hook stopped the teardown behind it"
+
+
+async def test_installing_twice_does_not_double_run_the_hooks() -> None:
+    """mount_cloud can be reached more than once in a test session."""
+    from pocketpaw_ee.cloud import _install_cloud_lifespan
+
+    ran: list[str] = []
+
+    async def start() -> None:
+        ran.append("start")
+
+    app = FastAPI()
+    _install_cloud_lifespan(app, [start], [])
+    _install_cloud_lifespan(app, [start], [])
+
+    await _run_lifespan(app)
+
+    assert ran == ["start"], f"the hook ran {len(ran)} times"
+
+
+def test_mount_cloud_registers_no_on_event_handlers() -> None:
+    """The regression guard, by AST over the real source.
+
+    ``@app.on_event(...)`` inside this function is the bug. Anyone adding a
+    background loop will reach for it, because it is what the nineteen lines
+    above theirs used to say, so this has to fail the build rather than be a
+    review note.
+    """
+    from pocketpaw_ee import cloud
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(cloud.mount_cloud)))
+    offenders = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "on_event"
+    ]
+    assert not offenders, (
+        f"mount_cloud registers on_event handlers at offsets {offenders}; "
+        "with a lifespan set they are collected and never run. Use @on_startup "
+        "/ @on_shutdown, which the composed lifespan actually invokes."
+    )
+
+
+def test_the_cloud_hooks_are_collected_and_handed_to_the_lifespan() -> None:
+    """A collector that collects nothing would pass the AST test above.
+
+    So this drives the real ``mount_cloud`` far enough to see that hooks were
+    registered and that the composed lifespan was installed on the app.
+    """
+    from pocketpaw_ee import cloud
+
+    source = textwrap.dedent(inspect.getsource(cloud.mount_cloud))
+    tree = ast.parse(source)
+    decorators = [
+        node.id
+        for fn in ast.walk(tree)
+        if isinstance(fn, ast.AsyncFunctionDef)
+        for node in fn.decorator_list
+        if isinstance(node, ast.Name)
+    ]
+    assert decorators.count("on_startup") + decorators.count("on_shutdown") >= 19, (
+        f"expected the 19 collected hooks, found {decorators.count('on_startup')} startup "
+        f"and {decorators.count('on_shutdown')} shutdown"
+    )
+
+    installs = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_install_cloud_lifespan"
+    ]
+    assert installs, "the hooks are collected and the lifespan is never installed"
+
+
+def test_the_agent_pool_start_is_idempotent() -> None:
+    """Two callers reach it once the hooks run again.
+
+    ``dashboard_lifecycle.startup_event`` starts the pool, and so does the cloud
+    hook that this fix revives. Without a guard the second call overwrites
+    ``_gc_task`` and orphans the first loop, which then runs forever with nothing
+    holding a handle to cancel it.
+    """
+    import asyncio
+
+    from pocketpaw.agents.pool import AgentPool
+
+    async def _check() -> None:
+        pool = AgentPool()
+        await pool.start()
+        first = pool._gc_task
+        await pool.start()
+        assert pool._gc_task is first, "the second start orphaned the first GC task"
+        await pool.stop()
+
+    asyncio.run(_check())
+
+
+def test_shutdown_event_calls_the_lifecycle_providers() -> None:
+    """``on_shutdown`` is declared, implemented, and was called by nothing.
+
+    ``startup_event`` iterates the ``pocketpaw.lifecycle`` providers; the mirror
+    in ``shutdown_event`` never existed, so everything CloudLifecycleHook started
+    outlived the process it belonged to.
+    """
+    from pocketpaw import dashboard_lifecycle
+
+    source = textwrap.dedent(inspect.getsource(dashboard_lifecycle.shutdown_event))
+    tree = ast.parse(source)
+    calls: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr == "on_shutdown":
+            calls.append(node.attr)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_ext_providers"
+        ):
+            calls.append("_ext_providers")
+
+    assert "_ext_providers" in calls, "shutdown_event never looks up the lifecycle providers"
+    assert "on_shutdown" in calls, "the providers are looked up and on_shutdown is not called"
+
+
+def test_the_wrong_comment_about_cloud_teardown_is_gone() -> None:
+    """The comment that let this survive review.
+
+    ``extensions.py`` asserted "most cloud teardown is handled inside
+    mount_cloud's own shutdown hook" — and mount_cloud's shutdown hooks were
+    exactly the ones that never ran. A reader checking whether teardown was
+    covered found a sentence saying yes.
+    """
+    from pocketpaw_ee import extensions
+
+    source = inspect.getsource(extensions)
+    assert "Most cloud teardown is handled inside mount_cloud" not in source, (
+        "the comment still claims mount_cloud handles teardown"
+    )
+
+
+def test_the_automations_status_registry_reports_the_right_flag() -> None:
+    """``temporal_sweeps`` is started under its own gate, not the scheduler one.
+
+    The endpoint that exists to answer "are the sweeps on" named the wrong
+    variable for that row, so an operator reading it got a confident wrong
+    answer about the one sweep that was actually running.
+    """
+    from pocketpaw_ee.cloud.automations_status import service
+
+    registry = {row.key: row for row in service.build_sweep_registry()}
+    assert "temporal_sweeps" in registry, f"row missing; keys are {sorted(registry)}"
+    assert registry["temporal_sweeps"].env_flag == "POCKETPAW_TEMPORAL_SWEEP_ENABLED", (
+        "temporal_sweeps is gated by its own variable in extensions.py, not by "
+        "the cloud scheduler flag"
+    )
+
+
+def test_a_sweep_reports_running_only_when_it_is_actually_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The false green that made the dead loops expensive.
+
+    ``build_sweep_registry`` set the row's live state from the environment
+    variable alone and never checked whether a loop existed. So the endpoint
+    that exists to answer "are the sweeps on" answered from a flag that had
+    never been connected to anything, for the entire period all sixteen were
+    dead.
+    """
+    from pocketpaw_ee.cloud._core import sweep_runtime
+    from pocketpaw_ee.cloud.automations_status import service
+
+    monkeypatch.setenv("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "true")
+    sweep_runtime.reset()
+
+    rows = {r.key: r for r in service.build_sweep_registry()}
+    gated = [r for r in rows.values() if r.env_flag == "POCKETPAW_CLOUD_SCHEDULER_ENABLED"]
+    assert gated, "no rows are gated by the cloud scheduler flag"
+
+    # The flag is on and no hook has run. That pair -- configured but not
+    # running -- is the exact state this deployment was in for months, and the
+    # old registry had no way to express it.
+    for row in gated:
+        assert row.env_flag_on is True
+        assert row.running is False, (
+            f"row {row.key!r} reports running with no start hook recorded; the "
+            "endpoint is answering from the env flag again"
+        )
+
+    # And it flips only when a hook actually completed.
+    sweep_runtime.mark_started("_start_cycle_scheduler")
+    try:
+        after = {r.key: r for r in service.build_sweep_registry()}
+        assert after["cycles_snapshot"].running is True
+        assert after["decisions_reconciler"].running is False, (
+            "one sweep starting must not mark the others running"
+        )
+    finally:
+        sweep_runtime.reset()
+
+
+def test_every_shutdown_hook_pairs_with_a_startup_hook_by_name() -> None:
+    """The lifespan clears a sweep's running mark by rewriting ``_stop_`` to ``_start_``.
+
+    That is a convention, not a mechanism, and a convention with no assertion is
+    how the bug this file exists for survived. A shutdown hook named anything
+    else makes ``mark_stopped`` a silent no-op, so the status endpoint would keep
+    reporting a torn-down sweep as running across a dashboard restart -- and
+    ``run_dashboard`` really does restart uvicorn in a loop, so the lifespan runs
+    more than once per process.
+    """
+    from pocketpaw_ee import cloud
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(cloud.mount_cloud)))
+    starts: set[str] = set()
+    stops: set[str] = set()
+    for fn in ast.walk(tree):
+        if not isinstance(fn, ast.AsyncFunctionDef):
+            continue
+        decorators = {d.id for d in fn.decorator_list if isinstance(d, ast.Name)}
+        if "on_startup" in decorators:
+            starts.add(fn.name)
+        if "on_shutdown" in decorators:
+            stops.add(fn.name)
+
+    assert starts and stops, "no collected hooks found; the AST walk is looking in the wrong place"
+
+    unpaired = sorted(
+        name
+        for name in stops
+        if not name.startswith("_stop_") or name.replace("_stop_", "_start_", 1) not in starts
+    )
+    # The chat-run drain has no startup half by design: it is a defence-in-depth
+    # teardown, not a sweep, so it never marks anything running.
+    unpaired = [name for name in unpaired if name != "_drain_chat_runs"]
+
+    assert not unpaired, (
+        f"shutdown hooks {unpaired} do not map to a startup hook by the "
+        "_stop_/_start_ convention, so the lifespan cannot clear their running mark"
+    )

--- a/tests/mutations/cloud_lifespan_hooks.json
+++ b/tests/mutations/cloud_lifespan_hooks.json
@@ -1,0 +1,107 @@
+[
+  {
+    "label": "the hooks go back on @app.on_event, which is the original bug",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "        @on_startup\n        async def _start_websandbox_reaper() -> None:",
+    "replace": "        @app.on_event(\"startup\")\n        async def _start_websandbox_reaper() -> None:",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "the composed lifespan is never installed, so every collected hook is dead again",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "    _install_cloud_lifespan(app, _startup_hooks, _shutdown_hooks)",
+    "replace": "    pass",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "the collectors collect nothing, so the lifespan runs an empty list",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "    def on_startup(fn: Callable[[], Awaitable[None]]) -> Callable[[], Awaitable[None]]:\n        _startup_hooks.append(fn)\n        return fn",
+    "replace": "    def on_startup(fn: Callable[[], Awaitable[None]]) -> Callable[[], Awaitable[None]]:\n        return fn",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "cloud hooks run BEFORE the host lifespan, so each loop ticks against an uninitialised Beanie",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "        async with host_lifespan(scoped_app) as maybe_state:\n            for hook in startup_hooks:",
+    "replace": "        for hook in startup_hooks:\n            await hook()\n        async with host_lifespan(scoped_app) as maybe_state:\n            for hook in []:",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "shutdown hooks run in registration order, so a dependency is torn down before its user",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "                for hook in reversed(shutdown_hooks):",
+    "replace": "                for hook in shutdown_hooks:",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "one failing startup hook propagates, so a dead sweep crash-loops the web process",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "                try:\n                    await hook()\n                except Exception:\n                    _logger.exception(\"Cloud startup hook %s failed\", name)\n                else:",
+    "replace": "                await hook()\n                if True:",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "the host lifespan is discarded rather than wrapped, so host startup never runs",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "    host_lifespan = app.router.lifespan_context",
+    "replace": "    from contextlib import nullcontext\n\n    def host_lifespan(_a):\n        return nullcontext(None)",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "installing twice stacks the wrapper, so every hook runs twice",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "    if getattr(app.state, \"_cloud_lifespan_installed\", False):\n        return\n    app.state._cloud_lifespan_installed = True",
+    "replace": "    app.state._cloud_lifespan_installed = True",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "a sweep is marked running whether or not its hook succeeded (the false green)",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "                except Exception:\n                    _logger.exception(\"Cloud startup hook %s failed\", name)\n                else:\n                    # Marked only on success",
+    "replace": "                except Exception:\n                    _logger.exception(\"Cloud startup hook %s failed\", name)\n                if True:\n                    # Marked only on success",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "the status registry reports running from the env flag again, not from what started",
+    "file": "ee/pocketpaw_ee/cloud/automations_status/service.py",
+    "find": "            running=sweep_runtime.is_running(start_hook),",
+    "replace": "            running=_env_flag_on(env_flag),",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "temporal_sweeps is listed under the cloud scheduler flag, which is not its gate",
+    "file": "ee/pocketpaw_ee/cloud/automations_status/service.py",
+    "find": "        \"Pocket temporal sweeps\",\n        \"temporal\",\n        _TEMPORAL_SWEEP_FLAG,",
+    "replace": "        \"Pocket temporal sweeps\",\n        \"temporal\",\n        _CLOUD_SCHEDULER_FLAG,",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "is_running answers yes for anything, so the endpoint cannot report a dead sweep",
+    "file": "ee/pocketpaw_ee/cloud/_core/sweep_runtime.py",
+    "find": "    return bool(name) and name in _STARTED",
+    "replace": "    return True",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "AgentPool.start loses its guard, so the second caller orphans the first GC loop",
+    "file": "src/pocketpaw/agents/pool.py",
+    "find": "        if self._gc_task is not None and not self._gc_task.done():\n            return\n        self._gc_task = asyncio.create_task(self._gc_loop())",
+    "replace": "        self._gc_task = asyncio.create_task(self._gc_loop())",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "shutdown_event stops calling the lifecycle providers, so cloud teardown never runs",
+    "file": "src/pocketpaw/dashboard_lifecycle.py",
+    "find": "        for _hook in _ext_providers(\"pocketpaw.lifecycle\"):\n            await _bounded(\"lifecycle_shutdown\", _hook.on_shutdown(), timeout=10.0)",
+    "replace": "        pass",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  },
+  {
+    "label": "the comment claiming mount_cloud handles teardown comes back",
+    "file": "ee/pocketpaw_ee/extensions.py",
+    "find": "        # NOTE: this method runs only because the host lifecycle calls it --",
+    "replace": "        # Most cloud teardown is handled inside mount_cloud's own shutdown hook.\n        # NOTE: this method runs only because the host lifecycle calls it --",
+    "tests": "tests/cloud/test_cloud_lifespan_hooks.py"
+  }
+]


### PR DESCRIPTION
`mount_cloud` registered nineteen handlers with `@app.on_event`. Starlette reads those lists only through `_DefaultLifespan`, which it installs only when the app was built without a `lifespan=`, and both host factories pass one. The handlers were collected into a list nothing reads.

Three had a compensating caller in the host lifespan. The other sixteen had exactly one caller each: the dead handler.

## What it cost, ranked

**The Web Cursor idle-TTL reaper leaked paid VMs, continuously.** It stops and deletes Daytona sandboxes past their idle window and marks the row reaped. It never ran, so every sandbox a user walked away from stayed billed until someone deleted it by hand. Rows never left `ready`, so the leak was also invisible in the table that would have shown it. This is the only one on the list that spends money every hour.

**The mandate cadence scheduler has never fired.** It turns `Charter.cadence` from a persisted label into a trigger. Anyone who set a cadence and waited got nothing, with no error.

**Autopilot does not survive a restart.** The boot reconciler that re-derives the loops from the persisted flag is one of the dead ones, so `autopilot.on` is true in the database and means nothing after the process that set it exits.

Then the decision-graph reconciler, the abandon-path sweeper, the cycle daily snapshot, and the two ingest loops.

## The fix

`_install_cloud_lifespan` composes a lifespan around whatever the host passed, so the OSS core needs no change and no knowledge of the cloud. It works against Starlette's `_DefaultLifespan` too, for a host that passes nothing.

Cloud hooks run **inside** the host's lifespan, and that ordering is the design rather than a detail. Every one of these loops reads Mongo, and Mongo is opened by `CloudLifecycleHook.on_startup`, which the host lifespan runs. Starting them first would give each loop a first tick against an uninitialised Beanie.

A hook that raises is logged and skipped. A background sweep that cannot start must leave a degraded box, not a restart loop.

The decorator swap is mechanical and preserves every handler body verbatim, which is what keeps the review surface small.

## Two things that had to come with it

**`on_shutdown` was called by nothing.** It is declared in the protocol, implemented by `CloudLifecycleHook`, and no caller existed. So the meeting scheduler, the pocket interval refresh, the temporal sweeps and the run sweeper all outlived the process they belonged to. `shutdown_event` now iterates the lifecycle providers, bounded, after the run drain.

**`AgentPool.start` is now idempotent.** Part one gives it a second real caller. The old code overwrote `_gc_task` and orphaned the first loop, which then ran forever with nothing holding a handle to cancel it. This is a regression the fix would otherwise have introduced.

## The false green that made this expensive

`GET /api/v1/automations/status` set each row's state from an environment variable and never checked whether a loop existed. It reported every sweep as on for the entire period none of them were, so the place you would look to check the sweeps confirmed they were fine.

Rows now carry `running`, set from a record written only after a start hook completes. The two fields are not redundant: `env_flag_on and not running` is the signature of "configured but broken", which is the state this deployment was actually in, and which no single field can express.

`temporal_sweeps` also named the wrong gate. It is started from `CloudLifecycleHook.on_startup` under its own variable, not the cloud scheduler flag, so the one sweep that was really running was reported against a variable that did not control it.

## The env gate, said plainly

All sixteen sit behind `POCKETPAW_CLOUD_SCHEDULER_ENABLED`. I checked: it is absent from the local `.env` and from `deploy/coolify/docker-compose.yaml`. So nothing was running either way, and turning the flag on before this change would have done nothing. That is worth knowing for anyone who believed the sweeps were one variable away.

Turning it on after this merges starts eight loops that have never run in production. That is a deploy-time decision, not something this PR makes.

## Gate

`tests/mutations/cloud_lifespan_hooks.json`, fifteen mutations, all observed to fail the tests. The first restores the original bug by putting one hook back on `@app.on_event`.

Twelve tests. The first measures Starlette's behaviour rather than restating it from a design document, so if a future version changes what `on_event` does, that test is where the news arrives. One pins the `_stop_` / `_start_` naming convention the lifespan relies on to clear a sweep's running mark, because a convention with no assertion is how this bug survived in the first place.

Repo-wide anchor validation green at 1093 anchors across 83 plans.

## Test status, and a finding about local runs

The suites that touch this change all pass: 113 passed, 1 xfailed.

The full suite reports 66 failures on this branch. **None are mine, and none are real.** I measured it: the same fourteen files give 57 failed and 267 passed both with my changes and with the working tree reset to `origin/dev` content. Identical counts, identical failures.

The cause is worth writing down, because it costs everyone who works in a worktree here. `security/url_validators.py` calls `load_dotenv()` at import, and python-dotenv walks **up** from the calling file, so a worktree inherits the parent checkout's `.env`. Real API keys then reach tests that assert nothing is configured. Dropping an empty `.env` into the worktree stops the walk, and those three files go from 4 failed to 86 passed with no other change.

That is also why the number moved between runs: 57 as a subset, 66 in the full suite, because the leak interacts with test ordering.
