### PR TITLE
fix(surface): preserve widget IDs in prompts

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/home.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/home.py
@@ -116,6 +116,8 @@ class _AttrDict:
         self._source = source
 
     def __getattr__(self, key: str):
+        if key == "id":
+            return self._source.get("id") or self._source.get("_id")
         return self._source.get(key)
 
 

--- a/ee/pocketpaw_ee/cloud/surface/handlers/pocket.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/pocket.py
@@ -213,6 +213,8 @@ class _AttrDict:
         self._source = source
 
     def __getattr__(self, key: str):
+        if key == "id":
+            return self._source.get("id") or self._source.get("_id")
         return self._source.get(key)
 
 

--- a/tests/cloud/surface/test_home_handler.py
+++ b/tests/cloud/surface/test_home_handler.py
@@ -23,17 +23,6 @@
 # instead of dropping the assertion, and a second test covers the grid a real new
 # user gets, which nothing had asserted.
 #
-# That second test also records a LIVE DEFECT it would otherwise have papered over:
-# every pinned row renders ``id=?`` because ``format_widget_line`` reads
-# ``widget.id`` while the wire dict carries ``_id``
-# (``pockets/dto.py::_widget_to_wire``) and ``_AttrDict`` answers a missing key with
-# ``None``. That is pocketpaw/CLAUDE.md's "Prompt rows must carry the id the tools
-# take" reintroduced by a key-name mismatch — invisible to the AST gate, since the
-# row does go through ``entity_line``, and invisible to the cap test, whose fixture
-# is built from objects that DO have ``.id``. It affects the pocket surface too. Not
-# fixed here (this PR owns the sites preamble); filed as its own task so the fix
-# lands with the handler.
-
 from __future__ import annotations
 
 import pytest
@@ -42,6 +31,8 @@ from pocketpaw_ee.cloud.pockets import service as pockets_service
 from pocketpaw_ee.cloud.pockets.dto import AddWidgetRequest
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
 from pocketpaw_ee.cloud.surface.handlers import home as home_handler
+
+from pocketpaw.prompt.entity import ID_TAIL_CHARS
 
 pytestmark = pytest.mark.usefixtures("mongo_db")
 
@@ -148,9 +139,7 @@ async def test_home_handler_empty_workspace_returns_minimal_preamble() -> None:
     """
     user_id = await _seed_user("owner-empty@surface.test")
     pocket, _ = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
-    # ``_id``, not ``id`` — the widget wire dict is the legacy shape
-    # (``dto._widget_to_wire``). That mismatch is also why these rows render
-    # ``id=?``; see test_home_handler_lists_the_auto_seeded_builtin.
+    # ``_id`` is the widget wire key emitted by ``dto._widget_to_wire``.
     for widget in pocket["widgets"]:
         await pockets_service.remove_widget(pocket["_id"], widget["_id"], user_id)
 
@@ -163,26 +152,7 @@ async def test_home_handler_empty_workspace_returns_minimal_preamble() -> None:
 
 
 async def test_home_handler_lists_the_auto_seeded_builtin() -> None:
-    """The state a real new user is actually in: one auto-seeded builtin pinned.
-
-    Added with the test above, because that one was the only coverage of a freshly
-    provisioned home grid and it had to stop describing one to keep testing the
-    empty block. Nothing asserted what the handler renders for the grid every new
-    user gets.
-
-    IT ALSO RECORDS A LIVE DEFECT rather than asserting the row is addressable,
-    because it is not: ``format_widget_line`` reads ``widget.id`` while the wire
-    dict this handler passes it carries the id under ``_id``
-    (``pockets/dto.py::_widget_to_wire``), and ``_AttrDict.__getattr__`` returns
-    ``None`` for a missing key — so every pinned row on the home AND pocket
-    surfaces renders ``id=?`` even though ``update_widget`` requires
-    ``widget_id``. That is the bug pocketpaw/CLAUDE.md's "Prompt rows must carry
-    the id the tools take" exists for, reintroduced by a key-name mismatch instead
-    of a hand-rolled row — which is why the AST gate cannot see it (the row does go
-    through ``entity_line``) and why the cap fixture, built from objects with a real
-    ``.id``, measures rows production never renders. Left as an assertion of what
-    ships, with its own task, so the fix lands with the handler and not here.
-    """
+    """A new user's auto-seeded widgets include the IDs required by update_widget."""
     user_id = await _seed_user("owner-seeded@surface.test")
     pocket, created = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
     assert created is True
@@ -193,4 +163,5 @@ async def test_home_handler_lists_the_auto_seeded_builtin() -> None:
     assert f'<pinned-widgets count="{len(pocket["widgets"])}"' in preamble
     for widget in pocket["widgets"]:
         assert widget["name"] in preamble
-    assert "id=?" in preamble
+        assert widget["_id"][-ID_TAIL_CHARS:] in preamble
+    assert "id=?" not in preamble

--- a/tests/cloud/surface/test_pocket_handler.py
+++ b/tests/cloud/surface/test_pocket_handler.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 import pytest
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
 from pocketpaw_ee.cloud.pockets import service as pockets_service
-from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+from pocketpaw_ee.cloud.pockets.dto import AddWidgetRequest, CreatePocketRequest
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
 from pocketpaw_ee.cloud.surface.handlers import pocket as pocket_handler
+
+from pocketpaw.prompt.entity import ID_TAIL_CHARS
 
 pytestmark = pytest.mark.usefixtures("mongo_db")
 
@@ -42,6 +44,10 @@ async def test_pocket_handler_summarizes_existing_pocket() -> None:
         user_id,
         CreatePocketRequest(name="Sales Pipeline"),
     )
+    await pockets_service.add_widget(
+        pocket["_id"], user_id, AddWidgetRequest(name="Revenue", type="native")
+    )
+    pocket = await pockets_service.get(pocket["_id"], user_id)
 
     preamble = (
         await pocket_handler.build_preamble(
@@ -54,6 +60,8 @@ async def test_pocket_handler_summarizes_existing_pocket() -> None:
     assert pocket["_id"] in preamble
     # The current-pocket tag carries the widget count.
     assert "widgets=" in preamble
+    assert pocket["widgets"][0]["_id"][-ID_TAIL_CHARS:] in preamble
+    assert "id=?" not in preamble
 
 
 async def test_pocket_handler_unknown_pocket_id_falls_back() -> None:


### PR DESCRIPTION
## Summary

- map the production widget wire key _id to the id attribute expected by prompt formatting
- cover both home and pocket surface handlers with real wire-dict regressions
- replace the existing assertion that documented id=? with the correct addressable prompt output

Fixes #1922

## Validation

- uv run pytest tests/cloud/surface/test_home_handler.py tests/cloud/surface/test_pocket_handler.py -q (6 passed)
- uv run ruff check . (passed)
- uv run pytest --ignore=tests/e2e (11,054 passed, 59 skipped; one unrelated existing failure in tests/test_context_budget.py::TestKbContext::test_successful_kb_fetch, independently reproducible with untouched upstream/dev files)