### PR TITLE
Logfire is mostly tracing an idle queue poll

### DIFF
--- a/src/pocketpaw/observability.py
+++ b/src/pocketpaw/observability.py
@@ -165,6 +165,9 @@ def _instrumentations() -> dict[str, Any]:
     ledger all run on SQLite and would emit a span per statement, which adds little
     over the operation span already wrapping them and would dominate the bill.
     ``POCKETPAW_LOGFIRE_INSTRUMENT`` can name them back in.
+
+    Known but off by default: redis, for the same reason measured rather than
+    predicted. See _DEFAULT_OFF.
     """
     import logfire
 
@@ -183,7 +186,8 @@ def _instrumentations() -> dict[str, Any]:
         # identically in a log line and are one attribute apart in a span.
         "httpx": lambda: logfire.instrument_httpx(capture_headers=False),
         "aiohttp_client": logfire.instrument_aiohttp_client,
-        # The arq queues and the run stream transport.
+        # The arq queues and the run stream transport. OFF BY DEFAULT — see
+        # _DEFAULT_OFF. Name it in POCKETPAW_LOGFIRE_INSTRUMENT to debug the queue.
         "redis": lambda: logfire.instrument_redis(capture_statement=False),
         # Mongo, under both motor and beanie.
         "pymongo": logfire.instrument_pymongo,
@@ -192,6 +196,29 @@ def _instrumentations() -> dict[str, Any]:
         # "was it the code or was it the box" without an SSH session.
         "system_metrics": logfire.instrument_system_metrics,
     }
+
+
+#: Known integrations that are NOT attached unless named explicitly. Same
+#: argument as sqlite3 and sqlalchemy above, but this one was measured in
+#: production rather than predicted.
+#:
+#: Redis here is dominated by polling that no one is debugging. The worker
+#: supervisor runs two arq lanes in one process and each polls its queue on
+#: arq's own timer, so an IDLE deployment emits a steady ZRANGEBYSCORE, ZCARD
+#: and PSETEX per lane per tick — roughly six spans a second, forever, per
+#: replica, whether or not a single job exists. The run-stream consumer's
+#: blocking XREADGROUP adds a multi-second span per block on top.
+#:
+#: Two costs, and the second is the one that matters. Logfire meters per span,
+#: so idle polling is a standing bill. And the poll spans bury the traces the
+#: tool was turned on to read: a chat run's trace is a handful of spans in a
+#: minute-wide window holding several hundred ZRANGEBYSCOREs.
+#:
+#: Nothing is lost by default. A slow enqueue or a slow stream write already
+#: sits inside the application span that wraps it; this only drops the command
+#: span underneath. Turn it back on for a session when the QUEUE ITSELF is the
+#: suspect: POCKETPAW_LOGFIRE_INSTRUMENT=<the others>,redis
+_DEFAULT_OFF = frozenset({"redis"})
 
 
 def _instrument(name: str, call: Any) -> bool:
@@ -212,17 +239,22 @@ def _instrument(name: str, call: Any) -> bool:
 
 
 def _selected_instrumentations() -> list[str]:
-    """Which integrations to attach. Everything, unless told otherwise.
+    """Which integrations to attach: everything except _DEFAULT_OFF.
 
     ``POCKETPAW_LOGFIRE_INSTRUMENT`` replaces the default set with an explicit
     comma-separated list, and ``none`` disables all of them. It exists because
     spans are metered per unit: if one integration turns out to dominate the bill,
     dropping it should not need a deploy of new code.
+
+    An explicit list is checked against everything KNOWN, not against the default
+    set, so it can name a _DEFAULT_OFF integration back on. That asymmetry is the
+    point: the default is what a deployment should run with, and the env var is
+    how someone debugging reaches past it for a session.
     """
     raw = os.environ.get("POCKETPAW_LOGFIRE_INSTRUMENT", "").strip()
     known = _instrumentations()
     if not raw:
-        return list(known)
+        return [name for name in known if name not in _DEFAULT_OFF]
     if raw.lower() == "none":
         return []
     wanted = [part.strip() for part in raw.split(",") if part.strip()]

