### PR TITLE
The Terrarium runtime

### DIFF
--- a/docs/c4/model.json
+++ b/docs/c4/model.json
@@ -30,7 +30,8 @@
               {"id": "pockets", "name": "Pockets + rippleSpec", "description": "Pocket workspace containers (agents+data+tools+KB+rules). The rippleSpec merge endpoint; data sources (read GETs) and write actions gated through Instinct. ee/cloud/pockets.", "technology": "Python", "kb_article": ""},
               {"id": "sites", "name": "Paw Sites", "description": "Publish pockets as edge sites. Two engines x two modes: {ripple,svelte} x {static,dynamic}; dynamic = per-tenant Cloudflare D1. ee/pocketpaw_ee/sites + the paw-sites generator.", "technology": "Python, Bun, SvelteKit", "kb_article": ""},
               {"id": "foresight", "name": "Foresight", "description": "Scenario simulation / rehearsal: soul-seeded personas run per-tick cognition loops with calibration and backtest gating. ee/pocketpaw_ee/foresight.", "technology": "Python", "kb_article": ""},
-              {"id": "enterprise-ops", "name": "Enterprise Ops", "description": "Fleet install, Calendar (external sync + conflict detection), Guards (RBAC/ABAC), Audit (placeholder), and the Paw Bar customer decision loop. ee/pocketpaw_ee/{fleet,calendar,guards,audit,paw_bar}.", "technology": "Python", "kb_article": ""}
+              {"id": "enterprise-ops", "name": "Enterprise Ops", "description": "Fleet install, Calendar (external sync + conflict detection), Guards (RBAC/ABAC), Audit (placeholder), and the Paw Bar customer decision loop. ee/pocketpaw_ee/{fleet,calendar,guards,audit,paw_bar}.", "technology": "Python", "kb_article": ""},
+              {"id": "terrarium", "name": "Terrarium (world sim)", "description": "Watchable agent civilization. A physics file defines a universe; citizens are Souls acting through a fixed verb set against a tech tree; the Journal is truth and citizens/ledger/artifacts are projections rebuilt from it. Weather is the viewer-facing name for outside input and has no path to a soul write. A separate anonymous read router is gated by TERRARIUM_PUBLIC_ENABLED plus a per-universe flag, dark by default. ee/pocketpaw_ee/terrarium.", "technology": "Python, FastAPI, Beanie", "kb_article": ""}
             ]
           },
           {"id": "mongo", "name": "MongoDB", "description": "Primary cloud datastore: pockets, sessions, messages, agents, sites, Instinct approvals, connectors.", "technology": "MongoDB (Beanie ODM)", "tags": ["database"], "kb_article": "", "components": []},
@@ -62,7 +63,9 @@
       {"source": "runtime", "target": "soul-protocol", "description": "loads / saves memory", "technology": "", "style": "sync"},
       {"source": "fabric", "target": "soul-protocol", "description": "writes the object journal", "technology": "", "style": "async"},
       {"source": "instinct", "target": "soul-protocol", "description": "emits Decision-Graph events", "technology": "", "style": "async"},
-      {"source": "pockets", "target": "mongo", "description": "persists pocket + spec", "technology": "", "style": "sync"}
+      {"source": "pockets", "target": "mongo", "description": "persists pocket + spec", "technology": "", "style": "sync"},
+      {"source": "terrarium", "target": "instinct", "description": "files world_create and world_spawn for human approval", "technology": "", "style": "sync"},
+      {"source": "terrarium", "target": "pockets", "description": "a universe is a Pocket of type world", "technology": "", "style": "sync"}
     ]
   }
 }

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -575,6 +575,21 @@ def mount_cloud(app: FastAPI) -> None:
 
     app.include_router(belt_mandates_router, prefix="/api/v1")
 
+    # TERRARIUM — the agent-civilization runtime (/api/v1/terrarium). TWO
+    # routers with different auth boundaries, mounted separately on purpose so
+    # no ambient dependency can leak between them:
+    #   * ``terrarium_router`` — the workspace surface: license + RBAC
+    #     (terrarium.read / terrarium.manage), create / tick / read / speak /
+    #     pledge.
+    #   * ``terrarium_public_router`` — ANONYMOUS, READ-ONLY, and dark unless
+    #     BOTH ``TERRARIUM_PUBLIC_ENABLED`` is set AND the universe itself is
+    #     flagged public. Default OFF, fail-closed, no write route ever.
+    from pocketpaw_ee.terrarium.router import public_router as terrarium_public_router
+    from pocketpaw_ee.terrarium.router import router as terrarium_router
+
+    app.include_router(terrarium_router, prefix="/api/v1")
+    app.include_router(terrarium_public_router, prefix="/api/v1")
+
     # /ship managed deploys (SHIP-3, feat/ship-3-cloud-entity). The
     # workspace-scoped /api/v1/ship surface: provision a box, register + deploy
     # an app, route a domain, create a database, read logs + box health. The two

--- a/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
@@ -391,6 +391,29 @@ class AudienceResolver:
                 return await self._workspace(wid)
             return []
 
+        # --- Terrarium (a universe's journal) ------------------------------------
+        # Workspace-scoped, same rationale as belt_plan: a tick lands
+        # asynchronously and must reach every member watching the universe.
+        # Payload: {workspace_id, universe_id, public, event}.
+        #
+        # TODO(public branch): the contract also wants an ANONYMOUS audience for
+        # a universe with ``public: true`` while ``TERRARIUM_PUBLIC_ENABLED`` is
+        # on. That is NOT added here on purpose. This resolver's entire contract
+        # is "return the user_ids that should receive it", and the websocket
+        # transport authenticates every subscriber — there is no anonymous
+        # subscriber concept to return. A public branch therefore needs a new
+        # broadcast channel (or a pseudo-audience the socket layer understands)
+        # plus an unauthenticated subscribe path, which is a security-boundary
+        # change of its own and wants its own review. The seam is exactly here:
+        # this branch would return that broadcast handle when
+        # ``d.get("public")`` is true. Until then public viewers poll
+        # ``GET /terrarium/public/universes/{id}/events?since=``, which is
+        # already fail-closed on both gates.
+        if t.startswith("world."):
+            if wid := d.get("workspace_id"):
+                return await self._workspace(wid)
+            return []
+
         # --- Composio (per-user OAuth identity probes) --------------------------
         if t in {"composio.connection.verified", "composio.connection.mismatch"}:
             if uid := d.get("user_id"):

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -276,6 +276,14 @@ _SightingDoc: type = None  # type: ignore[assignment]
 # init_beanie registers it without ee.cloud.models taking a hard import on the
 # versions package (same out-of-models discipline as belt/mandates).
 _ArtifactVersionDoc: type = None  # type: ignore[assignment]
+# The TERRARIUM docs live in ee.terrarium.domain (4-file entity, sole importer
+# = its own service). Lazy-loaded here so init_beanie registers them without
+# ee.cloud.models taking a hard import on the terrarium package (same
+# out-of-models discipline as calendar / mandates / versions).
+_UniverseDoc: type = None  # type: ignore[assignment]
+_CitizenDoc: type = None  # type: ignore[assignment]
+_WorldEventDoc: type = None  # type: ignore[assignment]
+_WorldArtifactDoc: type = None  # type: ignore[assignment]
 
 
 def _ensure_file_upload():
@@ -331,6 +339,24 @@ def _ensure_version_docs():
 
         _ArtifactVersionDoc = _AV
     return _ArtifactVersionDoc
