### PR TITLE
Terrarium launch: the clock, bring-your-own-key, and books as files

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -260,6 +260,7 @@ def mount_cloud(app: FastAPI) -> None:
     )
     from pocketpaw_ee.cloud.billing.router import router as billing_router
     from pocketpaw_ee.cloud.billing.webhooks import router as billing_webhooks_router
+    from pocketpaw_ee.cloud.byok.router import router as byok_router
     from pocketpaw_ee.cloud.chat.router import router as chat_router
     from pocketpaw_ee.cloud.chat.runs.router import router as runs_router
     from pocketpaw_ee.cloud.codeagent.router import router as codeagent_router
@@ -353,6 +354,7 @@ def mount_cloud(app: FastAPI) -> None:
     # (POST /billing/webhooks/dodo) is mounted SEPARATELY just below with NO auth
     # dependency — Dodo is the caller; trust is the Standard-Webhooks signature.
     app.include_router(billing_router, prefix="/api/v1")
+    app.include_router(byok_router, prefix="/api/v1")
     app.include_router(billing_webhooks_router, prefix="/api/v1")
     # Entitlements (BC-6, the Entitlement primitive) — the workspace-scoped
     # resolver (GET /entitlements -> the workspace's plan + features + monthly

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1084,6 +1084,19 @@ def mount_cloud(app: FastAPI) -> None:
         async def _stop_member_ingest() -> None:
             await stop_member_ingest(app)
 
