### PR TITLE
CORS preflights have been 500ing since FastAPI crossed 0.137

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,22 @@ dependencies = [
     # Dashboard (default mode — must be in core so `pip install pocketpaw` just works)
     "uvicorn[standard]>=0.31.1",
     "jinja2>=3.1.0",
-    "fastapi>=0.134.0",   # fastapi 0.134.0 first allowed starlette 1.0.0 (dropped upper bound)
+    # Lower bound: 0.134.0 first allowed starlette 1.0.0 (dropped its upper bound).
+    # Upper bound: 0.137 stopped flattening include_router()'s routes into
+    # app.routes and appends an _IncludedRouter with no `.path` instead.
+    # opentelemetry-instrumentation-fastapi's _get_route_details reads `.path`
+    # unconditionally on a partial match (path matches, method does not), which
+    # is every CORS preflight. The OTel ASGI middleware runs on every request,
+    # so under fastapi>=0.137 each OPTIONS returns 500 and the browser reports
+    # it as a CORS failure. Seen in production 2026-09-06: 163 preflight 500s
+    # on /chat/groups, /auth/ws/ticket, /agents and /auth/me.
+    #
+    # The real fix is opentelemetry-instrumentation-fastapi>=0.64b0, which
+    # handles both match shapes. We cannot take it: logfire pins
+    # opentelemetry-sdk<1.43.0 and 0.64b0 needs >=1.43 (pydantic/logfire#2041).
+    # LIFT THIS BOUND when that ceiling moves, not before. Gated by
+    # tests/test_fastapi_version_cap.py.
+    "fastapi>=0.134.0,<0.137",
     "qrcode[pil]>=7.4",
     "python-multipart>=0.0.22",
     # Logging & CLI
@@ -174,9 +189,10 @@ pydantic-ai = [
     #
     # The ``mcp`` extra pulls fastmcp, which moves ``starlette`` to the 1.x
     # line. That is INSIDE this project's declared range, not a violation of it:
-    # the core ``fastapi>=0.134.0`` pin exists precisely because 0.134.0 dropped
-    # starlette's upper bound, and fastapi 0.135.x requires only
-    # ``starlette>=0.46.0``.
+    # the core ``fastapi>=0.134.0,<0.137`` pin has 0.134.0 as its floor precisely
+    # because 0.134.0 dropped starlette's upper bound, and fastapi 0.135.x
+    # requires only ``starlette>=0.46.0``. The ceiling is unrelated to starlette
+    # — see the fastapi entry above.
     "pydantic-ai-slim[openai,mcp]==2.18.0",
     # Harness capabilities (compaction, subagents, skills, planning, tool
     # output limits, step persistence). 0.11.0 is likewise the newest release

--- a/src/pocketpaw/observability.py
+++ b/src/pocketpaw/observability.py
@@ -265,6 +265,18 @@ def instrument_fastapi_app(app: Any) -> bool:
     configure time. Call it once the routers are mounted — the instrumentor reads
     the route table to label spans by route TEMPLATE rather than by path, which is
     what keeps ``/api/v1/pockets/{id}`` one row instead of one row per pocket.
+
+    THE TRY/EXCEPT BELOW IS NOT A SAFETY NET FOR THE REQUEST PATH. It catches a
+    failure to *install* the instrumentation. What this call installs is ASGI
+    middleware that then runs on every request, outside this function and outside
+    any guard here, so a bug in it takes the whole API down while this function
+    reports success. That is not theoretical: reading the route table is exactly
+    where it broke. Under fastapi>=0.137 ``app.routes`` holds ``_IncludedRouter``
+    objects with no ``.path``, the instrumentor read it anyway on every CORS
+    preflight, and production served 163 preflight 500s that the browser reported
+    as CORS failures. Held off by the fastapi ceiling in pyproject; see
+    tests/test_fastapi_version_cap.py. Treat anything this installs as
+    load-bearing, whatever the docstring on observability says about it not being.
     """
     if not logfire_enabled():
         return False

--- a/tests/mutations/fastapi_version_cap.json
+++ b/tests/mutations/fastapi_version_cap.json
@@ -1,0 +1,9 @@
+[
+  {
+    "label": "the fastapi ceiling is lifted, so the deploy resolves fastapi>=0.137 again and every CORS preflight 500s in production",
+    "file": "pyproject.toml",
+    "find": "\"fastapi>=0.134.0,<0.137\",",
+    "replace": "\"fastapi>=0.134.0\",",
+    "tests": ["tests/test_fastapi_version_cap.py"]
+  }
+]

--- a/tests/test_fastapi_version_cap.py
+++ b/tests/test_fastapi_version_cap.py
@@ -1,0 +1,73 @@
+"""FastAPI must keep flattening include_router()'s routes into ``app.routes``.
+
+opentelemetry-instrumentation-fastapi reads ``route.path`` off the entries in
+``app.routes``. FastAPI 0.137 stopped flattening: ``include_router`` now appends
+a single ``_IncludedRouter`` that matches lazily and carries no ``.path``. OTel's
+``_get_route_details`` reads it unconditionally on a PARTIAL match — path matches,
+method does not — which is every CORS preflight. The OTel ASGI middleware runs on
+every request, so under fastapi>=0.137 each OPTIONS returns 500 and the browser
+reports it as a CORS failure.
+
+That is not hypothetical. Production on 2026-09-06 served 163 preflight 500s on
+/chat/groups, /auth/ws/ticket, /agents and /auth/me, and the frontend could not
+reach any of them. It reached that version because the deploy installs with
+``uv pip install '.[all]'``, which resolves from pyproject and ignores uv.lock —
+so the constraint in pyproject, not the lock, is what production obeys.
+
+The real fix is opentelemetry-instrumentation-fastapi>=0.64b0, which handles both
+match shapes. It is unreachable while logfire pins opentelemetry-sdk<1.43.0 and
+0.64b0 requires >=1.43 (pydantic/logfire#2041).
+
+Two tests, deliberately different in kind. The first measures FastAPI's actual
+behaviour, so it reports the day an upgrade reintroduces the shape whatever the
+version number says. The second pins the constraint that keeps production off it.
+
+Mutation that must fail these: widen the fastapi bound in pyproject.toml back to
+``fastapi>=0.134.0``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+from fastapi import APIRouter, FastAPI
+
+
+def test_included_routes_still_expose_a_path():
+    """The property OTel depends on, measured rather than assumed."""
+    app = FastAPI()
+    sub = APIRouter()
+
+    @sub.get("/thing")
+    async def _thing() -> dict:
+        return {}
+
+    app.include_router(sub, prefix="/sub")
+
+    pathless = [r for r in app.routes if not hasattr(r, "path")]
+    assert pathless == [], (
+        "app.routes contains entries with no `.path`: "
+        f"{[type(r).__name__ for r in pathless]}. "
+        "opentelemetry-instrumentation-fastapi reads .path on every request and "
+        "will 500 each CORS preflight. Either hold fastapi below the release "
+        "that did this, or upgrade opentelemetry-instrumentation-fastapi to "
+        ">=0.64b0 once logfire's opentelemetry-sdk<1.43.0 ceiling lifts."
+    )
+
+
+def test_pyproject_holds_fastapi_below_the_release_that_broke_it():
+    """The lock does not govern the deploy; this constraint does."""
+    root = pathlib.Path(__file__).resolve().parent.parent
+    text = (root / "pyproject.toml").read_text(encoding="utf-8")
+
+    match = re.search(r'^\s*"fastapi(?P<spec>[^"]*)",', text, re.M)
+    assert match, "no fastapi requirement found in pyproject.toml"
+
+    spec = match.group("spec")
+    assert "<0.137" in spec, (
+        f"fastapi is declared as 'fastapi{spec}' with no ceiling below 0.137. "
+        "The deploy resolves from pyproject, so removing this bound puts "
+        "fastapi>=0.137 into production and 500s every CORS preflight. Lift it "
+        "only once opentelemetry-instrumentation-fastapi>=0.64b0 is installable."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -5653,7 +5653,7 @@ requires-dist = [
     { name = "elevenlabs", marker = "extra == 'all-tools'", specifier = ">=1.0.0" },
     { name = "elevenlabs", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "elevenlabs", marker = "extra == 'voice'", specifier = ">=1.0.0" },
-    { name = "fastapi", specifier = ">=0.134.0" },
+    { name = "fastapi", specifier = ">=0.134.0,<0.137" },
     { name = "genai-prices", specifier = ">=0.0.73" },
     { name = "github-copilot-sdk", marker = "extra == 'all'", specifier = ">=0.1.0" },
     { name = "github-copilot-sdk", marker = "extra == 'copilot-sdk'", specifier = ">=0.1.0" },


### PR DESCRIPTION
Production served 163 preflight 500s on 2026-09-06. Every one was an `OPTIONS`,
and they were concentrated on four endpoints:

| count | request |
|---|---|
| 58 | `OPTIONS /api/v1/chat/groups` |
| 41 | `OPTIONS /api/v1/auth/ws/ticket` |
| 33 | `OPTIONS /api/v1/agents?limit=100` |
| 30 | `OPTIONS /api/v1/auth/me` |

A browser reports a failed preflight as a CORS error, so from the frontend those
four endpoints were simply unreachable. There are another 160 `429`s in the same
log, which look like the client retrying into a rate limit.

## What actually throws

```
File "opentelemetry/instrumentation/fastapi/__init__.py", line 495, in _get_route_details
    route = starlette_route.path
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

FastAPI 0.137 stopped flattening `include_router()`'s routes into `app.routes`.
It appends one lazily-matching `_IncludedRouter` instead, and that object has no
`.path`. OTel's `_get_route_details` reads `.path` unconditionally on a *partial*
match, where the path matches but the method does not. A CORS preflight is
exactly that. The OTel ASGI middleware runs on every request, so every preflight
500s.

## Why it appeared now, and why the fix is a dependency bound

The instrumentation came in with logfire. FastAPI 0.137 did not: the deploy
installs with `uv pip install --no-cache '.[all]'`, which resolves from
`pyproject.toml` and ignores `uv.lock`. Our lock pins fastapi 0.135.3; the newest
release is 0.141.1, and that is the sort of thing production has been getting.
So the merge did not introduce the break, it made a latent one reachable.

The consequence worth keeping: **the lock has never been what production runs**,
and the constraint in `pyproject.toml` is the only thing that governs it. Which
is why this PR moves a bound rather than refreshing a lock. I verified the change
against fastapi 0.136.3, the version the deploy now resolves, instead of only
against the 0.135.3 the lock installs.

The clean fix is `opentelemetry-instrumentation-fastapi>=0.64b0`, which handles
both match shapes. We cannot take it: logfire pins `opentelemetry-sdk<1.43.0` and
0.64b0 needs `>=1.43`. That is tracked upstream as pydantic/logfire#2041. The
ceiling here should be lifted when that moves, and the comment in `pyproject.toml`
says so.

## The try/except around instrumentation was never protection

`instrument_fastapi_app` wraps the logfire call and swallows failures, which reads
like observability cannot take the API down. It can. That guard catches a failure
to *install* the instrumentation; what the call installs is middleware that then
runs on every request, outside the guard. Reading the route table is where it
broke, and the function reported success the whole time. I have written that into
the docstring rather than left it as a thing to rediscover.

## Gate

Two tests, deliberately different in kind.

`test_included_routes_still_expose_a_path` builds a small app with
`include_router` and asserts every entry in `app.routes` has `.path`. It measures
FastAPI's behaviour, so it reports the day an upgrade reintroduces the shape,
whatever the version number is. `test_pyproject_holds_fastapi_below_the_release_that_broke_it`
pins the constraint, because that constraint is what production reads.

`tests/mutations/fastapi_version_cap.json` widens the bound back to
`fastapi>=0.134.0` and was run: caught.

## Two things this does not fix

**The deploy resolves dependencies fresh on every build.** `uv pip install
'.[all]'` means a redeploy can change every transitive version with nothing
recorded. That is how an untested fastapi reached production, and capping one
package does not change the mechanism. The fix belongs in the Coolify Dockerfile
in paw-workspace, and it needs care because the image installs two projects.

**The supply-chain floor does not reach the deployed image.** `[tool.uv]
exclude-newer = "2026-08-10"` is set in both `pyproject.toml` and `ee/pyproject.toml`,
and it governs `uv lock` / `uv sync`. It does not govern `uv pip install`. I
measured it rather than assuming: resolving inside the project directory still
picks fastapi 0.141.1, months past the cutoff. So the deployed image currently has
no minimum-release-age protection, which is the control the workspace CLAUDE.md
describes as being in force.