--- a/tests/mutations/logfire_bridge.json
+++ b/tests/mutations/logfire_bridge.json
@@ -114,8 +114,8 @@
   {
     "label": "POCKETPAW_LOGFIRE_INSTRUMENT is ignored, so the bill cannot be trimmed without a deploy",
     "file": "src/pocketpaw/observability.py",
-    "find": "    raw = os.environ.get(\"POCKETPAW_LOGFIRE_INSTRUMENT\", \"\").strip()\n    known = _instrumentations()\n    if not raw:\n        return list(known)",
-    "replace": "    raw = \"\"\n    known = _instrumentations()\n    if not raw:\n        return list(known)",
+    "find": "    raw = os.environ.get(\"POCKETPAW_LOGFIRE_INSTRUMENT\", \"\").strip()",
+    "replace": "    raw = \"\"",
     "tests": "tests/test_logfire_bridge.py"
   },
   {
@@ -172,6 +172,13 @@
     "file": "tests/conftest.py",
     "find": "    os.environ[_var] = _safe",
     "replace": "    os.environ.pop(_var, None)",
+    "tests": "tests/test_logfire_bridge.py"
+  },
+  {
+    "label": "redis goes back into the default set, so every idle deployment resumes emitting ~6 poll spans a second and buries the traces Logfire exists to show",
+    "file": "src/pocketpaw/observability.py",
+    "find": "_DEFAULT_OFF = frozenset({\"redis\"})",
+    "replace": "_DEFAULT_OFF = frozenset()",
     "tests": "tests/test_logfire_bridge.py"
   }
 ]

--- a/tests/test_logfire_bridge.py
+++ b/tests/test_logfire_bridge.py
@@ -463,10 +463,19 @@ def test_every_integration_in_the_default_set_attaches(monkeypatch: pytest.Monke
         "mcp",
         "httpx",
         "aiohttp_client",
-        "redis",
         "pymongo",
         "system_metrics",
     }, f"the default coverage changed: {attached}"