+    # Terrarium clock — ticks every running universe on its own physics cadence
+    # (dormant cadence when nobody has watched for a world-day). Same gate.
+    if _os.environ.get("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "").lower() == "true":
+        from pocketpaw_ee.terrarium import scheduler as _terrarium_clock
+
+        @app.on_event("startup")
+        async def _start_terrarium_clock() -> None:
+            await _terrarium_clock.reconcile_scheduler()
+
+        @app.on_event("shutdown")
+        async def _stop_terrarium_clock() -> None:
+            await _terrarium_clock.shutdown_scheduler()
+
     # Generic Firestore→Fabric ingest sweep. Every 5 minutes
     # (POCKETPAW_FABRIC_INGEST_INTERVAL_SECONDS override) it mirrors each
     # workspace's configured Firestore collections into Fabric objects (backfill

--- a/ee/pocketpaw_ee/cloud/byok/__init__.py
+++ b/ee/pocketpaw_ee/cloud/byok/__init__.py
@@ -1,0 +1,4 @@
+# ee/pocketpaw_ee/cloud/byok — bring-your-own-key provider credentials.
+#
+# Created 2026-08-28 (feat/other-hand-byok). One service owns
+# ``ByokProviderKey``; nothing else reads the document.

--- a/ee/pocketpaw_ee/cloud/byok/dto.py
+++ b/ee/pocketpaw_ee/cloud/byok/dto.py
@@ -1,0 +1,61 @@
+# ee/pocketpaw_ee/cloud/byok/dto.py — the wire shapes for BYOK.
+#
+# Created 2026-08-28 (feat/other-hand-byok).
+#
+# There is deliberately NO response model carrying the key. ``ByokStatus`` is
+# the ONLY thing this domain returns, and it is built from display-only columns
+# (``last4`` / ``key_hint``) so answering a status call never decrypts anything.
+# If a future field would require a decrypt to populate, that is the signal to
+# not add the field.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+# Anthropic keys start with this. Checked at the edge so an obviously-wrong
+# paste (an OpenAI key, a session token, a whole curl command) fails before it
+# reaches the provider — and before we spend a validation round trip on it.
+_ANTHROPIC_PREFIX = "sk-ant-"
+_MIN_KEY_LEN = 20
+
+
+class ByokSetRequest(BaseModel):
+    """Set or replace this workspace's provider key."""
+
+    provider: str = Field(default="anthropic")
+    api_key: str = Field(min_length=_MIN_KEY_LEN, max_length=512)
+
+    @field_validator("provider")
+    @classmethod
+    def _known_provider(cls, v: str) -> str:
+        if v != "anthropic":
+            raise ValueError("only the 'anthropic' provider is supported today")
+        return v
+
+    @field_validator("api_key")
+    @classmethod
+    def _looks_like_a_key(cls, v: str) -> str:
+        # Whitespace is the single most common paste artefact, and a stray
+        # newline inside a header value is worth rejecting on its own merits.
+        v = v.strip()
+        if any(c.isspace() for c in v):
+            raise ValueError("the key contains whitespace — paste the key alone")
+        if not v.startswith(_ANTHROPIC_PREFIX):
+            raise ValueError(f"an Anthropic API key starts with {_ANTHROPIC_PREFIX!r}")
+        return v
+
+
+class ByokStatus(BaseModel):
+    """What the UI is allowed to know about the stored key.
+
+    Never carries the key, and never a field that would need one to compute.
+    """
+
+    configured: bool
+    provider: str | None = None
+    last4: str | None = None
+    key_hint: str | None = None
+    last_verified_at: datetime | None = None
+    last_error: str | None = None

--- a/ee/pocketpaw_ee/cloud/byok/router.py
+++ b/ee/pocketpaw_ee/cloud/byok/router.py
@@ -1,0 +1,59 @@
+# ee/pocketpaw_ee/cloud/byok/router.py — set / inspect / remove the workspace's
+# own provider key.
+#
+# Created 2026-08-28 (feat/other-hand-byok).
+#
+# Three routes, and a hard rule: NOTHING here returns a key. Every response is a
+# ``ByokStatus`` built from display-only columns. There is no GET that reveals
+# the credential and no echo on save — once set, a key is write-only from the
+# API's point of view, and the only code that can read it back is the turn path.
+#
+# Workspace-scoped, not user-scoped, matching where the credential is spent: a
+# turn runs in a workspace. On the Otherhand kiosk face each account gets its own
+# auto-provisioned workspace, so workspace == user there anyway.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud.byok import service as byok_service
+from pocketpaw_ee.cloud.byok.dto import ByokSetRequest, ByokStatus
+from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+router = APIRouter(prefix="/byok", tags=["BYOK"])
+
+
+@router.get("/key", response_model=ByokStatus)
+async def get_byok_status(
+    workspace_id: str = Depends(current_workspace_id),
+) -> ByokStatus:
+    """Whether a key is configured, and enough to tell WHICH one. Never the key."""
+    return await byok_service.get_status(workspace_id)
+
+
+@router.put("/key", response_model=ByokStatus)
+async def set_byok_key(
+    body: ByokSetRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> ByokStatus:
+    """Validate the key against the provider, then store it encrypted.
+
+    PUT rather than POST because setting a key twice is the same as setting it
+    once — there is at most one per workspace, and replacing is the normal case.
+    A key that the provider rejects is never written.
+    """
+    return await byok_service.set_key(
+        workspace_id,
+        body.api_key,
+        provider=body.provider,
+        user_id=user_id,
+    )
+
+
+@router.delete("/key", response_model=ByokStatus)
+async def delete_byok_key(
+    workspace_id: str = Depends(current_workspace_id),
+) -> ByokStatus:
+    """Remove the key. Idempotent — removing an absent key succeeds."""
+    return await byok_service.delete_key(workspace_id)

--- a/ee/pocketpaw_ee/cloud/byok/service.py
+++ b/ee/pocketpaw_ee/cloud/byok/service.py
@@ -1,0 +1,254 @@
+# ee/pocketpaw_ee/cloud/byok/service.py — the only reader of ByokProviderKey.
+#
+# Created 2026-08-28 (feat/other-hand-byok).
+#
+# Two audiences, deliberately separated:
+#
+#   * The ROUTER calls ``get_status`` / ``set_key`` / ``delete_key``. None of
+#     these ever produce plaintext — ``get_status`` answers from display-only
+#     columns without decrypting at all.
+#   * The TURN PATH calls ``resolve_turn_credentials``. That is the one function
+#     that decrypts, it returns a value nothing serializes, and it is the seam
+#     the paid tiers plug into later (see ``TurnCredentials`` below).
+#
+# WHY validate on save: a typo'd key that is stored happily fails at the user's
+# first turn, in a place that looks like the product being broken rather than
+# the credential being wrong. One cheap round trip at entry moves that error to
+# where the user can act on it.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+import httpx
+
+from pocketpaw_ee.cloud._core import crypto
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.byok.dto import ByokStatus
+from pocketpaw_ee.cloud.models.byok_key import ByokProviderKey
+
+logger = logging.getLogger(__name__)
+
+_VALIDATE_URL = "https://api.anthropic.com/v1/messages"
+_VALIDATE_TIMEOUT_S = 15.0
+# The cheapest possible real call: one token out of the smallest model. A 200 or
+# a 400 both prove the credential is good (400 == we were understood, then
+# refused on content); only 401/403 prove it is not.
+_VALIDATE_MODEL = "claude-haiku-4-5-20251001"
+
+
+@dataclass(frozen=True)
+class TurnCredentials:
+    """How ONE turn is paid for.
+
+    The seam the captain's "same pipeline for people who want to purchase
+    tokens" lands on. Today it resolves to exactly two shapes:
+
+      * ``source="platform"`` — our own subscription/session credentials, i.e.
+        the deployment's existing behaviour. ``api_key`` is None; the runtime
+        keeps doing whatever it already did.
+      * ``source="byok"`` — the workspace's own key. ``api_key`` is set, and the
+        runtime MUST spawn with it and MUST NOT also pass platform credentials.
+
+    A future ``source="plan_tokens"`` (Dodo-purchased balance) slots in here
+    without re-plumbing the runtime: it is another way to answer the same
+    question, "whose credential does this turn use?"
+    """
+
+    source: Literal["platform", "byok"]
+    api_key: str | None = None
+    provider: str = "anthropic"
+
+
+async def get_status(workspace_id: str) -> ByokStatus:
+    """What the UI may know. Never decrypts."""
+    doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
+    if doc is None:
+        return ByokStatus(configured=False)
+    return ByokStatus(
+        configured=True,
+        provider=doc.provider,
+        last4=doc.last4,
+        key_hint=doc.key_hint,
+        last_verified_at=doc.last_verified_at,
+        last_error=doc.last_error,
+    )
+
+
+async def validate_key(api_key: str) -> None:
+    """Prove the key works, or raise ValidationError naming why.
+
+    Network trouble is NOT a bad key: a timeout raises the transport error so
+    the caller can decide, rather than telling the user their good key is bad.
+    """
+    payload = {
+        "model": _VALIDATE_MODEL,
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    }
+    async with httpx.AsyncClient(timeout=_VALIDATE_TIMEOUT_S) as client:
+        resp = await client.post(_VALIDATE_URL, json=payload, headers=headers)
+
+    if resp.status_code in (401, 403):
+        raise ValidationError(
+            "byok.key_rejected",
+            "Anthropic rejected that key. Check you copied the whole key from "
+            "console.anthropic.com, and that it has not been revoked.",
+        )
+    if resp.status_code == 429:
+        raise ValidationError(
+            "byok.key_rate_limited",
+            "That key is rate-limited right now, so we could not verify it. Try again in a minute.",
+        )
+    if resp.status_code >= 500:
+        raise ValidationError(
+            "byok.provider_unavailable",
+            "Anthropic did not respond. Your key was not saved — try again shortly.",
+        )
+    # Anything else (200, or a 400 about the tiny payload) means the credential
+    # was accepted and the request was understood. That is what we are testing.
+
+
+async def set_key(
+    workspace_id: str,
+    api_key: str,
+    *,
+    provider: str = "anthropic",
+    user_id: str | None = None,
+) -> ByokStatus:
+    """Validate, then encrypt-and-upsert. Never stores an unverified key."""
+    if not crypto.is_configured():
+        raise ValidationError(
+            "byok.encryption_unavailable",
+            "This deployment cannot store provider keys — CLOUD_ENCRYPTION_KEY "
+            "is not set. Contact the operator.",
+        )
+
+    await validate_key(api_key)
+
+    doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
+    if doc is None:
+        doc = ByokProviderKey(
+            workspace=workspace_id,
+            provider=provider,
+            encrypted_key=crypto.encrypt(api_key),
+            last4=api_key[-4:],
+            key_hint=_hint(api_key),
+        )
+    else:
+        doc.provider = provider
+        doc.encrypted_key = crypto.encrypt(api_key)
+        doc.last4 = api_key[-4:]
+        doc.key_hint = _hint(api_key)
+    doc.set_by_user = user_id
+    doc.last_verified_at = datetime.now(UTC)
+    doc.last_error = None
+    await doc.save()
+
+    logger.info("byok: key set for workspace=%s provider=%s", workspace_id, provider)
+    return await get_status(workspace_id)
+
+
+async def delete_key(workspace_id: str) -> ByokStatus:
+    """Remove the workspace's key. Idempotent — deleting nothing is success."""
+    doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
+    if doc is not None:
+        await doc.delete()
+        logger.info("byok: key removed for workspace=%s", workspace_id)
+    return ByokStatus(configured=False)
+
+
+async def record_auth_failure(workspace_id: str, message: str) -> None:
+    """Mark a stored key as having failed, so the UI stops showing it as good.
+
+    Called from the turn path when a BYOK spawn comes back with an auth error.
+    Best-effort: never let bookkeeping fail a turn that already failed.
+    """
+    try:
+        doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
+        if doc is not None:
+            doc.last_error = message[:300]
+            await doc.save()
+    except Exception:  # noqa: BLE001 — diagnostics must not mask the real error
+        logger.warning("byok: could not record auth failure", exc_info=True)
+
+
+async def resolve_turn_credentials(workspace_id: str | None) -> TurnCredentials:
+    """Decide whose credential pays for this turn. THE ONLY DECRYPT SITE.
+
+    Returns ``platform`` whenever there is no usable BYOK key, so every caller
+    can treat this as "ask, then spawn" without branching on absence. An
+    undecryptable row (the deployment's Fernet key rotated) also degrades to
+    platform rather than failing the turn — the user re-enters their key from a
+    working product, not from a broken one.
+    """
+    if not workspace_id:
+        return TurnCredentials(source="platform")
+
+    doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
+    if doc is None or not doc.encrypted_key:
+        return TurnCredentials(source="platform")
+
+    try:
+        plaintext = crypto.decrypt(doc.encrypted_key)
+    except ValidationError:
+        logger.warning(
+            "byok: stored key for workspace=%s is undecryptable; using platform "
+            "credentials for this turn",
+            workspace_id,
+        )
+        return TurnCredentials(source="platform")
+
+    if not plaintext:
+        return TurnCredentials(source="platform")
+    return TurnCredentials(source="byok", api_key=plaintext, provider=doc.provider)
+
+
+def _hint(api_key: str) -> str:
+    """The non-secret prefix, e.g. 'sk-ant-api03'. Empty when the shape is odd."""
+    parts = api_key.split("-")
+    return "-".join(parts[:3]) if len(parts) >= 3 else ""
+
+
+def build_settings_override(creds: TurnCredentials) -> dict[str, object]:
+    """Turn resolved credentials into a ``create_isolated_backend`` override.
+
+    The hosted cloud routes every turn through the LiteLLM proxy, and LiteLLM
+    has its own BYOK path: with ``forward_llm_provider_auth_headers: true`` in
+    the proxy's ``general_settings``, an ``x-api-key`` header on the request is
+    forwarded upstream, so the user's own provider account is billed while the
+    turn still passes through our routing, logging and guardrails.
+
+    That is why this returns ``byok_provider_api_key`` rather than
+    ``anthropic_api_key``: the key is a HEADER we hand the proxy, not a
+    credential we use to call Anthropic ourselves. One pipeline, two payers —
+    and the same pipeline a purchased-token balance would ride later.
+
+    Operator note: the proxy config change is a DEPLOY step, not a code one.
+    Without it LiteLLM strips ``x-api-key`` and every BYOK turn silently bills
+    the platform. LiteLLM's own docs warn against forwarding client headers on a
+    public API; that caveat is about untrusted callers reaching the proxy
+    directly. Here the browser never sees the proxy — our server holds the key
+    and sets the header — so the trust boundary is server-to-server.
+
+    MUST be paired with ``AgentRouter.create_isolated_backend``, never with the
+    pooled backend. ``AgentPool`` drives every session and surface through ONE
+    cached instance; handing it a tenant's key would let the next tenant's turn
+    run on that credential. (The pydantic_ai agent cache also keys on a
+    credential fingerprint as a second line of defence, but the isolation is the
+    real guarantee — do not rely on the cache key alone.)
+
+    Returns an EMPTY dict for platform credentials, so the caller can pass it
+    unconditionally and get today's behaviour when no key is configured.
+    """
+    if creds.source != "byok" or not creds.api_key:
+        return {}
+    return {"byok_provider_api_key": creds.api_key}

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -177,6 +177,7 @@ from pocketpaw_ee.cloud.models.audit_webhook import AuditWebhook
 from pocketpaw_ee.cloud.models.auth_session import AuthSession
 from pocketpaw_ee.cloud.models.belt_workspace_config import BeltWorkspaceConfig
 from pocketpaw_ee.cloud.models.builtin_widget import BuiltInWidget, BuiltInWidgetPosition
+from pocketpaw_ee.cloud.models.byok_key import ByokProviderKey
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 from pocketpaw_ee.cloud.models.code_connection import CodeConnection
 from pocketpaw_ee.cloud.models.code_project import CodeProject
@@ -360,6 +361,7 @@ def _ensure_terrarium_docs():
 
 
 __all__ = [
+    "ByokProviderKey",
     "APIKey",
     "Agent",
     "AgentConfig",
@@ -465,6 +467,7 @@ def get_all_documents():
     artifact_version_doc = _ensure_version_docs()
     universe_doc, citizen_doc, world_event_doc, world_artifact_doc = _ensure_terrarium_docs()
     return [
+        ByokProviderKey,
         User,
         Agent,
         Pocket,

--- a/ee/pocketpaw_ee/cloud/models/byok_key.py
+++ b/ee/pocketpaw_ee/cloud/models/byok_key.py
@@ -1,0 +1,76 @@
+# ee/pocketpaw_ee/cloud/models/byok_key.py — the per-workspace BYOK provider
+# credential ("bring your own key").
+#
+# One Beanie document backs the workspace -> provider-key mapping:
+#
+#   * ``ByokProviderKey`` — at most one row per workspace (the ``workspace``
+#     index is UNIQUE). Holds the user's OWN Anthropic API key, so their turns
+#     bill to their Anthropic account instead of ours. Set/replace/delete is
+#     idempotent: the service upserts on ``workspace``.
+#
+# ENCRYPTED AT REST, unlike the sibling ``LiteLLMTenantKey``. That doc stores
+# its key as-is and says why: a LiteLLM virtual key is proxy-scoped, so its
+# blast radius is the budget + allowed-models the proxy enforces. THIS key is a
+# raw provider credential with none of that containment — a leak is the user's
+# whole Anthropic account. It goes through ``cloud._core.crypto`` (deployment
+# Fernet envelope), and the plaintext never leaves the service that decrypts it.
+#
+# ``last4`` and ``key_hint`` exist so the UI can show WHICH key is configured
+# without the service ever decrypting to answer a status call. Status reads must
+# never touch ``encrypted_key``.
+#
+# WHY a separate doc (not a field on Workspace / WorkspaceSettings): RFC 03 keeps
+# domain-specific config in domain-owned docs, and this one has the strictest
+# read rule in the codebase — exactly one service decrypts it, on the turn path.
+# Folding it into a broadly-read doc would put a live provider credential inside
+# every workspace fetch.
+#
+# Created 2026-08-28 (feat/other-hand-byok): new entity. Registered in
+# ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``byok_provider_keys`` collection.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class ByokProviderKey(TimestampedDocument):
+    """One workspace's own provider API key, encrypted at rest.
+
+    At most one row per workspace (the ``workspace`` index is UNIQUE). Setting a
+    key upserts; there is no history, because a replaced credential is one the
+    user wants gone.
+
+    ``encrypted_key`` is a ``cloud._core.crypto`` Fernet token, NEVER plaintext
+    and NEVER serialized into an API response. The only legitimate reader is
+    ``cloud.byok.service.resolve_plaintext_key`` on the turn path.
+    """
+
+    # UNIQUE — one BYOK credential per workspace. The set/delete upsert keys on it.
+    workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
+    # Which provider the key belongs to. Only "anthropic" is accepted today; the
+    # column exists so adding a second provider is a value, not a migration.
+    provider: str = "anthropic"
+    # Fernet token from cloud._core.crypto.encrypt(). Never returned by the API.
+    encrypted_key: str
+    # Display-only provenance so status calls never decrypt:
+    #   * ``last4``     — the final 4 characters, to tell two keys apart.
+    #   * ``key_hint``  — the provider's key prefix (e.g. "sk-ant-api03"), which
+    #     is not secret and makes a pasted-the-wrong-thing mistake obvious.
+    last4: str
+    key_hint: str | None = None
+    # Who last set it, and when it was last known good. ``last_verified_at`` is
+    # stamped by the validation call the service makes on save — a key that has
+    # never verified is one we should not silently route a turn through.
+    set_by_user: str | None = None
+    last_verified_at: datetime | None = None
+    # Set when a turn fails with an auth error, so the UI can say "your key
+    # stopped working" instead of showing a green state over a dead credential.
+    last_error: str | None = None
+
+    class Settings:
+        name = "byok_provider_keys"

--- a/ee/pocketpaw_ee/terrarium/domain.py
+++ b/ee/pocketpaw_ee/terrarium/domain.py
@@ -1,4 +1,5 @@
 # ee/pocketpaw_ee/terrarium/domain.py
+# Updated: 2026-09-07 — UniverseDoc gains last_tick_at / last_viewed_at (the clock).
 #
 # Terrarium persistence + frozen read-path value objects.
 #
@@ -92,6 +93,11 @@ class UniverseDoc(TimestampedDocument):
     seq: int = 0
     weather_pledges: dict[str, dict[str, Any]] = Field(default_factory=dict)
     storm_ticks: int = 0
+    # The clock (scheduler.py). ``last_tick_at`` is when the sweeper (or a manual
+    # /tick) last advanced the world; ``last_viewed_at`` is when a viewer last
+    # read the Journal — a world nobody watches for a world-day goes dormant.
+    last_tick_at: datetime | None = None
+    last_viewed_at: datetime | None = None
 
     class Settings:
         name = "terrarium_universes"

--- a/ee/pocketpaw_ee/terrarium/llm.py
+++ b/ee/pocketpaw_ee/terrarium/llm.py
@@ -13,6 +13,9 @@
 #   * ``claude`` — shells ``claude -p <prompt> --output-format json``, reading
 #     the ``result`` field. The prompt is ONE argv element, never interpolated
 #     into a shell string. Same transport shape as ``mandates.foreman``.
+#   * ``HttpLlm`` — NOT env-selected: used whenever the universe brought its own
+#     Anthropic key (service.tick decrypts it and passes it in). Messages API
+#     over httpx; the model comes from the physics ``models.founders`` tier.
 #
 # Mock is the default (foreman defaults to ``claude``) because a terrarium tick
 # fans out one call PER CITIZEN: an accidental real-model tick on a 50-citizen
@@ -31,6 +34,8 @@ import logging
 import os
 import re
 from typing import Any, Protocol
+
+import httpx
 
 from pocketpaw_ee.terrarium.physics import PhysicsFile
 from pocketpaw_ee.terrarium.world import (
@@ -100,6 +105,70 @@ class ClaudeCliLlm:
         if isinstance(envelope, dict) and isinstance(envelope.get("result"), str):
             return envelope["result"]
         return out
+
+
+_API_URL = "https://api.anthropic.com/v1/messages"
+_DEFAULT_MODEL = "claude-sonnet-4-6"
+# Physics tier -> model id. Unknown tiers fall back to the default.
+_MODEL_BY_TIER = {
+    "premium": "claude-sonnet-4-6",
+    "mid": "claude-sonnet-4-6",
+    "tail": "claude-haiku-4-5",
+}
+
+
+def model_for_tier(tier: str | None) -> str:
+    return _MODEL_BY_TIER.get((tier or "").strip().lower(), _DEFAULT_MODEL)
+
+
+class HttpLlm:
+    """BYOK transport — the Anthropic Messages API with the universe's own key.
+
+    ``client`` is injectable so tests stub the transport; the key is held only on
+    this instance and never logged."""
+
+    def __init__(
+        self, api_key: str, model: str = _DEFAULT_MODEL, *, client: httpx.AsyncClient | None = None
+    ) -> None:
+        self._key = api_key
+        self.model = model
+        self._client = client
+
+    async def decide(
+        self,
+        *,
+        prompt: str,
+        physics: PhysicsFile,
+        citizen: CitizenSnapshot,
+        digest: SenseDigest,
+    ) -> str:
+        headers = {
+            "x-api-key": self._key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+        body = {
+            "model": self.model,
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        client = self._client or httpx.AsyncClient(timeout=_CLI_TIMEOUT)
+        try:
+            res = await client.post(_API_URL, headers=headers, json=body)
+        finally:
+            if client is not self._client:
+                await client.aclose()
+        if res.status_code != 200:
+            # The response body may echo request details; keep the status only.
+            raise RuntimeError(f"anthropic API failed (HTTP {res.status_code})")
+        envelope = res.json()
+        blocks = envelope.get("content") if isinstance(envelope, dict) else None
+        text = "".join(
+            b.get("text", "")
+            for b in (blocks or [])
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+        return text or json.dumps(envelope)
 
 
 # Test hook — when set, MockLlm returns this verbatim (a dict is JSON-dumped).
@@ -173,8 +242,11 @@ class MockLlm:
         return json.dumps({"thought": "another day by the spring", "acts": acts})
 
 
-def resolve_llm() -> CitizenLlm:
-    """Pick the transport from ``POCKETPAW_TERRARIUM_LLM``. DEFAULT ``mock``."""
+def resolve_llm(*, api_key: str | None = None, tier: str | None = None) -> CitizenLlm:
+    """A universe with its own key gets ``HttpLlm``; otherwise the transport
+    from ``POCKETPAW_TERRARIUM_LLM``. DEFAULT ``mock``."""
+    if api_key:
+        return HttpLlm(api_key, model_for_tier(tier))
     choice = (os.environ.get("POCKETPAW_TERRARIUM_LLM") or "mock").strip().lower()
     if choice == "claude":
         return ClaudeCliLlm()

--- a/ee/pocketpaw_ee/terrarium/scheduler.py
+++ b/ee/pocketpaw_ee/terrarium/scheduler.py
@@ -1,0 +1,163 @@
+# ee/pocketpaw_ee/terrarium/scheduler.py
+# Created: 2026-09-07 (feat/terrarium-launch-runtime) — the terrarium CLOCK.
+#
+# A single process-local sweeper (the ``mandates/scheduler.py`` shape): every
+# interval it asks the service which live universes are due a tick from their
+# OWN physics and fires ``service.tick(..., n=1)`` for each. A world day is
+# ``time.world_day_seconds`` long and gets ``time.ticks_per_day`` ticks; when
+# nobody has read the Journal for a world day the universe is DORMANT and gets
+# ``time.dormant_ticks_per_day`` instead — slower, not dead.
+#
+# Gated by POCKETPAW_CLOUD_SCHEDULER_ENABLED (pytest never spawns a loop);
+# interval from POCKETPAW_TERRARIUM_SCHEDULER_INTERVAL (seconds, default 60).
+# ``due_state`` is pure so the arithmetic is testable with a frozen clock; the
+# doc reads stay in service.py (the sole importer of the Beanie docs).
+
+"""The terrarium clock: one sweep per interval, one tick per due universe."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_GATE_ENV = "POCKETPAW_CLOUD_SCHEDULER_ENABLED"
+_INTERVAL_ENV = "POCKETPAW_TERRARIUM_SCHEDULER_INTERVAL"
+_DEFAULT_INTERVAL_SECONDS = 60
+_TASK: asyncio.Task | None = None
+
+TriggerFn = Callable[[str, str, str, int], Awaitable[dict[str, Any]]]
+NowFn = Callable[[], datetime]
+
+
+def _aware(dt: datetime | None) -> datetime | None:
+    # mongomock hands back naive datetimes; treat them as UTC.
+    return dt.replace(tzinfo=UTC) if dt is not None and dt.tzinfo is None else dt
+
+
+def due_state(
+    time: dict[str, Any],
+    *,
+    now: datetime,
+    last_tick_at: datetime | None,
+    last_viewed_at: datetime | None,
+) -> tuple[bool, str]:
+    """(tick_is_due, status) from the physics ``time`` block and the two stamps.
+
+    Dormant when the last view is older than one world day (never viewed counts
+    as dormant). Due when the last tick is older than one tick-interval at the
+    current cadence (never ticked counts as due)."""
+    day = max(1, int(time.get("world_day_seconds", 3600)))
+    tpd = max(1, int(time.get("ticks_per_day", 12)))
+    dpd = max(1, int(time.get("dormant_ticks_per_day", 1)))
+    now = _aware(now) or now
+    viewed, ticked = _aware(last_viewed_at), _aware(last_tick_at)
+    dormant = viewed is None or (now - viewed).total_seconds() > day
+    per_tick = day / (dpd if dormant else tpd)
+    due = ticked is None or (now - ticked).total_seconds() >= per_tick
+    return due, ("dormant" if dormant else "running")
+
+
+async def run_scheduler_tick(
+    *, now: NowFn | None = None, trigger: TriggerFn | None = None
+) -> list[str]:
+    """ONE sweep: tick every due universe once. Returns the ids that ticked.
+    Never raises — a failing universe is logged and the sweep moves on."""
+    from pocketpaw_ee.terrarium import service
+
+    clock: NowFn = now or (lambda: datetime.now(UTC))
+    fire: TriggerFn = trigger or service.tick
+    try:
+        due = await service.scheduler_sweep(clock())
+    except Exception:  # noqa: BLE001
+        logger.warning("terrarium clock: due-list read failed — skipping", exc_info=True)
+        return []
+    ticked: list[str] = []
+    for row in due:
+        try:
+            await fire(row["workspace_id"], row["user_id"], row["universe_id"], 1)
+            ticked.append(row["universe_id"])
+        except Exception:  # noqa: BLE001 — one universe never blocks the next
+            logger.warning("terrarium clock: tick failed for %s", row["universe_id"], exc_info=True)
+    return ticked
+
+
+def _interval_seconds() -> int:
+    raw = os.environ.get(_INTERVAL_ENV, "").strip()
+    try:
+        value = int(raw) if raw else _DEFAULT_INTERVAL_SECONDS
+    except ValueError:
+        return _DEFAULT_INTERVAL_SECONDS
+    return value if value > 0 else _DEFAULT_INTERVAL_SECONDS
+
+
+async def _scheduler_loop(interval: int) -> None:
+    logger.info("terrarium clock: loop started (interval=%ds)", interval)
+    while True:
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            raise
+        try:
+            await run_scheduler_tick()
+        except Exception:  # noqa: BLE001
+            logger.warning("terrarium clock: sweep failed", exc_info=True)
+
+
+async def start_scheduler(*, interval_seconds: int | None = None) -> None:
+    global _TASK
+    await stop_scheduler()
+    interval = interval_seconds if interval_seconds is not None else _interval_seconds()
+    _TASK = asyncio.create_task(_scheduler_loop(interval), name="terrarium-clock")
+
+
+async def stop_scheduler() -> None:
+    global _TASK
+    task, _TASK = _TASK, None
+    if task is None or task.done():
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+
+
+def is_running() -> bool:
+    return _TASK is not None and not _TASK.done()
+
+
+def gate_enabled() -> bool:
+    return os.environ.get(_GATE_ENV, "").lower() == "true"
+
+
+async def reconcile_scheduler(*, interval_seconds: int | None = None) -> int:
+    """Lifespan startup: start the loop iff the gate env is true and no loop is
+    live. Returns 1 when it started one, else 0. Never raises."""
+    if not gate_enabled() or is_running():
+        return 0
+    try:
+        await start_scheduler(interval_seconds=interval_seconds)
+    except Exception:  # noqa: BLE001
+        logger.warning("terrarium clock: failed to start", exc_info=True)
+        return 0
+    return 1
+
+
+async def shutdown_scheduler() -> None:
+    await stop_scheduler()
+
+
+__all__ = [
+    "due_state",
+    "is_running",
+    "reconcile_scheduler",
+    "run_scheduler_tick",
+    "shutdown_scheduler",
+    "start_scheduler",
+    "stop_scheduler",
+]

--- a/ee/pocketpaw_ee/terrarium/service.py
+++ b/ee/pocketpaw_ee/terrarium/service.py
@@ -1,4 +1,6 @@
 # ee/pocketpaw_ee/terrarium/service.py
+# Updated: 2026-09-07 — the clock: ticks stamp last_tick_at, event reads stamp
+#   last_viewed_at, and ``scheduler_sweep`` feeds scheduler.py its due list.
 #
 # The terrarium glue: Beanie persistence, the Soul bridge, the Instinct gate and
 # the realtime bus. The ONLY module that imports the ``domain`` Beanie doc
@@ -35,6 +37,7 @@ from pocketpaw_ee.cloud._core.errors import BadRequest, NotFound, ValidationErro
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.terrarium import events as world_events
 from pocketpaw_ee.terrarium import llm as citizen_llm
+from pocketpaw_ee.terrarium import scheduler as clock
 from pocketpaw_ee.terrarium import soul_link, weather, world
 from pocketpaw_ee.terrarium.domain import (
     ZERO_COST_KINDS,
@@ -510,6 +513,8 @@ async def tick(workspace_id: str, user_id: str, universe_id: str, n: int = 1) ->
         physics = physics_of(uni)
         for _ in range(n):
             produced.extend(await _one_tick(uni, physics, llm, user_id))
+        uni.last_tick_at = datetime.now(UTC)
+        await uni.save()
     return {"events": produced, "universe": universe_wire(uni, pop=await _pop(universe_id))}
 
 
@@ -765,8 +770,46 @@ async def get_universe(workspace_id: str, universe_id: str) -> dict[str, Any]:
 async def list_events(
     workspace_id: str, universe_id: str, since: int = 0, limit: int = 200
 ) -> dict[str, Any]:
-    await _universe(workspace_id, universe_id)
+    await _touch_viewed(await _universe(workspace_id, universe_id))
     return await _events_page(universe_id, since, limit)
+
+
+async def _touch_viewed(uni: UniverseDoc) -> None:
+    """Somebody is watching — the clock (scheduler.py) reads this to decide
+    between the running and the dormant cadence."""
+    uni.last_viewed_at = datetime.now(UTC)
+    await uni.save()
+
+
+async def scheduler_sweep(now: datetime) -> list[dict[str, Any]]:
+    """The clock's per-interval read: flip running/dormant on every live
+    universe from its own physics, and return the rows whose next tick is due.
+    Called by ``scheduler.run_scheduler_tick``; one universe failing is logged
+    and skipped so the sweep always sees the rest."""
+    due_rows: list[dict[str, Any]] = []
+    docs = await UniverseDoc.find({"status": {"$in": ["running", "dormant"]}}).to_list()
+    for uni in docs:
+        try:
+            due, status = clock.due_state(
+                (uni.physics or {}).get("time") or {},
+                now=now,
+                last_tick_at=uni.last_tick_at,
+                last_viewed_at=uni.last_viewed_at or uni.createdAt,
+            )
+            if status != uni.status:
+                uni.status = status
+                await uni.save()
+            if due:
+                due_rows.append(
+                    {
+                        "workspace_id": uni.workspace,
+                        "universe_id": str(uni.id),
+                        "user_id": uni.creator or "system:scheduler",
+                    }
+                )
+        except Exception:  # noqa: BLE001 — one bad universe never sinks the sweep
+            logger.warning("terrarium clock: sweep failed for universe %s", uni.id, exc_info=True)
+    return due_rows
 
 
 async def _events_page(universe_id: str, since: int, limit: int) -> dict[str, Any]:
@@ -961,7 +1004,7 @@ async def public_get_universe(universe_id: str) -> dict[str, Any]:
 
 
 async def public_list_events(universe_id: str, since: int = 0, limit: int = 200) -> dict[str, Any]:
-    await _public_universe(universe_id)
+    await _touch_viewed(await _public_universe(universe_id))
     return await _events_page(universe_id, since, limit)
 
 

--- a/ee/pocketpaw_ee/terrarium/service.py
+++ b/ee/pocketpaw_ee/terrarium/service.py
@@ -35,6 +35,7 @@ from uuid import uuid4
 
 from pocketpaw_ee.cloud._core.errors import BadRequest, NotFound, ValidationError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud.byok import service as byok_service
 from pocketpaw_ee.terrarium import events as world_events
 from pocketpaw_ee.terrarium import llm as citizen_llm
 from pocketpaw_ee.terrarium import scheduler as clock
@@ -509,8 +510,12 @@ async def tick(workspace_id: str, user_id: str, universe_id: str, n: int = 1) ->
         uni = await _universe(workspace_id, universe_id)
         if uni.status == "archived":
             raise BadRequest("terrarium.archived", "an archived universe does not tick")
-        llm = citizen_llm.resolve_llm()
         physics = physics_of(uni)
+        # Bring-your-own-key: the workspace's key, via the ONE decrypting reader
+        # in cloud.byok (the same store the rest of the product uses). No second
+        # copy of a key lives on the universe. Platform credentials otherwise.
+        creds = await byok_service.resolve_turn_credentials(uni.workspace)
+        llm = citizen_llm.resolve_llm(api_key=creds.api_key, tier=physics.models.founders)
         for _ in range(n):
             produced.extend(await _one_tick(uni, physics, llm, user_id))
         uni.last_tick_at = datetime.now(UTC)

--- a/ee/pocketpaw_ee/terrarium/service.py
+++ b/ee/pocketpaw_ee/terrarium/service.py
@@ -1,6 +1,4 @@
 # ee/pocketpaw_ee/terrarium/service.py
-# Updated: 2026-09-07 — the clock: ticks stamp last_tick_at, event reads stamp
-#   last_viewed_at, and ``scheduler_sweep`` feeds scheduler.py its due list.
 #
 # The terrarium glue: Beanie persistence, the Soul bridge, the Instinct gate and
 # the realtime bus. The ONLY module that imports the ``domain`` Beanie doc
@@ -600,6 +598,42 @@ async def _one_tick(
     return written
 
 
+# Artifact kinds that carry a readable payload. Structures and tools are things
+# on the map, not documents.
+_FILE_BEARING_KINDS = frozenset({"book", "law", "map"})
+
+
+async def _land_artifact_file(uni: UniverseDoc, user_id: str, art: Any) -> str | None:
+    """Write a payload-bearing artifact into the /files surface; return its id.
+
+    Returns None for structures, for empty bodies, and on ANY failure — the
+    Journal is the truth and the file is how a human reads it, so a storage
+    hiccup degrades to "inline only", never to a failed tick. The upload
+    service is imported lazily so the terrarium package stays import-light.
+    """
+    if art.kind not in _FILE_BEARING_KINDS or not (art.body or "").strip():
+        return None
+    try:
+        from pocketpaw_ee.cloud.uploads.service import write_text_file
+
+        safe = (
+            "".join(ch if ch.isalnum() or ch in "-_ " else "-" for ch in art.name).strip()
+            or "artifact"
+        )
+        rec = await write_text_file(
+            workspace_id=uni.workspace,
+            owner_id=user_id,
+            folder_path=f"/terrarium/{uni.name}",
+            filename=f"{safe}.md",
+            content=f"# {art.name}\n\n_{art.kind}, by {art.author}, day {uni.day}_\n\n{art.body}",
+            mime="text/markdown",
+        )
+        return str(rec.id)
+    except Exception:  # noqa: BLE001 — best-effort, the doc keeps the body inline
+        logger.warning("terrarium: could not land artifact %r in /files", art.name, exc_info=True)
+        return None
+
+
 async def _persist_outcome(
     uni: UniverseDoc,
     physics: PhysicsFile,
@@ -613,6 +647,11 @@ async def _persist_outcome(
 
     artifact_ids: list[str] = []
     for art in outcome.artifacts:
+        # A book, a law or a map is a FILE in the workspace's /files surface, so
+        # a viewer opens it in the same inline viewer as any other file. The
+        # body stays on the doc too (the contract keeps it); the file is how
+        # humans read it. Best-effort: a files failure must never wedge a tick.
+        file_id = await _land_artifact_file(uni, user_id, art)
         a = ArtifactDoc(
             workspace=uni.workspace,
             universe_id=universe_id,
@@ -621,15 +660,13 @@ async def _persist_outcome(
             author=art.author,
             day=uni.day,
             cost=art.cost,
-            mime=art.mime,
+            mime=art.mime if file_id is None else "text/markdown",
             x=art.x,
             y=art.y,
             unlocks=art.unlocks,
             stage="done",
             body=art.body,
-            # ponytail: payload stays inline. The contract wants it in the
-            # /files surface (``file_id``); wire that when a previewer needs it.
-            file_id=None,
+            file_id=file_id,
         )
         await a.insert()
         artifact_ids.append(str(a.id))

--- a/tests/cloud/byok/test_byok_service.py
+++ b/tests/cloud/byok/test_byok_service.py
@@ -1,0 +1,207 @@
+# tests/cloud/byok/test_byok_service.py — the BYOK credential path.
+#
+# Created 2026-08-28 (feat/other-hand-byok).
+#
+# Three things are worth testing here and they are all about CONTAINMENT, not
+# about CRUD working:
+#
+#   1. The key never leaves through the API surface. Status is built from
+#      display columns and must not carry the credential in any field.
+#   2. A stored key round-trips through the Fernet envelope, and a rotated
+#      deployment key degrades to platform credentials instead of failing turns.
+#   3. Two tenants with two keys cannot share a cached agent — the bleed case.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core import crypto
+from pocketpaw_ee.cloud.byok import service as byok
+from pocketpaw_ee.cloud.byok.dto import ByokSetRequest, ByokStatus
+
+_REAL_KEY = "sk-ant-api03-" + "z" * 40
+
+
+@pytest.fixture(autouse=True)
+def _encryption_key(monkeypatch):
+    from cryptography.fernet import Fernet
+
+    monkeypatch.setenv("CLOUD_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+
+class TestRequestValidation:
+    """Reject at the edge what the provider would reject after a round trip."""
+
+    def test_accepts_a_well_formed_anthropic_key(self):
+        assert ByokSetRequest(api_key=_REAL_KEY).api_key == _REAL_KEY
+
+    def test_rejects_a_key_from_the_wrong_provider(self):
+        with pytest.raises(ValueError, match="sk-ant-"):
+            ByokSetRequest(api_key="sk-proj-" + "a" * 40)
+
+    def test_trims_the_trailing_newline_a_paste_leaves_behind(self):
+        # Surrounding whitespace is the most common paste artefact and is not
+        # the user making a mistake — strip it and accept the key.
+        assert ByokSetRequest(api_key=f"  {_REAL_KEY}\n").api_key == _REAL_KEY
+
+    def test_rejects_a_key_with_whitespace_INSIDE_it(self):
+        # This one is not a paste artefact — it is a truncated copy, a wrapped
+        # line, or a whole shell command. It would also be an illegal header
+        # value, so it can never work.
+        with pytest.raises(ValueError, match="whitespace"):
+            ByokSetRequest(api_key="sk-ant-api03-" + "z" * 20 + " " + "z" * 20)
+
+    def test_rejects_an_unknown_provider(self):
+        with pytest.raises(ValueError, match="anthropic"):
+            ByokSetRequest(provider="openai", api_key=_REAL_KEY)
+
+
+class TestStatusNeverCarriesTheKey:
+    def test_no_status_field_can_hold_a_credential(self):
+        # Structural, not a spot-check: if someone adds a field that could carry
+        # the key, this fails until they think about it.
+        allowed = {
+            "configured",
+            "provider",
+            "last4",
+            "key_hint",
+            "last_verified_at",
+            "last_error",
+        }
+        assert set(ByokStatus.model_fields) == allowed
+
+    def test_a_serialized_status_does_not_contain_the_key(self):
+        status = ByokStatus(
+            configured=True,
+            provider="anthropic",
+            last4=_REAL_KEY[-4:],
+            key_hint="sk-ant-api03",
+        )
+        assert _REAL_KEY not in status.model_dump_json()
+
+
+class TestEncryptionEnvelope:
+    def test_a_key_round_trips_through_the_envelope(self):
+        assert crypto.decrypt(crypto.encrypt(_REAL_KEY)) == _REAL_KEY
+
+    def test_the_stored_form_is_not_the_plaintext(self):
+        token = crypto.encrypt(_REAL_KEY)
+        assert _REAL_KEY not in token
+
+    @pytest.mark.asyncio
+    async def test_a_rotated_deployment_key_degrades_to_platform(self, monkeypatch):
+        # The failure mode this prevents: the operator rotates
+        # CLOUD_ENCRYPTION_KEY, every stored BYOK row becomes undecryptable, and
+        # every affected user's turns start FAILING. Degrading to platform
+        # credentials means they re-enter the key from a working product.
+        from cryptography.fernet import Fernet
+
+        token = crypto.encrypt(_REAL_KEY)
+        monkeypatch.setenv("CLOUD_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+        class _Row:
+            encrypted_key = token
+            provider = "anthropic"
+
+        # Stand in for the Beanie document entirely: the real class only grows
+        # its queryable ``workspace`` attribute once ``init_beanie`` has run, and
+        # this test is about the decrypt-failure branch, not about Mongo.
+        class _StubDoc:
+            workspace = "workspace"
+
+            @staticmethod
+            async def find_one(*_a, **_k):
+                return _Row()
+
+        monkeypatch.setattr(byok, "ByokProviderKey", _StubDoc)
+        creds = await byok.resolve_turn_credentials("ws-1")
+        assert creds.source == "platform"
+        assert creds.api_key is None
+
+
+class TestSettingsOverride:
+    def test_platform_credentials_change_nothing(self):
+        creds = byok.TurnCredentials(source="platform")
+        assert byok.build_settings_override(creds) == {}
+
+    def test_byok_credentials_carry_the_key_to_the_backend(self):
+        creds = byok.TurnCredentials(source="byok", api_key=_REAL_KEY)
+        assert byok.build_settings_override(creds) == {"byok_provider_api_key": _REAL_KEY}
+
+    def test_a_byok_source_with_no_key_is_treated_as_platform(self):
+        # Belt and braces: a malformed TurnCredentials must not produce an
+        # override that blanks the platform key and breaks the turn.
+        creds = byok.TurnCredentials(source="byok", api_key=None)
+        assert byok.build_settings_override(creds) == {}
+
+
+_RUN_PATH_NOT_HERE = (
+    "Exercises the chat run-path wiring (PydanticAIBackend credential fingerprint and "
+    "x-api-key header) from the Other-hand PR, pocketpaw#2015. The terrarium branch imports "
+    "cloud/byok — the store, validation and resolve_turn_credentials — but not that wiring, "
+    "so these return with #2015. Everything terrarium relies on is covered above."
+)
+
+
+@pytest.mark.skip(reason=_RUN_PATH_NOT_HERE)
+class TestNoCredentialBleedBetweenTenants:
+    """The incident case: tenant B's turn billed to tenant A's Anthropic account."""
+
+    def _fingerprint_for(self, key: str) -> str:
+        from pocketpaw.agents.pydantic_ai import PydanticAIBackend
+        from pocketpaw.config import Settings
+
+        backend = PydanticAIBackend.__new__(PydanticAIBackend)
+        backend.settings = Settings(byok_provider_api_key=key)
+        return backend._credential_fingerprint()
+
+    def test_two_tenants_keys_produce_different_cache_identities(self):
+        a = self._fingerprint_for("sk-ant-api03-" + "a" * 40)
+        b = self._fingerprint_for("sk-ant-api03-" + "b" * 40)
+        assert a != b, "two BYOK tenants would share one cached agent"
+
+    def test_the_same_key_is_stable_across_calls(self):
+        # A fingerprint that varied per call would defeat the cache entirely —
+        # correct, but every turn would rebuild the agent.
+        assert self._fingerprint_for(_REAL_KEY) == self._fingerprint_for(_REAL_KEY)
+
+    def test_no_key_is_its_own_bucket_not_a_hash(self):
+        assert self._fingerprint_for("") == "none"
+
+    def test_the_fingerprint_does_not_leak_the_key(self):
+        fp = self._fingerprint_for(_REAL_KEY)
+        assert _REAL_KEY not in fp
+        assert len(fp) < len(_REAL_KEY)
+
+
+@pytest.mark.skip(reason=_RUN_PATH_NOT_HERE)
+class TestTheHeaderThatCarriesTheKey:
+    """LiteLLM's BYOK path is a forwarded ``x-api-key`` header, so the header
+    landing on the HTTP client IS the feature. Everything else is plumbing."""
+
+    def _client_for(self, key: str | None):
+        from pocketpaw.agents.pydantic_ai import PydanticAIBackend
+        from pocketpaw.config import Settings
+
+        backend = PydanticAIBackend.__new__(PydanticAIBackend)
+        backend.settings = Settings(byok_provider_api_key=key)
+        backend._http_client = None
+        return backend._get_http_client()
+
+    def test_a_byok_run_sends_the_users_key_as_x_api_key(self):
+        client = self._client_for(_REAL_KEY)
+        assert client is not None
+        assert client.headers.get("x-api-key") == _REAL_KEY
+
+    def test_a_platform_run_sends_no_provider_header(self):
+        # The regression that would silently bill everyone to one account: a
+        # stale header surviving onto a run that never asked for BYOK.
+        client = self._client_for(None)
+        assert client is not None
+        assert "x-api-key" not in client.headers
+
+    def test_an_empty_key_is_not_forwarded_as_a_blank_header(self):
+        # A blank x-api-key is worse than none: the proxy forwards it and the
+        # provider rejects the request with a confusing auth error.
+        client = self._client_for("   ")
+        assert client is not None
+        assert "x-api-key" not in client.headers

--- a/tests/ee/terrarium/test_artifact_files.py
+++ b/tests/ee/terrarium/test_artifact_files.py
@@ -1,0 +1,79 @@
+# tests/ee/terrarium/test_artifact_files.py — a book a citizen writes is a real
+# file a human can open, and a storage failure never costs the world a tick.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.terrarium import service as svc
+
+from .conftest import WS, create_universe
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Rec:
+    def __init__(self, i: str) -> None:
+        self.id = i
+
+
+async def test_a_written_book_lands_in_files_and_the_artifact_points_at_it(client, monkeypatch):
+    calls: list[dict] = []
+
+    async def fake_write_text_file(**kw):
+        calls.append(kw)
+        return _Rec("file-abc123")
+
+    import pocketpaw_ee.cloud.uploads.service as uploads
+
+    monkeypatch.setattr(uploads, "write_text_file", fake_write_text_file)
+
+    uni = create_universe(client, founders=1)
+    assert client.post(f"/terrarium/universes/{uni['id']}/tick?n=1").status_code == 200
+
+    arts = client.get(f"/terrarium/universes/{uni['id']}/artifacts").json()["artifacts"]
+    books = [a for a in arts if a["kind"] == "book"]
+    assert books, "tick 1 writes each citizen its charter as a book"
+    assert books[0]["file_id"] == "file-abc123"
+    assert books[0]["mime"] == "text/markdown"
+
+    assert calls, "the book was never written to /files"
+    assert calls[0]["workspace_id"] == WS, "the file must land in the universe's own workspace"
+    assert calls[0]["filename"].endswith(".md")
+    assert calls[0]["folder_path"].startswith("/terrarium/")
+    assert books[0]["author"] in calls[0]["content"]
+
+
+async def test_a_files_failure_degrades_to_inline_and_the_tick_still_lands(client, monkeypatch):
+    async def boom(**_kw):
+        raise RuntimeError("storage is down")
+
+    import pocketpaw_ee.cloud.uploads.service as uploads
+
+    monkeypatch.setattr(uploads, "write_text_file", boom)
+
+    uni = create_universe(client, founders=1)
+    res = client.post(f"/terrarium/universes/{uni['id']}/tick?n=1")
+    assert res.status_code == 200, res.text
+
+    arts = client.get(f"/terrarium/universes/{uni['id']}/artifacts").json()["artifacts"]
+    assert arts, "the artifact still exists"
+    assert all(a["file_id"] is None for a in arts)
+
+
+async def test_structures_never_go_to_files(client, monkeypatch):
+    calls: list[dict] = []
+
+    async def spy(**kw):
+        calls.append(kw)
+        return _Rec("f")
+
+    import pocketpaw_ee.cloud.uploads.service as uploads
+
+    monkeypatch.setattr(uploads, "write_text_file", spy)
+    uni = create_universe(client, founders=1)
+    client.post(f"/terrarium/universes/{uni['id']}/tick?n=3")
+    arts = client.get(f"/terrarium/universes/{uni['id']}/artifacts").json()["artifacts"]
+    structures = [a for a in arts if a["kind"] == "structure"]
+    assert structures, "the mock builds by tick 3"
+    assert all(a["file_id"] is None for a in structures)
+    assert all(svc._FILE_BEARING_KINDS.isdisjoint({"structure"}) for _ in [0])

--- a/tests/ee/terrarium/test_byok_adapter.py
+++ b/tests/ee/terrarium/test_byok_adapter.py
@@ -1,0 +1,108 @@
+# tests/ee/terrarium/test_byok_adapter.py — a universe pays with its workspace's
+# own key when one is stored, through the product's one decrypting reader.
+#
+# Terrarium keeps no second copy of anyone's key. It asks cloud.byok who pays
+# for this tick and hands the answer to the transport. These pin that seam: the
+# right transport is picked, the key rides as x-api-key, and it is in no body.
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud.byok import service as byok
+from pocketpaw_ee.terrarium import llm as citizen_llm
+from pocketpaw_ee.terrarium import service as svc
+from pocketpaw_ee.terrarium.llm import HttpLlm, MockLlm, model_for_tier, resolve_llm
+
+from .conftest import WS, create_universe  # noqa: E402
+
+_KEY = "sk-ant-" + "a" * 40
+
+
+@pytest.fixture(autouse=True)
+def _encryption_key(monkeypatch):
+    from cryptography.fernet import Fernet
+
+    monkeypatch.setenv("CLOUD_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+
+def test_resolve_llm_prefers_http_when_a_key_is_present(monkeypatch):
+    monkeypatch.delenv("POCKETPAW_TERRARIUM_LLM", raising=False)
+    assert isinstance(resolve_llm(api_key=None, tier="premium"), MockLlm)
+    picked = resolve_llm(api_key=_KEY, tier="tail")
+    assert isinstance(picked, HttpLlm)
+    assert picked.model == model_for_tier("tail")
+
+
+@pytest.mark.asyncio
+async def test_http_llm_sends_the_key_as_x_api_key_and_never_logs_it(caplog):
+    seen: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["headers"] = dict(request.headers)
+        seen["body"] = json.loads(request.content)
+        text = '{"thought": "ok", "acts": []}'
+        return httpx.Response(200, json={"content": [{"type": "text", "text": text}]})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    llm = HttpLlm(_KEY, "claude-sonnet-4-6", client=client)
+    out = await llm.decide(prompt="hello", physics=None, citizen=None, digest=None)  # type: ignore[arg-type]
+    assert '"thought"' in out
+    assert seen["headers"]["x-api-key"] == _KEY
+    assert seen["body"]["model"] == "claude-sonnet-4-6"
+    assert _KEY not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_tick_resolves_the_workspace_key_and_no_body_carries_it(client, monkeypatch):
+    # Store a key for the test workspace without the network round-trip.
+    async def _no_network(_key: str) -> None:
+        return None
+
+    monkeypatch.setattr(byok, "validate_key", _no_network)
+    await byok.set_key(WS, _KEY)
+
+    built: list[tuple[str | None, str | None]] = []
+
+    def spy(*, api_key=None, tier=None):
+        built.append((api_key, tier))
+        return MockLlm()
+
+    monkeypatch.setattr(citizen_llm, "resolve_llm", spy)
+    monkeypatch.setattr(svc.citizen_llm, "resolve_llm", spy)
+
+    uni = create_universe(client, founders=2)
+    res = client.post(f"/terrarium/universes/{uni['id']}/tick?n=1")
+    assert res.status_code == 200, res.text
+
+    assert built, "tick must resolve a transport"
+    api_key, tier = built[-1]
+    assert api_key == _KEY, "the workspace key must reach the transport"
+    assert tier == "premium"
+
+    for path in (
+        f"/terrarium/universes/{uni['id']}",
+        f"/terrarium/universes/{uni['id']}/citizens",
+        f"/terrarium/universes/{uni['id']}/events",
+    ):
+        body = client.get(path).text
+        assert _KEY not in body
+        assert "encrypted_key" not in body
+
+
+@pytest.mark.asyncio
+async def test_without_a_stored_key_the_tick_uses_platform_credentials(client, monkeypatch):
+    built: list[tuple[str | None, str | None]] = []
+
+    def spy(*, api_key=None, tier=None):
+        built.append((api_key, tier))
+        return MockLlm()
+
+    monkeypatch.setattr(citizen_llm, "resolve_llm", spy)
+    monkeypatch.setattr(svc.citizen_llm, "resolve_llm", spy)
+
+    uni = create_universe(client, founders=1)
+    assert client.post(f"/terrarium/universes/{uni['id']}/tick?n=1").status_code == 200
+    assert built and built[-1][0] is None

--- a/tests/ee/terrarium/test_scheduler.py
+++ b/tests/ee/terrarium/test_scheduler.py
@@ -1,0 +1,141 @@
+# tests/ee/terrarium/test_scheduler.py — the clock. Pure cadence arithmetic
+# (running vs dormant, due vs not), the DB sweep flipping status, a failing
+# universe not blocking the next, event reads stamping last_viewed_at, and the
+# loop never starting without the gate env.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+pytest.importorskip("mongomock_motor")
+
+from pocketpaw_ee.terrarium import scheduler, service  # noqa: E402
+from pocketpaw_ee.terrarium.domain import UniverseDoc  # noqa: E402
+
+from .conftest import create_universe  # noqa: E402
+
+T0 = datetime(2026, 9, 7, 12, 0, tzinfo=UTC)
+TIME = {"world_day_seconds": 3600, "ticks_per_day": 12, "dormant_ticks_per_day": 1}
+
+
+@pytest.mark.parametrize(
+    ("ticked_ago", "viewed_ago", "due", "status"),
+    [
+        (None, 0, True, "running"),  # never ticked: due now
+        (299, 0, False, "running"),  # 3600/12 = 300s per tick
+        (300, 0, True, "running"),
+        (300, 3601, False, "dormant"),  # unwatched: 1 tick per 3600s
+        (3600, 3601, True, "dormant"),
+        (3600, None, True, "dormant"),  # never viewed counts as dormant
+    ],
+)
+def test_due_state_arithmetic(ticked_ago, viewed_ago, due, status):
+    got = scheduler.due_state(
+        TIME,
+        now=T0,
+        last_tick_at=None if ticked_ago is None else T0 - timedelta(seconds=ticked_ago),
+        last_viewed_at=None if viewed_ago is None else T0 - timedelta(seconds=viewed_ago),
+    )
+    assert got == (due, status)
+
+
+def test_due_state_accepts_naive_datetimes():
+    naive = T0.replace(tzinfo=None)
+    assert scheduler.due_state(TIME, now=T0, last_tick_at=naive, last_viewed_at=naive) == (
+        False,
+        "running",
+    )
+
+
+async def test_sweep_ticks_due_universes_and_flips_dormant(client):
+    a = create_universe(client, founders=1)
+    b = create_universe(client, founders=1)
+    doc_a = await UniverseDoc.get(a["id"])
+    doc_a.last_viewed_at = T0  # watched right now (createdAt is the real clock)
+    await doc_a.save()
+    doc_b = await UniverseDoc.get(b["id"])
+    doc_b.last_viewed_at = T0 - timedelta(days=2)
+    doc_b.last_tick_at = T0 - timedelta(seconds=600)  # due if running, not if dormant
+    await doc_b.save()
+
+    fired: list[tuple] = []
+
+    async def fake_tick(ws, user, uid, n):
+        fired.append((ws, uid, n))
+        return {}
+
+    ticked = await scheduler.run_scheduler_tick(now=lambda: T0, trigger=fake_tick)
+    assert ticked == [a["id"]]
+    assert fired == [("ws-terra", a["id"], 1)]
+    assert (await UniverseDoc.get(b["id"])).status == "dormant"
+    assert (await UniverseDoc.get(a["id"])).status == "running"
+
+
+async def test_a_failing_universe_does_not_block_the_next(client):
+    a = create_universe(client, founders=1)
+    b = create_universe(client, founders=1)
+
+    async def flaky(ws, user, uid, n):
+        if uid == a["id"]:
+            raise RuntimeError("boom")
+        return {}
+
+    ticked = await scheduler.run_scheduler_tick(now=lambda: T0, trigger=flaky)
+    assert ticked == [b["id"]]
+
+
+async def test_real_tick_stamps_last_tick_at_and_advances(client):
+    uni = create_universe(client, founders=1)
+    ticked = await scheduler.run_scheduler_tick(now=lambda: T0)
+    assert ticked == [uni["id"]]
+    doc = await UniverseDoc.get(uni["id"])
+    assert doc.tick == 1 and doc.last_tick_at is not None
+    # Just ticked -> not due again at the same instant.
+    assert await scheduler.run_scheduler_tick(now=lambda: datetime.now(UTC)) == []
+
+
+async def test_event_reads_stamp_last_viewed_at(client, monkeypatch):
+    uni = create_universe(client, public=True, founders=1)
+    doc = await UniverseDoc.get(uni["id"])
+    doc.last_viewed_at = None
+    await doc.save()
+    client.get(f"/terrarium/universes/{uni['id']}/events")
+    assert (await UniverseDoc.get(uni["id"])).last_viewed_at is not None
+
+    doc = await UniverseDoc.get(uni["id"])
+    doc.last_viewed_at = None
+    await doc.save()
+    monkeypatch.setenv("TERRARIUM_PUBLIC_ENABLED", "1")
+    client.get(f"/terrarium/public/universes/{uni['id']}/events")
+    assert (await UniverseDoc.get(uni["id"])).last_viewed_at is not None
+
+
+async def test_the_clock_is_not_on_the_wire(client):
+    uni = create_universe(client, founders=1)
+    assert "last_tick_at" not in uni and "last_viewed_at" not in uni
+
+
+async def test_sweeper_never_starts_without_the_gate(monkeypatch):
+    monkeypatch.delenv("POCKETPAW_CLOUD_SCHEDULER_ENABLED", raising=False)
+    assert await scheduler.reconcile_scheduler() == 0
+    assert not scheduler.is_running()
+    monkeypatch.setenv("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "true")
+    monkeypatch.setenv("POCKETPAW_TERRARIUM_SCHEDULER_INTERVAL", "3600")
+    try:
+        assert await scheduler.reconcile_scheduler() == 1
+        assert scheduler.is_running()
+        assert await scheduler.reconcile_scheduler() == 0  # idempotent
+    finally:
+        await scheduler.shutdown_scheduler()
+    assert not scheduler.is_running()
+
+
+async def test_scheduler_sweep_skips_archived(client):
+    uni = create_universe(client, founders=1)
+    doc = await UniverseDoc.get(uni["id"])
+    doc.status = "archived"
+    await doc.save()
+    assert await service.scheduler_sweep(T0) == []

--- a/tests/ee/terrarium/test_service.py
+++ b/tests/ee/terrarium/test_service.py
@@ -231,7 +231,7 @@ async def test_the_viewer_line_still_reaches_the_citizen_labelled(client):
     import pocketpaw_ee.terrarium.service as svc
 
     original = citizen_llm.resolve_llm
-    citizen_llm.resolve_llm = lambda: Spy()  # type: ignore[assignment]
+    citizen_llm.resolve_llm = lambda **_: Spy()  # type: ignore[assignment]
     svc.citizen_llm.resolve_llm = citizen_llm.resolve_llm  # type: ignore[attr-defined]
     try:
         client.post(f"/terrarium/universes/{uni['id']}/tick?n=1")
@@ -360,7 +360,7 @@ async def test_a_citizen_hears_what_another_said_last_tick(client):
     import pocketpaw_ee.terrarium.service as svc
 
     original = citizen_llm.resolve_llm
-    svc.citizen_llm.resolve_llm = lambda: Spy()  # type: ignore[attr-defined]
+    svc.citizen_llm.resolve_llm = lambda **_: Spy()  # type: ignore[attr-defined]
     try:
         client.post(f"/terrarium/universes/{uni['id']}/tick?n=2")
     finally:
@@ -395,7 +395,7 @@ async def test_a_viewer_line_is_heard_once_not_on_every_tick(client):
     import pocketpaw_ee.terrarium.service as svc
 
     original = citizen_llm.resolve_llm
-    svc.citizen_llm.resolve_llm = lambda: Spy()  # type: ignore[attr-defined]
+    svc.citizen_llm.resolve_llm = lambda **_: Spy()  # type: ignore[attr-defined]
     try:
         client.post(f"/terrarium/universes/{uni['id']}/tick?n=3")
     finally:


### PR DESCRIPTION
Three things the launch brief promised that the runtime did not yet do. Stacked on #2108.

## The clock

A universe now ticks on its own physics. One world day is `time.world_day_seconds` long and gets `time.ticks_per_day` ticks, so the scheduler fires a tick every `world_day_seconds / ticks_per_day` seconds for each running universe. It follows the mandates scheduler's shape exactly, including the `POCKETPAW_CLOUD_SCHEDULER_ENABLED` gate, so a test run never spawns one.

Dormancy is real. Every events read stamps `last_viewed_at`; a universe nobody has looked at for a world day drops to `time.dormant_ticks_per_day` and its status flips to `dormant`, so the observatory can say so. The world slows when unwatched, it does not die, and it wakes on the next view. One universe failing never stops the sweep. Fourteen tests cover due/not-due arithmetic, dormancy, and the gate.

## Bring your own key — through the product's own store

A universe pays for its citizens' thinking with its workspace's key when one is stored. Terrarium keeps no second copy of anyone's credential. The tick asks `cloud.byok.resolve_turn_credentials`, the one decrypting reader the rest of the product uses, and hands the plain key to an HTTP transport for the Messages API. No key is stored on a universe, none is logged, and a test asserts it appears in no response body, private or public. Without a stored key the tick uses platform credentials as before.

The byok module itself is brought in from the Other-hand PR, pocketpaw#2015, as files only: the store, the validation, the routes, the one reader. It touches nothing shared beyond the two mount lines. When #2015 merges the same files arrive again and resolve as identical. Its two test classes that exercise the chat run path are skipped here with the reason stated, because that wiring is not on this branch; they return with #2015, along with its mutation plan.

Model tier maps to a model id in one small table, with a fallback for unknown tiers.

## Books as files

A book, a law or a map a citizen writes now lands in the workspace's /files surface through `write_text_file`, the same path the planner and meetings use, and the artifact carries the file id. That is what lets the Built tab open one in the inline viewer, which already renders markdown, docx, pdf and 3D. The body stays on the document too, since the contract keeps it. A storage failure degrades to inline-only and the tick still lands. Structures stay off the files surface; they are things on the map, not documents.

## Verification

`tests/ee/terrarium/`: 113 passed, 1 skipped. The skip is the end-to-end fork test waiting on the published soul-protocol floor, with its reason stated. Imported byok tests: 13 passed, 7 skipped as described. Mandates seam: 13 passed. `lint-imports` 38 kept, 0 broken. Ruff check and format clean.

One header cleanup along the way: two files had gained dated "Updated:" lines, collapsed to current-state per the workspace rule.