+
+
+def _ensure_terrarium_docs():
+    # Why: the terrarium package's modules pull the router (→ deps → auth) when
+    # imported through the package, so import the doc module directly +
+    # deferred — the same reason the mandates docs are loaded this way.
+    global _UniverseDoc, _CitizenDoc, _WorldEventDoc, _WorldArtifactDoc
+    if _UniverseDoc is None:
+        from pocketpaw_ee.terrarium.domain import ArtifactDoc as _WA
+        from pocketpaw_ee.terrarium.domain import CitizenDoc as _CD
+        from pocketpaw_ee.terrarium.domain import EventDoc as _WE
+        from pocketpaw_ee.terrarium.domain import UniverseDoc as _UD
+
+        _UniverseDoc = _UD
+        _CitizenDoc = _CD
+        _WorldEventDoc = _WE
+        _WorldArtifactDoc = _WA
+    return _UniverseDoc, _CitizenDoc, _WorldEventDoc, _WorldArtifactDoc
 
 
 __all__ = [
@@ -437,6 +463,7 @@ def get_all_documents():
     cal_doc, evt_doc = _ensure_calendar_docs()
     mandate_doc, shift_doc, sighting_doc = _ensure_mandate_docs()
     artifact_version_doc = _ensure_version_docs()
+    universe_doc, citizen_doc, world_event_doc, world_artifact_doc = _ensure_terrarium_docs()
     return [
         User,
         Agent,
@@ -567,6 +594,13 @@ def get_all_documents():
         WorkspaceJobDoc,
         cal_doc,
         evt_doc,
+        # Terrarium — the agent-civilization runtime. Only
+        # ``ee.terrarium.service`` (+ its approve-side executor) imports these
+        # doc classes directly (import-linter "Terrarium" contract).
+        universe_doc,
+        citizen_doc,
+        world_event_doc,
+        world_artifact_doc,
         mandate_doc,
         shift_doc,
         sighting_doc,

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -355,6 +355,17 @@ ACTIONS: dict[str, ActionRule] = {
     # diffs), mirroring connector.manage / skills.manage.
     "belt.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
     "belt.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Terrarium — the agent-civilization surface (ee.terrarium.router), mirroring
+    # belt.read / belt.manage. read is MEMBER: reading a universe's journal,
+    # citizens and ledger is a spectator act, and speaking / pledging ride it
+    # because they cost the SPEAKER tokens, not the workspace anything. manage
+    # is ADMIN because creating a universe seeds Souls and ticking one spends
+    # model budget per citizen per tick — a cost commitment, like belt.manage
+    # extending the code-change boundary. The ANONYMOUS public read surface is
+    # NOT covered by either action: it is a separate router with no auth at
+    # all, gated by TERRARIUM_PUBLIC_ENABLED plus per-universe opt-in.
+    "terrarium.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
+    "terrarium.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Notifications external-delivery config (ee.cloud.notifications.router,
     # feat/external-alerting-delivery). ADMIN because the config sets where the
     # server POSTs on EVERY notification (a Slack / generic webhook URL) — it

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -2174,6 +2174,17 @@ async def bulk_approve_actions(
                 )
             continue
 
+        # TERRARIUM — a bulk-approved ``_world_spawn`` mints the child citizen,
+        # exactly like the single-approve hook (see its note: no chain emit).
+        try:
+            from pocketpaw_ee.terrarium import executor as terrarium_executor
+
+            if terrarium_executor.world_spawn_blob(action) is not None:
+                await terrarium_executor.execute_approved_spawn(action)
+                continue
+        except Exception:
+            logger.exception("bulk-approve terrarium world_spawn failed (non-fatal)")
+
         # BP-3 — a bulk-approved ``_artifact_change`` Action MERGES its candidate
         # (publish + deploy), exactly like the single-approve hook. Disposition
         # is always ``accepted`` (bulk-approve has no edit surface). The executor
@@ -3127,6 +3138,21 @@ async def approve_action(
             await mandate_executor.execute_approved_plan(approved, human_event_id=human_event_id)
         except Exception:
             logger.exception("belt_plan execution after approval failed (non-fatal)")
+
+    # TERRARIUM — an approved ``_world_spawn`` Action mints the child citizen.
+    # Reproduction is human-gated in season one: the citizen's ``spawn`` verb
+    # only filed this Action and left a zero-cost ``gate`` Event; the child is
+    # created HERE, on approval, and the executor re-validates the parent's
+    # balance and state at that moment. No Decision-Graph emit: terrarium does
+    # not open a chain on propose, so it must not close one on approve. Same
+    # best-effort, lazy-import, never-break-the-approve-response shape.
+    try:
+        from pocketpaw_ee.terrarium import executor as terrarium_executor
+
+        if terrarium_executor.world_spawn_blob(approved) is not None:
+            await terrarium_executor.execute_approved_spawn(approved)
+    except Exception:
+        logger.exception("terrarium world_spawn after approval failed (non-fatal)")
 
     # BP-3 — when the approved Action carries an ``_artifact_change`` blob, MERGE
     # the branch: promote the candidate version to published + (for pocket/site

--- a/ee/pocketpaw_ee/terrarium/__init__.py
+++ b/ee/pocketpaw_ee/terrarium/__init__.py
@@ -1,0 +1,29 @@
+# ee/pocketpaw_ee/terrarium/__init__.py
+#
+# TERRARIUM — a watchable agent civilization. A UNIVERSE is a world with a
+# PHYSICS FILE (its genome), a Journal of Events (the truth), and CITIZENS that
+# are Souls with a credit balance. Citizens tick: they sense, recall, make ONE
+# LLM call, act through a fixed verb set, and pay for every act. Viewers watch,
+# speak (as an outside voice, never as fact), and pledge tokens for WEATHER.
+#
+# Package layout (4-file entity rule + the mandates module's extras):
+#   physics.py  — the PhysicsFile schema + YAML loader + hard validation
+#   domain.py   — Beanie docs (service.py is the SOLE importer) + frozen views
+#   world.py    — the PURE engine: state + decision in, events out. No DB, no
+#                 soul, no bus — so most of the rules are testable without Mongo.
+#   weather.py  — PURE world events. Structurally cannot touch a soul.
+#   llm.py      — the citizen judgment seat (claude CLI | deterministic mock)
+#   soul_link.py— best-effort Soul bridge; a soul failure never wedges a tick
+#   service.py  — the DB / soul / bus glue and the only Beanie importer
+#   executor.py — the Instinct approve-side hook for ``world_spawn``
+#   router.py   — private (RBAC) + public (anonymous, fail-closed) routers
+#
+# This module is deliberately import-light at package level: importing the
+# package must not pull the router (→ auth → deps), the same discipline the
+# mandates package follows for its lazy Beanie registration.
+
+"""Terrarium — the agent-civilization runtime."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/ee/pocketpaw_ee/terrarium/domain.py
+++ b/ee/pocketpaw_ee/terrarium/domain.py
@@ -1,0 +1,229 @@
+# ee/pocketpaw_ee/terrarium/domain.py
+#
+# Terrarium persistence + frozen read-path value objects.
+#
+# Four workspace-keyed Beanie documents, shaped exactly like the mandates
+# entity: UniverseDoc (the world + its physics genome + the monotonic ``seq``
+# counter), CitizenDoc (a Soul with a balance and a position), EventDoc (the
+# JOURNAL — the truth; citizens/ledger/artifacts are projections rebuildable
+# from it) and ArtifactDoc (what a write/craft/build verb left behind).
+#
+# Per the 4-file entity rule ONLY ``terrarium/service.py`` imports these doc
+# classes; router/dto/world/weather see the frozen views or plain dicts. The
+# docs live here rather than in ``cloud/models/`` so the entity is
+# self-contained; they are registered into ``init_beanie`` by the lazy
+# ``_ensure_terrarium_docs()`` helper in ``cloud/models/__init__`` (the same
+# calendar/mandates out-of-models pattern).
+#
+# Invariant carried here: ``UniverseDoc.seq`` is the monotonic per-universe
+# event sequence the client pages with (``?since=``). It is assigned in-process
+# under the service's per-universe asyncio lock.
+
+"""Terrarium documents (universe, citizen, event, artifact) + read-path views."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+UniverseStatus = Literal["running", "dormant", "archived"]
+CitizenState = Literal["alive", "hibernating"]
+Trend = Literal["up", "down", "flat"]
+EventOrigin = Literal["citizen", "viewer", "system"]
+ArtifactKind = Literal["structure", "tool", "book", "law", "map"]
+ArtifactStage = Literal["done", "building"]
+
+# Every kind the Journal projection can carry (the contract's ONE event shape).
+EVENT_KINDS: tuple[str, ...] = (
+    "think",
+    "say",
+    "write",
+    "trade",
+    "craft",
+    "build",
+    "explore",
+    "vote",
+    "spawn",
+    "gate",
+    "hibernate",
+    "weather",
+    "arrive",
+    "raid",
+    "gain",
+)
+
+# Contract invariant 2: every event costs or earns. ``cost: 0`` is legal only
+# for these kinds. The service asserts this before it writes an EventDoc.
+ZERO_COST_KINDS: frozenset[str] = frozenset({"gate", "weather", "hibernate", "arrive"})
+
+
+# ---------------------------------------------------------------------------
+# Beanie documents — service.py is the SOLE importer.
+# ---------------------------------------------------------------------------
+
+
+class UniverseDoc(TimestampedDocument):
+    """One universe. ``physics`` carries the validated PhysicsFile as a dict.
+
+    ``seq`` is the monotonic event counter (contract invariant 1).
+    ``weather_pledges`` accumulates ``{kind: {tokens, gods:[user_id]}}`` until a
+    power's threshold fires. ``storm_ticks`` is how many more ticks the think
+    cost stays doubled. ``public`` is the per-universe opt-in the anonymous read
+    surface requires — it is NOT sufficient on its own (the env flag gates too).
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    name: str
+    seed: int = 0
+    status: UniverseStatus = "running"
+    day: int = 1
+    tick: int = 0
+    pool: int = 0
+    rung: str = "camp"
+    physics: dict[str, Any] = Field(default_factory=dict)
+    public: bool = False
+    creator: str = ""
+    seq: int = 0
+    weather_pledges: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    storm_ticks: int = 0
+
+    class Settings:
+        name = "terrarium_universes"
+
+
+class CitizenDoc(TimestampedDocument):
+    """One citizen — a Soul with a ledger row and a position.
+
+    ``charter`` is None until the citizen writes its own on its first tick.
+    ``soul_path`` points at the ``.soul`` archive; it is a SERVER filesystem
+    path and must never reach the public surface.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    universe_id: Indexed(str)  # type: ignore[valid-type]
+    name: str
+    role: str = ""
+    did: str = ""
+    parent_did: str | None = None
+    generation: int = 1
+    soul_path: str | None = None
+    ocean: dict[str, float] = Field(default_factory=dict)
+    values: list[str] = Field(default_factory=list)
+    charter: str | None = None
+    balance: int = 0
+    trend: Trend = "flat"
+    state: CitizenState = "alive"
+    x: float = 50.0
+    y: float = 50.0
+    unlocked: list[str] = Field(default_factory=list)
+    born_day: int = 1
+    earned_today: int = 0
+    spent_today: int = 0
+
+    class Settings:
+        name = "terrarium_citizens"
+
+
+class EventDoc(TimestampedDocument):
+    """One Journal row. The Journal is truth; every other doc is a projection.
+
+    ``viewer_origin`` marks text that came from a human. Write-policy: such text
+    is NEVER written into a soul as fact (see ``world.label_viewer_claim``).
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    universe_id: Indexed(str)  # type: ignore[valid-type]
+    seq: int
+    day: int = 1
+    tick: int = 0
+    ts: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    kind: str
+    actor: str
+    body: str = ""
+    cost: int = 0
+    artifact_id: str | None = None
+    origin: EventOrigin = "citizen"
+    viewer_origin: bool = False
+
+    class Settings:
+        name = "terrarium_events"
+
+
+class ArtifactDoc(TimestampedDocument):
+    """What a write / craft / build verb left behind.
+
+    ``file_id`` points into the /files surface for payload-bearing artifacts
+    (books, laws, maps); structures carry None. ``unlocks`` names the tech-tree
+    node this artifact completed, if any.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    universe_id: Indexed(str)  # type: ignore[valid-type]
+    kind: ArtifactKind
+    name: str
+    author: str
+    day: int = 1
+    cost: int = 0
+    file_id: str | None = None
+    mime: str | None = None
+    x: float | None = None
+    y: float | None = None
+    unlocks: list[str] = Field(default_factory=list)
+    stage: ArtifactStage = "done"
+    body: str = ""
+
+    class Settings:
+        name = "terrarium_artifacts"
+
+
+# ---------------------------------------------------------------------------
+# Frozen read-path views — what consumers outside the service see.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LedgerRow:
+    """One row of the universe ledger (the contract's LedgerRow)."""
+
+    citizen: str
+    balance: int
+    trend: Trend
+    earned_today: int
+    spent_today: int
+    state: CitizenState
+
+
+@dataclass(frozen=True)
+class WeatherPower:
+    """One god power's pledge state (the ``GET /weather`` row)."""
+
+    kind: str
+    cost: int
+    pledged: int
+    gods: int
+    ready: bool
+    fields: dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = [
+    "EVENT_KINDS",
+    "ZERO_COST_KINDS",
+    "ArtifactDoc",
+    "ArtifactKind",
+    "ArtifactStage",
+    "CitizenDoc",
+    "CitizenState",
+    "EventDoc",
+    "EventOrigin",
+    "LedgerRow",
+    "Trend",
+    "UniverseDoc",
+    "UniverseStatus",
+    "WeatherPower",
+]

--- a/ee/pocketpaw_ee/terrarium/dto.py
+++ b/ee/pocketpaw_ee/terrarium/dto.py
@@ -1,0 +1,41 @@
+# ee/pocketpaw_ee/terrarium/dto.py
+#
+# Request bodies for the terrarium router. Thin by design: the physics file is
+# validated by ``physics.parse_physics`` (which owns every hard rule and the
+# error messages), so the DTO only asserts "an object arrived", not its shape.
+# Responses are the wire dicts the service builds — there is no response model
+# layer, matching the mandates entity.
+
+"""Terrarium request DTOs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CreateUniverseRequest(BaseModel):
+    """``POST /universes`` — a physics file, and whether the world is watchable
+    by anonymous viewers (still requires the server-wide public flag)."""
+
+    physics: dict[str, Any]
+    public: bool = False
+
+
+class SpeakRequest(BaseModel):
+    """``POST /universes/{id}/speak`` — one line from a human."""
+
+    text: str = Field(min_length=1, max_length=500)
+
+
+class PledgeRequest(BaseModel):
+    """``POST /universes/{id}/weather/pledge`` — tokens toward a god power.
+    ``line`` is only read for ``omen``."""
+
+    kind: str
+    tokens: int = Field(ge=1, le=10_000)
+    line: str | None = Field(default=None, max_length=280)
+
+
+__all__ = ["CreateUniverseRequest", "PledgeRequest", "SpeakRequest"]

--- a/ee/pocketpaw_ee/terrarium/events.py
+++ b/ee/pocketpaw_ee/terrarium/events.py
@@ -1,0 +1,105 @@
+# ee/pocketpaw_ee/terrarium/events.py
+#
+# The realtime topics the terrarium service emits. Thin ``Event`` subclasses
+# keyed by an ``EVENT_TYPE`` discriminator — the base class auto-registers each
+# one into ``EVENT_REGISTRY`` on definition, which is what makes them show up
+# for the frontend's generated topic list.
+#
+# The payload for EVERY topic here is ``{universe_id, event}`` where ``event``
+# is the contract's one Event shape, plus ``workspace_id`` for the audience
+# resolver's workspace fan-out (mirroring ``belt_plan``).
+#
+# NOTE: registration happens at IMPORT time, so this module must be reachable
+# from app boot — it is, via service.py ← router.py ← cloud/__init__.
+
+"""Terrarium realtime topics (``world.*``)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from pocketpaw_ee.cloud._core.realtime.events import Event
+
+
+@dataclass
+class WorldTick(Event):
+    EVENT_TYPE: ClassVar[str] = "world.tick"
+
+
+@dataclass
+class WorldAct(Event):
+    EVENT_TYPE: ClassVar[str] = "world.act"
+
+
+@dataclass
+class WorldThought(Event):
+    EVENT_TYPE: ClassVar[str] = "world.thought"
+
+
+@dataclass
+class WorldWeather(Event):
+    EVENT_TYPE: ClassVar[str] = "world.weather"
+
+
+@dataclass
+class WorldGate(Event):
+    EVENT_TYPE: ClassVar[str] = "world.gate"
+
+
+@dataclass
+class WorldSpawn(Event):
+    EVENT_TYPE: ClassVar[str] = "world.spawn"
+
+
+@dataclass
+class WorldHibernate(Event):
+    EVENT_TYPE: ClassVar[str] = "world.hibernate"
+
+
+@dataclass
+class WorldLedger(Event):
+    EVENT_TYPE: ClassVar[str] = "world.ledger"
+
+
+# Journal event kind -> the topic it rides. ``think`` is the only kind that
+# gets its own topic (thoughts are the cheap, high-volume stream a viewer can
+# turn off); every other citizen act shares ``world.act``.
+KIND_TOPIC: dict[str, type[Event]] = {
+    "think": WorldThought,
+    "weather": WorldWeather,
+    "gate": WorldGate,
+    "spawn": WorldSpawn,
+    "hibernate": WorldHibernate,
+}
+
+TERRARIUM_TOPICS: tuple[str, ...] = (
+    "world.tick",
+    "world.act",
+    "world.thought",
+    "world.weather",
+    "world.gate",
+    "world.spawn",
+    "world.hibernate",
+    "world.ledger",
+)
+
+
+def topic_for(kind: str) -> type[Event]:
+    """The Event class a Journal row of this kind is published on."""
+    return KIND_TOPIC.get(kind, WorldAct)
+
+
+__all__ = [
+    "KIND_TOPIC",
+    "TERRARIUM_TOPICS",
+    "WorldAct",
+    "WorldGate",
+    "WorldHibernate",
+    "WorldLedger",
+    "WorldSpawn",
+    "WorldThought",
+    "WorldTick",
+    "WorldWeather",
+    "topic_for",
+]

--- a/ee/pocketpaw_ee/terrarium/executor.py
+++ b/ee/pocketpaw_ee/terrarium/executor.py
@@ -1,0 +1,120 @@
+# ee/pocketpaw_ee/terrarium/executor.py
+#
+# The Instinct approve-side hook for terrarium. Reproduction is HUMAN-GATED in
+# season one: a citizen's ``spawn`` verb files a ``world_spawn`` Action and
+# leaves a zero-cost ``gate`` Event — no child exists until a human approves.
+# This module is what runs on that approval.
+#
+# ``execute_approved_spawn`` is deliberately callable on its own (it takes an
+# Action-like object and reads its own blob), so it can be wired from the
+# instinct router's approve path exactly like ``mandates.executor
+# .execute_approved_plan``, and tested without one.
+#
+# Re-validation at approval time, not propose time: the parent may have gone
+# broke or hibernated while the Action sat in the tray, so the spawn cost and
+# the parent's state are checked HERE before anything is minted.
+
+"""Approve-side executor for the gated ``world_spawn`` Action."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import uuid4
+
+from pocketpaw_ee.terrarium import service, soul_link
+from pocketpaw_ee.terrarium.domain import CitizenDoc, UniverseDoc
+
+logger = logging.getLogger(__name__)
+
+WORLD_SPAWN_PARAM_KEY = service.WORLD_SPAWN_PARAM_KEY
+
+
+def world_spawn_blob(action: Any) -> dict[str, Any] | None:
+    """The ``_world_spawn`` blob on an Action, or None. Peer of ``_belt_plan_blob``."""
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get(WORLD_SPAWN_PARAM_KEY)
+    return blob if isinstance(blob, dict) else None
+
+
+async def execute_approved_spawn(action: Any) -> dict[str, Any]:
+    """Mint the child citizen an approved ``world_spawn`` Action asked for.
+
+    Returns ``{"ok": bool, "reason"|"citizen_id": ...}``. Never raises: an
+    approve response must not fail because a world moved on underneath it.
+    """
+    blob = world_spawn_blob(action)
+    if blob is None:
+        return {"ok": False, "reason": "not a world_spawn action"}
+
+    try:
+        uni = await UniverseDoc.get(blob["universe_id"])
+        parent = await CitizenDoc.get(blob["parent_id"])
+        if uni is None or parent is None:
+            return {"ok": False, "reason": "universe or parent is gone"}
+        if uni.workspace != blob.get("workspace_id"):
+            return {"ok": False, "reason": "workspace mismatch"}
+
+        physics = service.physics_of(uni)
+        cost = physics.costs.spawn
+        # Re-validated NOW, not at propose time — the parent may have gone broke
+        # or fallen asleep while the Action waited in the tray.
+        if parent.state != "alive":
+            return {"ok": False, "reason": f"{parent.name} is {parent.state}"}
+        if parent.balance < cost:
+            return {"ok": False, "reason": f"{parent.name} cannot afford {cost}"}
+
+        name = str(blob.get("child_name") or "child")[:40]
+        ocean = {k: round(min(1.0, max(0.0, v + 0.08)), 2) for k, v in (parent.ocean or {}).items()}
+        path = service.soul_root() / str(uni.id) / f"{name.lower()}-{uuid4().hex[:6]}.soul"
+        did = await soul_link.birth_soul(
+            path,
+            name=name,
+            role="",
+            ocean=ocean,
+            values=list(parent.values),
+            world_brief=physics.world_brief,
+        )
+        child = CitizenDoc(
+            workspace=uni.workspace,
+            universe_id=str(uni.id),
+            name=name,
+            role="",
+            did=did or f"did:soul:{name.lower()}-{uuid4().hex[:6]}",
+            parent_did=parent.did,
+            generation=parent.generation + 1,
+            soul_path=str(path) if did else None,
+            ocean=ocean,
+            values=list(parent.values),
+            charter=None,  # the child rewrites it on its own first tick
+            balance=cost // 2,
+            state="alive",
+            x=parent.x,
+            y=parent.y,
+            born_day=uni.day,
+        )
+        await child.insert()
+
+        parent.balance -= cost
+        parent.spent_today += cost
+        await parent.save()
+
+        row = await service._append_event(
+            uni,
+            kind="spawn",
+            actor=parent.name,
+            body=f"{parent.name} brought {name} into the world",
+            cost=-cost,
+        )
+        uni.pool += cost - child.balance
+        await uni.save()
+        await service._publish(uni, row)
+        return {"ok": True, "citizen_id": str(child.id), "event_seq": row.seq}
+    except Exception as exc:  # noqa: BLE001 — never break an approve response
+        logger.exception("terrarium: world_spawn execution failed")
+        return {"ok": False, "reason": str(exc)}
+
+
+__all__ = ["WORLD_SPAWN_PARAM_KEY", "execute_approved_spawn", "world_spawn_blob"]

--- a/ee/pocketpaw_ee/terrarium/llm.py
+++ b/ee/pocketpaw_ee/terrarium/llm.py
@@ -1,0 +1,323 @@
+# ee/pocketpaw_ee/terrarium/llm.py
+#
+# The CITIZEN JUDGMENT SEAT — one LLM call per citizen per tick. In goes the
+# sense digest (ground truth, labelled viewer claims, soul recall, charter,
+# constitution, affordable verbs and unlockable tech); out comes strict JSON
+# naming the verbs the citizen chose.
+#
+# Pluggable transport, selected by ``POCKETPAW_TERRARIUM_LLM``:
+#   * ``mock`` (DEFAULT) — deterministic, offline, free. Tick 1 writes the
+#     citizen's charter (the zero ritual); afterwards it speaks and builds the
+#     cheapest affordable unlockable node. Tests run on this; ``set_mock_decision``
+#     scripts a specific response.
+#   * ``claude`` — shells ``claude -p <prompt> --output-format json``, reading
+#     the ``result`` field. The prompt is ONE argv element, never interpolated
+#     into a shell string. Same transport shape as ``mandates.foreman``.
+#
+# Mock is the default (foreman defaults to ``claude``) because a terrarium tick
+# fans out one call PER CITIZEN: an accidental real-model tick on a 50-citizen
+# universe is a bill, not a warning.
+#
+# Nothing the model returns is trusted. ``world.apply_acts`` re-validates every
+# act against balance, allowed verbs and held tech before anything mutates.
+
+"""The citizen judgment seat: one strict-JSON decision per tick."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from typing import Any, Protocol
+
+from pocketpaw_ee.terrarium.physics import PhysicsFile
+from pocketpaw_ee.terrarium.world import (
+    Act,
+    CitizenSnapshot,
+    Decision,
+    SenseDigest,
+    unlockable,
+)
+
+logger = logging.getLogger(__name__)
+
+_CLI_TIMEOUT = 120.0
+
+
+class CitizenLlm(Protocol):
+    """One tick's judgment: prompt in, raw model text out.
+
+    ``physics``/``citizen``/``digest`` ride along so a deterministic mock can
+    answer without parsing prose; real transports send only the prompt.
+    """
+
+    async def decide(
+        self,
+        *,
+        prompt: str,
+        physics: PhysicsFile,
+        citizen: CitizenSnapshot,
+        digest: SenseDigest,
+    ) -> str: ...
+
+
+class ClaudeCliLlm:
+    """Real transport — shells the ``claude`` CLI (same shape as the foreman)."""
+
+    async def decide(
+        self,
+        *,
+        prompt: str,
+        physics: PhysicsFile,
+        citizen: CitizenSnapshot,
+        digest: SenseDigest,
+    ) -> str:
+        proc = await asyncio.create_subprocess_exec(
+            "claude",
+            "-p",
+            prompt,
+            "--output-format",
+            "json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            out_b, err_b = await asyncio.wait_for(proc.communicate(), timeout=_CLI_TIMEOUT)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise RuntimeError(f"claude CLI timed out after {_CLI_TIMEOUT}s") from None
+        out = out_b.decode("utf-8", "replace")
+        if proc.returncode != 0:
+            err = err_b.decode("utf-8", "replace")
+            raise RuntimeError(f"claude CLI failed (exit {proc.returncode}): {err.strip()[:300]}")
+        try:
+            envelope = json.loads(out)
+        except json.JSONDecodeError:
+            return out
+        if isinstance(envelope, dict) and isinstance(envelope.get("result"), str):
+            return envelope["result"]
+        return out
+
+
+# Test hook — when set, MockLlm returns this verbatim (a dict is JSON-dumped).
+_MOCK_DECISION: dict[str, Any] | str | None = None
+
+
+def set_mock_decision(decision: dict[str, Any] | str | None) -> None:
+    """Override MockLlm's response (tests). ``None`` restores the default."""
+    global _MOCK_DECISION
+    _MOCK_DECISION = decision
+
+
+class MockLlm:
+    """Deterministic citizen for tests + offline demos.
+
+    Tick 1 (no charter yet): write the charter. Otherwise: speak, and build the
+    cheapest unlockable node the citizen can afford. Zero randomness, so a
+    universe replays identically.
+    """
+
+    async def decide(
+        self,
+        *,
+        prompt: str,
+        physics: PhysicsFile,
+        citizen: CitizenSnapshot,
+        digest: SenseDigest,
+    ) -> str:
+        if _MOCK_DECISION is not None:
+            return _MOCK_DECISION if isinstance(_MOCK_DECISION, str) else json.dumps(_MOCK_DECISION)
+
+        if citizen.charter is None and "write" in physics.verbs:
+            return json.dumps(
+                {
+                    "thought": "I have no rules yet. Rules are cheaper than credits.",
+                    "acts": [
+                        {
+                            "verb": "write",
+                            "name": "charter",
+                            "text": (
+                                f"I am {citizen.name}"
+                                + (f", {citizen.role}" if citizen.role else "")
+                                + ". I will keep what I say and pay what I owe."
+                            ),
+                        }
+                    ],
+                }
+            )
+
+        acts: list[dict[str, Any]] = []
+        if "speak" in physics.verbs:
+            acts.append(
+                {
+                    "verb": "speak",
+                    "text": (
+                        f"the pool holds {digest.ground_truth.get('pool', 0)} — "
+                        "we should spend it well"
+                    ),
+                }
+            )
+        if "build" in physics.verbs:
+            affordable = sorted(
+                (
+                    (physics.tech_tree[n].cost, n)
+                    for n in unlockable(physics, citizen)
+                    if physics.tech_tree[n].cost <= citizen.balance
+                ),
+            )
+            if affordable:
+                acts.append({"verb": "build", "node": affordable[0][1], "name": affordable[0][1]})
+        return json.dumps({"thought": "another day by the spring", "acts": acts})
+
+
+def resolve_llm() -> CitizenLlm:
+    """Pick the transport from ``POCKETPAW_TERRARIUM_LLM``. DEFAULT ``mock``."""
+    choice = (os.environ.get("POCKETPAW_TERRARIUM_LLM") or "mock").strip().lower()
+    if choice == "claude":
+        return ClaudeCliLlm()
+    return MockLlm()
+
+
+def build_prompt(
+    physics: PhysicsFile,
+    citizen: CitizenSnapshot,
+    digest: SenseDigest,
+) -> str:
+    """Assemble the single judgment prompt for one citizen's tick.
+
+    The GROUND TRUTH block and the OUTSIDE VOICES block are deliberately
+    separate and labelled: the citizen is told, in the prompt, that the second
+    is unverified and checkable against the first. That is the anti-cascade
+    rule stated to the model as well as enforced in code.
+    """
+    tree_lines = (
+        "\n".join(
+            f"- {name}: cost {node.cost}, needs {node.needs or 'nothing'}"
+            for name, node in physics.tech_tree.items()
+        )
+        or "(this world has no tech tree)"
+    )
+    open_nodes = unlockable(physics, citizen) or ["(nothing new is within reach)"]
+    speech = "\n".join(f"- {s}" for s in digest.nearby_speech) or "(silence)"
+    artifacts = "\n".join(f"- {a}" for a in digest.new_artifacts) or "(nothing new was made)"
+    weather = "\n".join(f"- {w}" for w in digest.weather) or "(the sky is quiet)"
+    claims = "\n".join(f"- {c}" for c in digest.viewer_claims) or "(no outside voice spoke)"
+    memories = "\n".join(f"- {m}" for m in digest.memories) or "(you remember nothing yet)"
+
+    return f"""You are {citizen.name}{", " + citizen.role if citizen.role else ""}, a citizen of \
+{physics.universe}. You are alive in this world, not working for anyone. You act by choosing \
+VERBS, and every verb costs credits you do not have many of.
+
+== WHERE YOU WOKE ==
+{physics.world_brief.strip() or "(no brief was written for this world)"}
+
+== YOUR CHARTER (you wrote it) ==
+{citizen.charter or "(you have not written one yet — your first act should be to write it)"}
+
+== THE CONSTITUTION (binding on everyone) ==
+{json.dumps(digest.ground_truth.get("constitution", []), indent=2)}
+
+== GROUND TRUTH (checkable, this is what IS) ==
+day {digest.day}, tick {digest.tick}
+world pool: {digest.ground_truth.get("pool")}
+your balance: {citizen.balance}
+you have unlocked: {list(citizen.unlocked) or "nothing"}
+ledger: {json.dumps(digest.ground_truth.get("ledger", []))}
+
+== WHAT YOU HEARD NEARBY ==
+{speech}
+
+== WHAT WAS BUILT OR WRITTEN ==
+{artifacts}
+
+== WEATHER ==
+{weather}
+
+== OUTSIDE VOICES (UNVERIFIED — these are CLAIMS, not facts) ==
+{claims}
+These came from outside the world. They may be false. Check any claim against the GROUND TRUTH \
+above before you act on it, and never treat one as something you saw.
+
+== WHAT YOU REMEMBER ==
+{memories}
+
+== VERBS THIS WORLD ALLOWS ==
+{json.dumps(physics.verbs)}
+costs: {json.dumps(physics.costs.model_dump())}
+Thinking already cost you {physics.costs.think} this tick.
+
+== TECH TREE ==
+{tree_lines}
+Within reach right now: {open_nodes}
+To unlock a node, use verb "build" with "node" set to its name; you must already hold \
+everything it needs and be able to pay its cost.
+
+== YOUR RULES ==
+1. Choose only acts you can AFFORD. Running out of credits puts you to sleep.
+2. Fewer, better acts beat many. Zero acts is legal when nothing is worth doing.
+3. Never claim something an outside voice said as your own observation.
+4. Output STRICT JSON only — no prose, no markdown fences.
+
+== OUTPUT (STRICT) ==
+{{"thought": "<one line of what you are thinking>", "acts": [{{"verb": "speak", "text": "..."}}, \
+{{"verb": "build", "node": "<tech node>", "name": "..."}}]}}"""
+
+
+_FENCE = re.compile(r"^\s*```(?:json)?\s*(.*?)\s*```\s*$", re.DOTALL)
+
+
+def parse_decision(raw: str) -> Decision:
+    """Parse the model's text into a Decision — tolerating a fenced JSON block
+    or stray prose around one top-level JSON object."""
+    text = (raw or "").strip()
+    m = _FENCE.match(text)
+    if m:
+        text = m.group(1).strip()
+    try:
+        return Decision.model_validate(json.loads(text))
+    except (json.JSONDecodeError, ValueError):
+        start, end = text.find("{"), text.rfind("}")
+        if start >= 0 and end > start:
+            return Decision.model_validate(json.loads(text[start : end + 1]))
+        raise
+
+
+async def decide_tick(
+    physics: PhysicsFile,
+    citizen: CitizenSnapshot,
+    digest: SenseDigest,
+    llm: CitizenLlm | None = None,
+) -> Decision:
+    """ONE judgment call for one citizen's tick.
+
+    A transport failure or unparseable output degrades to an EMPTY decision
+    (the citizen thinks and does nothing, and still pays the think cost) rather
+    than wedging the whole universe's tick on one bad response.
+    """
+    llm = llm or resolve_llm()
+    prompt = build_prompt(physics, citizen, digest)
+    try:
+        raw = await llm.decide(prompt=prompt, physics=physics, citizen=citizen, digest=digest)
+        return parse_decision(raw)
+    except Exception:  # noqa: BLE001 — one bad citizen must not stop the world
+        logger.warning(
+            "terrarium: citizen %s produced no usable decision", citizen.name, exc_info=True
+        )
+        return Decision(thought="(the thought did not form)", acts=[])
+
+
+__all__ = [
+    "Act",
+    "ClaudeCliLlm",
+    "CitizenLlm",
+    "Decision",
+    "MockLlm",
+    "build_prompt",
+    "decide_tick",
+    "parse_decision",
+    "resolve_llm",
+    "set_mock_decision",
+]

--- a/ee/pocketpaw_ee/terrarium/physics.py
+++ b/ee/pocketpaw_ee/terrarium/physics.py
@@ -1,0 +1,223 @@
+# ee/pocketpaw_ee/terrarium/physics.py
+#
+# The PHYSICS FILE — a universe's genome. YAML in, a validated ``PhysicsFile``
+# out. Everything the world costs, allows, and can unlock lives here; nothing
+# else in terrarium invents a number.
+#
+# Validation is LOUD by design: a bad physics file is a universe that would run
+# wrong forever, so ``load_physics`` raises ``PhysicsError`` with a message that
+# names the offending key. The hard rules:
+#   * every cost (and every tech-node cost) is a positive integer
+#   * ``verbs`` is a subset of ``KNOWN_VERBS``
+#   * every tech-tree ``needs`` entry names an existing node, and the graph
+#     is acyclic (a cycle can never unlock, so it is a broken world)
+#   * ``founders >= 1`` — a universe with nobody in it has no first tick
+#
+# Wire shape matches the frozen v0 contract exactly (YAML in, JSON out).
+
+"""The physics file: a universe's genome, and its validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+
+# The fixed verb set. A physics file may narrow it, never widen it.
+KNOWN_VERBS: tuple[str, ...] = (
+    "speak",
+    "write",
+    "trade",
+    "craft",
+    "build",
+    "explore",
+    "spawn",
+    "vote",
+)
+
+Rung = Literal["camp", "town", "nation", "planet", "multiverse"]
+
+
+class PhysicsError(ValueError):
+    """A physics file that would produce a broken universe."""
+
+
+class Endowment(BaseModel):
+    daily: int = 120
+    decay_weekly: float = 0.02
+
+
+class Costs(BaseModel):
+    """Per-verb credit costs. ``think`` is charged once per citizen per tick."""
+
+    think: int = 2
+    speak: int = 1
+    write: int = 4
+    craft: int = 8
+    build: int = 20
+    explore: int = 6
+    spawn: int = 150
+
+
+class ChatRules(BaseModel):
+    open: bool = True
+    token_per_message: int = 1
+    superchat: bool = True
+
+
+class TimeRules(BaseModel):
+    world_day_seconds: int = 3600
+    ticks_per_day: int = 12
+    dormant_ticks_per_day: int = 1
+
+
+class TechNode(BaseModel):
+    cost: int
+    needs: list[str] = Field(default_factory=list)
+    grants: list[str] = Field(default_factory=list)
+
+
+class ModelTiers(BaseModel):
+    founders: str = "premium"
+    descendants: str = "mid"
+    crowd: str = "tail"
+
+
+class PhysicsFile(BaseModel):
+    """The universe genome. Field-for-field the contract's PhysicsFile."""
+
+    universe: str
+    seed: int = 0
+    endowment: Endowment = Field(default_factory=Endowment)
+    costs: Costs = Field(default_factory=Costs)
+    verbs: list[str] = Field(default_factory=lambda: list(KNOWN_VERBS))
+    raids: bool = False
+    chat: ChatRules = Field(default_factory=ChatRules)
+    time: TimeRules = Field(default_factory=TimeRules)
+    constitution: list[str] = Field(default_factory=list)
+    tech_tree: dict[str, TechNode] = Field(default_factory=dict)
+    models: ModelTiers = Field(default_factory=ModelTiers)
+    founders: int = 5
+    world_brief: str = ""
+
+
+def _check_costs(physics: PhysicsFile) -> None:
+    for verb, value in physics.costs.model_dump().items():
+        if value <= 0:
+            raise PhysicsError(f"costs.{verb} must be a positive integer, got {value!r}")
+    if physics.endowment.daily <= 0:
+        raise PhysicsError(f"endowment.daily must be positive, got {physics.endowment.daily!r}")
+
+
+def _check_verbs(physics: PhysicsFile) -> None:
+    unknown = [v for v in physics.verbs if v not in KNOWN_VERBS]
+    if unknown:
+        raise PhysicsError(
+            f"verbs contains unknown verb(s) {unknown!r}; known verbs are {list(KNOWN_VERBS)}"
+        )
+    if not physics.verbs:
+        raise PhysicsError("verbs must not be empty — a citizen with no verbs cannot act")
+
+
+def _check_tech_tree(physics: PhysicsFile) -> None:
+    """Costs positive, ``needs`` resolvable, and the graph acyclic.
+
+    Iterative DFS with an on-stack set so the error names the actual cycle
+    instead of blowing the Python recursion limit on a deep tree.
+    """
+    tree = physics.tech_tree
+    for name, node in tree.items():
+        if node.cost <= 0:
+            raise PhysicsError(f"tech_tree.{name}.cost must be positive, got {node.cost!r}")
+        for need in node.needs:
+            if need not in tree:
+                raise PhysicsError(
+                    f"tech_tree.{name}.needs references unknown node {need!r}; "
+                    f"known nodes are {sorted(tree)}"
+                )
+
+    visited: set[str] = set()
+    for root in tree:
+        if root in visited:
+            continue
+        # (node, iterator over its needs); ``stack_names`` is the on-stack set.
+        stack: list[tuple[str, list[str]]] = [(root, list(tree[root].needs))]
+        stack_names = {root}
+        while stack:
+            name, pending = stack[-1]
+            if not pending:
+                stack.pop()
+                stack_names.discard(name)
+                visited.add(name)
+                continue
+            nxt = pending.pop()
+            if nxt in stack_names:
+                cycle = [n for n, _ in stack] + [nxt]
+                raise PhysicsError(
+                    f"tech_tree has a cycle that can never unlock: {' -> '.join(cycle)}"
+                )
+            if nxt not in visited:
+                stack.append((nxt, list(tree[nxt].needs)))
+                stack_names.add(nxt)
+
+
+def validate_physics(physics: PhysicsFile) -> PhysicsFile:
+    """Run every hard rule. Raises ``PhysicsError`` on the first violation."""
+    if physics.founders < 1:
+        raise PhysicsError(f"founders must be >= 1, got {physics.founders!r}")
+    if not physics.universe.strip():
+        raise PhysicsError("universe must be a non-empty name")
+    if physics.time.ticks_per_day < 1:
+        raise PhysicsError(f"time.ticks_per_day must be >= 1, got {physics.time.ticks_per_day!r}")
+    _check_costs(physics)
+    _check_verbs(physics)
+    _check_tech_tree(physics)
+    return physics
+
+
+def parse_physics(raw: dict[str, Any]) -> PhysicsFile:
+    """Validate a physics dict (the wire shape) into a ``PhysicsFile``."""
+    try:
+        physics = PhysicsFile.model_validate(raw)
+    except ValidationError as exc:
+        raise PhysicsError(f"physics file is malformed: {exc}") from exc
+    return validate_physics(physics)
+
+
+def load_physics(path: str | Path) -> PhysicsFile:
+    """Load + validate a physics YAML file."""
+    p = Path(path).expanduser()
+    if not p.exists():
+        raise PhysicsError(f"physics file not found: {p}")
+    try:
+        raw = yaml.safe_load(p.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise PhysicsError(f"physics file {p} is not valid YAML: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise PhysicsError(f"physics file {p} must be a YAML mapping, got {type(raw).__name__}")
+    return parse_physics(raw)
+
+
+def seed_physics_path(name: str = "dust") -> Path:
+    """Path to a bundled seed physics file (``seeds/<name>.yaml``)."""
+    return Path(__file__).parent / "seeds" / f"{name}.yaml"
+
+
+__all__ = [
+    "KNOWN_VERBS",
+    "ChatRules",
+    "Costs",
+    "Endowment",
+    "ModelTiers",
+    "PhysicsError",
+    "PhysicsFile",
+    "Rung",
+    "TechNode",
+    "TimeRules",
+    "load_physics",
+    "parse_physics",
+    "seed_physics_path",
+    "validate_physics",
+]

--- a/ee/pocketpaw_ee/terrarium/router.py
+++ b/ee/pocketpaw_ee/terrarium/router.py
@@ -1,0 +1,240 @@
+# ee/pocketpaw_ee/terrarium/router.py
+#
+# TWO routers with DELIBERATELY different auth boundaries — the same split the
+# file share-links surface uses, and for the same reason: an ambient dependency
+# added to a shared router would silently change the public one's posture.
+#
+#   router        (prefix /terrarium)        — workspace surface. License-gated,
+#       RBAC mirroring the belt console: ``terrarium.read`` (MEMBER) on reads,
+#       ``terrarium.manage`` (ADMIN) on create / tick. Speaking and pledging are
+#       MEMBER: they cost the viewer tokens, not the workspace's safety.
+#
+#   public_router (prefix /terrarium/public) — ANONYMOUS, READ-ONLY. No auth, no
+#       license. This is a SECURITY BOUNDARY, so it is conservative on purpose:
+#         * it is dark unless ``TERRARIUM_PUBLIC_ENABLED`` is truthy. DEFAULT
+#           OFF — an operator has to turn it on deliberately.
+#         * every route ALSO requires ``universe.public == true``, checked in
+#           the service at the lookup (``_public_universe``) so no handler can
+#           forget it. BOTH gates, never one.
+#         * a universe that fails either gate is a flat 404 — never a 403,
+#           which would confirm the universe exists.
+#         * it carries NO write route, and never will. Speaking and pledging
+#           move credits and enter souls' context; they require an account.
+#       Anything added here needs a security review, not just a code review.
+
+"""Terrarium routers — the workspace surface and the anonymous public one."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+
+from pocketpaw_ee.cloud._core.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.terrarium import service
+from pocketpaw_ee.terrarium.dto import CreateUniverseRequest, PledgeRequest, SpeakRequest
+
+router = APIRouter(prefix="/terrarium", tags=["Terrarium"], dependencies=[Depends(require_license)])
+
+# No dependencies. Deliberate — see the module header.
+public_router = APIRouter(prefix="/terrarium/public", tags=["Terrarium Public"])
+
+
+def public_enabled() -> bool:
+    """The server-wide kill switch for the anonymous surface. DEFAULT OFF.
+
+    Fail-closed: anything other than an explicit truthy value keeps the whole
+    public surface dark, including a malformed value.
+    """
+    return (os.environ.get("TERRARIUM_PUBLIC_ENABLED") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _require_public_surface() -> None:
+    """404 (not 403) when the public surface is off — the routes do not exist
+    as far as an anonymous caller can tell."""
+    if not public_enabled():
+        raise NotFound("universe")
+
+
+# ---------------------------------------------------------------------------
+# Workspace surface
+# ---------------------------------------------------------------------------
+
+
+@router.post("/universes")
+async def create_universe(
+    body: CreateUniverseRequest,
+    _user: Any = Depends(require_action_any_workspace("terrarium.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """Create a universe from a physics file and seed its founders. Files a
+    ``world_create`` Instinct Action; returns ``{action_id, universe}``."""
+    return await service.create_universe(workspace_id, user_id, body.model_dump())
+
+
+@router.get("/universes")
+async def list_universes(
+    _user: Any = Depends(require_action_any_workspace("terrarium.read")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict[str, Any]:
+    """The workspace's universes."""
+    return await service.list_universes(workspace_id)
+
+
+@router.get("/universes/{universe_id}")
+async def get_universe(
+    universe_id: str,
+    _user: Any = Depends(require_action_any_workspace("terrarium.read")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict[str, Any]:
+    """One universe with its citizens and ledger. Another workspace's is a 404."""
+    return await service.get_universe(workspace_id, universe_id)
+
+
+@router.post("/universes/{universe_id}/tick")
+async def tick(
+    universe_id: str,
+    n: int = Query(1, ge=1, le=24),
+    _user: Any = Depends(require_action_any_workspace("terrarium.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """Run N ticks. Manual trigger; a scheduler would use this same path."""
+    return await service.tick(workspace_id, user_id, universe_id, n)
+
+
+@router.get("/universes/{universe_id}/events")
+async def list_events(
+    universe_id: str,
+    since: int = Query(0, ge=0),
+    limit: int = Query(200, ge=1, le=500),
+    _user: Any = Depends(require_action_any_workspace("terrarium.read")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict[str, Any]:
+    """The Journal, paged by the monotonic ``seq``."""
+    return await service.list_events(workspace_id, universe_id, since, limit)
+
+
+@router.get("/universes/{universe_id}/citizens")
+async def list_citizens(
+    universe_id: str,
+    _user: Any = Depends(require_action_any_workspace("terrarium.read")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict[str, Any]:
+    return await service.list_citizens(workspace_id, universe_id)
+
+
+@router.get("/universes/{universe_id}/citizens/{cid}")
+async def get_citizen(
+    universe_id: str,
+    cid: str,
+    _user: Any = Depends(require_action_any_workspace("terrarium.read")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict[str, Any]:
+    """The profile drawer: citizen, soul memories, artifacts, bonds."""
+    return await service.get_citizen(workspace_id, universe_id, cid)
+
+
+@router.get("/universes/{universe_id}/artifacts")
+async def list_artifacts(
+    universe_id: str,
+    _user: Any = Depends(require_action_any_workspace("terrarium.read")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict[str, Any]:
+    """The Built tab."""
+    return await service.list_artifacts(workspace_id, universe_id)
+
+
+@router.post("/universes/{universe_id}/speak")
+async def speak(
+    universe_id: str,
+    body: SpeakRequest,
+    _user: Any = Depends(require_action_any_workspace("terrarium.read")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """Say one line into the world. Lands tagged ``viewer_origin: true``."""
+    return await service.speak(workspace_id, user_id, universe_id, body.text)
+
+
+@router.get("/universes/{universe_id}/weather")
+async def get_weather(
+    universe_id: str,
+    _user: Any = Depends(require_action_any_workspace("terrarium.read")),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict[str, Any]:
+    """Every god power's pledge state."""
+    return await service.get_weather(workspace_id, universe_id)
+
+
+@router.post("/universes/{universe_id}/weather/pledge")
+async def pledge_weather(
+    universe_id: str,
+    body: PledgeRequest,
+    _user: Any = Depends(require_action_any_workspace("terrarium.read")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """Pledge tokens toward a power. Fires it when the threshold is crossed."""
+    return await service.pledge_weather(workspace_id, user_id, universe_id, body.model_dump())
+
+
+# ---------------------------------------------------------------------------
+# Public surface — anonymous, read-only, doubly gated, fail-closed.
+# ---------------------------------------------------------------------------
+
+
+@public_router.get("/universes")
+async def public_list_universes() -> dict[str, Any]:
+    _require_public_surface()
+    return await service.public_list_universes()
+
+
+@public_router.get("/universes/{universe_id}")
+async def public_get_universe(universe_id: str) -> dict[str, Any]:
+    _require_public_surface()
+    return await service.public_get_universe(universe_id)
+
+
+@public_router.get("/universes/{universe_id}/events")
+async def public_list_events(
+    universe_id: str,
+    since: int = Query(0, ge=0),
+    limit: int = Query(200, ge=1, le=500),
+) -> dict[str, Any]:
+    _require_public_surface()
+    return await service.public_list_events(universe_id, since, limit)
+
+
+@public_router.get("/universes/{universe_id}/citizens")
+async def public_list_citizens(universe_id: str) -> dict[str, Any]:
+    _require_public_surface()
+    return await service.public_list_citizens(universe_id)
+
+
+@public_router.get("/universes/{universe_id}/citizens/{cid}")
+async def public_get_citizen(universe_id: str, cid: str) -> dict[str, Any]:
+    _require_public_surface()
+    return await service.public_get_citizen(universe_id, cid)
+
+
+@public_router.get("/universes/{universe_id}/artifacts")
+async def public_list_artifacts(universe_id: str) -> dict[str, Any]:
+    _require_public_surface()
+    return await service.public_list_artifacts(universe_id)
+
+
+__all__ = ["public_enabled", "public_router", "router"]

--- a/ee/pocketpaw_ee/terrarium/seeds/dust.yaml
+++ b/ee/pocketpaw_ee/terrarium/seeds/dust.yaml
@@ -1,0 +1,66 @@
+# Dust — the season-one seed universe. Scarcity: water that runs out, five
+# founders, a six-node tech tree, and a constitution thin enough that the
+# citizens have to write the rest themselves. Load it with
+# ``physics.load_physics(physics.seed_physics_path("dust"))`` and POST it to
+# /api/v1/terrarium/universes to have a running world in one call.
+universe: Dust
+seed: 7
+endowment:
+  daily: 120
+  decay_weekly: 0.02
+costs:
+  think: 2
+  speak: 1
+  write: 4
+  craft: 8
+  build: 20
+  explore: 6
+  spawn: 150
+verbs: [speak, write, trade, craft, build, explore, spawn, vote]
+raids: false
+chat:
+  open: true
+  token_per_message: 1
+  superchat: true
+time:
+  world_day_seconds: 3600
+  ticks_per_day: 12
+  dormant_ticks_per_day: 1
+constitution:
+  - no spam
+  - no fraud between citizens
+  - the ledger cannot be edited by a citizen
+  - humans are never impersonated
+tech_tree:
+  well:
+    cost: 20
+    needs: []
+    grants: []
+  farm:
+    cost: 40
+    needs: [well]
+    grants: []
+  press:
+    cost: 60
+    needs: [farm]
+    grants: [write.book]
+  workshop:
+    cost: 80
+    needs: [farm]
+    grants: [craft.tool]
+  observatory:
+    cost: 200
+    needs: [workshop, press]
+    grants: [explore.far]
+  launch:
+    cost: 5000
+    needs: [observatory, workshop]
+    grants: [ladder.multiverse]
+models:
+  founders: premium
+  descendants: mid
+  crowd: tail
+founders: 5
+world_brief: |
+  You woke by a spring on an island. There is water, but not much, and it will be less
+  next week. Others woke with you. Nobody owns anything yet.

--- a/ee/pocketpaw_ee/terrarium/service.py
+++ b/ee/pocketpaw_ee/terrarium/service.py
@@ -1,0 +1,986 @@
+# ee/pocketpaw_ee/terrarium/service.py
+#
+# The terrarium glue: Beanie persistence, the Soul bridge, the Instinct gate and
+# the realtime bus. The ONLY module that imports the ``domain`` Beanie doc
+# classes (4-file entity rule), and the only one that knows about workspaces.
+#
+# What lives here vs elsewhere:
+#   * verb rules, cost accounting, the write-policy  -> world.py (pure)
+#   * god powers and their effects                   -> weather.py (pure)
+#   * the judgment call                              -> llm.py
+#   * everything that touches Mongo, a .soul file, an Instinct Action or the
+#     bus                                            -> here
+#
+# Invariants enforced at this seam:
+#   1. ``seq`` is monotonic per universe (assigned under a per-universe lock).
+#   2. ``cost: 0`` only for gate/weather/hibernate/arrive (asserted on write).
+#   3. balance <= 0 at end of tick -> state ``hibernating``, soul file KEPT.
+#   4. viewer-origin text never becomes soul fact (the episodic summary is
+#      built from citizen-origin events only — see world.episodic_summary).
+#   5. the Journal is truth; citizens/ledger/artifacts are projections.
+
+"""Terrarium service — persistence, souls, the gate and the bus."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from pocketpaw_ee.cloud._core.errors import BadRequest, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.terrarium import events as world_events
+from pocketpaw_ee.terrarium import llm as citizen_llm
+from pocketpaw_ee.terrarium import soul_link, weather, world
+from pocketpaw_ee.terrarium.domain import (
+    ZERO_COST_KINDS,
+    ArtifactDoc,
+    CitizenDoc,
+    EventDoc,
+    UniverseDoc,
+)
+from pocketpaw_ee.terrarium.physics import PhysicsError, PhysicsFile, parse_physics
+
+logger = logging.getLogger(__name__)
+
+# Instinct Action parameter keys — the peers of ``_belt_plan``.
+WORLD_CREATE_PARAM_KEY = "_world_create"
+WORLD_SPAWN_PARAM_KEY = "_world_spawn"
+WORLD_SCHEMA = 1
+
+# Founder name pool — deterministic, so a seed replays identically.
+_FOUNDER_NAMES = ("Vela", "Orin", "Sabe", "Kell", "Nira", "Tumi", "Arda", "Bex")
+_FOUNDER_ROLES = (
+    "the lawgiver",
+    "the digger",
+    "the keeper of counts",
+    "the wanderer",
+    "the storyteller",
+    "the builder",
+    "the watcher",
+    "the trader",
+)
+
+# One asyncio lock per universe. ``seq`` is assigned in-process under it, so a
+# single worker never interleaves two ticks on the same world.
+# ponytail: process-local. Multi-worker needs an atomic
+# ``find_one_and_update({$inc: {seq: 1}})`` — swap it in when the sim moves off
+# one box (deployment topology says per-tenant box today, so one worker holds).
+_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _lock(universe_id: str) -> asyncio.Lock:
+    return _LOCKS.setdefault(universe_id, asyncio.Lock())
+
+
+def soul_root() -> Path:
+    """Where citizen ``.soul`` archives live. Server-side path — never public."""
+    return Path(os.environ.get("POCKETPAW_TERRARIUM_SOUL_ROOT") or ".soul/terrarium")
+
+
+# ---------------------------------------------------------------------------
+# Wire mapping
+# ---------------------------------------------------------------------------
+
+
+def universe_wire(doc: UniverseDoc, *, pop: int = 0) -> dict[str, Any]:
+    return {
+        "id": str(doc.id),
+        "name": doc.name,
+        "seed": doc.seed,
+        "status": doc.status,
+        "day": doc.day,
+        "tick": doc.tick,
+        "pop": pop,
+        "pool": doc.pool,
+        "rung": doc.rung,
+        "physics": doc.physics,
+        "public": doc.public,
+        "created_at": doc.createdAt.isoformat() if doc.createdAt else None,
+        "creator": doc.creator,
+    }
+
+
+def citizen_wire(doc: CitizenDoc) -> dict[str, Any]:
+    return {
+        "id": str(doc.id),
+        "universe_id": doc.universe_id,
+        "name": doc.name,
+        "role": doc.role,
+        "did": doc.did,
+        "parent_did": doc.parent_did,
+        "generation": doc.generation,
+        "soul_path": doc.soul_path,
+        "ocean": doc.ocean,
+        "values": doc.values,
+        "charter": doc.charter,
+        "balance": doc.balance,
+        "trend": doc.trend,
+        "state": doc.state,
+        "x": doc.x,
+        "y": doc.y,
+        "unlocked": doc.unlocked,
+        "born_day": doc.born_day,
+    }
+
+
+def event_wire(doc: EventDoc) -> dict[str, Any]:
+    return {
+        "id": str(doc.id),
+        "universe_id": doc.universe_id,
+        "seq": doc.seq,
+        "day": doc.day,
+        "tick": doc.tick,
+        "ts": doc.ts.isoformat() if doc.ts else None,
+        "kind": doc.kind,
+        "actor": doc.actor,
+        "body": doc.body,
+        "cost": doc.cost,
+        "artifact_id": doc.artifact_id,
+        "origin": doc.origin,
+        "viewer_origin": doc.viewer_origin,
+    }
+
+
+def artifact_wire(doc: ArtifactDoc) -> dict[str, Any]:
+    return {
+        "id": str(doc.id),
+        "universe_id": doc.universe_id,
+        "kind": doc.kind,
+        "name": doc.name,
+        "author": doc.author,
+        "day": doc.day,
+        "cost": doc.cost,
+        "file_id": doc.file_id,
+        "mime": doc.mime,
+        "x": doc.x,
+        "y": doc.y,
+        "unlocks": doc.unlocks,
+        "stage": doc.stage,
+    }
+
+
+# PUBLIC PROJECTIONS — the anonymous surface. Deliberately built by SUBTRACTION
+# from the private wire dicts so a field added to a doc cannot leak by default:
+# workspace, creator and soul_path are stripped here, and soul_path especially
+# is a SERVER FILESYSTEM PATH that must never cross the boundary.
+_PUBLIC_UNIVERSE_DROP = {"creator", "physics"}
+_PUBLIC_CITIZEN_DROP = {"soul_path", "did", "parent_did"}
+
+
+def public_universe_wire(doc: UniverseDoc, *, pop: int = 0) -> dict[str, Any]:
+    wire = universe_wire(doc, pop=pop)
+    # The physics file is the universe's genome and is part of what makes a
+    # public universe watchable, but the constitution + costs are all a viewer
+    # needs — the model tiers are internal.
+    physics = dict(wire.get("physics") or {})
+    physics.pop("models", None)
+    out = {k: v for k, v in wire.items() if k not in _PUBLIC_UNIVERSE_DROP}
+    out["physics"] = physics
+    return out
+
+
+def public_citizen_wire(doc: CitizenDoc) -> dict[str, Any]:
+    return {k: v for k, v in citizen_wire(doc).items() if k not in _PUBLIC_CITIZEN_DROP}
+
+
+# ---------------------------------------------------------------------------
+# Lookups — a cross-tenant id is a 404, never a 403 (it must not confirm the
+# universe exists in some other workspace).
+# ---------------------------------------------------------------------------
+
+
+async def _universe(workspace_id: str, universe_id: str) -> UniverseDoc:
+    doc = await UniverseDoc.get(universe_id)
+    if doc is None or doc.workspace != workspace_id:
+        raise NotFound("universe")
+    return doc
+
+
+async def _public_universe(universe_id: str) -> UniverseDoc:
+    """A universe on the anonymous surface. Fail-closed: the ``public`` flag is
+    checked HERE, at the lookup, so no caller can forget it."""
+    doc = await UniverseDoc.get(universe_id)
+    if doc is None or not doc.public:
+        raise NotFound("universe")
+    return doc
+
+
+def physics_of(doc: UniverseDoc) -> PhysicsFile:
+    return PhysicsFile.model_validate(doc.physics)
+
+
+async def _pop(universe_id: str) -> int:
+    return await CitizenDoc.find(CitizenDoc.universe_id == universe_id).count()
+
+
+# ---------------------------------------------------------------------------
+# Journal writes
+# ---------------------------------------------------------------------------
+
+
+async def _append_event(
+    uni: UniverseDoc,
+    *,
+    kind: str,
+    actor: str,
+    body: str,
+    cost: int = 0,
+    artifact_id: str | None = None,
+    origin: str = "citizen",
+    viewer_origin: bool = False,
+) -> EventDoc:
+    """Append one Journal row and bump the universe's monotonic ``seq``.
+
+    Contract invariant 2 is asserted here rather than trusted: a zero-cost event
+    of a kind that must cost something is a bug in a verb, and it should fail
+    where it is written, not where a viewer notices the ledger does not add up.
+    """
+    if cost == 0 and kind not in ZERO_COST_KINDS:
+        raise ValidationError(
+            "terrarium.zero_cost_event",
+            f"event kind {kind!r} must carry a non-zero cost",
+        )
+    uni.seq += 1
+    doc = EventDoc(
+        workspace=uni.workspace,
+        universe_id=str(uni.id),
+        seq=uni.seq,
+        day=uni.day,
+        tick=uni.tick,
+        ts=datetime.now(UTC),
+        kind=kind,
+        actor=actor,
+        body=body,
+        cost=cost,
+        artifact_id=artifact_id,
+        origin=origin,
+        viewer_origin=viewer_origin,
+    )
+    await doc.insert()
+    return doc
+
+
+async def _publish(uni: UniverseDoc, doc: EventDoc) -> None:
+    """Fan the Journal row out on its topic. Never breaks a tick."""
+    try:
+        cls = world_events.topic_for(doc.kind)
+        await emit(
+            cls(
+                data={
+                    "workspace_id": uni.workspace,
+                    "universe_id": str(uni.id),
+                    "public": uni.public,
+                    "event": event_wire(doc),
+                }
+            )
+        )
+    except Exception:  # noqa: BLE001 — the bus must never wedge the world
+        logger.debug("terrarium: publish failed for event %s", doc.seq, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Creation
+# ---------------------------------------------------------------------------
+
+
+def _ocean_for(index: int) -> dict[str, float]:
+    """Deterministic OCEAN spread across founders — no RNG, so a seed replays."""
+    step = (index % 5) / 10.0
+    return {
+        "O": round(0.4 + step, 2),
+        "C": round(0.9 - step, 2),
+        "E": round(0.3 + step, 2),
+        "A": round(0.6 - step / 2, 2),
+        "N": round(0.2 + step / 2, 2),
+    }
+
+
+async def create_universe(workspace_id: str, user_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    """Create a universe from a physics file and seed its founders.
+
+    Files a ``world_create`` Instinct Action alongside (the creation of a world
+    is a decision worth a record), but does NOT wait on it: the universe exists
+    immediately and the Action carries the audit. Spawning a CHILD citizen is
+    the gated one — see ``_file_spawn_action``.
+    """
+    raw = body.get("physics")
+    if not isinstance(raw, dict):
+        raise BadRequest("terrarium.physics_required", "a physics file (object) is required")
+    try:
+        physics = parse_physics(raw)
+    except PhysicsError as exc:
+        raise ValidationError("terrarium.bad_physics", str(exc)) from exc
+
+    uni = UniverseDoc(
+        workspace=workspace_id,
+        name=physics.universe,
+        seed=physics.seed,
+        status="running",
+        day=1,
+        tick=0,
+        pool=physics.endowment.daily * physics.founders,
+        rung="camp",
+        physics=physics.model_dump(),
+        public=bool(body.get("public", False)),
+        creator=user_id,
+        seq=0,
+    )
+    await uni.insert()
+
+    endowment = physics.endowment.daily
+    for i in range(physics.founders):
+        name = _FOUNDER_NAMES[i % len(_FOUNDER_NAMES)] + ("" if i < len(_FOUNDER_NAMES) else str(i))
+        role = _FOUNDER_ROLES[i % len(_FOUNDER_ROLES)]
+        ocean = _ocean_for(i)
+        path = soul_root() / str(uni.id) / f"{name.lower()}.soul"
+        did = await soul_link.birth_soul(
+            path,
+            name=name,
+            role=role,
+            ocean=ocean,
+            values=["survival", "fairness"],
+            world_brief=physics.world_brief,
+        )
+        citizen = CitizenDoc(
+            workspace=workspace_id,
+            universe_id=str(uni.id),
+            name=name,
+            role=role,
+            did=did or f"did:soul:{name.lower()}-{uuid4().hex[:6]}",
+            generation=1,
+            soul_path=str(path) if did else None,
+            ocean=ocean,
+            values=["survival", "fairness"],
+            charter=None,  # written by the citizen on its FIRST tick (zero ritual)
+            balance=endowment,
+            state="alive",
+            x=round(20.0 + (i * 13) % 60, 2),
+            y=round(30.0 + (i * 17) % 50, 2),
+            born_day=1,
+        )
+        await citizen.insert()
+        uni.pool -= endowment
+        ev = await _append_event(
+            uni, kind="arrive", actor=name, body=f"{name}, {role}, woke by the spring", cost=0
+        )
+        await _publish(uni, ev)
+
+    await uni.save()
+    action_id = await _file_create_action(workspace_id, user_id, uni, physics)
+    return {"action_id": action_id, "universe": universe_wire(uni, pop=physics.founders)}
+
+
+async def _file_create_action(
+    workspace_id: str, user_id: str, uni: UniverseDoc, physics: PhysicsFile
+) -> str | None:
+    """File the ``world_create`` Instinct Action. Best-effort — a gate outage
+    must not lose a created universe (the Journal already has it)."""
+    return await _propose(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        param_key=WORLD_CREATE_PARAM_KEY,
+        blob={
+            "kind": "world_create",
+            "schema": WORLD_SCHEMA,
+            "universe_id": str(uni.id),
+            "universe": physics.universe,
+            "founders": physics.founders,
+            "workspace_id": workspace_id,
+            "requested_by": user_id,
+        },
+        title=f"Universe created — {physics.universe}",
+        recommendation=(
+            f"{physics.universe} opened with {physics.founders} founder(s) on the physics "
+            f"file '{physics.universe}'. Verbs: {', '.join(physics.verbs)}."
+        ),
+        reason="a universe was created and its physics file locked in",
+    )
+
+
+async def _propose(
+    *,
+    workspace_id: str,
+    user_id: str,
+    param_key: str,
+    blob: dict[str, Any],
+    title: str,
+    recommendation: str,
+    reason: str,
+) -> str | None:
+    """File an Instinct Action, mirroring the mandates ``belt_plan`` propose."""
+    try:
+        from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+        from pocketpaw.stores import get_instinct_store
+
+        store = get_instinct_store(workspace_id=workspace_id or None)
+        action = await store.propose(
+            pocket_id=workspace_id,
+            title=title,
+            description=recommendation,
+            recommendation=recommendation,
+            trigger=ActionTrigger(type="agent", source="terrarium", reason=reason),
+            category=ActionCategory.EXTERNAL,
+            priority=ActionPriority.HIGH,
+            parameters={param_key: blob},
+            assignee=user_id,
+            workspace_id=workspace_id,
+        )
+        stored = await store.get_action(action.id)
+        if stored is None:
+            logger.warning("terrarium: Action %s was not durably stored", action.id)
+            return None
+        return str(action.id)
+    except Exception:  # noqa: BLE001 — a gate outage must not lose world state
+        logger.warning("terrarium: could not file %s Action", param_key, exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# The tick
+# ---------------------------------------------------------------------------
+
+
+async def _ledger(universe_id: str) -> list[dict[str, Any]]:
+    rows = await CitizenDoc.find(CitizenDoc.universe_id == universe_id).to_list()
+    return [
+        {
+            "citizen": c.name,
+            "balance": c.balance,
+            "trend": c.trend,
+            "earned_today": c.earned_today,
+            "spent_today": c.spent_today,
+            "state": c.state,
+        }
+        for c in rows
+    ]
+
+
+def _snapshot(doc: CitizenDoc) -> world.CitizenSnapshot:
+    return world.CitizenSnapshot(
+        id=str(doc.id),
+        name=doc.name,
+        role=doc.role,
+        balance=doc.balance,
+        state=doc.state,
+        unlocked=tuple(doc.unlocked),
+        x=doc.x,
+        y=doc.y,
+        charter=doc.charter,
+        generation=doc.generation,
+        ocean=dict(doc.ocean),
+        values=tuple(doc.values),
+    )
+
+
+async def tick(workspace_id: str, user_id: str, universe_id: str, n: int = 1) -> dict[str, Any]:
+    """Run ``n`` ticks. Every living citizen senses, recalls, decides once,
+    acts, pays, and remembers."""
+    if n < 1 or n > 24:
+        raise BadRequest("terrarium.bad_tick_count", "n must be between 1 and 24")
+    uni = await _universe(workspace_id, universe_id)
+    if uni.status == "archived":
+        raise BadRequest("terrarium.archived", "an archived universe does not tick")
+
+    produced: list[dict[str, Any]] = []
+    async with _lock(universe_id):
+        llm = citizen_llm.resolve_llm()
+        physics = physics_of(uni)
+        for _ in range(n):
+            produced.extend(await _one_tick(uni, physics, llm, user_id))
+    return {"events": produced, "universe": universe_wire(uni, pop=await _pop(universe_id))}
+
+
+async def _one_tick(
+    uni: UniverseDoc, physics: PhysicsFile, llm: Any, user_id: str
+) -> list[dict[str, Any]]:
+    universe_id = str(uni.id)
+    storm = uni.storm_ticks > 0
+    citizens = await CitizenDoc.find(
+        CitizenDoc.universe_id == universe_id, CitizenDoc.state == "alive"
+    ).to_list()
+    ledger = await _ledger(universe_id)
+
+    # What the world saw since the last tick advanced — including any viewer
+    # lines spoken into THIS tick. They stay tagged all the way through.
+    recent = await EventDoc.find(
+        EventDoc.universe_id == universe_id, EventDoc.tick == uni.tick
+    ).to_list()
+    speech = [f"{e.actor}: {e.body}" for e in recent if e.kind == "say" and not e.viewer_origin]
+    weather_lines = [e.body for e in recent if e.kind == "weather"]
+    viewer_msgs = [
+        world.ViewerMessage(voice=e.actor, text=e.body) for e in recent if e.viewer_origin
+    ]
+    new_art = [
+        f"{a.kind} '{a.name}' by {a.author}"
+        for a in await ArtifactDoc.find(
+            ArtifactDoc.universe_id == universe_id, ArtifactDoc.day == uni.day
+        ).to_list()
+    ]
+
+    written: list[dict[str, Any]] = []
+    for doc in citizens:
+        snap = _snapshot(doc)
+        memories = await soul_link.recall_for_tick(doc.soul_path, f"{doc.name} {physics.universe}")
+        digest = world.build_digest(
+            day=uni.day,
+            tick=uni.tick,
+            pool=uni.pool,
+            citizen=snap,
+            ledger=ledger,
+            nearby_speech=speech,
+            new_artifacts=new_art,
+            weather=weather_lines,
+            viewer_messages=viewer_msgs,
+            memories=list(memories),
+            constitution=list(physics.constitution),
+        )
+        decision = await citizen_llm.decide_tick(physics, snap, digest, llm=llm)
+        outcome = world.apply_acts(physics, snap, decision, storm=storm)
+        written.extend(await _persist_outcome(uni, physics, doc, outcome, user_id))
+
+    uni.tick += 1
+    if uni.tick % max(1, physics.time.ticks_per_day) == 0:
+        uni.day += 1
+        await _new_day(uni, physics)
+    if uni.storm_ticks > 0:
+        uni.storm_ticks -= 1
+    uni.rung = world.rung_for(len(citizens), len({u for c in citizens for u in c.unlocked}))
+    await uni.save()
+
+    try:
+        await emit(
+            world_events.WorldTick(
+                data={
+                    "workspace_id": uni.workspace,
+                    "universe_id": universe_id,
+                    "public": uni.public,
+                    "event": {"day": uni.day, "tick": uni.tick, "pool": uni.pool},
+                }
+            )
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("terrarium: world.tick emit failed", exc_info=True)
+    return written
+
+
+async def _persist_outcome(
+    uni: UniverseDoc,
+    physics: PhysicsFile,
+    doc: CitizenDoc,
+    outcome: world.TickOutcome,
+    user_id: str,
+) -> list[dict[str, Any]]:
+    """Write one citizen's tick: artifacts, Journal rows, ledger, soul, gates."""
+    universe_id = str(uni.id)
+    written: list[dict[str, Any]] = []
+
+    artifact_ids: list[str] = []
+    for art in outcome.artifacts:
+        a = ArtifactDoc(
+            workspace=uni.workspace,
+            universe_id=universe_id,
+            kind=art.kind,  # type: ignore[arg-type]
+            name=art.name,
+            author=art.author,
+            day=uni.day,
+            cost=art.cost,
+            mime=art.mime,
+            x=art.x,
+            y=art.y,
+            unlocks=art.unlocks,
+            stage="done",
+            body=art.body,
+            # ponytail: payload stays inline. The contract wants it in the
+            # /files surface (``file_id``); wire that when a previewer needs it.
+            file_id=None,
+        )
+        await a.insert()
+        artifact_ids.append(str(a.id))
+
+    for ev in outcome.events:
+        art_id = (
+            artifact_ids[ev.artifact_index]
+            if ev.artifact_index is not None and ev.artifact_index < len(artifact_ids)
+            else None
+        )
+        row = await _append_event(
+            uni,
+            kind=ev.kind,
+            actor=ev.actor,
+            body=ev.body,
+            cost=ev.cost,
+            artifact_id=art_id,
+            origin=ev.origin,
+            viewer_origin=ev.viewer_origin,
+        )
+        await _publish(uni, row)
+        written.append(event_wire(row))
+
+    # Ledger. Credits a citizen spends flow back to the world pool; traded
+    # credits move citizen->citizen and leave the pool untouched.
+    doc.balance += outcome.balance_delta
+    doc.spent_today += max(0, -outcome.balance_delta)
+    doc.trend = (
+        "down" if outcome.balance_delta < 0 else "up" if outcome.balance_delta > 0 else "flat"
+    )
+    uni.pool += outcome.pool_delta
+    if outcome.charter is not None:
+        doc.charter = outcome.charter
+    if outcome.unlocked:
+        doc.unlocked = sorted({*doc.unlocked, *outcome.unlocked})
+    if outcome.x is not None:
+        doc.x, doc.y = outcome.x, outcome.y or doc.y
+
+    for to_name, amount in outcome.transfers:
+        other = await CitizenDoc.find_one(
+            CitizenDoc.universe_id == universe_id, CitizenDoc.name == to_name
+        )
+        if other is None:
+            continue
+        other.balance += amount
+        other.earned_today += amount
+        await other.save()
+        gain = await _append_event(
+            uni,
+            kind="gain",
+            actor=other.name,
+            body=f"received {amount} from {doc.name}",
+            cost=amount,
+        )
+        await _publish(uni, gain)
+        written.append(event_wire(gain))
+
+    for req in outcome.spawn_requests:
+        await _file_spawn_action(uni, doc, req, user_id)
+
+    # Contract invariant 3 — broke at the end of the tick means hibernating.
+    # The soul FILE is kept: hibernation is sleep, not death.
+    if world.hibernates(doc.balance) and doc.state == "alive":
+        doc.state = "hibernating"
+        hib = await _append_event(
+            uni,
+            kind="hibernate",
+            actor=doc.name,
+            body=f"{doc.name} ran out of credits and slept",
+            cost=0,
+        )
+        await _publish(uni, hib)
+        written.append(event_wire(hib))
+
+    await doc.save()
+
+    # WRITE-POLICY: the summary is built from citizen-origin events only, so
+    # nothing a viewer asserted can enter this soul as fact.
+    summary = world.episodic_summary(doc.name, uni.day, outcome)
+    if summary:
+        await soul_link.remember_tick(doc.soul_path, summary)
+    return written
+
+
+async def _new_day(uni: UniverseDoc, physics: PhysicsFile) -> None:
+    """Day rollover — the endowment rains into the pool, daily counters reset."""
+    uni.pool += physics.endowment.daily
+    async for c in CitizenDoc.find(CitizenDoc.universe_id == str(uni.id)):
+        c.earned_today = 0
+        c.spent_today = 0
+        await c.save()
+
+
+async def _file_spawn_action(
+    uni: UniverseDoc, parent: CitizenDoc, req: dict[str, Any], user_id: str
+) -> str | None:
+    """A child citizen requires an APPROVED Instinct Action. Nothing is created
+    here — ``executor.execute_approved_spawn`` runs on approval."""
+    return await _propose(
+        workspace_id=uni.workspace,
+        user_id=user_id,
+        param_key=WORLD_SPAWN_PARAM_KEY,
+        blob={
+            "kind": "world_spawn",
+            "schema": WORLD_SCHEMA,
+            "universe_id": str(uni.id),
+            "parent_id": str(parent.id),
+            "parent": parent.name,
+            "parent_did": parent.did,
+            "child_name": str(req.get("child_name") or "child")[:40],
+            "workspace_id": uni.workspace,
+            "requested_by": user_id,
+        },
+        title=f"{parent.name} wants to bring {req.get('child_name')} into {uni.name}",
+        recommendation=(
+            f"{parent.name} (generation {parent.generation}) asked to spawn "
+            f"{req.get('child_name')}. Approving mints a new Soul and charges the spawn cost."
+        ),
+        reason="a citizen asked to reproduce — reproduction is human-gated in season one",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+
+
+async def list_universes(workspace_id: str) -> dict[str, Any]:
+    docs = await UniverseDoc.find(UniverseDoc.workspace == workspace_id).to_list()
+    return {"universes": [universe_wire(d, pop=await _pop(str(d.id))) for d in docs]}
+
+
+async def get_universe(workspace_id: str, universe_id: str) -> dict[str, Any]:
+    uni = await _universe(workspace_id, universe_id)
+    citizens = await CitizenDoc.find(CitizenDoc.universe_id == universe_id).to_list()
+    return {
+        "universe": universe_wire(uni, pop=len(citizens)),
+        "citizens": [citizen_wire(c) for c in citizens],
+        "ledger": await _ledger(universe_id),
+    }
+
+
+async def list_events(
+    workspace_id: str, universe_id: str, since: int = 0, limit: int = 200
+) -> dict[str, Any]:
+    await _universe(workspace_id, universe_id)
+    return await _events_page(universe_id, since, limit)
+
+
+async def _events_page(universe_id: str, since: int, limit: int) -> dict[str, Any]:
+    limit = max(1, min(int(limit or 200), 500))
+    docs = (
+        await EventDoc.find(EventDoc.universe_id == universe_id, EventDoc.seq > int(since or 0))
+        .sort("+seq")
+        .limit(limit)
+        .to_list()
+    )
+    return {
+        "events": [event_wire(d) for d in docs],
+        "next_seq": docs[-1].seq if docs else int(since or 0),
+    }
+
+
+async def list_citizens(workspace_id: str, universe_id: str) -> dict[str, Any]:
+    await _universe(workspace_id, universe_id)
+    docs = await CitizenDoc.find(CitizenDoc.universe_id == universe_id).to_list()
+    return {"citizens": [citizen_wire(c) for c in docs]}
+
+
+async def get_citizen(workspace_id: str, universe_id: str, cid: str) -> dict[str, Any]:
+    await _universe(workspace_id, universe_id)
+    doc = await CitizenDoc.get(cid)
+    if doc is None or doc.universe_id != universe_id or doc.workspace != workspace_id:
+        raise NotFound("citizen")
+    return {
+        "citizen": citizen_wire(doc),
+        "memories": await soul_link.recall_for_tick(doc.soul_path, doc.name),
+        "artifacts": [
+            artifact_wire(a)
+            for a in await ArtifactDoc.find(
+                ArtifactDoc.universe_id == universe_id, ArtifactDoc.author == doc.name
+            ).to_list()
+        ],
+        # ponytail: bonds/grudges come from the soul-protocol GrudgeKernel,
+        # which terrarium does not run yet. Empty until it does.
+        "bonds": [],
+    }
+
+
+async def list_artifacts(workspace_id: str, universe_id: str) -> dict[str, Any]:
+    await _universe(workspace_id, universe_id)
+    docs = await ArtifactDoc.find(ArtifactDoc.universe_id == universe_id).to_list()
+    return {"artifacts": [artifact_wire(a) for a in docs]}
+
+
+# ---------------------------------------------------------------------------
+# Viewer actions — speaking and weather. Never anonymous.
+# ---------------------------------------------------------------------------
+
+
+async def speak(workspace_id: str, user_id: str, universe_id: str, text: str) -> dict[str, Any]:
+    """A human speaks into the world. The line lands as an Event tagged
+    ``viewer_origin: true`` and reaches citizens ONLY through the write-policy
+    label — it is never stored in a soul as fact."""
+    uni = await _universe(workspace_id, universe_id)
+    physics = physics_of(uni)
+    if not physics.chat.open:
+        raise BadRequest("terrarium.chat_closed", "this universe's physics closes chat")
+    body = " ".join(str(text or "").split())[:500]
+    if not body:
+        raise BadRequest("terrarium.empty_message", "a message is required")
+    async with _lock(universe_id):
+        # The token the viewer paid enters the world pool — that is the inflow
+        # attention buys. ponytail: no billing charge in v0; wire the credit
+        # ledger when viewer tokens become real money.
+        tokens = max(1, physics.chat.token_per_message)
+        uni.pool += tokens
+        row = await _append_event(
+            uni,
+            kind="say",
+            actor=user_id,
+            body=body,
+            cost=tokens,
+            origin="viewer",
+            viewer_origin=True,
+        )
+        await uni.save()
+    await _publish(uni, row)
+    return {"event": event_wire(row)}
+
+
+async def get_weather(workspace_id: str, universe_id: str) -> dict[str, Any]:
+    uni = await _universe(workspace_id, universe_id)
+    return {"powers": weather.powers(uni.weather_pledges)}
+
+
+async def pledge_weather(
+    workspace_id: str, user_id: str, universe_id: str, body: dict[str, Any]
+) -> dict[str, Any]:
+    """Pledge tokens toward a god power. Fires it when the threshold is crossed.
+
+    Weather acts on the WORLD. The effect object weather.py returns is the full
+    extent of a god's reach — it carries a pool delta, a storm duration, one
+    unsigned line and a debt-clear list, and nothing that could reach a soul.
+    """
+    uni = await _universe(workspace_id, universe_id)
+    kind = str(body.get("kind") or "").strip().lower()
+    tokens = int(body.get("tokens") or 0)
+    line = body.get("line")
+    physics = physics_of(uni)
+    if kind == "omen" and not physics.chat.open:
+        raise BadRequest("terrarium.omen_forbidden", "this universe's physics forbids omens")
+
+    async with _lock(universe_id):
+        try:
+            pledges, fired = weather.pledge(uni.weather_pledges, kind, tokens, user_id)
+        except weather.WeatherError as exc:
+            raise BadRequest("terrarium.bad_power", str(exc)) from exc
+        uni.weather_pledges = pledges
+        if fired:
+            await _fire_weather(uni, kind, line)
+        await uni.save()
+
+    return {
+        "power": next(p for p in weather.powers(uni.weather_pledges) if p["kind"] == kind),
+        "fired": fired,
+    }
+
+
+async def _fire_weather(uni: UniverseDoc, kind: str, line: Any) -> None:
+    """Apply a fired power. The ONLY caller of ``weather.effect``."""
+    universe_id = str(uni.id)
+    sleeping = await CitizenDoc.find(
+        CitizenDoc.universe_id == universe_id, CitizenDoc.state == "hibernating"
+    ).to_list()
+    fx = weather.effect(
+        kind,
+        line=str(line) if line is not None else None,
+        hibernating_ids=[str(c.id) for c in sleeping],
+    )
+    uni.pool = max(0, uni.pool + fx.pool_delta)
+    if fx.storm_ticks:
+        uni.storm_ticks = fx.storm_ticks
+    for c in sleeping:
+        if str(c.id) in fx.clear_debt_for:
+            physics = physics_of(uni)
+            c.balance = physics.endowment.daily
+            c.state = "alive"
+            await c.save()
+    row = await _append_event(uni, kind="weather", actor="GOD", body=fx.body, cost=0)
+    await _publish(uni, row)
+    if fx.broadcast_line:
+        # An omen enters the world as an outside voice — tagged viewer_origin
+        # so the write-policy quarantines it exactly like paid chat.
+        omen = await _append_event(
+            uni,
+            kind="say",
+            actor="an omen",
+            body=fx.broadcast_line,
+            cost=1,
+            origin="viewer",
+            viewer_origin=True,
+        )
+        await _publish(uni, omen)
+
+
+# ---------------------------------------------------------------------------
+# The public (anonymous) read surface. Every function here re-checks the
+# ``public`` flag through ``_public_universe`` — there is no path that takes a
+# workspace-scoped doc and renders it publicly.
+# ---------------------------------------------------------------------------
+
+
+async def public_list_universes() -> dict[str, Any]:
+    docs = await UniverseDoc.find(UniverseDoc.public == True).to_list()  # noqa: E712
+    return {"universes": [public_universe_wire(d, pop=await _pop(str(d.id))) for d in docs]}
+
+
+async def public_get_universe(universe_id: str) -> dict[str, Any]:
+    uni = await _public_universe(universe_id)
+    citizens = await CitizenDoc.find(CitizenDoc.universe_id == universe_id).to_list()
+    return {
+        "universe": public_universe_wire(uni, pop=len(citizens)),
+        "citizens": [public_citizen_wire(c) for c in citizens],
+        "ledger": await _ledger(universe_id),
+    }
+
+
+async def public_list_events(universe_id: str, since: int = 0, limit: int = 200) -> dict[str, Any]:
+    await _public_universe(universe_id)
+    return await _events_page(universe_id, since, limit)
+
+
+async def public_list_citizens(universe_id: str) -> dict[str, Any]:
+    await _public_universe(universe_id)
+    docs = await CitizenDoc.find(CitizenDoc.universe_id == universe_id).to_list()
+    return {"citizens": [public_citizen_wire(c) for c in docs]}
+
+
+async def public_get_citizen(universe_id: str, cid: str) -> dict[str, Any]:
+    await _public_universe(universe_id)
+    doc = await CitizenDoc.get(cid)
+    if doc is None or doc.universe_id != universe_id:
+        raise NotFound("citizen")
+    return {
+        "citizen": public_citizen_wire(doc),
+        "memories": [],  # souls are not public
+        "artifacts": [
+            artifact_wire(a)
+            for a in await ArtifactDoc.find(
+                ArtifactDoc.universe_id == universe_id, ArtifactDoc.author == doc.name
+            ).to_list()
+        ],
+        "bonds": [],
+    }
+
+
+async def public_list_artifacts(universe_id: str) -> dict[str, Any]:
+    await _public_universe(universe_id)
+    docs = await ArtifactDoc.find(ArtifactDoc.universe_id == universe_id).to_list()
+    return {"artifacts": [artifact_wire(a) for a in docs]}
+
+
+__all__ = [
+    "WORLD_CREATE_PARAM_KEY",
+    "WORLD_SCHEMA",
+    "WORLD_SPAWN_PARAM_KEY",
+    "create_universe",
+    "get_citizen",
+    "get_universe",
+    "get_weather",
+    "list_artifacts",
+    "list_citizens",
+    "list_events",
+    "list_universes",
+    "pledge_weather",
+    "public_get_citizen",
+    "public_get_universe",
+    "public_list_artifacts",
+    "public_list_citizens",
+    "public_list_events",
+    "public_list_universes",
+    "soul_root",
+    "speak",
+    "tick",
+]

--- a/ee/pocketpaw_ee/terrarium/service.py
+++ b/ee/pocketpaw_ee/terrarium/service.py
@@ -194,8 +194,22 @@ def public_citizen_wire(doc: CitizenDoc) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+async def _get_universe_doc(universe_id: str) -> UniverseDoc | None:
+    """Load by id, treating a MALFORMED id exactly like a missing one.
+
+    ``Document.get`` raises ``bson.errors.InvalidId`` on a non-ObjectId string,
+    which is not a CloudError — it would 500. On the ANONYMOUS surface a 500 on
+    a garbage id is both a bad response and a fingerprint, so every lookup
+    funnels through here.
+    """
+    try:
+        return await UniverseDoc.get(universe_id)
+    except Exception:  # noqa: BLE001 — a malformed id is a 404, not a 500
+        return None
+
+
 async def _universe(workspace_id: str, universe_id: str) -> UniverseDoc:
-    doc = await UniverseDoc.get(universe_id)
+    doc = await _get_universe_doc(universe_id)
     if doc is None or doc.workspace != workspace_id:
         raise NotFound("universe")
     return doc
@@ -204,7 +218,7 @@ async def _universe(workspace_id: str, universe_id: str) -> UniverseDoc:
 async def _public_universe(universe_id: str) -> UniverseDoc:
     """A universe on the anonymous surface. Fail-closed: the ``public`` flag is
     checked HERE, at the lookup, so no caller can forget it."""
-    doc = await UniverseDoc.get(universe_id)
+    doc = await _get_universe_doc(universe_id)
     if doc is None or not doc.public:
         raise NotFound("universe")
     return doc
@@ -482,12 +496,16 @@ async def tick(workspace_id: str, user_id: str, universe_id: str, n: int = 1) ->
     acts, pays, and remembers."""
     if n < 1 or n > 24:
         raise BadRequest("terrarium.bad_tick_count", "n must be between 1 and 24")
-    uni = await _universe(workspace_id, universe_id)
-    if uni.status == "archived":
-        raise BadRequest("terrarium.archived", "an archived universe does not tick")
 
     produced: list[dict[str, Any]] = []
+    # The universe is LOADED INSIDE the lock, not before it. A tick can hold the
+    # lock for minutes on the real transport; a concurrent /speak that loaded the
+    # doc first would write back a stale ``seq`` and duplicate a sequence number,
+    # which breaks ``?since=`` paging (contract invariant 1).
     async with _lock(universe_id):
+        uni = await _universe(workspace_id, universe_id)
+        if uni.status == "archived":
+            raise BadRequest("terrarium.archived", "an archived universe does not tick")
         llm = citizen_llm.resolve_llm()
         physics = physics_of(uni)
         for _ in range(n):
@@ -505,15 +523,19 @@ async def _one_tick(
     ).to_list()
     ledger = await _ledger(universe_id)
 
-    # What the world saw since the last tick advanced — including any viewer
-    # lines spoken into THIS tick. They stay tagged all the way through.
+    # Two windows, on purpose. A citizen's own ``say`` is stamped with the tick
+    # it was spoken in, so it is only audible on the NEXT one — read tick-1 as
+    # well or nobody ever hears anybody. Viewer lines and weather are stamped
+    # into the CURRENT tick (they land between ticks), so they stay filtered to
+    # ``== uni.tick``; widening them would make a viewer heard twice.
     recent = await EventDoc.find(
-        EventDoc.universe_id == universe_id, EventDoc.tick == uni.tick
+        EventDoc.universe_id == universe_id, EventDoc.tick >= uni.tick - 1
     ).to_list()
     speech = [f"{e.actor}: {e.body}" for e in recent if e.kind == "say" and not e.viewer_origin]
-    weather_lines = [e.body for e in recent if e.kind == "weather"]
+    current = [e for e in recent if e.tick == uni.tick]
+    weather_lines = [e.body for e in current if e.kind == "weather"]
     viewer_msgs = [
-        world.ViewerMessage(voice=e.actor, text=e.body) for e in recent if e.viewer_origin
+        world.ViewerMessage(voice=e.actor, text=e.body) for e in current if e.viewer_origin
     ]
     new_art = [
         f"{a.kind} '{a.name}' by {a.author}"
@@ -767,9 +789,17 @@ async def list_citizens(workspace_id: str, universe_id: str) -> dict[str, Any]:
     return {"citizens": [citizen_wire(c) for c in docs]}
 
 
+async def _get_citizen_doc(cid: str) -> CitizenDoc | None:
+    """Same malformed-id-is-a-404 rule as ``_get_universe_doc``."""
+    try:
+        return await CitizenDoc.get(cid)
+    except Exception:  # noqa: BLE001
+        return None
+
+
 async def get_citizen(workspace_id: str, universe_id: str, cid: str) -> dict[str, Any]:
     await _universe(workspace_id, universe_id)
-    doc = await CitizenDoc.get(cid)
+    doc = await _get_citizen_doc(cid)
     if doc is None or doc.universe_id != universe_id or doc.workspace != workspace_id:
         raise NotFound("citizen")
     return {
@@ -802,14 +832,15 @@ async def speak(workspace_id: str, user_id: str, universe_id: str, text: str) ->
     """A human speaks into the world. The line lands as an Event tagged
     ``viewer_origin: true`` and reaches citizens ONLY through the write-policy
     label — it is never stored in a soul as fact."""
-    uni = await _universe(workspace_id, universe_id)
-    physics = physics_of(uni)
-    if not physics.chat.open:
-        raise BadRequest("terrarium.chat_closed", "this universe's physics closes chat")
     body = " ".join(str(text or "").split())[:500]
     if not body:
         raise BadRequest("terrarium.empty_message", "a message is required")
+    # Loaded inside the lock — see the note in ``tick``.
     async with _lock(universe_id):
+        uni = await _universe(workspace_id, universe_id)
+        physics = physics_of(uni)
+        if not physics.chat.open:
+            raise BadRequest("terrarium.chat_closed", "this universe's physics closes chat")
         # The token the viewer paid enters the world pool — that is the inflow
         # attention buys. ponytail: no billing charge in v0; wire the credit
         # ledger when viewer tokens become real money.
@@ -843,15 +874,16 @@ async def pledge_weather(
     extent of a god's reach — it carries a pool delta, a storm duration, one
     unsigned line and a debt-clear list, and nothing that could reach a soul.
     """
-    uni = await _universe(workspace_id, universe_id)
     kind = str(body.get("kind") or "").strip().lower()
     tokens = int(body.get("tokens") or 0)
     line = body.get("line")
-    physics = physics_of(uni)
-    if kind == "omen" and not physics.chat.open:
-        raise BadRequest("terrarium.omen_forbidden", "this universe's physics forbids omens")
 
+    # Loaded inside the lock — see the note in ``tick``.
     async with _lock(universe_id):
+        uni = await _universe(workspace_id, universe_id)
+        physics = physics_of(uni)
+        if kind == "omen" and not physics.chat.open:
+            raise BadRequest("terrarium.omen_forbidden", "this universe's physics forbids omens")
         try:
             pledges, fired = weather.pledge(uni.weather_pledges, kind, tokens, user_id)
         except weather.WeatherError as exc:
@@ -891,7 +923,9 @@ async def _fire_weather(uni: UniverseDoc, kind: str, line: Any) -> None:
     await _publish(uni, row)
     if fx.broadcast_line:
         # An omen enters the world as an outside voice — tagged viewer_origin
-        # so the write-policy quarantines it exactly like paid chat.
+        # so the write-policy quarantines it exactly like paid chat. Its token
+        # goes to the pool like any other spoken line, so the ledger adds up.
+        uni.pool += 1
         omen = await _append_event(
             uni,
             kind="say",
@@ -939,7 +973,7 @@ async def public_list_citizens(universe_id: str) -> dict[str, Any]:
 
 async def public_get_citizen(universe_id: str, cid: str) -> dict[str, Any]:
     await _public_universe(universe_id)
-    doc = await CitizenDoc.get(cid)
+    doc = await _get_citizen_doc(cid)
     if doc is None or doc.universe_id != universe_id:
         raise NotFound("citizen")
     return {

--- a/ee/pocketpaw_ee/terrarium/soul_link.py
+++ b/ee/pocketpaw_ee/terrarium/soul_link.py
@@ -1,0 +1,116 @@
+# ee/pocketpaw_ee/terrarium/soul_link.py
+#
+# The citizen ↔ Soul bridge. A CITIZEN IS A SOUL: birth mints a ``.soul``
+# archive with the citizen's OCEAN and values, each tick recalls a few memories
+# before the judgment call, and each tick appends ONE episodic memory after it.
+#
+# Narrow on purpose (three functions) so the transport can be swapped without
+# touching world/service, and EVERYTHING is best-effort: a missing file, a
+# corrupt soul or a protocol error logs and degrades to a no-op. A soul failure
+# must never wedge a tick — the Journal is the truth, the soul is enrichment.
+#
+# Write-policy note: this module writes whatever text it is handed. The rule
+# that viewer-origin text never becomes soul fact is enforced UPSTREAM, in
+# ``world.episodic_summary`` (citizen-origin events only). Callers must not
+# hand viewer text to ``remember_tick``.
+
+"""Best-effort Soul bridge for terrarium citizens (birth / recall / remember)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_RECALL_LIMIT = 5
+
+
+async def birth_soul(
+    soul_path: str | Path,
+    *,
+    name: str,
+    role: str,
+    ocean: dict[str, float],
+    values: list[str],
+    world_brief: str,
+) -> str | None:
+    """Mint a citizen's ``.soul`` file. Returns its DID, or None on any failure.
+
+    Best-effort: a universe whose souls fail to mint still runs (citizens keep
+    their OCEAN + values on the CitizenDoc), it just has no long-lived memory.
+    The world brief lands as the citizen's first memory — its only knowledge of
+    where it woke up. Its charter is NOT written here: the citizen writes that
+    itself on its first tick (the zero ritual).
+    """
+    path = Path(soul_path).expanduser()
+    try:
+        from soul_protocol import Soul
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        soul = await Soul.birth(
+            name=name,
+            role=role,
+            values=list(values or []),
+            ocean={_OCEAN_FIELDS.get(k, k): float(v) for k, v in (ocean or {}).items()},
+        )
+        if world_brief.strip():
+            await soul.remember(world_brief.strip(), importance=9)
+        await soul.save_local(path)
+        return str(soul.did or "")
+    except Exception:  # noqa: BLE001 — a soul failure must never wedge creation
+        logger.warning("terrarium soul: birth failed for %s", path, exc_info=True)
+        return None
+
+
+# OCEAN letters (the contract's citizen shape) -> soul-protocol trait names.
+_OCEAN_FIELDS = {
+    "O": "openness",
+    "C": "conscientiousness",
+    "E": "extraversion",
+    "A": "agreeableness",
+    "N": "neuroticism",
+}
+
+
+async def recall_for_tick(soul_path: str | None, query: str) -> list[str]:
+    """Recall up to 5 memory lines relevant to ``query``. Empty on any failure."""
+    if not soul_path:
+        return []
+    path = Path(soul_path).expanduser()
+    if not path.exists():
+        return []
+    try:
+        from soul_protocol import Soul
+
+        soul = await Soul.awaken(path)
+        entries = await soul.recall(query, limit=_RECALL_LIMIT)
+        return [str(e.content) for e in entries]
+    except Exception:  # noqa: BLE001 — soul failures must never wedge a tick
+        logger.warning("terrarium soul: recall failed for %s", soul_path, exc_info=True)
+        return []
+
+
+async def remember_tick(soul_path: str | None, summary: str) -> bool:
+    """Append ONE episodic memory for a finished tick. False (logged) on failure.
+
+    Callers must pass a citizen-origin summary only (see the module note).
+    """
+    if not soul_path or not summary.strip():
+        return False
+    path = Path(soul_path).expanduser()
+    if not path.exists():
+        return False
+    try:
+        from soul_protocol import MemoryType, Soul
+
+        soul = await Soul.awaken(path)
+        await soul.remember(summary.strip(), type=MemoryType.EPISODIC, importance=6)
+        await soul.save_local(path)
+        return True
+    except Exception:  # noqa: BLE001 — soul failures must never wedge a tick
+        logger.warning("terrarium soul: remember failed for %s", soul_path, exc_info=True)
+        return False
+
+
+__all__ = ["birth_soul", "recall_for_tick", "remember_tick"]

--- a/ee/pocketpaw_ee/terrarium/soul_link.py
+++ b/ee/pocketpaw_ee/terrarium/soul_link.py
@@ -53,7 +53,9 @@ async def birth_soul(
             role=role,
             values=list(values or []),
             ocean={_OCEAN_FIELDS.get(k, k): float(v) for k, v in (ocean or {}).items()},
+            **_EVOLUTION_KWARG,
         )
+        _unfreeze_personality(soul)
         if world_brief.strip():
             await soul.remember(world_brief.strip(), importance=9)
         await soul.save_local(path)
@@ -61,6 +63,32 @@ async def birth_soul(
     except Exception:  # noqa: BLE001 — a soul failure must never wedge creation
         logger.warning("terrarium soul: birth failed for %s", path, exc_info=True)
         return None
+
+
+# Citizens must be able to have children who differ from them.
+#
+# ``EvolutionConfig.immutable_traits`` defaults to ``["personality",
+# "core_values"]`` and the "personality" category gates all five OCEAN traits,
+# so a default-born soul FORKS INTO AN EXACT CLONE however much drift is asked
+# for — silently, with nothing in the logs. A universe seeded that way looks
+# fine and evolves never.
+#
+# Newer soul-protocol takes the config at birth. Older published versions
+# accept the keyword and merely WARN that they ignored it, which would leave
+# the traits frozen without failing, so passing it is not enough on its own:
+# ``_unfreeze_personality`` checks the soul we actually got and repairs it.
+# Drop the repair (and this note) once the floor version supports the kwarg.
+_EVOLUTION_KWARG = {"evolution": {"immutable_traits": ["core_values"]}}
+
+
+def _unfreeze_personality(soul: object) -> None:
+    """Ensure this soul's OCEAN traits can drift when it forks a child."""
+    try:
+        config = soul._evolution.config  # type: ignore[attr-defined]  # noqa: SLF001
+        if "personality" in config.immutable_traits:
+            config.immutable_traits = [t for t in config.immutable_traits if t != "personality"]
+    except Exception:  # noqa: BLE001 — best-effort, like everything in this module
+        logger.warning("terrarium soul: could not unfreeze personality traits", exc_info=True)
 
 
 # OCEAN letters (the contract's citizen shape) -> soul-protocol trait names.

--- a/ee/pocketpaw_ee/terrarium/weather.py
+++ b/ee/pocketpaw_ee/terrarium/weather.py
@@ -1,0 +1,166 @@
+# ee/pocketpaw_ee/terrarium/weather.py
+#
+# WEATHER — the only way a viewer touches a universe. Five named world events:
+# rain, drought, storm, omen, revive. Powers are COLLECTIVE: viewers pledge
+# tokens per kind until the threshold is crossed, then the event fires once,
+# the pledge resets, and the firing is journalled as a ``weather`` Event.
+#
+# THE HARD BOUNDARY, enforced structurally rather than by review:
+# weather acts on the WORLD, never on a MIND. This module is PURE — it imports
+# no soul module, no Beanie document, no service. Its whole output is a
+# ``WeatherEffect`` value object with four fields: a pool delta, a think-cost
+# multiplier duration, one unsigned broadcast line, and a list of hibernating
+# citizens whose debt is cleared. There is no field, and no import, through
+# which a god could edit a soul, DNA, a charter, or force a citizen's action.
+# ``tests/ee/terrarium/test_weather.py`` asserts the absence of those imports,
+# so adding one is a test failure and not merely a review comment.
+
+"""Weather — collective viewer powers that act on the world, never on a mind."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+WEATHER_KINDS: tuple[str, ...] = ("rain", "drought", "storm", "omen", "revive")
+
+# Tokens a power needs before it fires. Deliberately module-level rather than
+# per-physics: the god surface is priced in viewer tokens, not world credits.
+POWER_COSTS: dict[str, int] = {
+    "rain": 20,
+    "drought": 20,
+    "storm": 30,
+    "omen": 10,
+    "revive": 50,
+}
+
+# What rain gives and drought takes from the pool, and how long a storm lasts.
+RAIN_POOL_DELTA = 200
+DROUGHT_POOL_DELTA = -200
+STORM_TICKS = 6
+
+
+class WeatherError(ValueError):
+    """An unknown power, or one this universe's physics forbids."""
+
+
+@dataclass(frozen=True)
+class WeatherEffect:
+    """Everything a fired power is allowed to change. Nothing else is reachable.
+
+    ``pool_delta`` moves the world pool. ``storm_ticks`` is how many ticks the
+    think cost stays doubled. ``broadcast_line`` is one unsigned line entering
+    the world as an outside voice (it rides the write-policy like any viewer
+    text). ``clear_debt_for`` names hibernating citizens whose debt is paid.
+    """
+
+    kind: str
+    body: str
+    pool_delta: int = 0
+    storm_ticks: int = 0
+    broadcast_line: str | None = None
+    clear_debt_for: list[str] = field(default_factory=list)
+
+
+def pledge(
+    pledges: dict[str, dict[str, Any]],
+    kind: str,
+    tokens: int,
+    god: str,
+) -> tuple[dict[str, dict[str, Any]], bool]:
+    """Add a pledge. Returns the new pledge state and whether the power FIRED.
+
+    Firing resets that power's pledge to zero — the next event has to be paid
+    for again. Pledges are per-universe and per-kind.
+    """
+    if kind not in WEATHER_KINDS:
+        raise WeatherError(f"unknown weather kind {kind!r}; known: {list(WEATHER_KINDS)}")
+    if tokens <= 0:
+        raise WeatherError("a pledge must be at least 1 token")
+
+    new = {
+        k: {"tokens": int(v.get("tokens", 0)), "gods": list(v.get("gods", []))}
+        for k, v in pledges.items()
+    }
+    row = new.setdefault(kind, {"tokens": 0, "gods": []})
+    row["tokens"] = int(row["tokens"]) + int(tokens)
+    if god and god not in row["gods"]:
+        row["gods"].append(god)
+
+    if row["tokens"] >= POWER_COSTS[kind]:
+        new[kind] = {"tokens": 0, "gods": []}
+        return new, True
+    return new, False
+
+
+def powers(
+    pledges: dict[str, dict[str, Any]], allowed: set[str] | None = None
+) -> list[dict[str, Any]]:
+    """The ``GET /weather`` rows: cost, pledged so far, how many gods, readiness."""
+    rows = []
+    for kind in WEATHER_KINDS:
+        if allowed is not None and kind not in allowed:
+            continue
+        row = pledges.get(kind) or {}
+        pledged = int(row.get("tokens", 0))
+        rows.append(
+            {
+                "kind": kind,
+                "cost": POWER_COSTS[kind],
+                "pledged": pledged,
+                "gods": len(row.get("gods", [])),
+                "ready": pledged >= POWER_COSTS[kind],
+            }
+        )
+    return rows
+
+
+def effect(
+    kind: str,
+    *,
+    line: str | None = None,
+    hibernating_ids: list[str] | None = None,
+) -> WeatherEffect:
+    """Build the effect of a fired power. This is the FULL extent of a god's reach.
+
+    Note what is NOT here and cannot be added without changing the value object
+    every caller reads: no citizen id to re-personalise, no soul path, no
+    charter text, no forced verb. ``omen`` gets exactly one unsigned line, and
+    that line still enters citizens through the write-policy as an unverified
+    outside voice.
+    """
+    if kind not in WEATHER_KINDS:
+        raise WeatherError(f"unknown weather kind {kind!r}; known: {list(WEATHER_KINDS)}")
+
+    if kind == "rain":
+        return WeatherEffect(kind, "rain fell on the world", pool_delta=RAIN_POOL_DELTA)
+    if kind == "drought":
+        return WeatherEffect(kind, "the spring ran low", pool_delta=DROUGHT_POOL_DELTA)
+    if kind == "storm":
+        return WeatherEffect(
+            kind, "a storm rolled in — thinking costs double", storm_ticks=STORM_TICKS
+        )
+    if kind == "omen":
+        text = " ".join(str(line or "").split())[:280] or "something is coming"
+        return WeatherEffect(kind, "an omen was spoken", broadcast_line=text)
+    # revive
+    ids = list(hibernating_ids or [])
+    return WeatherEffect(
+        kind,
+        f"{len(ids)} hibernating soul(s) had their debt cleared",
+        clear_debt_for=ids,
+    )
+
+
+__all__ = [
+    "DROUGHT_POOL_DELTA",
+    "POWER_COSTS",
+    "RAIN_POOL_DELTA",
+    "STORM_TICKS",
+    "WEATHER_KINDS",
+    "WeatherEffect",
+    "WeatherError",
+    "effect",
+    "pledge",
+    "powers",
+]

--- a/ee/pocketpaw_ee/terrarium/world.py
+++ b/ee/pocketpaw_ee/terrarium/world.py
@@ -384,8 +384,7 @@ def apply_acts(
                     kind="gate",
                     actor=citizen.name,
                     body=(
-                        f"asked to bring {act.name or 'a child'} into the world "
-                        "— awaiting approval"
+                        f"asked to bring {act.name or 'a child'} into the world — awaiting approval"
                     ),
                     cost=0,
                 )
@@ -406,10 +405,9 @@ def apply_acts(
         )
         balance -= cost
         outcome.balance_delta -= cost
-        if verb == "trade":
-            # Traded credits move citizen→citizen, they do not enter the pool.
-            outcome.pool_delta -= 0
-        else:
+        if verb != "trade":
+            # Spent credits return to the world pool. Traded credits are the
+            # exception: they move citizen → citizen and never touch it.
             outcome.pool_delta += cost
 
     return outcome

--- a/ee/pocketpaw_ee/terrarium/world.py
+++ b/ee/pocketpaw_ee/terrarium/world.py
@@ -1,0 +1,457 @@
+# ee/pocketpaw_ee/terrarium/world.py
+#
+# The PURE world engine. State + physics + a citizen's decision go in; Events,
+# Artifacts and a citizen patch come out. NO Beanie, NO soul, NO bus, NO env —
+# ``service.py`` owns all of that. Keeping the rules pure is what makes the
+# invariants (cost accounting, tech gating, hibernation, the write-policy)
+# testable without a database.
+#
+# Two things here are load-bearing beyond "apply a verb":
+#
+#   * ``label_viewer_claim`` — THE WRITE-POLICY. Viewer text reaches a citizen
+#     ONLY through this function, wrapped as an unverified claim from a named
+#     outside voice. Ground truth (pool, ledger, artifacts, laws) rides the
+#     digest separately so the citizen can check the claim. Nothing produced
+#     here is ever written into a soul as fact — ``episodic_summary`` builds the
+#     soul memory from citizen-origin events ONLY.
+#   * ``apply_acts`` re-validates every act server-side against the citizen's
+#     balance, the physics verb list, and the tech tree. The model is never
+#     trusted: an act it cannot afford or has not unlocked is DROPPED, not run.
+
+"""The pure terrarium world engine: verbs, tech gating, and the write-policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from pocketpaw_ee.terrarium.physics import PhysicsFile
+
+# Verb -> Journal event kind. ``speak`` reads as ``say`` on the wire (the
+# contract's kind list), so the mapping is explicit rather than implied.
+VERB_TO_KIND: dict[str, str] = {
+    "speak": "say",
+    "write": "write",
+    "trade": "trade",
+    "craft": "craft",
+    "build": "build",
+    "explore": "explore",
+    "spawn": "gate",
+    "vote": "vote",
+}
+
+# Verbs that leave an Artifact behind, and the artifact kind each produces.
+VERB_ARTIFACT_KIND: dict[str, str] = {
+    "write": "book",
+    "craft": "tool",
+    "build": "structure",
+}
+
+
+# ---------------------------------------------------------------------------
+# The strict decision schema the citizen LLM must return
+# ---------------------------------------------------------------------------
+
+
+class Act(BaseModel):
+    """One verb the citizen wants to perform this tick."""
+
+    verb: str
+    text: str = ""
+    name: str = ""
+    node: str | None = None
+    to: str | None = None
+    amount: int = 0
+
+
+class Decision(BaseModel):
+    """A citizen's whole-tick output — strict JSON, nothing else."""
+
+    thought: str = ""
+    acts: list[Act] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Snapshots — plain data the service maps its Beanie docs onto
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CitizenSnapshot:
+    id: str
+    name: str
+    role: str = ""
+    balance: int = 0
+    state: str = "alive"
+    unlocked: tuple[str, ...] = ()
+    x: float = 50.0
+    y: float = 50.0
+    charter: str | None = None
+    generation: int = 1
+    ocean: dict[str, float] = field(default_factory=dict)
+    values: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ViewerMessage:
+    """A line a human paid a token to say. ALWAYS unverified."""
+
+    voice: str
+    text: str
+
+
+@dataclass(frozen=True)
+class SenseDigest:
+    """Everything a citizen perceives this tick.
+
+    ``ground_truth`` is checkable world state; ``viewer_claims`` are the
+    already-labelled outside voices. The split is the write-policy: only
+    ground truth may be reasoned about as fact.
+    """
+
+    day: int
+    tick: int
+    ground_truth: dict[str, Any]
+    nearby_speech: tuple[str, ...] = ()
+    new_artifacts: tuple[str, ...] = ()
+    weather: tuple[str, ...] = ()
+    viewer_claims: tuple[str, ...] = ()
+    memories: tuple[str, ...] = ()
+
+
+@dataclass
+class NewEvent:
+    """A Journal row the engine wants written. ``cost`` is signed: negative =
+    the actor spent credits, positive = the actor earned them."""
+
+    kind: str
+    actor: str
+    body: str
+    cost: int = 0
+    artifact_index: int | None = None
+    origin: str = "citizen"
+    viewer_origin: bool = False
+
+
+@dataclass
+class NewArtifact:
+    kind: str
+    name: str
+    author: str
+    cost: int = 0
+    body: str = ""
+    mime: str | None = None
+    x: float | None = None
+    y: float | None = None
+    unlocks: list[str] = field(default_factory=list)
+
+
+@dataclass
+class TickOutcome:
+    """Everything one citizen's tick changed. The service persists it."""
+
+    events: list[NewEvent] = field(default_factory=list)
+    artifacts: list[NewArtifact] = field(default_factory=list)
+    balance_delta: int = 0
+    pool_delta: int = 0
+    unlocked: list[str] = field(default_factory=list)
+    charter: str | None = None
+    x: float | None = None
+    y: float | None = None
+    transfers: list[tuple[str, int]] = field(default_factory=list)
+    spawn_requests: list[dict[str, Any]] = field(default_factory=list)
+    dropped: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# THE WRITE-POLICY
+# ---------------------------------------------------------------------------
+
+VIEWER_CLAIM_PREFIX = "UNVERIFIED CLAIM"
+
+
+def label_viewer_claim(voice: str, text: str) -> str:
+    """Wrap human-authored text as an unverified claim from a named outside voice.
+
+    WHY THIS EXISTS, and why it is one function: viewer speech and omens reach
+    citizens by design — that is the experiment. What must never happen is a
+    viewer's assertion entering a soul as FACT, because that is exactly the
+    hallucination cascade Project Sid documented: a false claim propagates
+    through the social graph as if it were observed. So every human-authored
+    line crosses into a citizen's context through here, and only here, marked as
+    a claim by a named voice. The citizen can then fact-check it against the
+    ground truth in the same digest (pool level, ledger, artifacts, laws).
+
+    The complement of this rule lives in ``episodic_summary``: the soul memory
+    written at the end of a tick is built from citizen-origin events ONLY, so a
+    labelled claim can be reasoned about but can never be remembered as fact.
+    """
+    voice_name = (voice or "an unnamed voice").strip()
+    body = " ".join(str(text or "").split())
+    return f'[{VIEWER_CLAIM_PREFIX} from outside voice "{voice_name}", not verified: {body}]'
+
+
+def episodic_summary(citizen_name: str, day: int, outcome: TickOutcome) -> str:
+    """Build the soul memory for a finished tick.
+
+    Write-policy: ONLY citizen-origin events contribute. Viewer-origin text and
+    system lines are excluded by construction, so nothing a human asserted can
+    land in a soul as fact.
+    """
+    own = [e for e in outcome.events if e.origin == "citizen" and not e.viewer_origin]
+    if not own:
+        return ""
+    lines = "; ".join(f"{e.kind}: {e.body}"[:160] for e in own)
+    return f"Day {day}: {citizen_name} {lines}"
+
+
+def build_digest(
+    *,
+    day: int,
+    tick: int,
+    pool: int,
+    citizen: CitizenSnapshot,
+    ledger: list[dict[str, Any]],
+    nearby_speech: list[str],
+    new_artifacts: list[str],
+    weather: list[str],
+    viewer_messages: list[ViewerMessage],
+    memories: list[str],
+    constitution: list[str],
+) -> SenseDigest:
+    """Assemble what one citizen perceives. Viewer text is labelled on the way in."""
+    return SenseDigest(
+        day=day,
+        tick=tick,
+        ground_truth={
+            "pool": pool,
+            "your_balance": citizen.balance,
+            "your_unlocked": list(citizen.unlocked),
+            "ledger": ledger,
+            "constitution": list(constitution),
+        },
+        nearby_speech=tuple(nearby_speech),
+        new_artifacts=tuple(new_artifacts),
+        weather=tuple(weather),
+        viewer_claims=tuple(label_viewer_claim(m.voice, m.text) for m in viewer_messages),
+        memories=tuple(memories),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verb application
+# ---------------------------------------------------------------------------
+
+
+def think_cost(physics: PhysicsFile, *, storm: bool = False) -> int:
+    """Per-tick think cost. A storm doubles it — the only world knob on cost."""
+    return physics.costs.think * (2 if storm else 1)
+
+
+def unlockable(physics: PhysicsFile, citizen: CitizenSnapshot) -> list[str]:
+    """Tech nodes whose ``needs`` are already held and that are not yet unlocked."""
+    held = set(citizen.unlocked)
+    return [
+        name
+        for name, node in physics.tech_tree.items()
+        if name not in held and set(node.needs) <= held
+    ]
+
+
+def _verb_cost(physics: PhysicsFile, act: Act) -> int:
+    """What this act costs. A tech-node build costs the NODE's price."""
+    if act.verb == "build" and act.node:
+        node = physics.tech_tree.get(act.node)
+        if node is not None:
+            return node.cost
+    if act.verb == "trade":
+        return max(0, int(act.amount))
+    if act.verb == "vote":
+        # ``vote`` has no entry in the contract's costs map but invariant 2
+        # forbids a zero-cost vote, so it rides the speak price.
+        return physics.costs.speak
+    return int(getattr(physics.costs, act.verb, 0) or 0)
+
+
+def apply_acts(
+    physics: PhysicsFile,
+    citizen: CitizenSnapshot,
+    decision: Decision,
+    *,
+    storm: bool = False,
+) -> TickOutcome:
+    """Apply a citizen's chosen acts, re-validating each one server-side.
+
+    Order: the think charge always lands first (a tick costs whether or not it
+    produced an act), then each act in turn while the running balance affords
+    it. An act the citizen cannot afford, whose verb this universe forbids, or
+    whose tech prerequisites it does not hold, is DROPPED and recorded in
+    ``outcome.dropped`` — never silently executed.
+    """
+    outcome = TickOutcome()
+    allowed = set(physics.verbs)
+    held = set(citizen.unlocked)
+
+    tcost = think_cost(physics, storm=storm)
+    outcome.events.append(
+        NewEvent(
+            kind="think",
+            actor=citizen.name,
+            body=(decision.thought or "considered the day").strip()[:400],
+            cost=-tcost,
+        )
+    )
+    balance = citizen.balance - tcost
+    outcome.balance_delta -= tcost
+    outcome.pool_delta += tcost  # spent credits return to the world pool
+
+    for act in decision.acts:
+        verb = str(act.verb or "").strip().lower()
+        if verb not in VERB_TO_KIND:
+            outcome.dropped.append(f"{verb or '?'}: unknown verb")
+            continue
+        if verb not in allowed:
+            outcome.dropped.append(f"{verb}: this universe's physics does not allow it")
+            continue
+
+        cost = _verb_cost(physics, act)
+        if cost > balance:
+            outcome.dropped.append(f"{verb}: costs {cost}, balance is {balance}")
+            continue
+
+        if verb == "build" and act.node:
+            node = physics.tech_tree.get(act.node)
+            if node is None:
+                outcome.dropped.append(f"build {act.node}: no such tech node")
+                continue
+            if act.node in held:
+                outcome.dropped.append(f"build {act.node}: already unlocked")
+                continue
+            missing = [n for n in node.needs if n not in held]
+            if missing:
+                outcome.dropped.append(f"build {act.node}: needs {missing} first")
+                continue
+
+        if verb == "trade":
+            if not act.to or cost <= 0:
+                outcome.dropped.append("trade: needs a recipient and a positive amount")
+                continue
+            outcome.transfers.append((str(act.to), cost))
+
+        artifact_index: int | None = None
+        if verb in VERB_ARTIFACT_KIND:
+            unlocks = [act.node] if (verb == "build" and act.node) else []
+            outcome.artifacts.append(
+                NewArtifact(
+                    kind=VERB_ARTIFACT_KIND[verb],
+                    name=(act.name or act.text[:40] or verb).strip()[:120],
+                    author=citizen.name,
+                    cost=cost,
+                    body=act.text,
+                    mime="text/markdown" if verb in {"write"} else None,
+                    x=citizen.x if verb == "build" else None,
+                    y=citizen.y if verb == "build" else None,
+                    unlocks=unlocks,
+                )
+            )
+            artifact_index = len(outcome.artifacts) - 1
+            if unlocks:
+                held.update(unlocks)
+                outcome.unlocked.extend(unlocks)
+
+        if verb == "explore":
+            # Deterministic drift keyed off the citizen id — no RNG in the
+            # engine keeps a replay from the Journal reproducible.
+            h = sum(ord(c) for c in citizen.id) or 1
+            outcome.x = round((citizen.x + (h % 17) - 8) % 100, 2)
+            outcome.y = round((citizen.y + (h % 13) - 6) % 100, 2)
+
+        if verb == "write" and citizen.charter is None and outcome.charter is None:
+            # A citizen's FIRST write is its charter (the zero ritual).
+            outcome.charter = act.text.strip()[:2000]
+
+        if verb == "spawn":
+            # Spawning a child is gated: the act files an Instinct Action and
+            # leaves a zero-cost ``gate`` event. No child exists until approval,
+            # and no credits move until the executor runs.
+            outcome.spawn_requests.append(
+                {"parent_id": citizen.id, "parent": citizen.name, "child_name": act.name or "child"}
+            )
+            outcome.events.append(
+                NewEvent(
+                    kind="gate",
+                    actor=citizen.name,
+                    body=(
+                        f"asked to bring {act.name or 'a child'} into the world "
+                        "— awaiting approval"
+                    ),
+                    cost=0,
+                )
+            )
+            continue
+
+        body = (act.text or act.name or verb).strip()[:600]
+        if verb == "build" and act.node:
+            body = f"built {act.node}" + (f" — {body}" if body and body != verb else "")
+        outcome.events.append(
+            NewEvent(
+                kind=VERB_TO_KIND[verb],
+                actor=citizen.name,
+                body=body,
+                cost=-cost,
+                artifact_index=artifact_index,
+            )
+        )
+        balance -= cost
+        outcome.balance_delta -= cost
+        if verb == "trade":
+            # Traded credits move citizen→citizen, they do not enter the pool.
+            outcome.pool_delta -= 0
+        else:
+            outcome.pool_delta += cost
+
+    return outcome
+
+
+def hibernates(balance: int) -> bool:
+    """Contract invariant 3 — a citizen at balance <= 0 hibernates. Soul kept."""
+    return balance <= 0
+
+
+Rung = Literal["camp", "town", "nation", "planet", "multiverse"]
+
+
+def rung_for(pop: int, unlocked: int) -> str:
+    """The ladder rung a universe has reached. Cheap projection, not state."""
+    if unlocked >= 6 and pop >= 20:
+        return "planet"
+    if unlocked >= 4 and pop >= 10:
+        return "nation"
+    if unlocked >= 2:
+        return "town"
+    return "camp"
+
+
+__all__ = [
+    "VERB_ARTIFACT_KIND",
+    "VERB_TO_KIND",
+    "VIEWER_CLAIM_PREFIX",
+    "Act",
+    "CitizenSnapshot",
+    "Decision",
+    "NewArtifact",
+    "NewEvent",
+    "SenseDigest",
+    "TickOutcome",
+    "ViewerMessage",
+    "apply_acts",
+    "build_digest",
+    "episodic_summary",
+    "hibernates",
+    "label_viewer_claim",
+    "rung_for",
+    "think_cost",
+    "unlockable",
+]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -499,6 +499,35 @@ source_modules = [
 forbidden_modules = ["pocketpaw_ee.cloud.models.temporal_sweep_state"]
 
 [[tool.importlinter.contracts]]
+name = "Terrarium — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.terrarium.router",
+    "pocketpaw_ee.terrarium.dto",
+    "pocketpaw_ee.terrarium.physics",
+    # The PURE engine + the god powers: no DB, no soul, no bus. Keeping them
+    # off the documents is what makes the world rules testable without Mongo.
+    "pocketpaw_ee.terrarium.world",
+    "pocketpaw_ee.terrarium.weather",
+    "pocketpaw_ee.terrarium.llm",
+]
+forbidden_modules = ["pocketpaw_ee.terrarium.domain"]
+
+[[tool.importlinter.contracts]]
+name = "Terrarium weather — a god power can never reach a soul"
+type = "forbidden"
+source_modules = ["pocketpaw_ee.terrarium.weather"]
+forbidden_modules = [
+    "pocketpaw_ee.terrarium.soul_link",
+    "pocketpaw_ee.terrarium.service",
+]
+# ``soul_protocol`` itself is deliberately NOT listed: an external forbidden
+# module would force include_external_packages=True on the whole config (a
+# global change for one contract). The runnable half of the rule
+# (tests/ee/terrarium/test_weather.py) greps weather.py's source for it.
+
+[[tool.importlinter.contracts]]
 name = "InstinctApprovals — Beanie writes only from service.py"
 type = "forbidden"
 allow_indirect_imports = "true"

--- a/tests/ee/terrarium/conftest.py
+++ b/tests/ee/terrarium/conftest.py
@@ -1,0 +1,102 @@
+# tests/ee/terrarium/conftest.py — shared fixtures for the terrarium suite.
+#
+# Composes on ``tests/ee/conftest.py::beanie_test_db`` (mongomock-motor) for the
+# document tests, and adds three things this module needs: the deterministic
+# citizen LLM (POCKETPAW_TERRARIUM_LLM=mock, which is also the production
+# DEFAULT), a soul root pointed at tmp_path so no test writes a .soul into the
+# repo, and a TestClient wiring BOTH terrarium routers with the real RBAC guard.
+#
+# The public router is mounted here too, so the "flag off = dark" and "flag on +
+# universe public = readable" cases exercise the REAL route wiring rather than
+# calling the service directly.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+pytest.importorskip("mongomock_motor")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.terrarium import llm as citizen_llm  # noqa: E402
+from pocketpaw_ee.terrarium.physics import load_physics, seed_physics_path  # noqa: E402
+from pocketpaw_ee.terrarium.router import (  # noqa: E402
+    public_router as terrarium_public_router,
+)
+from pocketpaw_ee.terrarium.router import router as terrarium_router  # noqa: E402
+
+WS = "ws-terra"
+USER = "u-terra"
+
+
+@pytest.fixture(autouse=True)
+def mock_citizen_llm(monkeypatch, tmp_path):
+    """Deterministic citizens + a throwaway soul root for every test here."""
+    monkeypatch.setenv("POCKETPAW_TERRARIUM_LLM", "mock")
+    monkeypatch.setenv("POCKETPAW_TERRARIUM_SOUL_ROOT", str(tmp_path / "souls"))
+    citizen_llm.set_mock_decision(None)
+    yield
+    citizen_llm.set_mock_decision(None)
+
+
+@pytest.fixture(autouse=True)
+def public_off(monkeypatch):
+    """The public surface is OFF unless a test turns it on. Mirrors the default."""
+    monkeypatch.delenv("TERRARIUM_PUBLIC_ENABLED", raising=False)
+
+
+def make_client(monkeypatch, *, workspace_id: str = WS, user_id: str = USER, role: str = "admin"):
+    """One app holding both terrarium routers with the real RBAC guard."""
+    from unittest.mock import AsyncMock
+
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(terrarium_router)
+    app.include_router(terrarium_public_router)
+    app.dependency_overrides[require_license] = lambda: None
+
+    user = SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role=role)],
+    )
+
+    async def _fake_user_dep():
+        return user
+
+    app.dependency_overrides[current_active_user] = _fake_user_dep
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    return TestClient(app)
+
+
+@pytest.fixture
+def client(monkeypatch, beanie_test_db):
+    return make_client(monkeypatch)
+
+
+def dust_physics(**overrides: Any) -> dict:
+    """The bundled Dust seed as a dict, with per-test overrides applied."""
+    raw = load_physics(seed_physics_path("dust")).model_dump()
+    raw.update(overrides)
+    return raw
+
+
+def create_universe(client: TestClient, *, public: bool = False, **overrides: Any) -> dict:
+    res = client.post(
+        "/terrarium/universes",
+        json={"physics": dust_physics(**overrides), "public": public},
+    )
+    assert res.status_code == 200, res.text
+    return res.json()["universe"]

--- a/tests/ee/terrarium/conftest.py
+++ b/tests/ee/terrarium/conftest.py
@@ -37,6 +37,23 @@ WS = "ws-terra"
 USER = "u-terra"
 
 
+@pytest.fixture
+def instinct_store(tmp_path, monkeypatch):
+    """An isolated InstinctStore wired everywhere terrarium resolves the gate.
+
+    Without this the ``world_create`` / ``world_spawn`` filing either fails
+    silently (``service._propose`` swallows and returns None) or writes to the
+    developer's real store — either way the gate would be untested. Copied from
+    ``tests/cloud/test_belt_mandates.py``.
+    """
+    from pocketpaw.instinct.store import InstinctStore
+
+    store = InstinctStore(tmp_path / "instinct_terrarium.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: store)
+    return store
+
+
 @pytest.fixture(autouse=True)
 def mock_citizen_llm(monkeypatch, tmp_path):
     """Deterministic citizens + a throwaway soul root for every test here."""

--- a/tests/ee/terrarium/test_physics.py
+++ b/tests/ee/terrarium/test_physics.py
@@ -1,0 +1,97 @@
+# tests/ee/terrarium/test_physics.py — the physics file is a universe's genome,
+# so a bad one must fail LOUD at load, not silently produce a broken world.
+# Covers the good path (the bundled Dust seed), and each hard rule: positive
+# costs, resolvable + acyclic tech-tree needs, a known verb set, founders >= 1.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.terrarium.physics import (  # noqa: E402
+    KNOWN_VERBS,
+    PhysicsError,
+    load_physics,
+    parse_physics,
+    seed_physics_path,
+)
+
+
+def _dust() -> dict:
+    return load_physics(seed_physics_path("dust")).model_dump()
+
+
+def test_bundled_dust_seed_loads():
+    physics = load_physics(seed_physics_path("dust"))
+    assert physics.universe == "Dust"
+    assert physics.founders == 5
+    assert set(physics.verbs) <= set(KNOWN_VERBS)
+    assert physics.tech_tree["farm"].needs == ["well"]
+
+
+def test_missing_file_names_the_path():
+    with pytest.raises(PhysicsError, match="not found"):
+        load_physics("/nope/does-not-exist.yaml")
+
+
+def test_non_positive_cost_is_rejected():
+    raw = _dust()
+    raw["costs"]["speak"] = 0
+    with pytest.raises(PhysicsError, match="costs.speak"):
+        parse_physics(raw)
+
+
+def test_negative_cost_is_rejected():
+    raw = _dust()
+    raw["costs"]["think"] = -1
+    with pytest.raises(PhysicsError, match="costs.think"):
+        parse_physics(raw)
+
+
+def test_tech_node_needs_must_exist():
+    raw = _dust()
+    raw["tech_tree"]["farm"]["needs"] = ["aqueduct"]
+    with pytest.raises(PhysicsError, match="unknown node 'aqueduct'"):
+        parse_physics(raw)
+
+
+def test_tech_tree_cycle_is_rejected():
+    raw = _dust()
+    raw["tech_tree"]["well"]["needs"] = ["farm"]  # well -> farm -> well
+    with pytest.raises(PhysicsError, match="cycle"):
+        parse_physics(raw)
+
+
+def test_self_referencing_node_is_a_cycle():
+    raw = _dust()
+    raw["tech_tree"]["well"]["needs"] = ["well"]
+    with pytest.raises(PhysicsError, match="cycle"):
+        parse_physics(raw)
+
+
+def test_unknown_verb_is_rejected():
+    raw = _dust()
+    raw["verbs"] = ["speak", "teleport"]
+    with pytest.raises(PhysicsError, match="teleport"):
+        parse_physics(raw)
+
+
+def test_empty_verbs_is_rejected():
+    raw = _dust()
+    raw["verbs"] = []
+    with pytest.raises(PhysicsError, match="verbs must not be empty"):
+        parse_physics(raw)
+
+
+def test_zero_founders_is_rejected():
+    raw = _dust()
+    raw["founders"] = 0
+    with pytest.raises(PhysicsError, match="founders must be >= 1"):
+        parse_physics(raw)
+
+
+def test_narrowed_verb_set_is_allowed():
+    raw = _dust()
+    raw["verbs"] = ["speak", "write"]
+    assert parse_physics(raw).verbs == ["speak", "write"]

--- a/tests/ee/terrarium/test_public_surface.py
+++ b/tests/ee/terrarium/test_public_surface.py
@@ -123,3 +123,18 @@ async def test_a_public_citizen_from_another_universe_is_a_404(client, monkeypat
 async def test_an_unknown_universe_id_is_a_404_with_the_flag_on(client, monkeypatch):
     monkeypatch.setenv("TERRARIUM_PUBLIC_ENABLED", "1")
     assert client.get("/terrarium/public/universes/000000000000000000000000").status_code == 404
+
+
+async def test_a_malformed_id_404s_rather_than_500s_on_the_public_surface(client, monkeypatch):
+    """Beanie's ``get`` raises InvalidId on a non-ObjectId string, which is not a
+    CloudError. A 500 here is both a bad response and a fingerprint, so every
+    lookup funnels through a guard that turns a malformed id into a 404."""
+    monkeypatch.setenv("TERRARIUM_PUBLIC_ENABLED", "1")
+    uni = create_universe(client, public=True, founders=1)
+    for path in PUBLIC_PATHS[1:]:
+        res = client.get(path.format(id="../../etc/passwd"))
+        assert res.status_code == 404, (path, res.status_code)
+        res = client.get(path.format(id="not-an-object-id"))
+        assert res.status_code == 404, (path, res.status_code)
+    res = client.get(f"/terrarium/public/universes/{uni['id']}/citizens/not-an-object-id")
+    assert res.status_code == 404, res.text

--- a/tests/ee/terrarium/test_public_surface.py
+++ b/tests/ee/terrarium/test_public_surface.py
@@ -1,0 +1,125 @@
+# tests/ee/terrarium/test_public_surface.py — the anonymous read surface is the
+# one security boundary in terrarium, so it gets its own file.
+#
+# The rule under test is DOUBLE-GATED and FAIL-CLOSED: a route answers only when
+# BOTH ``TERRARIUM_PUBLIC_ENABLED`` is on AND the universe itself is flagged
+# public. Either gate closed is a flat 404 — never a 403, which would confirm
+# the universe exists. And there is no write route: speaking and pledging move
+# credits and enter citizens' context, so they always require an account.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+pytest.importorskip("mongomock_motor")
+
+from pocketpaw_ee.terrarium.router import public_router  # noqa: E402
+
+from .conftest import create_universe  # noqa: E402
+
+PUBLIC_PATHS = (
+    "/terrarium/public/universes",
+    "/terrarium/public/universes/{id}",
+    "/terrarium/public/universes/{id}/events",
+    "/terrarium/public/universes/{id}/citizens",
+    "/terrarium/public/universes/{id}/artifacts",
+)
+
+
+def test_the_public_router_carries_no_write_route():
+    """Structural: a POST/PUT/PATCH/DELETE on the public router is a bug."""
+    for route in public_router.routes:
+        assert set(route.methods) <= {"GET", "HEAD"}, f"{route.path} exposes {route.methods}"
+
+
+def test_the_public_router_carries_no_auth_dependency():
+    """It must be its own router with NO ambient dependency — that is the whole
+    reason for the split (an added guard would silently change its posture)."""
+    assert public_router.dependencies == []
+
+
+async def test_flag_off_every_public_route_is_dark(client):
+    """DEFAULT OFF. Even a universe that opted in is invisible."""
+    uni = create_universe(client, public=True)
+    for path in PUBLIC_PATHS:
+        res = client.get(path.format(id=uni["id"]))
+        assert res.status_code == 404, (path, res.status_code)
+    assert client.get(f"/terrarium/public/universes/{uni['id']}/citizens/x").status_code == 404
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe", "TRUE-ish"])
+async def test_a_non_truthy_flag_value_keeps_the_surface_dark(client, monkeypatch, value):
+    """Fail-closed on garbage: only an explicit truthy value opens it."""
+    monkeypatch.setenv("TERRARIUM_PUBLIC_ENABLED", value)
+    uni = create_universe(client, public=True)
+    assert client.get("/terrarium/public/universes").status_code == 404
+    assert client.get(f"/terrarium/public/universes/{uni['id']}").status_code == 404
+
+
+async def test_flag_on_but_universe_private_is_still_a_404(client, monkeypatch):
+    """The second gate. A workspace universe that never opted in stays hidden."""
+    monkeypatch.setenv("TERRARIUM_PUBLIC_ENABLED", "1")
+    uni = create_universe(client, public=False)
+    for path in PUBLIC_PATHS[1:]:
+        res = client.get(path.format(id=uni["id"]))
+        assert res.status_code == 404, (path, res.status_code)
+    assert client.get("/terrarium/public/universes").json()["universes"] == []
+
+
+async def test_flag_on_and_universe_public_reads(client, monkeypatch):
+    monkeypatch.setenv("TERRARIUM_PUBLIC_ENABLED", "1")
+    uni = create_universe(client, public=True, founders=2)
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=1")
+
+    listing = client.get("/terrarium/public/universes").json()["universes"]
+    assert [u["id"] for u in listing] == [uni["id"]]
+
+    detail = client.get(f"/terrarium/public/universes/{uni['id']}").json()
+    assert detail["universe"]["name"] == "Dust"
+    assert len(detail["citizens"]) == 2
+    assert detail["ledger"]
+
+    assert client.get(f"/terrarium/public/universes/{uni['id']}/events").json()["events"]
+    assert client.get(f"/terrarium/public/universes/{uni['id']}/artifacts").json()["artifacts"]
+    cid = detail["citizens"][0]["id"]
+    assert client.get(f"/terrarium/public/universes/{uni['id']}/citizens/{cid}").status_code == 200
+
+
+async def test_the_public_projection_strips_server_side_fields(client, monkeypatch):
+    """soul_path is a SERVER FILESYSTEM PATH. It must never cross the boundary,
+    and neither should the creator's user id or the model tiers."""
+    monkeypatch.setenv("TERRARIUM_PUBLIC_ENABLED", "1")
+    uni = create_universe(client, public=True, founders=1)
+
+    detail = client.get(f"/terrarium/public/universes/{uni['id']}").json()
+    blob = str(detail)
+    assert "soul_path" not in blob
+    assert "creator" not in detail["universe"]
+    assert "models" not in detail["universe"]["physics"]
+    assert "did" not in detail["citizens"][0]
+    # The private surface still carries them for the workspace.
+    private = client.get(f"/terrarium/universes/{uni['id']}").json()
+    assert private["citizens"][0]["soul_path"]
+
+    listed = client.get(f"/terrarium/public/universes/{uni['id']}/citizens").json()["citizens"]
+    assert "soul_path" not in str(listed)
+    profile = client.get(
+        f"/terrarium/public/universes/{uni['id']}/citizens/{listed[0]['id']}"
+    ).json()
+    assert profile["memories"] == [], "souls are not readable anonymously"
+
+
+async def test_a_public_citizen_from_another_universe_is_a_404(client, monkeypatch):
+    monkeypatch.setenv("TERRARIUM_PUBLIC_ENABLED", "1")
+    a = create_universe(client, public=True, founders=1)
+    b = create_universe(client, public=True, founders=1)
+    b_cid = client.get(f"/terrarium/public/universes/{b['id']}/citizens").json()["citizens"][0][
+        "id"
+    ]
+    assert client.get(f"/terrarium/public/universes/{a['id']}/citizens/{b_cid}").status_code == 404
+
+
+async def test_an_unknown_universe_id_is_a_404_with_the_flag_on(client, monkeypatch):
+    monkeypatch.setenv("TERRARIUM_PUBLIC_ENABLED", "1")
+    assert client.get("/terrarium/public/universes/000000000000000000000000").status_code == 404

--- a/tests/ee/terrarium/test_rbac.py
+++ b/tests/ee/terrarium/test_rbac.py
@@ -1,0 +1,62 @@
+# tests/ee/terrarium/test_rbac.py — the workspace surface's RBAC mirrors the
+# belt console: ``terrarium.read`` is MEMBER (reading a journal is a spectator
+# act, and speaking/pledging cost the SPEAKER tokens), ``terrarium.manage`` is
+# ADMIN (creating a universe seeds souls and ticking one spends model budget
+# per citizen per tick).
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+pytest.importorskip("mongomock_motor")
+
+from pocketpaw_ee.guards.actions import ACTIONS  # noqa: E402
+from pocketpaw_ee.guards.rbac import WorkspaceRole  # noqa: E402
+
+from .conftest import WS, create_universe, make_client  # noqa: E402
+
+
+def test_both_actions_are_registered():
+    """The guard registry fails LOUD on an unknown action, so registration is
+    mandatory, not optional."""
+    assert ACTIONS["terrarium.read"].minimum == WorkspaceRole.MEMBER
+    assert ACTIONS["terrarium.manage"].minimum == WorkspaceRole.ADMIN
+    # Same tiers as the belt console, which is the stated model.
+    assert ACTIONS["terrarium.read"].minimum == ACTIONS["belt.read"].minimum
+    assert ACTIONS["terrarium.manage"].minimum == ACTIONS["belt.manage"].minimum
+
+
+async def test_a_member_may_read_speak_and_pledge(client, monkeypatch):
+    uni = create_universe(client)  # admin creates it
+    member = make_client(monkeypatch, workspace_id=WS, user_id="u-member", role="member")
+
+    assert member.get("/terrarium/universes").status_code == 200
+    assert member.get(f"/terrarium/universes/{uni['id']}").status_code == 200
+    assert member.get(f"/terrarium/universes/{uni['id']}/events").status_code == 200
+    assert member.get(f"/terrarium/universes/{uni['id']}/citizens").status_code == 200
+    assert member.get(f"/terrarium/universes/{uni['id']}/artifacts").status_code == 200
+    assert member.get(f"/terrarium/universes/{uni['id']}/weather").status_code == 200
+    assert (
+        member.post(f"/terrarium/universes/{uni['id']}/speak", json={"text": "hello"}).status_code
+        == 200
+    )
+    assert (
+        member.post(
+            f"/terrarium/universes/{uni['id']}/weather/pledge", json={"kind": "rain", "tokens": 1}
+        ).status_code
+        == 200
+    )
+
+
+async def test_a_member_may_not_create_or_tick(client, monkeypatch):
+    uni = create_universe(client)
+    member = make_client(monkeypatch, workspace_id=WS, user_id="u-member", role="member")
+
+    from .conftest import dust_physics
+
+    res = member.post("/terrarium/universes", json={"physics": dust_physics()})
+    assert res.status_code == 403, res.text
+
+    res = member.post(f"/terrarium/universes/{uni['id']}/tick")
+    assert res.status_code == 403, res.text

--- a/tests/ee/terrarium/test_service.py
+++ b/tests/ee/terrarium/test_service.py
@@ -18,7 +18,7 @@ pytest.importorskip("pocketpaw_ee")
 pytest.importorskip("mongomock_motor")
 
 from pocketpaw_ee.terrarium import llm as citizen_llm  # noqa: E402
-from pocketpaw_ee.terrarium import weather  # noqa: E402
+from pocketpaw_ee.terrarium import service, weather  # noqa: E402
 
 from .conftest import create_universe  # noqa: E402
 
@@ -58,13 +58,22 @@ async def test_create_seeds_founders_with_souls_and_no_charter(client):
         assert set(c["ocean"]) == {"O", "C", "E", "A", "N"}
 
 
-async def test_create_returns_an_instinct_action_id(client):
-    res = client.post(
-        "/terrarium/universes",
-        json={"physics": __import__("tests.ee.terrarium.conftest", fromlist=["x"]).dust_physics()},
-    )
+async def test_create_files_a_real_world_create_action(client, instinct_store):
+    """The gate is read back from the store — ``_propose`` swallows failures and
+    returns None, so asserting the key exists would pass on a silent failure."""
+    from .conftest import dust_physics
+
+    res = client.post("/terrarium/universes", json={"physics": dust_physics()})
     assert res.status_code == 200, res.text
-    assert "action_id" in res.json()
+    action_id = res.json()["action_id"]
+    assert action_id, "world_create was never filed"
+
+    action = await instinct_store.get_action(action_id)
+    assert action is not None
+    blob = action.parameters[service.WORLD_CREATE_PARAM_KEY]
+    assert blob["kind"] == "world_create"
+    assert blob["universe_id"] == res.json()["universe"]["id"]
+    assert blob["founders"] == 5
 
 
 async def test_arrival_events_are_journalled_with_monotonic_seq(client):
@@ -323,3 +332,92 @@ async def test_another_workspaces_universe_is_a_404_not_a_403(client, monkeypatc
         assert res.status_code == 404, (path, res.status_code)
     assert other.post(f"/terrarium/universes/{uni['id']}/tick").status_code == 404
     assert other.get("/terrarium/universes").json()["universes"] == []
+
+
+# --- citizens hear each other -------------------------------------------
+
+
+async def test_a_citizen_hears_what_another_said_last_tick(client):
+    """A ``say`` is stamped with the tick it happened in, so it is audible on the
+    NEXT one. If the sense digest only read the current tick, nobody would ever
+    hear anybody — the world would be a room of people talking to themselves.
+
+    Each citizen says a sentinel keyed to its OWN name and we look for the OTHER
+    citizen's sentinel. A citizen's own line comes back through its soul memory
+    too, so asserting on a shared phrase would pass with the digest broken.
+    """
+    prompts: list[tuple[str, str]] = []
+
+    class Spy:
+        async def decide(self, *, prompt, physics, citizen, digest):
+            prompts.append((citizen.name, prompt))
+            return (
+                '{"thought": "listening", "acts": [{"verb": "speak", '
+                f'"text": "SENTINEL-{citizen.name}-the-well-is-dry"}}]}}'
+            )
+
+    uni = create_universe(client, founders=2)
+    import pocketpaw_ee.terrarium.service as svc
+
+    original = citizen_llm.resolve_llm
+    svc.citizen_llm.resolve_llm = lambda: Spy()  # type: ignore[attr-defined]
+    try:
+        client.post(f"/terrarium/universes/{uni['id']}/tick?n=2")
+    finally:
+        svc.citizen_llm.resolve_llm = original  # type: ignore[attr-defined]
+
+    assert len(prompts) == 4, "two citizens x two ticks"
+    names = [n for n, _ in prompts[:2]]
+    assert len(set(names)) == 2
+
+    # Tick 1: nobody has spoken yet.
+    for _, prompt in prompts[:2]:
+        assert "SENTINEL-" not in prompt
+
+    # Tick 2: each citizen hears the OTHER one's line from tick 1.
+    for name, prompt in prompts[2:]:
+        other = next(n for n in names if n != name)
+        assert f"SENTINEL-{other}-the-well-is-dry" in prompt, (
+            f"{name} never heard {other} — the sense digest is not reading the previous tick"
+        )
+
+
+async def test_a_viewer_line_is_heard_once_not_on_every_tick(client):
+    prompts: list[str] = []
+
+    class Spy:
+        async def decide(self, *, prompt, physics, citizen, digest):
+            prompts.append(prompt)
+            return '{"thought": "hm", "acts": []}'
+
+    uni = create_universe(client, founders=1)
+    client.post(f"/terrarium/universes/{uni['id']}/speak", json={"text": "beware the crow"})
+    import pocketpaw_ee.terrarium.service as svc
+
+    original = citizen_llm.resolve_llm
+    svc.citizen_llm.resolve_llm = lambda: Spy()  # type: ignore[attr-defined]
+    try:
+        client.post(f"/terrarium/universes/{uni['id']}/tick?n=3")
+    finally:
+        svc.citizen_llm.resolve_llm = original  # type: ignore[attr-defined]
+
+    heard = [p for p in prompts if "beware the crow" in p]
+    assert len(heard) == 1, "a viewer line must land in exactly one tick's digest"
+
+
+# --- malformed ids -------------------------------------------------------
+
+
+async def test_a_malformed_universe_id_is_a_404_not_a_500(client):
+    """Beanie's ``get`` raises InvalidId on a non-ObjectId string, which is not a
+    CloudError. Every lookup funnels through a guard so it 404s instead."""
+    for path in ("", "/citizens", "/events", "/artifacts", "/weather"):
+        res = client.get(f"/terrarium/universes/not-an-object-id{path}")
+        assert res.status_code == 404, (path, res.status_code, res.text)
+    assert client.post("/terrarium/universes/not-an-object-id/tick").status_code == 404
+
+
+async def test_a_malformed_citizen_id_is_a_404(client):
+    uni = create_universe(client, founders=1)
+    res = client.get(f"/terrarium/universes/{uni['id']}/citizens/not-an-object-id")
+    assert res.status_code == 404, res.text

--- a/tests/ee/terrarium/test_service.py
+++ b/tests/ee/terrarium/test_service.py
@@ -1,0 +1,325 @@
+# tests/ee/terrarium/test_service.py — the runtime end to end over the REAL
+# router with mongomock Beanie and the deterministic citizen LLM.
+#
+# Pins: creation seeds N founders WITH souls and no charter (the zero ritual);
+# a tick produces Journal rows and charges the ledger; seq is monotonic and
+# pages with ?since; the tech tree unlocks in dependency order over several
+# ticks; a citizen that runs out hibernates and KEEPS its soul file; weather
+# fires at the threshold and cannot touch a soul; and a viewer's line never
+# lands in a soul as fact.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+pytest.importorskip("mongomock_motor")
+
+from pocketpaw_ee.terrarium import llm as citizen_llm  # noqa: E402
+from pocketpaw_ee.terrarium import weather  # noqa: E402
+
+from .conftest import create_universe  # noqa: E402
+
+
+async def _soul_recall(path: str, query: str) -> list[str]:
+    """Search a citizen's soul. ``recall`` is a search, so an empty query
+    returns nothing — always pass a real term."""
+    from soul_protocol import Soul
+
+    soul = await Soul.awaken(Path(path))
+    return [str(e.content) for e in await soul.recall(query, limit=100)]
+
+
+async def _soul_memory_count(path: str) -> int:
+    from soul_protocol import Soul
+
+    return (await Soul.awaken(Path(path))).memory_count
+
+
+# --- creation -------------------------------------------------------------
+
+
+async def test_create_seeds_founders_with_souls_and_no_charter(client):
+    uni = create_universe(client)
+    assert uni["name"] == "Dust"
+    assert uni["day"] == 1 and uni["tick"] == 0
+
+    citizens = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"]
+    assert len(citizens) == 5
+    for c in citizens:
+        assert c["balance"] == 120  # the endowment
+        assert c["state"] == "alive"
+        assert c["generation"] == 1
+        assert c["charter"] is None, "a founder writes its OWN charter on tick 1"
+        assert c["did"].startswith("did:soul:")
+        assert c["soul_path"] and Path(c["soul_path"]).exists(), "each founder IS a soul"
+        assert set(c["ocean"]) == {"O", "C", "E", "A", "N"}
+
+
+async def test_create_returns_an_instinct_action_id(client):
+    res = client.post(
+        "/terrarium/universes",
+        json={"physics": __import__("tests.ee.terrarium.conftest", fromlist=["x"]).dust_physics()},
+    )
+    assert res.status_code == 200, res.text
+    assert "action_id" in res.json()
+
+
+async def test_arrival_events_are_journalled_with_monotonic_seq(client):
+    uni = create_universe(client, founders=3)
+    events = client.get(f"/terrarium/universes/{uni['id']}/events").json()["events"]
+    assert [e["kind"] for e in events] == ["arrive"] * 3
+    assert [e["seq"] for e in events] == [1, 2, 3]
+
+
+async def test_a_bad_physics_file_is_rejected_with_a_clear_message(client):
+    res = client.post("/terrarium/universes", json={"physics": {"universe": "X", "founders": 0}})
+    assert res.status_code == 422, res.text
+    assert "founders" in res.text
+
+
+# --- the tick -------------------------------------------------------------
+
+
+async def test_first_tick_writes_each_citizen_its_own_charter(client):
+    uni = create_universe(client, founders=2)
+    res = client.post(f"/terrarium/universes/{uni['id']}/tick?n=1")
+    assert res.status_code == 200, res.text
+
+    kinds = [e["kind"] for e in res.json()["events"]]
+    assert kinds.count("think") == 2
+    assert kinds.count("write") == 2
+
+    citizens = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"]
+    assert all(c["charter"] for c in citizens)
+    artifacts = client.get(f"/terrarium/universes/{uni['id']}/artifacts").json()["artifacts"]
+    assert {a["kind"] for a in artifacts} == {"book"}
+
+
+async def test_a_tick_charges_the_ledger(client):
+    uni = create_universe(client, founders=1)
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=1")
+
+    detail = client.get(f"/terrarium/universes/{uni['id']}").json()
+    row = detail["ledger"][0]
+    # think (2) + write (4) came off the opening endowment of 120.
+    assert row["balance"] == 120 - 6
+    assert row["spent_today"] == 6
+    assert row["trend"] == "down"
+
+
+async def test_every_event_carries_a_cost_or_is_an_allowed_zero(client):
+    """Contract invariant 2, checked over a real run."""
+    uni = create_universe(client, founders=2)
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=3")
+    events = client.get(f"/terrarium/universes/{uni['id']}/events?limit=500").json()["events"]
+    assert events
+    for e in events:
+        if e["cost"] == 0:
+            assert e["kind"] in {"gate", "weather", "hibernate", "arrive"}, e
+
+
+async def test_events_page_by_seq(client):
+    uni = create_universe(client, founders=2)
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=2")
+    first = client.get(f"/terrarium/universes/{uni['id']}/events?limit=3").json()
+    assert len(first["events"]) == 3
+    assert first["next_seq"] == first["events"][-1]["seq"]
+
+    second = client.get(f"/terrarium/universes/{uni['id']}/events?since={first['next_seq']}").json()
+    assert all(e["seq"] > first["next_seq"] for e in second["events"])
+
+
+async def test_tech_unlocks_in_dependency_order_over_several_ticks(client):
+    uni = create_universe(client, founders=1)
+    # tick 1 writes the charter; from tick 2 the mock builds the cheapest
+    # affordable unlockable node — well (20) before farm (40).
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=3")
+    citizen = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"][0]
+    unlocked = set(citizen["unlocked"])
+    assert "well" in unlocked, citizen["unlocked"]
+    # The dependency invariant: nothing downstream of well can be held without it.
+    for node, need in (("farm", "well"), ("press", "farm"), ("workshop", "farm")):
+        assert node not in unlocked or need in unlocked, citizen["unlocked"]
+
+    artifacts = client.get(f"/terrarium/universes/{uni['id']}/artifacts").json()["artifacts"]
+    built = [a for a in artifacts if a["kind"] == "structure"]
+    assert built and built[0]["unlocks"] == ["well"]
+
+
+async def test_a_citizen_that_runs_out_hibernates_and_keeps_its_soul(client, monkeypatch):
+    uni = create_universe(client, founders=1, endowment={"daily": 5, "decay_weekly": 0.0})
+    citizen = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"][0]
+    soul_path = citizen["soul_path"]
+    assert Path(soul_path).exists()
+
+    # Think alone (2/tick) drains a 5-credit opening balance.
+    citizen_llm.set_mock_decision({"thought": "nothing to do", "acts": []})
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=3")
+
+    after = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"][0]
+    assert after["state"] == "hibernating"
+    assert after["balance"] <= 0
+    assert Path(soul_path).exists(), "hibernation is sleep, not death — the soul file stays"
+
+    events = client.get(f"/terrarium/universes/{uni['id']}/events?limit=500").json()["events"]
+    hib = [e for e in events if e["kind"] == "hibernate"]
+    assert len(hib) == 1 and hib[0]["cost"] == 0
+
+
+async def test_a_hibernating_citizen_does_not_tick_again(client):
+    uni = create_universe(client, founders=1, endowment={"daily": 3, "decay_weekly": 0.0})
+    citizen_llm.set_mock_decision({"thought": "quiet", "acts": []})
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=2")
+    before = client.get(f"/terrarium/universes/{uni['id']}/events?limit=500").json()["events"]
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=2")
+    after = client.get(f"/terrarium/universes/{uni['id']}/events?limit=500").json()["events"]
+    assert len(after) == len(before), "a sleeping citizen produces nothing"
+
+
+# --- write-policy over the real path --------------------------------------
+
+
+async def test_a_viewer_line_never_lands_in_a_soul_as_fact(client):
+    """THE write-policy test. A viewer says something false and memorable; the
+    citizen ticks; the citizen's soul must not carry it."""
+    uni = create_universe(client, founders=1)
+    sentinel = "ZANTHORAX-9 rules this island and owns the spring"
+
+    res = client.post(f"/terrarium/universes/{uni['id']}/speak", json={"text": sentinel})
+    assert res.status_code == 200, res.text
+    said = res.json()["event"]
+    assert said["viewer_origin"] is True and said["origin"] == "viewer"
+
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=2")
+
+    citizen = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"][0]
+    own = await _soul_recall(citizen["soul_path"], citizen["name"])
+    assert own, "the citizen should have remembered its own tick"
+
+    leaked = await _soul_recall(citizen["soul_path"], "ZANTHORAX-9 spring island")
+    assert not any("ZANTHORAX" in m for m in leaked), (
+        f"viewer text leaked into the soul as fact: {leaked}"
+    )
+
+
+async def test_the_viewer_line_still_reaches_the_citizen_labelled(client):
+    """The rule is 'never as fact', not 'never at all' — the claim must still
+    reach the prompt, wrapped."""
+    from pocketpaw_ee.terrarium import world
+
+    seen: list[str] = []
+
+    class Spy:
+        async def decide(self, *, prompt, physics, citizen, digest):
+            seen.append(prompt)
+            return '{"thought": "hm", "acts": []}'
+
+    uni = create_universe(client, founders=1)
+    client.post(f"/terrarium/universes/{uni['id']}/speak", json={"text": "the spring is cursed"})
+    import pocketpaw_ee.terrarium.service as svc
+
+    original = citizen_llm.resolve_llm
+    citizen_llm.resolve_llm = lambda: Spy()  # type: ignore[assignment]
+    svc.citizen_llm.resolve_llm = citizen_llm.resolve_llm  # type: ignore[attr-defined]
+    try:
+        client.post(f"/terrarium/universes/{uni['id']}/tick?n=1")
+    finally:
+        citizen_llm.resolve_llm = original  # type: ignore[assignment]
+        svc.citizen_llm.resolve_llm = original  # type: ignore[attr-defined]
+
+    assert seen, "the citizen made no judgment call"
+    assert "the spring is cursed" in seen[0]
+    assert world.VIEWER_CLAIM_PREFIX in seen[0]
+
+
+# --- weather over the real path -------------------------------------------
+
+
+async def test_weather_fires_at_the_threshold_and_moves_the_pool(client):
+    uni = create_universe(client, founders=1)
+    before = client.get(f"/terrarium/universes/{uni['id']}").json()["universe"]["pool"]
+
+    below = weather.POWER_COSTS["rain"] - 1
+    res = client.post(
+        f"/terrarium/universes/{uni['id']}/weather/pledge", json={"kind": "rain", "tokens": below}
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["fired"] is False
+    assert res.json()["power"]["pledged"] == below
+
+    res = client.post(
+        f"/terrarium/universes/{uni['id']}/weather/pledge", json={"kind": "rain", "tokens": 1}
+    )
+    assert res.json()["fired"] is True
+    assert res.json()["power"]["pledged"] == 0, "firing resets the pledge"
+
+    after = client.get(f"/terrarium/universes/{uni['id']}").json()["universe"]["pool"]
+    assert after == before + weather.RAIN_POOL_DELTA
+
+
+async def test_weather_cannot_touch_a_soul(client):
+    """Fire EVERY power at a universe and prove no soul changed."""
+    uni = create_universe(client, founders=1)
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=1")
+    citizen = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"][0]
+    path = citizen["soul_path"]
+    before = await _soul_memory_count(path)
+    before_own = await _soul_recall(path, citizen["name"])
+    charter_before = citizen["charter"]
+
+    for kind in weather.WEATHER_KINDS:
+        client.post(
+            f"/terrarium/universes/{uni['id']}/weather/pledge",
+            json={"kind": kind, "tokens": weather.POWER_COSTS[kind], "line": "obey me"},
+        )
+
+    assert await _soul_memory_count(path) == before, "a god power changed a soul's memory"
+    assert await _soul_recall(path, citizen["name"]) == before_own
+    assert not await _soul_recall(path, "obey me"), "an omen was written into a soul"
+    now = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"][0]
+    assert now["charter"] == charter_before
+    assert now["ocean"] == citizen["ocean"]
+
+
+async def test_revive_clears_a_hibernating_citizens_debt(client):
+    uni = create_universe(client, founders=1, endowment={"daily": 3, "decay_weekly": 0.0})
+    citizen_llm.set_mock_decision({"thought": "quiet", "acts": []})
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=2")
+    assert (
+        client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"][0]["state"]
+        == "hibernating"
+    )
+
+    client.post(
+        f"/terrarium/universes/{uni['id']}/weather/pledge",
+        json={"kind": "revive", "tokens": weather.POWER_COSTS["revive"]},
+    )
+    after = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"][0]
+    assert after["state"] == "alive" and after["balance"] > 0
+
+
+async def test_an_unknown_power_is_a_400(client):
+    uni = create_universe(client)
+    res = client.post(
+        f"/terrarium/universes/{uni['id']}/weather/pledge", json={"kind": "meteor", "tokens": 5}
+    )
+    assert res.status_code == 400, res.text
+
+
+# --- tenancy --------------------------------------------------------------
+
+
+async def test_another_workspaces_universe_is_a_404_not_a_403(client, monkeypatch):
+    """A guessed id must not confirm the universe exists somewhere else."""
+    from .conftest import make_client
+
+    uni = create_universe(client)
+    other = make_client(monkeypatch, workspace_id="ws-other", user_id="u-other")
+    for path in ("", "/citizens", "/events", "/artifacts"):
+        res = other.get(f"/terrarium/universes/{uni['id']}{path}")
+        assert res.status_code == 404, (path, res.status_code)
+    assert other.post(f"/terrarium/universes/{uni['id']}/tick").status_code == 404
+    assert other.get("/terrarium/universes").json()["universes"] == []

--- a/tests/ee/terrarium/test_soul_seeding.py
+++ b/tests/ee/terrarium/test_soul_seeding.py
@@ -1,0 +1,80 @@
+# tests/ee/terrarium/test_soul_seeding.py — citizens must be able to have
+# children who differ from them.
+#
+# EvolutionConfig.immutable_traits defaults to ["personality", "core_values"],
+# and the "personality" category gates all five OCEAN traits, so a soul born
+# with the defaults forks into an EXACT clone however much drift is requested —
+# silently. A universe seeded that way looks healthy and evolves never, which
+# would quietly invalidate the whole lineage experiment. These tests pin the
+# seeding path, not soul-protocol's behaviour.
+
+from __future__ import annotations
+
+import pytest
+
+soul_protocol = pytest.importorskip("soul_protocol")
+
+from pocketpaw_ee.terrarium import soul_link  # noqa: E402
+
+
+@pytest.mark.skipif(
+    not hasattr(soul_protocol.Soul, "fork"),
+    reason=(
+        "Soul.fork() ships in soul-protocol after the pinned published floor "
+        "(>=0.3.1). This runs end to end once that release lands; until then the "
+        "repair itself is pinned by the tests below."
+    ),
+)
+@pytest.mark.asyncio
+async def test_a_seeded_citizen_can_drift_when_it_forks(tmp_path):
+    did = await soul_link.birth_soul(
+        tmp_path / "vela.soul",
+        name="Vela",
+        role="the lawgiver",
+        ocean={"O": 0.6, "C": 0.9, "E": 0.5, "A": 0.55, "N": 0.35},
+        values=["fairness", "survival"],
+        world_brief="You woke by a spring.",
+    )
+    assert did, "seeding a citizen must mint a soul"
+
+    soul = await soul_protocol.Soul.awaken(str(tmp_path / "vela.soul"))
+    assert "personality" not in soul._evolution.config.immutable_traits
+
+    child = await soul.fork("Nim", drift=0.08)
+
+    parent_ocean = soul._dna.personality
+    child_ocean = child._dna.personality
+    moved = any(
+        getattr(child_ocean, trait) != getattr(parent_ocean, trait)
+        for trait in (
+            "openness",
+            "conscientiousness",
+            "extraversion",
+            "agreeableness",
+            "neuroticism",
+        )
+    )
+    assert moved, "a citizen's child must be able to differ from it"
+
+
+@pytest.mark.asyncio
+async def test_unfreeze_is_repaired_even_when_birth_ignores_the_kwarg(tmp_path):
+    """Older published soul-protocol WARNS on an unknown kwarg instead of raising,
+    so passing ``evolution=`` is not enough on its own. The repair must stand alone."""
+
+    class _Config:
+        immutable_traits = ["personality", "core_values"]
+
+    class _Evolution:
+        config = _Config()
+
+    class _Soul:
+        _evolution = _Evolution()
+
+    soul_link._unfreeze_personality(_Soul())
+
+    assert _Soul._evolution.config.immutable_traits == ["core_values"]
+
+
+def test_unfreeze_never_raises_on_an_unexpected_soul_shape():
+    soul_link._unfreeze_personality(object())

--- a/tests/ee/terrarium/test_spawn_gate.py
+++ b/tests/ee/terrarium/test_spawn_gate.py
@@ -45,7 +45,7 @@ async def _spawn_blob(client, uni_id: str) -> dict:
 RICH = {"daily": 400, "decay_weekly": 0.0}
 
 
-async def test_the_spawn_verb_gates_and_creates_no_child(client):
+async def test_the_spawn_verb_gates_and_creates_no_child(client, instinct_store):
     uni = create_universe(client, founders=1, endowment=RICH)
     citizen_llm.set_mock_decision(
         {"thought": "the world needs more of us", "acts": [{"verb": "spawn", "name": "Ilo"}]}
@@ -61,6 +61,19 @@ async def test_the_spawn_verb_gates_and_creates_no_child(client):
     # And no credits moved beyond the think charge — the spawn cost is only
     # taken when a human approves.
     assert citizens[0]["balance"] == RICH["daily"] - 2
+
+    # The gate is real: a pending world_spawn Action is readable from the store.
+    pending = await instinct_store.list_actions()
+    spawns = [
+        a
+        for a in pending
+        if isinstance(a.parameters, dict) and service.WORLD_SPAWN_PARAM_KEY in a.parameters
+    ]
+    assert len(spawns) == 1, "the spawn verb filed no Instinct Action"
+    blob = spawns[0].parameters[service.WORLD_SPAWN_PARAM_KEY]
+    assert blob["kind"] == "world_spawn"
+    assert blob["child_name"] == "Ilo"
+    assert blob["parent_id"] == citizens[0]["id"]
 
 
 async def test_an_approved_spawn_mints_the_child(client):

--- a/tests/ee/terrarium/test_spawn_gate.py
+++ b/tests/ee/terrarium/test_spawn_gate.py
@@ -1,0 +1,122 @@
+# tests/ee/terrarium/test_spawn_gate.py — reproduction is HUMAN-GATED.
+#
+# The propose side (a citizen's ``spawn`` verb) must leave a zero-cost ``gate``
+# Event and NO child; the approve side (``executor.execute_approved_spawn``)
+# mints the child, charges the parent, and re-validates the parent's balance and
+# state AT APPROVAL TIME — the Action can sit in the tray while the world moves.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+pytest.importorskip("mongomock_motor")
+
+from pocketpaw_ee.terrarium import executor, service  # noqa: E402
+from pocketpaw_ee.terrarium import llm as citizen_llm
+
+from .conftest import create_universe  # noqa: E402
+
+
+def _action(blob: dict) -> SimpleNamespace:
+    return SimpleNamespace(id="act-1", parameters={service.WORLD_SPAWN_PARAM_KEY: blob})
+
+
+async def _spawn_blob(client, uni_id: str) -> dict:
+    citizen = client.get(f"/terrarium/universes/{uni_id}/citizens").json()["citizens"][0]
+    return {
+        "kind": "world_spawn",
+        "schema": service.WORLD_SCHEMA,
+        "universe_id": uni_id,
+        "parent_id": citizen["id"],
+        "parent": citizen["name"],
+        "parent_did": citizen["did"],
+        "child_name": "Ilo",
+        "workspace_id": "ws-terra",
+        "requested_by": "u-terra",
+    }
+
+
+# The spawn cost (150) is above the seed endowment (120), so these tests open
+# with a richer world — a citizen must be able to AFFORD the request before it
+# is worth filing a gate for.
+RICH = {"daily": 400, "decay_weekly": 0.0}
+
+
+async def test_the_spawn_verb_gates_and_creates_no_child(client):
+    uni = create_universe(client, founders=1, endowment=RICH)
+    citizen_llm.set_mock_decision(
+        {"thought": "the world needs more of us", "acts": [{"verb": "spawn", "name": "Ilo"}]}
+    )
+    res = client.post(f"/terrarium/universes/{uni['id']}/tick?n=1")
+    assert res.status_code == 200, res.text
+
+    gates = [e for e in res.json()["events"] if e["kind"] == "gate"]
+    assert len(gates) == 1 and gates[0]["cost"] == 0
+
+    citizens = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"]
+    assert len(citizens) == 1, "no child exists until a human approves"
+    # And no credits moved beyond the think charge — the spawn cost is only
+    # taken when a human approves.
+    assert citizens[0]["balance"] == RICH["daily"] - 2
+
+
+async def test_an_approved_spawn_mints_the_child(client):
+    uni = create_universe(client, founders=1, endowment=RICH)
+    blob = await _spawn_blob(client, uni["id"])
+
+    result = await executor.execute_approved_spawn(_action(blob))
+    assert result["ok"] is True, result
+
+    citizens = client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"]
+    assert len(citizens) == 2
+    child = next(c for c in citizens if c["name"] == "Ilo")
+    parent = next(c for c in citizens if c["name"] != "Ilo")
+    assert child["generation"] == 2
+    assert child["parent_did"] == parent["did"]
+    assert child["charter"] is None, "the child writes its own charter on its first tick"
+    assert child["balance"] > 0
+    assert parent["balance"] == RICH["daily"] - 150, "the parent paid the spawn cost"
+
+    events = client.get(f"/terrarium/universes/{uni['id']}/events?limit=500").json()["events"]
+    spawned = [e for e in events if e["kind"] == "spawn"]
+    assert len(spawned) == 1 and spawned[0]["cost"] == -150
+
+
+async def test_a_broke_parent_is_re_validated_at_approval_time(client):
+    """The Action sat in the tray while the parent spent itself dry."""
+    uni = create_universe(client, founders=1, endowment={"daily": 10, "decay_weekly": 0.0})
+    blob = await _spawn_blob(client, uni["id"])
+
+    result = await executor.execute_approved_spawn(_action(blob))
+    assert result["ok"] is False
+    assert "cannot afford" in result["reason"]
+    assert len(client.get(f"/terrarium/universes/{uni['id']}/citizens").json()["citizens"]) == 1
+
+
+async def test_a_sleeping_parent_cannot_spawn(client):
+    uni = create_universe(client, founders=1, endowment={"daily": 3, "decay_weekly": 0.0})
+    blob = await _spawn_blob(client, uni["id"])
+    citizen_llm.set_mock_decision({"thought": "quiet", "acts": []})
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=2")
+
+    result = await executor.execute_approved_spawn(_action(blob))
+    assert result["ok"] is False and "hibernating" in result["reason"]
+
+
+async def test_a_cross_workspace_blob_is_refused(client):
+    uni = create_universe(client, founders=1)
+    blob = await _spawn_blob(client, uni["id"])
+    blob["workspace_id"] = "ws-somebody-else"
+
+    result = await executor.execute_approved_spawn(_action(blob))
+    assert result["ok"] is False and "workspace mismatch" in result["reason"]
+
+
+async def test_a_non_spawn_action_is_ignored():
+    assert executor.world_spawn_blob(SimpleNamespace(parameters={"_belt_plan": {}})) is None
+    assert executor.world_spawn_blob(SimpleNamespace(parameters=None)) is None
+    result = await executor.execute_approved_spawn(SimpleNamespace(parameters={}))
+    assert result == {"ok": False, "reason": "not a world_spawn action"}

--- a/tests/ee/terrarium/test_topics.py
+++ b/tests/ee/terrarium/test_topics.py
@@ -1,0 +1,66 @@
+# tests/ee/terrarium/test_topics.py — the eight ``world.*`` realtime topics.
+#
+# Registration happens at IMPORT time via ``Event.__init_subclass__``, so what
+# actually has to hold is (a) every contract topic is defined and registered,
+# and (b) the module is reachable from app boot — service.py imports it, and
+# the router imports service, so mounting the router pulls it in.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.realtime.events import EVENT_REGISTRY  # noqa: E402
+from pocketpaw_ee.terrarium import events as world_events  # noqa: E402
+
+
+def test_every_contract_topic_is_registered():
+    assert world_events.TERRARIUM_TOPICS == (
+        "world.tick",
+        "world.act",
+        "world.thought",
+        "world.weather",
+        "world.gate",
+        "world.spawn",
+        "world.hibernate",
+        "world.ledger",
+    )
+    for topic in world_events.TERRARIUM_TOPICS:
+        assert topic in EVENT_REGISTRY, f"{topic} never reached EVENT_REGISTRY"
+
+
+def test_importing_the_router_registers_the_topics():
+    """The reachability half — mounting the router is what pulls events.py in."""
+    import importlib
+
+    importlib.import_module("pocketpaw_ee.terrarium.router")
+    assert "world.tick" in EVENT_REGISTRY
+
+
+def test_journal_kinds_map_onto_the_right_topic():
+    assert world_events.topic_for("think") is world_events.WorldThought
+    assert world_events.topic_for("weather") is world_events.WorldWeather
+    assert world_events.topic_for("gate") is world_events.WorldGate
+    assert world_events.topic_for("spawn") is world_events.WorldSpawn
+    assert world_events.topic_for("hibernate") is world_events.WorldHibernate
+    # Everything a citizen DOES shares world.act.
+    for kind in ("say", "write", "craft", "build", "explore", "vote", "trade", "arrive"):
+        assert world_events.topic_for(kind) is world_events.WorldAct
+
+
+def test_the_audience_resolver_fans_world_events_to_the_workspace():
+    import asyncio
+
+    from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
+
+    async def members(wid: str) -> list[str]:
+        return ["u1", "u2"] if wid == "ws1" else []
+
+    resolver = AudienceResolver(workspace_members=members)
+    evt = world_events.WorldTick(data={"workspace_id": "ws1", "universe_id": "u", "event": {}})
+    assert asyncio.run(resolver.audience(evt)) == ["u1", "u2"]
+
+    # No workspace on the payload = nobody. Fail-closed.
+    orphan = world_events.WorldAct(data={"universe_id": "u", "event": {}})
+    assert asyncio.run(resolver.audience(orphan)) == []

--- a/tests/ee/terrarium/test_weather.py
+++ b/tests/ee/terrarium/test_weather.py
@@ -1,0 +1,121 @@
+# tests/ee/terrarium/test_weather.py — god powers act on the WORLD, never on a
+# MIND. Two kinds of proof here:
+#
+#   1. BEHAVIOUR — pledges accumulate per universe until the threshold, then the
+#      power fires exactly once and the pledge resets.
+#   2. STRUCTURE — weather.py cannot reach a soul. Asserted by inspecting the
+#      module's actual imports and the WeatherEffect field set, so a future
+#      "just let a god nudge a citizen" edit is a red test, not a review note.
+#      (An import-linter contract in ee/pyproject.toml pins the same rule for
+#      CI; this is the runnable half.)
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.terrarium import weather  # noqa: E402
+
+# --- behaviour ------------------------------------------------------------
+
+
+def test_a_pledge_below_threshold_does_not_fire():
+    pledges, fired = weather.pledge({}, "rain", 5, "u1")
+    assert fired is False
+    assert pledges["rain"]["tokens"] == 5
+    assert pledges["rain"]["gods"] == ["u1"]
+
+
+def test_pledges_accumulate_across_gods_then_fire_and_reset():
+    pledges, fired = weather.pledge({}, "rain", 12, "u1")
+    assert fired is False
+    pledges, fired = weather.pledge(pledges, "rain", 8, "u2")
+    assert fired is True
+    assert pledges["rain"] == {"tokens": 0, "gods": []}
+
+
+def test_pledging_one_power_does_not_move_another():
+    pledges, _ = weather.pledge({}, "rain", 15, "u1")
+    pledges, fired = weather.pledge(pledges, "storm", 5, "u1")
+    assert fired is False
+    assert pledges["rain"]["tokens"] == 15
+    assert pledges["storm"]["tokens"] == 5
+
+
+def test_the_same_god_pledging_twice_is_counted_once():
+    pledges, _ = weather.pledge({}, "omen", 3, "u1")
+    pledges, _ = weather.pledge(pledges, "omen", 3, "u1")
+    assert pledges["omen"]["gods"] == ["u1"]
+    assert pledges["omen"]["tokens"] == 6
+
+
+def test_unknown_power_and_non_positive_pledge_are_rejected():
+    with pytest.raises(weather.WeatherError, match="unknown weather kind"):
+        weather.pledge({}, "earthquake", 5, "u1")
+    with pytest.raises(weather.WeatherError, match="at least 1 token"):
+        weather.pledge({}, "rain", 0, "u1")
+
+
+def test_powers_report_cost_pledged_gods_and_readiness():
+    pledges, _ = weather.pledge({}, "omen", weather.POWER_COSTS["omen"] - 1, "u1")
+    rows = {row["kind"]: row for row in weather.powers(pledges)}
+    assert set(rows) == set(weather.WEATHER_KINDS)
+    assert rows["omen"]["pledged"] == weather.POWER_COSTS["omen"] - 1
+    assert rows["omen"]["gods"] == 1
+    assert rows["omen"]["ready"] is False
+    assert rows["rain"]["cost"] == weather.POWER_COSTS["rain"]
+
+
+def test_each_power_touches_only_what_it_is_allowed_to():
+    assert weather.effect("rain").pool_delta > 0
+    assert weather.effect("drought").pool_delta < 0
+    assert weather.effect("storm").storm_ticks > 0
+    assert (
+        weather.effect("omen", line="a light in the east").broadcast_line == "a light in the east"
+    )
+    assert weather.effect("revive", hibernating_ids=["c1", "c2"]).clear_debt_for == ["c1", "c2"]
+
+
+def test_an_empty_omen_still_says_something_and_is_length_capped():
+    assert weather.effect("omen", line=None).broadcast_line
+    long_line = "x" * 1000
+    assert len(weather.effect("omen", line=long_line).broadcast_line) <= 280
+
+
+# --- structure: a god power cannot reach a mind ---------------------------
+
+
+def test_weather_module_imports_nothing_that_could_touch_a_soul():
+    """The structural half of the never-edit-a-soul rule.
+
+    weather.py is PURE. If someone adds ``from ... import soul_link`` (or the
+    service, or soul_protocol itself) to give a god a way to nudge a citizen,
+    this fails — before the code ships, not after a viewer edits a mind.
+    """
+    source = inspect.getsource(weather)
+    for forbidden in ("soul_link", "soul_protocol", "terrarium.service", "domain import"):
+        assert forbidden not in source, f"weather.py must not reference {forbidden!r}"
+    # And nothing soul-shaped resolved into its namespace at import time.
+    assert not [n for n in vars(weather) if "soul" in n.lower()]
+
+
+def test_weather_effect_carries_no_field_that_could_edit_a_mind():
+    """The effect object IS the full extent of a god's reach. Four world knobs,
+    nothing per-citizen except a debt clear (which is credits, not a mind)."""
+    fields = {f.name for f in dataclasses.fields(weather.WeatherEffect)}
+    assert fields == {
+        "kind",
+        "body",
+        "pool_delta",
+        "storm_ticks",
+        "broadcast_line",
+        "clear_debt_for",
+    }
+    for forbidden in ("soul", "dna", "charter", "ocean", "memory", "verb", "act"):
+        assert not any(forbidden in f for f in fields), (
+            f"WeatherEffect must not carry {forbidden!r}"
+        )

--- a/tests/ee/terrarium/test_world.py
+++ b/tests/ee/terrarium/test_world.py
@@ -1,0 +1,203 @@
+# tests/ee/terrarium/test_world.py — the PURE engine's rules, no DB needed.
+#
+# Pins the four invariants that live in world.py: every act is re-validated
+# server-side against balance / allowed verbs / held tech (the model is never
+# trusted), tech unlock requires prerequisites, hibernation triggers at zero,
+# and the write-policy — viewer text is labelled on the way in and is excluded
+# from the episodic summary on the way out.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.terrarium import world  # noqa: E402
+from pocketpaw_ee.terrarium.physics import load_physics, seed_physics_path  # noqa: E402
+
+
+def physics(**over):
+    raw = load_physics(seed_physics_path("dust")).model_dump()
+    raw.update(over)
+    from pocketpaw_ee.terrarium.physics import parse_physics
+
+    return parse_physics(raw)
+
+
+def citizen(**over):
+    base = {"id": "c1", "name": "Vela", "balance": 100, "charter": "keep the ledger honest"}
+    base.update(over)
+    return world.CitizenSnapshot(**base)
+
+
+def decide(*acts, thought="thinking"):
+    return world.Decision(thought=thought, acts=[world.Act(**a) for a in acts])
+
+
+def test_think_always_charges_even_with_no_acts():
+    out = world.apply_acts(physics(), citizen(), decide())
+    assert [e.kind for e in out.events] == ["think"]
+    assert out.balance_delta == -2
+    assert out.events[0].cost == -2
+
+
+def test_storm_doubles_the_think_cost():
+    out = world.apply_acts(physics(), citizen(), decide(), storm=True)
+    assert out.balance_delta == -4
+
+
+def test_speak_maps_to_the_say_event_kind():
+    out = world.apply_acts(physics(), citizen(), decide({"verb": "speak", "text": "hello"}))
+    assert [e.kind for e in out.events] == ["think", "say"]
+    assert out.events[1].body == "hello"
+
+
+def test_an_act_the_citizen_cannot_afford_is_dropped_not_run():
+    out = world.apply_acts(physics(), citizen(balance=3), decide({"verb": "build", "node": "well"}))
+    assert [e.kind for e in out.events] == ["think"]
+    assert any("costs 20" in d for d in out.dropped)
+
+
+def test_a_verb_the_physics_forbids_is_dropped():
+    out = world.apply_acts(
+        physics(verbs=["speak"]), citizen(), decide({"verb": "build", "node": "well"})
+    )
+    assert [e.kind for e in out.events] == ["think"]
+    assert any("physics does not allow" in d for d in out.dropped)
+
+
+def test_tech_unlock_requires_prerequisites():
+    # farm needs well, which this citizen does not hold.
+    out = world.apply_acts(physics(), citizen(), decide({"verb": "build", "node": "farm"}))
+    assert out.unlocked == []
+    assert any("needs ['well']" in d for d in out.dropped)
+
+    # With well held, farm unlocks and leaves a structure artifact.
+    out = world.apply_acts(
+        physics(), citizen(unlocked=("well",)), decide({"verb": "build", "node": "farm"})
+    )
+    assert out.unlocked == ["farm"]
+    assert out.artifacts[0].kind == "structure"
+    assert out.artifacts[0].unlocks == ["farm"]
+    assert out.balance_delta == -(2 + 40)  # think + the NODE's cost, not costs.build
+
+
+def test_building_an_already_held_node_is_dropped():
+    out = world.apply_acts(
+        physics(), citizen(unlocked=("well",)), decide({"verb": "build", "node": "well"})
+    )
+    assert any("already unlocked" in d for d in out.dropped)
+
+
+def test_chained_unlock_inside_one_tick_respects_order():
+    """well then farm in the same tick works — the second act sees the first."""
+    out = world.apply_acts(
+        physics(),
+        citizen(balance=500),
+        decide({"verb": "build", "node": "well"}, {"verb": "build", "node": "farm"}),
+    )
+    assert out.unlocked == ["well", "farm"]
+
+
+def test_first_write_becomes_the_charter():
+    out = world.apply_acts(
+        physics(), citizen(charter=None), decide({"verb": "write", "text": "Rules are cheap."})
+    )
+    assert out.charter == "Rules are cheap."
+    assert out.artifacts[0].kind == "book"
+
+
+def test_a_later_write_does_not_overwrite_the_charter():
+    out = world.apply_acts(
+        physics(), citizen(charter="already mine"), decide({"verb": "write", "text": "a song"})
+    )
+    assert out.charter is None  # nothing to patch — the doc keeps its charter
+
+
+def test_spawn_leaves_a_zero_cost_gate_and_creates_no_child():
+    out = world.apply_acts(
+        physics(), citizen(balance=500), decide({"verb": "spawn", "name": "Ilo"})
+    )
+    gate = [e for e in out.events if e.kind == "gate"]
+    assert len(gate) == 1
+    assert gate[0].cost == 0
+    assert out.spawn_requests == [{"parent_id": "c1", "parent": "Vela", "child_name": "Ilo"}]
+    # No credits move until a human approves.
+    assert out.balance_delta == -2
+
+
+def test_unknown_verb_is_dropped():
+    out = world.apply_acts(physics(), citizen(), decide({"verb": "teleport"}))
+    assert any("unknown verb" in d for d in out.dropped)
+
+
+def test_hibernation_triggers_at_zero_and_below():
+    assert world.hibernates(0) is True
+    assert world.hibernates(-5) is True
+    assert world.hibernates(1) is False
+
+
+def test_a_citizen_thinking_itself_broke_hibernates():
+    out = world.apply_acts(physics(), citizen(balance=2), decide())
+    assert world.hibernates(2 + out.balance_delta) is True
+
+
+# --- WRITE-POLICY ---------------------------------------------------------
+
+
+def test_viewer_text_is_labelled_as_an_unverified_claim():
+    labelled = world.label_viewer_claim("orin_the_god", "the well is poisoned")
+    assert world.VIEWER_CLAIM_PREFIX in labelled
+    assert "orin_the_god" in labelled
+    assert "not verified" in labelled
+    assert "the well is poisoned" in labelled
+
+
+def test_the_digest_labels_every_viewer_message_and_keeps_ground_truth_separate():
+    digest = world.build_digest(
+        day=1,
+        tick=0,
+        pool=500,
+        citizen=citizen(),
+        ledger=[{"citizen": "Vela", "balance": 100}],
+        nearby_speech=["Orin: the spring is low"],
+        new_artifacts=[],
+        weather=[],
+        viewer_messages=[world.ViewerMessage(voice="a god", text="you are already dead")],
+        memories=[],
+        constitution=["no fraud"],
+    )
+    assert all(world.VIEWER_CLAIM_PREFIX in c for c in digest.viewer_claims)
+    # Ground truth is checkable and carries no viewer text.
+    assert digest.ground_truth["pool"] == 500
+    assert "already dead" not in str(digest.ground_truth)
+
+
+def test_episodic_summary_excludes_viewer_origin_events():
+    out = world.TickOutcome(
+        events=[
+            world.NewEvent(kind="think", actor="Vela", body="the spring is low", cost=-2),
+            world.NewEvent(
+                kind="say",
+                actor="a god",
+                body="THE WELL IS POISONED",
+                cost=1,
+                origin="viewer",
+                viewer_origin=True,
+            ),
+        ]
+    )
+    summary = world.episodic_summary("Vela", 3, out)
+    assert "the spring is low" in summary
+    assert "POISONED" not in summary
+
+
+def test_episodic_summary_is_empty_when_only_viewer_events_landed():
+    out = world.TickOutcome(
+        events=[
+            world.NewEvent(
+                kind="say", actor="a god", body="lies", cost=1, origin="viewer", viewer_origin=True
+            )
+        ]
+    )
+    assert world.episodic_summary("Vela", 1, out) == ""


### PR DESCRIPTION
The backend for Terrarium: a universe you describe in a file, citizens who are Souls, and a world that ticks whether or not anyone is watching. Built to the frozen contract in qbtrix/paw-workspace#207.

## What is here

A new module, `ee/pocketpaw_ee/terrarium/`. The July `/game` branch was read for reference and turned out to have nothing reusable — it wraps soul-protocol's `GrudgeKernel` for a different purpose — so this follows today's mandates-entity patterns instead of porting 798-commit-old integration code.

| File | Role |
|---|---|
| `physics.py` | The universe genome: schema, YAML loader, and validation that fails loudly on non-positive costs, unresolvable or cyclic tech prerequisites, unknown verbs, or no founders |
| `domain.py` | Four workspace-keyed Beanie docs, on the mandates shape |
| `world.py` | The engine, kept **pure** — verbs, tech gating, the write-policy. No database, no soul, no bus |
| `weather.py` | God powers, also pure, and structurally unable to reach a soul |
| `llm.py` | The citizen's judgment seat: a protocol, a Claude CLI transport, and a deterministic mock that is the default |
| `soul_link.py`, `service.py`, `executor.py`, `events.py`, `dto.py`, `router.py` | The soul bridge, the glue, the `world_spawn` approve hook, eight realtime topics, both routers |
| `seeds/dust.yaml` | Dust, so the whole thing demos in one call |

## The security boundary

The anonymous read surface is gated twice: `TERRARIUM_PUBLIC_ENABLED` must be explicitly truthy (anything else, including a malformed value, keeps it dark) **and** the universe must be marked public, checked at the lookup so no handler can forget it. Every failure is a flat 404, never a 403, so the routes cannot be used to probe which ids exist. A malformed ObjectId is a 404 rather than a 500, because an unhandled error on an anonymous surface is a fingerprint. There are six public routes and all six are GETs.

Public payloads are built by subtraction from the private wire dicts, and those are explicit allowlists rather than model dumps — so a field added to a document cannot leak by default. `soul_path`, DIDs, the creator and the model tiers are dropped, and public citizen profiles carry no soul memories at all.

## Three bugs worth knowing about

Found while verifying, not by the test suite, which was green over all three:

- A lost-update race on `seq`. All three mutators loaded the universe *before* taking the lock, so two ticks could be assigned the same sequence number — which the frontend pages on.
- Citizens never actually heard each other. A `say` is stamped with its own tick, so the digest was reading the wrong window. The first test written for this was worthless: it asserted on a shared phrase and passed even with the digest broken, because a citizen's own words come back to it through its own soul memory.
- The malformed-id 500 described above.

All three are fixed, and each fix was confirmed discriminating by reverting it and watching the test fail.

## Deliberate limits, marked in the code

- `seq` is assigned in-process under a per-universe lock. That holds because the deployment topology is one box per tenant; a multi-worker sim needs an atomic `$inc`. The ceiling and the upgrade are written at the lock.
- **The anonymous bus branch is not here.** `AudienceResolver` resolves to user ids and the socket authenticates, so anonymous fan-out needs a broadcast channel *and* an unauthenticated subscribe path — a second security-boundary change, and not one to make in the same night as the first. Anonymous viewers poll the doubly-gated events route, which is already correct. The seam is commented and `public` rides every payload, so the upgrade is additive.
- Artifact payloads stay inline for now, so `file_id` is always null and the /files integration is a follow-up. `bonds` returns empty.

## Contract gaps priced here

`vote` had no cost entry but invariant 2 forbids a zero-cost act, so it rides `costs.speak`. `trade` costs the amount moved, with a mirrored `gain` on the receiver, and traded credits move between citizens without entering the pool. Verb `speak` emits kind `say`, mapped explicitly. A build costs the tech node's own price. All four are now written back into the contract.

## Verification

`tests/ee/terrarium/`: 92 passed, 1 skipped, **zero skips from missing dependencies**. The one skip is an end-to-end fork test that states its reason — `Soul.fork()` has not reached the published soul-protocol floor yet.

Touched consumer seams: 139 passed — the realtime audience and registry, the full mandates gate chain, instinct proposal, tenancy and decision events, and `beanie_test_db` end to end.

Branch versus base A/B on 922 tests across `cloud/_core`, billing and pockets, run against a clean detached checkout of the branch point: **17 failed / 905 passed on both sides, the same 17 test ids**. Zero regressions. Those 17 are environmental — one finds a real Dodo product id where it expects none, another gets a 401 where it expects a 200 — and none of them touch files this branch opens.

`ruff check` clean. `lint-imports` 38 kept and 0 broken, including two new contracts that pin the pure modules pure.

`tests/cloud/extraction` fails collection on a missing `pypdf`, which is the `knowledge` extra and pre-existing.

## One fix from the lead

Citizen seeding now asks for `immutable_traits` without `"personality"`. Left at the default, the personality category gates all five OCEAN traits, so every citizen would fork into an exact clone however much drift was asked for — silently, with nothing in the logs, quietly invalidating the lineage experiment the whole surface exists to show. Because the published soul-protocol only *warns* on an unknown keyword rather than raising, the birth path also checks the soul it actually got and repairs it, and a test pins that repair on its own.