### PR TITLE
fix(cloud-projects): tenant came from a header, on a router with no auth

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/ee_auth_bridge.py
+++ b/ee/pocketpaw_ee/cloud/_core/ee_auth_bridge.py
@@ -100,6 +100,24 @@ class EEAuthBridgeMiddleware(BaseHTTPMiddleware):
         if user is None:
             return await call_next(request)
 
+        # Stamp the SESSION's tenant so OSS-package routers mounted under
+        # /api/v1/ can scope themselves without importing pocketpaw_ee (the
+        # open-core import boundary forbids it, and an import-linter contract
+        # enforces that).
+        #
+        # This exists because src/pocketpaw/api/v1/cloud_projects.py stores
+        # per-tenant data and had no way to learn the tenant, so it read one
+        # out of an X-Workspace-Id header. A header is chosen by the caller, so
+        # every tenant's project storage was readable and writable by anyone
+        # who named the workspace. These two attributes are the supported way
+        # for an OSS router to get an authenticated tenant; nothing else on
+        # request.state carries one.
+        #
+        # Set for EVERY resolved user, not only superusers — an ordinary
+        # workspace member is exactly who needs their own workspace resolved.
+        request.state.workspace_id = getattr(user, "active_workspace", None)
+        request.state.user_id = str(getattr(user, "id", "") or "") or None
+
         # full_access is the OSS superuser bypass — reserve it for genuine
         # platform administrators. A workspace owner/admin is NOT a superuser
         # over the OSS guards (settings/channels/budget); granting it here let

--- a/src/pocketpaw/api/v1/cloud_projects.py
+++ b/src/pocketpaw/api/v1/cloud_projects.py
@@ -18,6 +18,12 @@ Updated: 2026-09-04 — ``_upload_directory`` no longer walks the cloned tree on
     the event loop. The ``os.walk`` moved into ``_walk_repo_files`` and is
     reached through ``asyncio.to_thread``; the uploads themselves stay in the
     coroutine because each one awaits the storage adapter.
+Updated: 2026-09-07 — the router had no auth dependency and took its tenant
+    from an ``X-Workspace-Id`` header defaulting to ``"default"``, so an
+    anonymous caller could read, write and enumerate any workspace's project
+    storage by naming it. Every route now depends on ``resolve_project_scope``,
+    which trusts the session the EE auth bridge resolved and otherwise refuses.
+    See that function for why ``require_scope`` is the wrong gate here.
 """
 
 from __future__ import annotations
@@ -31,7 +37,7 @@ import tempfile
 from collections.abc import AsyncIterator
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
 
@@ -86,23 +92,62 @@ async def _empty_stream() -> AsyncIterator[bytes]:
         yield b""
 
 
-def _resolve_ids(http_request: Request) -> tuple[str, str]:
-    """Extract workspace_id and user_id from the request context.
+# The middle segment of the storage key. It has always been the constant
+# "local" for every caller that reaches this router in practice — cloud callers
+# authenticate with a session cookie, which set neither api_key nor oauth_token,
+# so the old _resolve_ids fell through to its default on every cloud request.
+# It is kept as a constant deliberately: the workspace segment is the tenancy
+# boundary, and changing this one would orphan every project already stored
+# under projects/<workspace>/local/. Treat it as a vestigial path component,
+# not as an owner.
+_USER_SEGMENT = "local"
 