+
+    assert "redis" not in attached, (
+        "redis is known but off by default: two arq lanes poll their queues on "
+        "arq's timer, so an idle deployment emits roughly six command spans a "
+        "second forever and buries the traces Logfire was turned on to read"
+    )
+    assert "redis" in observability._instrumentations(), (
+        "it must stay SELECTABLE — POCKETPAW_LOGFIRE_INSTRUMENT is how someone "
+        "debugging the queue reaches it for a session"
+    )
 
 
 def test_the_capture_flags_that_would_export_customer_data_are_off(
@@ -484,7 +493,9 @@ def test_the_capture_flags_that_would_export_customer_data_are_off(
 
     calls: dict[str, Any] = {}
     monkeypatch.setitem(sys.modules, "logfire", _recording_logfire(calls))
-    monkeypatch.delenv("POCKETPAW_LOGFIRE_INSTRUMENT", raising=False)
+    # redis is off by default, and its capture flag still has to be right for
+    # the session someone turns it on for.
+    monkeypatch.setenv("POCKETPAW_LOGFIRE_INSTRUMENT", "httpx,redis")
 
     instrument_everything()
 
@@ -564,7 +575,9 @@ def test_one_broken_integration_does_not_stop_the_others(
     attached = instrument_everything()
 
     assert "httpx" not in attached
-    assert "redis" in attached, "a missing optional package took the rest down with it"
+    # A witness that comes AFTER httpx in the registry, so it can only be here
+    # if the loop carried on past the failure rather than stopping at it.
+    assert "pymongo" in attached, "a missing optional package took the rest down with it"
 
 
 def test_fastapi_is_not_instrumented_with_the_switch_off(


### PR DESCRIPTION
An idle deployment emits a steady stream of Redis command spans:

```
00:39:46  ZRANGEBYSCORE ? ? ? ? ? ?   1.08ms
00:39:46  ZRANGEBYSCORE ? ? ? ? ? ?   846µs
00:39:46  ZCARD ?                     869µs
00:39:46  ZCARD ?                     777µs
00:39:46  PSETEX ? ? ?                965µs
00:39:46  XREADGROUP  <ongoing>       10.6s
```

Roughly six spans a second, forever, per replica. The worker supervisor runs two
arq lanes in one process and each polls its own queue on arq's timer, which is
why the commands come in pairs and why the rate has nothing to do with whether
any job exists. The `XREADGROUP` is the run-stream consumer's blocking read, so
it shows up as a multi-second span per block.

## Why this is worth changing rather than tolerating

Logfire meters per span, so idle polling is a standing bill on a deployment doing
no work.

The bigger cost is that it buries the thing the tool was turned on for. A chat
run's trace is a handful of spans; the window it sits in holds several hundred
`ZRANGEBYSCORE`s. Scrolling to the trace you want is the problem, not the money.

## The change

`redis` becomes known but off by default. That is the same call this module
already makes for sqlite3 and sqlalchemy, and the docstring says why in those
words: a span per statement that "adds little over the operation span already
wrapping them and would dominate the bill." The difference is that this one was
measured in production instead of predicted.

Nothing is lost by default. A slow enqueue or a slow stream write already sits
inside the application span that wraps it — this only drops the command span
underneath. When the queue itself is the suspect, name it back:

```
POCKETPAW_LOGFIRE_INSTRUMENT=pydantic_ai,claude_agent_sdk,anthropic,openai,mcp,httpx,aiohttp_client,pymongo,system_metrics,redis
```

That path is deliberately checked against everything *known* rather than against
the default set, which is what makes reaching past the default possible at all.
It is read from `os.environ`, so it is a restart and not a deploy.

## Gate

The default-coverage test asserts both halves: `redis` absent from the default,
and still present in the registry — so this cannot quietly become a deletion
instead of a demotion.

Two sibling tests leaned on redis being default-on. One now forces it on so it
keeps testing that `capture_statement=False` (the redis statement carries the arq
job payload, which for the chat lane is the conversation). The other used redis as
its "the loop carried on past the failure" witness and now uses pymongo, which
comes after httpx in the registry and so proves the same thing.

Mutations: emptying `_DEFAULT_OFF` was run and caught, and so was the repointed
env-var anchor described below.

## A correction to what this PR first claimed about line endings

The first push of this branch said the Windows CRLF problem was "a local
artifact, not a coverage hole," on the grounds that CI runs on Linux against LF
blobs. CI then failed, which is the useful part: that reasoning was wrong for the
three files this branch touches.

The check that catches it is `Mutation plan anchors`, and it was right. The
commit had rewritten all three files from LF to CRLF *in the committed blobs* —
780 changed lines in `observability.py` for a 38-line edit. There is no
`.gitattributes` in this repo and nothing normalises on the way in, so the CRLF
went to the remote and Linux CI read it back exactly as written. `mutate.py`
compares raw bytes and the plans store `\n`, so all eight multi-line anchors into
that file stopped resolving. A plan with one bad anchor applies none of its
mutations, so `logfire_bridge.json` was silently proving nothing.

So the distinction that matters is not Windows versus Linux, it is *worktree*
versus *blob*. A CRLF working copy is a local artifact and CI never sees it. A
CRLF blob is committed state and CI sees it everywhere. This was the second.

The three files are back to LF, which is the whole of the 1300-line diff that is
now gone.

One anchor still needed repointing on its merits. It quoted four lines around the
env-var read and the last of the four is a line this change edits:

```
    raw = os.environ.get("POCKETPAW_LOGFIRE_INSTRUMENT", "").strip()
    known = _instrumentations()
    if not raw:
        return list(known)          <- this line changed
```

It now anchors on the single line it actually mutates, the env-var read itself.
The harm it names is unchanged — the variable is ignored and the default set is
returned regardless — and a single-line anchor cannot be broken by a neighbouring
line moving, or by a line-ending flip.

Repo-wide validation is back to `1118 anchors across 85 plans`.

## Worth doing separately

A `.gitattributes` pinning `eol=lf` would make this class of bug impossible
rather than reviewable. It renormalises files well outside this change, so it
does not belong in this PR.