-    ``workspace_id`` is read from the ``X-Workspace-Id`` request header.
-    ``user_id`` is extracted from the authenticated request context
-    (API key or OAuth token), falling back to ``"local"`` in self-hosted
-    single-user mode.
+# The workspace for a deployment with no cloud session — a local install, or an
+# OSS caller holding a master token or an API key. Matches the value the old
+# header default produced, so existing local projects keep resolving.
+_LOCAL_WORKSPACE = "default"
+
+
+async def resolve_project_scope(request: Request) -> tuple[str, str]:
+    """Resolve (workspace_id, user_segment), or refuse the request.
+
+    THIS IS THE TENANCY BOUNDARY OF THIS ROUTER. Every route stores and reads
+    under ``projects/{workspace_id}/...``, so whatever this returns decides
+    which tenant's files a caller reaches.
+
+    It used to be ``http_request.headers.get("X-Workspace-Id", "default")``.
+    A header is chosen by the caller, and the router carried no auth
+    dependency, so an anonymous request could read, write and enumerate any
+    tenant's project storage by naming the workspace — and workspace ids are
+    not secret, the frontend sends one on every request.
+
+    Two sources are trusted, in order, and nothing else is:
+
+    1. ``request.state.workspace_id``, stamped by the EE auth bridge middleware
+       from the caller's own JWT session. This is the cloud path. The OSS
+       package cannot import pocketpaw_ee, so a plain request-state attribute
+       is the seam; see ee/pocketpaw_ee/cloud/_core/ee_auth_bridge.py.
+    2. An OSS-authenticated caller with no cloud session — master token,
+       dashboard cookie, genuine localhost, a pp_ API key, or an OAuth token.
+       That is a single-tenant install, and it gets the local workspace.
+
+    Anything else is anonymous and gets a 401. Note this router cannot use
+    require_scope: the cloud frontend calls it as an ordinary workspace member,
+    and the EE bridge grants OSS full_access only to platform superusers, so a
+    scope gate would 403 every legitimate cloud user.
     """
-    workspace_id = http_request.headers.get("X-Workspace-Id", "default")
-    user_id: str = "local"
-    api_key = getattr(http_request.state, "api_key", None)
-    if api_key is not None:
-        user_id = getattr(api_key, "user_id", "local")
-    oauth_token = getattr(http_request.state, "oauth_token", None)
-    if oauth_token is not None:
-        user_id = getattr(oauth_token, "sub", str(oauth_token.get("sub", "local")))
-    return workspace_id, user_id
+    workspace_id = getattr(request.state, "workspace_id", None)
+    if workspace_id:
+        return str(workspace_id), _USER_SEGMENT
+
+    if (
+        getattr(request.state, "full_access", False)
+        or getattr(request.state, "api_key", None) is not None
+        or getattr(request.state, "oauth_token", None) is not None
+    ):
+        return _LOCAL_WORKSPACE, _USER_SEGMENT
+
+    raise HTTPException(status_code=401, detail="Unauthorized")
 
 
 async def _require_project(workspace_id: str, user_id: str, project_name: str) -> str:
@@ -355,7 +400,7 @@ async def _clone_into_vm(
 @router.post("/cloud/projects")
 async def create_cloud_project(
     req: CreateCloudProjectRequest,
-    http_request: Request,
+    scope: tuple[str, str] = Depends(resolve_project_scope),
 ) -> CreateCloudProjectResponse:
     """Create a new project folder in cloud storage.
 
@@ -363,11 +408,9 @@ async def create_cloud_project(
 
         projects/{workspace_id}/{user_id}/{project_name}/
 
-    ``workspace_id`` is read from the ``X-Workspace-Id`` request header
-    (set automatically by the frontend's ``api.*`` client helpers).
-    ``user_id`` is extracted from the authenticated request context
-    (API key or OAuth token), falling back to ``"local"`` in self-hosted
-    single-user mode.
+    ``workspace_id`` comes from ``resolve_project_scope`` — the caller's own
+    session, never a request header. ``user_id`` is the constant path segment
+    described there.
 
     When ``provision_workspace`` is true and Daytona is configured, a
     sandbox VM is provisioned for the project and files are synced from
@@ -375,6 +418,7 @@ async def create_cloud_project(
 
     Returns 409 if a project with the same name already exists.
     """
+    workspace_id, user_id = scope
     name = req.project_name.strip()
     if not name:
         raise HTTPException(status_code=400, detail="project_name must not be empty")
@@ -383,7 +427,6 @@ async def create_cloud_project(
     if len(name) > 128:
         raise HTTPException(status_code=400, detail="project_name too long (max 128 chars)")
 
-    workspace_id, user_id = _resolve_ids(http_request)
     project_key = f"projects/{workspace_id}/{user_id}/{name}/"
 
     # Idempotency check — skip creation if the marker already exists.
@@ -430,7 +473,7 @@ async def create_cloud_project(
 @router.post("/cloud/projects/clone")
 async def clone_git_repo(
     req: CloneGitRepoRequest,
-    http_request: Request,
+    scope: tuple[str, str] = Depends(resolve_project_scope),
 ) -> CreateCloudProjectResponse:
     """Clone a git repository into a new cloud project.
 
@@ -442,13 +485,13 @@ async def clone_git_repo(
     (e.g. ``https://github.com/user/repo.git`` → ``user-repo``).
     Returns 409 if a project with the same derived name already exists.
     """
+    workspace_id, user_id = scope
     url = req.repo_url.strip()
     if not url:
         raise HTTPException(status_code=400, detail="repo_url must not be empty")
 
     project_name = _extract_project_name(url)
 
-    workspace_id, user_id = _resolve_ids(http_request)
     project_key = f"projects/{workspace_id}/{user_id}/{project_name}/"
 
     # Idempotency check — reject if a project with this derived name exists.
@@ -539,7 +582,7 @@ async def clone_git_repo(
 
 @router.get("/cloud/projects")
 async def list_cloud_projects(
-    http_request: Request,
+    scope: tuple[str, str] = Depends(resolve_project_scope),
 ) -> list[dict]:
     """List all cloud projects for the current workspace + user.
 
@@ -550,7 +593,7 @@ async def list_cloud_projects(
     keys with a prefix. S3 adapters do; the local adapter implements
     ``local_path()`` and we fall back to filesystem ``iterdir``.
     """
-    workspace_id, user_id = _resolve_ids(http_request)
+    workspace_id, user_id = scope
     prefix = f"projects/{workspace_id}/{user_id}/"
 
     projects: list[dict] = []
@@ -603,14 +646,14 @@ def _adapter_key(project_key: str, relative_path: str) -> str:
 async def browse_cloud_project_files(
     project_name: str,
     path: str = Query("", description="Relative path within the project"),
-    http_request: Request = None,
+    scope: tuple[str, str] = Depends(resolve_project_scope),
 ) -> BrowseResponse:
     """List the contents of a directory within a cloud project.
 
     ``path`` is relative to the project root. Empty string or ``"."``
     lists the project root.
     """
-    workspace_id, user_id = _resolve_ids(http_request)
+    workspace_id, user_id = scope
     project_key = await _require_project(workspace_id, user_id, project_name)
     key = _adapter_key(project_key, path)
 
@@ -635,14 +678,14 @@ async def browse_cloud_project_files(
 async def read_cloud_project_file(
     project_name: str,
     path: str = Query(..., description="Relative file path within the project"),
-    http_request: Request = None,
+    scope: tuple[str, str] = Depends(resolve_project_scope),
 ):
     """Read a file from a cloud project and return its raw content.
 
     The path is relative to the project root. The response uses the
     file's MIME type for syntax highlighting in the browser.
     """
-    workspace_id, user_id = _resolve_ids(http_request)
+    workspace_id, user_id = scope
     project_key = await _require_project(workspace_id, user_id, project_name)
 
     if not path or path.strip("/") == "":
@@ -678,14 +721,14 @@ async def read_cloud_project_file(
 async def write_cloud_project_file(
     project_name: str,
     req: WriteFileRequest,
-    http_request: Request = None,
+    scope: tuple[str, str] = Depends(resolve_project_scope),
 ) -> FileActionResponse:
     """Create or overwrite a file within a cloud project.
 
     The body ``path`` is relative to the project root. Parent directories
     are created automatically.
     """
-    workspace_id, user_id = _resolve_ids(http_request)
+    workspace_id, user_id = scope
     project_key = await _require_project(workspace_id, user_id, project_name)
 
     relative = req.path.strip("/")
@@ -712,13 +755,13 @@ async def write_cloud_project_file(
 async def create_cloud_project_file(
     project_name: str,
     req: CreateFileRequest,
-    http_request: Request = None,
+    scope: tuple[str, str] = Depends(resolve_project_scope),
 ) -> FileActionResponse:
     """Create a new file within a cloud project.
 
     Returns 409 if the file already exists.
     """
-    workspace_id, user_id = _resolve_ids(http_request)
+    workspace_id, user_id = scope
     project_key = await _require_project(workspace_id, user_id, project_name)
 
     relative = req.path.strip("/")
@@ -757,14 +800,14 @@ async def create_cloud_project_file(
 async def mkdir_cloud_project(
     project_name: str,
     req: MkdirRequest,
-    http_request: Request = None,
+    scope: tuple[str, str] = Depends(resolve_project_scope),
 ) -> FileActionResponse:
     """Create a directory within a cloud project.
 
     The directory is a zero-byte marker object at the corresponding key
     prefix. Returns 409 if the directory already exists.
     """
-    workspace_id, user_id = _resolve_ids(http_request)
+    workspace_id, user_id = scope
     project_key = await _require_project(workspace_id, user_id, project_name)
 
     relative = req.path.strip("/")
@@ -797,13 +840,13 @@ async def mkdir_cloud_project(
 async def rename_cloud_project_item(
     project_name: str,
     req: RenameRequest,
-    http_request: Request = None,
+    scope: tuple[str, str] = Depends(resolve_project_scope),
 ) -> FileActionResponse:
     """Rename or move a file/directory within a cloud project.
 
     Both ``path`` and ``new_path`` are relative to the project root.
     """
-    workspace_id, user_id = _resolve_ids(http_request)
+    workspace_id, user_id = scope
     project_key = await _require_project(workspace_id, user_id, project_name)
 
     old_relative = req.path.strip("/")
@@ -831,10 +874,10 @@ async def rename_cloud_project_item(
 async def delete_cloud_project_item(
     project_name: str,
     path: str = Query(..., description="Relative path to delete"),
-    http_request: Request = None,
+    scope: tuple[str, str] = Depends(resolve_project_scope),
 ) -> FileActionResponse:
     """Delete a file or empty directory within a cloud project."""
-    workspace_id, user_id = _resolve_ids(http_request)
+    workspace_id, user_id = scope
     project_key = await _require_project(workspace_id, user_id, project_name)
 
     relative = path.strip("/")

--- a/tests/cloud/auth/test_ee_auth_bridge_tenant_stamp.py
+++ b/tests/cloud/auth/test_ee_auth_bridge_tenant_stamp.py
@@ -1,0 +1,128 @@
+"""The EE auth bridge stamps the session's tenant for OSS-package routers.
+
+This is a seam, not a convenience. ``src/pocketpaw/api/v1/cloud_projects.py``
+stores per-tenant data under ``projects/{workspace_id}/...`` but lives in the
+OSS package, which cannot import ``pocketpaw_ee`` — an import-linter contract
+forbids it. With no way to learn the tenant it read one out of an
+``X-Workspace-Id`` header, which the caller chooses, so every workspace's
+project storage was reachable by anyone who named it.
+
+``request.state.workspace_id`` is how an OSS router gets an AUTHENTICATED
+tenant. Nothing else on ``request.state`` carries one: ``full_access`` is a
+boolean and is reserved for platform superusers, and ``api_key`` / ``oauth_token``
+have no workspace field at all.
+
+The property that matters, and the one a reasonable-looking change breaks: it is
+stamped for EVERY resolved user, not only superusers. The full_access grant
+immediately below it is deliberately superuser-only (the 2026-06-10 escalation
+fix), and it would be an easy and wrong tidy-up to fold these into that branch.
+An ordinary workspace member is exactly the caller who needs their own workspace
+resolved — they are who uses the /code surface.
+
+Mutations that must fail these tests: not stamping the workspace, stamping it
+only for superusers, and stamping it from a request header.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("AUTH_SECRET", "test-bridge-secret-do-not-use-in-prod")
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.ee_auth_bridge import EEAuthBridgeMiddleware
+from pocketpaw_ee.cloud.auth.core import SECRET, RevocableJWTStrategy
+from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+
+_WS_ID = "w-stamp-test"
+
+
+def _build_app() -> FastAPI:
+    """An app whose one route reports what the bridge put on request.state."""
+    app = FastAPI()
+    app.add_middleware(EEAuthBridgeMiddleware)
+
+    @app.get("/api/v1/whoami")
+    async def _whoami(request: Request) -> dict:
+        return {
+            "workspace_id": getattr(request.state, "workspace_id", None),
+            "user_id": getattr(request.state, "user_id", None),
+            "full_access": getattr(request.state, "full_access", False),
+        }
+
+    return app
+
+
+async def _seed(email: str, role: str, *, is_superuser: bool = False) -> User:
+    user = User(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        is_superuser=is_superuser,
+        active_workspace=_WS_ID,
+        workspaces=[WorkspaceMembership(workspace=_WS_ID, role=role)],
+    )
+    await user.insert()
+    return user
+
+
+async def _mint(user: User) -> str:
+    strategy = RevocableJWTStrategy(secret=SECRET, lifetime_seconds=60)
+    return await strategy.write_token(user)
+
+
+@pytest_asyncio.fixture
+async def env(mongo_db):  # noqa: ARG001 — forces Beanie init
+    member = await _seed("member@stamp.test", "member")
+    admin = await _seed("root@stamp.test", "owner", is_superuser=True)
+    tokens = {"member": await _mint(member), "admin": await _mint(admin)}
+    async with AsyncClient(
+        transport=ASGITransport(app=_build_app()), base_url="http://t"
+    ) as client:
+        yield client, tokens, member
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_member_gets_their_workspace_stamped(env) -> None:
+    """The case the seam exists for, and the one a superuser-only stamp breaks."""
+    client, tokens, member = env
+    res = await client.get("/api/v1/whoami", cookies={"paw_auth": tokens["member"]})
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["workspace_id"] == _WS_ID
+    assert body["user_id"] == str(member.id)
+    # Unchanged by this seam: an ordinary member is still not a platform admin.
+    assert body["full_access"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_header_does_not_influence_the_stamp(env) -> None:
+    """The tenant comes from the JWT, so naming another workspace changes nothing."""
+    client, tokens, _ = env
+    res = await client.get(
+        "/api/v1/whoami",
+        cookies={"paw_auth": tokens["member"]},
+        headers={"X-Workspace-Id": "w-victim"},
+    )
+    assert res.json()["workspace_id"] == _WS_ID
+
+
+@pytest.mark.asyncio
+async def test_an_unauthenticated_request_is_stamped_with_nothing(env) -> None:
+    """No session means no tenant, which is what makes the OSS side fail closed."""
+    client, _, _ = env
+    res = await client.get("/api/v1/whoami", headers={"X-Workspace-Id": "w-victim"})
+    assert res.json()["workspace_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_superuser_is_stamped_too_and_still_gets_full_access(env) -> None:
+    client, tokens, _ = env
+    body = (await client.get("/api/v1/whoami", cookies={"paw_auth": tokens["admin"]})).json()
+    assert body["workspace_id"] == _WS_ID
+    assert body["full_access"] is True

--- a/tests/mutations/cloud_projects_tenancy.json
+++ b/tests/mutations/cloud_projects_tenancy.json
@@ -1,0 +1,65 @@
+[
+  {
+    "label": "read the workspace from a header again, the shipped bug",
+    "file": "src/pocketpaw/api/v1/cloud_projects.py",
+    "find": "    workspace_id = getattr(request.state, \"workspace_id\", None)\n    if workspace_id:",
+    "replace": "    workspace_id = request.headers.get(\"X-Workspace-Id\") or getattr(\n        request.state, \"workspace_id\", None\n    )\n    if workspace_id:",
+    "tests": [
+      "tests/v1/test_cloud_projects_tenancy.py"
+    ]
+  },
+  {
+    "label": "fall back to a default workspace instead of refusing",
+    "file": "src/pocketpaw/api/v1/cloud_projects.py",
+    "find": "    raise HTTPException(status_code=401, detail=\"Unauthorized\")",
+    "replace": "    return _LOCAL_WORKSPACE, _USER_SEGMENT",
+    "tests": [
+      "tests/v1/test_cloud_projects_tenancy.py"
+    ]
+  },
+  {
+    "label": "let the header win over the resolved session",
+    "file": "src/pocketpaw/api/v1/cloud_projects.py",
+    "find": "        return str(workspace_id), _USER_SEGMENT",
+    "replace": "        return str(request.headers.get(\"X-Workspace-Id\") or workspace_id), _USER_SEGMENT",
+    "tests": [
+      "tests/v1/test_cloud_projects_tenancy.py"
+    ]
+  },
+  {
+    "label": "drop the dependency from the list route",
+    "file": "src/pocketpaw/api/v1/cloud_projects.py",
+    "find": "async def list_cloud_projects(\n    scope: tuple[str, str] = Depends(resolve_project_scope),\n) -> list[dict]:",
+    "replace": "async def list_cloud_projects(\n    scope: tuple[str, str] = (\"default\", \"local\"),\n) -> list[dict]:",
+    "tests": [
+      "tests/v1/test_cloud_projects_tenancy.py"
+    ]
+  },
+  {
+    "label": "stop stamping the session workspace in the EE bridge",
+    "file": "ee/pocketpaw_ee/cloud/_core/ee_auth_bridge.py",
+    "find": "        request.state.workspace_id = getattr(user, \"active_workspace\", None)",
+    "replace": "        request.state.workspace_id = None",
+    "tests": [
+      "tests/cloud/auth/test_ee_auth_bridge_tenant_stamp.py"
+    ]
+  },
+  {
+    "label": "fold the tenant stamp into the superuser branch",
+    "file": "ee/pocketpaw_ee/cloud/_core/ee_auth_bridge.py",
+    "find": "        request.state.workspace_id = getattr(user, \"active_workspace\", None)\n        request.state.user_id = str(getattr(user, \"id\", \"\") or \"\") or None\n",
+    "replace": "        if getattr(user, \"is_superuser\", False):\n            request.state.workspace_id = getattr(user, \"active_workspace\", None)\n            request.state.user_id = str(getattr(user, \"id\", \"\") or \"\") or None\n",
+    "tests": [
+      "tests/cloud/auth/test_ee_auth_bridge_tenant_stamp.py"
+    ]
+  },
+  {
+    "label": "stamp the tenant from a request header",
+    "file": "ee/pocketpaw_ee/cloud/_core/ee_auth_bridge.py",
+    "find": "        request.state.workspace_id = getattr(user, \"active_workspace\", None)",
+    "replace": "        request.state.workspace_id = request.headers.get(\n            \"X-Workspace-Id\"\n        ) or getattr(user, \"active_workspace\", None)",
+    "tests": [
+      "tests/cloud/auth/test_ee_auth_bridge_tenant_stamp.py"
+    ]
+  }
+]

--- a/tests/v1/test_cloud_projects_tenancy.py
+++ b/tests/v1/test_cloud_projects_tenancy.py
@@ -1,0 +1,182 @@
+"""Cloud project storage took its tenant from a header, with no auth at all.
+
+``src/pocketpaw/api/v1/cloud_projects.py`` declared its router with no
+dependencies — ``grep -c 'Depends('`` over the file returned 0 — and resolved
+the tenant with::
+
+    workspace_id = http_request.headers.get("X-Workspace-Id", "default")
+
+Ten routes store and read under ``projects/{workspace_id}/{user_id}/``: create,
+list, browse, read, write, create-file, mkdir, rename, delete, and a
+server-side ``git clone``. So an anonymous caller could read, write and
+enumerate any tenant's project storage by naming the workspace in a header, and
+workspace ids are not secret — the frontend sends one on every request.
+
+WHY NOT require_scope
+
+The obvious gate is wrong here, and the wrongness is invisible from inside this
+file. The cloud frontend calls these routes as an ORDINARY workspace member,
+authenticated by a session cookie. The EE auth bridge grants OSS ``full_access``
+only to platform superusers, and a cookie sets neither ``api_key`` nor
+``oauth_token`` — so ``require_scope(...)`` would 403 every legitimate cloud
+user while an audit ticked the box.
+
+The tenant instead comes from ``request.state.workspace_id``, which the EE auth
+bridge stamps from the caller's own JWT. The OSS package cannot import
+pocketpaw_ee (an import-linter contract forbids it), so a request-state
+attribute is the seam.
+
+WHAT DID NOT CHANGE, DELIBERATELY
+
+The middle ``user_id`` segment stays the constant ``"local"``. It always was
+one in practice: cloud callers authenticate by cookie, so the old resolver fell
+through to its default on every cloud request. Making it a real user id would
+read correctly and orphan every project already stored under
+``projects/<workspace>/local/``. The workspace segment is the tenancy boundary;
+this one is a vestigial path component.
+
+Mutations that must fail these tests: reading the workspace from a header
+again, returning a default instead of raising for an anonymous caller, and
+dropping the dependency from any route.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.routing import APIRoute
+from httpx import ASGITransport, AsyncClient
+from starlette.requests import Request
+
+from pocketpaw.api.v1.cloud_projects import resolve_project_scope
+
+MODULE = "pocketpaw.api.v1.cloud_projects"
+SOURCE = (
+    Path(__file__).resolve().parents[2] / "src" / "pocketpaw" / "api" / "v1" / "cloud_projects.py"
+)
+
+
+def _request(headers: dict[str, str] | None = None, **state) -> Request:
+    """A bare ASGI request with the given headers and request.state values."""
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    request = Request({"type": "http", "method": "GET", "path": "/", "headers": raw})
+    for key, value in state.items():
+        setattr(request.state, key, value)
+    return request
+
+
+# ---------------------------------------------------------------------------
+# The resolver.
+# ---------------------------------------------------------------------------
+
+
+async def test_an_anonymous_caller_is_refused():
+    """No session, no OSS credential: 401, not a default workspace.
+
+    The old code returned ``"default"`` here, which is how every anonymous
+    caller landed in the same namespace and could enumerate it.
+    """
+    with pytest.raises(HTTPException) as exc:
+        await resolve_project_scope(_request())
+    assert exc.value.status_code == 401
+
+
+async def test_a_header_cannot_choose_the_tenant():
+    """The reproduction, at the boundary itself.
+
+    A caller with no session sends X-Workspace-Id and is refused rather than
+    served that workspace.
+    """
+    with pytest.raises(HTTPException) as exc:
+        await resolve_project_scope(_request({"X-Workspace-Id": "ws-victim"}))
+    assert exc.value.status_code == 401
+
+
+async def test_a_header_cannot_override_a_resolved_session():
+    """Authenticated as one tenant, naming another: the session wins.
+
+    This is the case a naive fix misses. Adding an auth dependency while
+    leaving the header read in place authenticates the caller and then still
+    lets them act on any tenant they name.
+    """
+    request = _request({"X-Workspace-Id": "ws-victim"}, workspace_id="ws-attacker")
+    workspace_id, _ = await resolve_project_scope(request)
+    assert workspace_id == "ws-attacker"
+
+
+async def test_the_session_workspace_is_used_when_present():
+    workspace_id, user_segment = await resolve_project_scope(_request(workspace_id="ws-1"))
+    assert workspace_id == "ws-1"
+    assert user_segment == "local"
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"full_access": True},
+        {"api_key": object()},
+        {"oauth_token": object()},
+    ],
+)
+async def test_an_oss_authenticated_caller_gets_the_local_workspace(state):
+    """A single-tenant install still works, and keeps its existing key prefix.
+
+    ``"default"`` is the value the old header default produced, so projects
+    already on disk keep resolving.
+    """
+    workspace_id, user_segment = await resolve_project_scope(_request(**state))
+    assert (workspace_id, user_segment) == ("default", "local")
+
+
+# ---------------------------------------------------------------------------
+# Every route, not just the ones a test remembered to name.
+# ---------------------------------------------------------------------------
+
+
+def test_every_route_resolves_its_tenant_through_the_dependency():
+    module = importlib.import_module(MODULE)
+    routes = [r for r in module.router.routes if isinstance(r, APIRoute)]
+    assert routes, "expected the cloud projects router to expose HTTP routes"
+
+    missing = [
+        f"{sorted(r.methods or {'ANY'})[0]} {r.path}"
+        for r in routes
+        if not any(d.call is resolve_project_scope for d in r.dependant.dependencies)
+    ]
+    assert missing == [], (
+        "cloud project routes that do not take their tenant from the "
+        "authenticated caller:\n  " + "\n  ".join(missing)
+    )
+
+
+def test_the_module_never_reads_a_request_header():
+    """Asserted against the parsed module, so the docstrings may still name the
+    old header while explaining the boundary. A string search cannot tell an
+    explanation from a live read."""
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+    reads = [
+        f"line {node.lineno}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr == "headers"
+    ]
+    assert reads == [], (
+        f"the router reads a request header; nothing the caller writes may "
+        f"choose the tenant: {reads}"
+    )
+
+
+async def test_an_anonymous_request_to_a_real_route_is_rejected():
+    """End to end through the ASGI stack, with no request.state set at all."""
+    module = importlib.import_module(MODULE)
+    app = FastAPI()
+    app.include_router(module.router, prefix="/api/v1")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        response = await client.get(
+            "/api/v1/cloud/projects", headers={"X-Workspace-Id": "ws-victim"}
+        )
+    assert response.status_code == 401, response.text


### PR DESCRIPTION
## What was wrong

`src/pocketpaw/api/v1/cloud_projects.py` declared its router with no dependencies — `grep -c 'Depends('` over the file returned 0 — and resolved the tenant with:

```python
workspace_id = http_request.headers.get("X-Workspace-Id", "default")
```

Ten routes store and read under `projects/{workspace_id}/{user_id}/`: create, list, browse, read, write, create-file, mkdir, rename, delete, and a server-side `git clone`. An anonymous caller could read, write and enumerate any tenant's project storage by naming the workspace in a header, and workspace ids are not secret.

Audit finding C-4.

## Why not require_scope

The obvious gate is wrong here, and the wrongness is invisible from inside the file. The cloud frontend calls these routes as an **ordinary workspace member** authenticated by a session cookie. The EE auth bridge grants OSS `full_access` only to platform superusers, and a cookie sets neither `api_key` nor `oauth_token`. A scope gate would have 403'd every legitimate cloud user while looking like a fix in review.

## What changed

The tenant comes from `request.state.workspace_id`, stamped by the EE auth bridge from the caller's own JWT. The OSS package cannot import `pocketpaw_ee` (import-linter contract), so a request-state attribute is the seam, and the bridge already resolved the `User` on every request — this is two lines there.

It is stamped for **every** resolved user, not only superusers. The `full_access` grant immediately below it is deliberately superuser-only (the 2026-06-10 escalation fix) and it would be an easy, wrong tidy-up to fold these together. An ordinary member is exactly the caller who needs their own workspace resolved.

`resolve_project_scope` then trusts that, falls back to the local workspace for an OSS-authenticated caller with no cloud session (master token, dashboard cookie, genuine localhost, `pp_` key, OAuth token), and otherwise raises 401.

## What deliberately did not change

The middle `user_id` segment stays the constant `"local"`. It always was one in practice: cloud callers authenticate by cookie, so the old resolver fell through to its default on every cloud request. Making it a real user id reads correctly and would orphan every project already stored under `projects/<workspace>/local/`. The workspace segment is the tenancy boundary; this one is a vestigial path component, and it is now documented as such.

The local fallback is `"default"` for the same reason — it is the value the old header default produced, so projects already on disk keep resolving.

## Not fixed here

`POST /cloud/projects/clone` still git-clones a caller-supplied URL with no host validation, so it remains an SSRF and a disk-fill vector from an authenticated tenant. It is no longer anonymous, which was the critical part. I left it rather than guessing: rejecting private ranges would also block a customer cloning from their own internal git host, and that is a product decision. Worth its own issue.

## Tests

`tests/v1/test_cloud_projects_tenancy.py` and `tests/cloud/auth/test_ee_auth_bridge_tenant_stamp.py`, with `tests/mutations/cloud_projects_tenancy.json`. Seven mutations, all caught.

The route coverage is enumerated from the router rather than listed by hand, so a new route that forgets the dependency fails the suite. There is also an AST assertion that the module reads no request header at all, which lets the docstrings keep naming the old header while explaining the boundary.

643 tests pass across `tests/v1/`, `tests/cloud/auth/`, and the codeproject/daytona suites.