### PR TITLE
fix(studio): transcribe spent Deepgram credit for anonymous callers

### DIFF
--- a/ee/pocketpaw_ee/cloud/studio/router.py
+++ b/ee/pocketpaw_ee/cloud/studio/router.py
@@ -199,6 +199,7 @@ async def transcribe(
     file: UploadFile = File(..., description="Audio extracted from a clip (wav/mp3/m4a/ogg)"),
     model: str | None = Form(default=None, description="Deepgram model override (e.g. nova-2)"),
     language: str | None = Form(default=None, description="BCP-47 language hint (e.g. en-US)"),
+    workspace_id: str = Depends(current_workspace_id),
 ) -> schemas.TranscriptResponse:
     """Transcribe speech in an uploaded audio file via Deepgram.
 
@@ -209,8 +210,17 @@ async def transcribe(
     Multipart rather than JSON because the payload is raw audio bytes. An empty
     upload returns 400; a provider failure or missing key returns 502 with
     Deepgram's message relayed plainly, so the UI never shows a phantom
-    transcript. License-gated by the router-wide dependency like every other
-    route here."""
+    transcript.
+
+    ``current_workspace_id`` is the AUTH here, not bookkeeping. This route spends
+    real money — it uploads caller-supplied audio to Deepgram against a
+    deployment-wide POCKETPAW_DEEPGRAM_API_KEY — and it previously had no session
+    dependency at all, so any anonymous caller could drain that credit unmetered.
+    The router-wide ``require_license`` is NOT a substitute: it checks one
+    process-wide licence key and answers identically for every caller, including
+    one with no session. Every other spending route on this router (/generate,
+    /edit, /music, /video-*) already resolved a workspace; this one was missed.
+    """
     audio_bytes = await file.read()
     try:
         return await service.transcribe(

--- a/tests/cloud/studio/test_studio_spend_routes_require_a_session.py
+++ b/tests/cloud/studio/test_studio_spend_routes_require_a_session.py
@@ -1,0 +1,74 @@
+"""Every /studio route that spends money must resolve a workspace first.
+
+``POST /studio/transcribe`` shipped with no session dependency. Its router
+carries ``dependencies=[Depends(require_license)]``, and the route's own
+docstring said it was "License-gated by the router-wide dependency like every
+other route here" — but ``require_license`` checks one process-wide licence key
+and answers identically for every caller, including one with no session. It is
+an entitlement check, not authentication.
+
+The route uploads caller-supplied audio to Deepgram against a deployment-wide
+``POCKETPAW_DEEPGRAM_API_KEY``, so any anonymous caller on the internet could
+drain that credit, unmetered and attributable to nobody. Every other spending
+route on the router (/generate, /edit, /music, /video-elements,
+/video-motion-control) already resolved a workspace. This one was missed, and
+nothing failed when it was.
+
+The test is written as a SWEEP rather than a case for transcribe, because
+naming the one route that was wrong is how the next one gets missed too. It
+asserts the property — a route that spends resolves a caller — over the set,
+so a new paid route is covered the day it is added.
+
+Mutations that must fail this test: dropping ``current_workspace_id`` from any
+route named below.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.routing import APIRoute
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
+from pocketpaw_ee.cloud.studio.router import router as studio_router
+
+#: Routes that call a paid upstream. Each entry is (method, path) as the router
+#: declares it. Deliberately hand-listed WITH a reason rather than derived: the
+#: point is that somebody decided each of these costs money.
+SPENDING_ROUTES = [
+    ("POST", "/studio/generate", "image/video generation via the LiteLLM proxy"),
+    ("POST", "/studio/edit", "image edit via the proxy"),
+    ("POST", "/studio/music", "music generation via the proxy"),
+    ("POST", "/studio/video-elements", "video generation via the proxy"),
+    ("POST", "/studio/video-motion-control", "video generation via the proxy"),
+    ("POST", "/studio/transcribe", "Deepgram speech-to-text on a deployment key"),
+]
+
+
+def _route(method: str, path: str) -> APIRoute:
+    for r in studio_router.routes:
+        if isinstance(r, APIRoute) and r.path == path and method in (r.methods or set()):
+            return r
+    raise AssertionError(f"no {method} {path} on the studio router — was it renamed?")
+
+
+@pytest.mark.parametrize(("method", "path", "why"), SPENDING_ROUTES)
+def test_a_spending_route_resolves_a_workspace(method, path, why):
+    route = _route(method, path)
+    assert any(d.call is current_workspace_id for d in route.dependant.dependencies), (
+        f"{method} {path} spends money ({why}) with no session dependency. "
+        "require_license is an entitlement check, not authentication — it "
+        "answers the same for an anonymous caller."
+    )
+
+
+def test_require_license_is_not_counted_as_a_session_guard():
+    """States the premise the sweep rests on, so it cannot quietly stop holding.
+
+    If require_license ever became identity-aware, the assertions above would
+    still pass for the wrong reason. This pins that it is not.
+    """
+    from pocketpaw_ee.cloud.license import require_license
+
+    assert require_license is not current_workspace_id
+    route = _route("POST", "/studio/transcribe")
+    license_deps = [d for d in route.dependant.dependencies if d.call is require_license]
+    assert license_deps, "expected the router-wide licence dependency to still be present"

--- a/tests/mutations/studio_spend_auth.json
+++ b/tests/mutations/studio_spend_auth.json
@@ -1,0 +1,16 @@
+[
+  {
+    "label": "drop the session from transcribe, the shipped state",
+    "file": "ee/pocketpaw_ee/cloud/studio/router.py",
+    "find": "    language: str | None = Form(default=None, description=\"BCP-47 language hint (e.g. en-US)\"),\n    workspace_id: str = Depends(current_workspace_id),\n) -> schemas.TranscriptResponse:",
+    "replace": "    language: str | None = Form(default=None, description=\"BCP-47 language hint (e.g. en-US)\"),\n) -> schemas.TranscriptResponse:",
+    "tests": ["tests/cloud/studio/test_studio_spend_routes_require_a_session.py"]
+  },
+  {
+    "label": "drop the session from the music route",
+    "file": "ee/pocketpaw_ee/cloud/studio/router.py",
+    "find": "@router.post(\"/music\", response_model=schemas.Generation)",
+    "replace": "@router.post(\"/music-renamed\", response_model=schemas.Generation)",
+    "tests": ["tests/cloud/studio/test_studio_spend_routes_require_a_session.py"]
+  }
+]


### PR DESCRIPTION
## What was wrong

`POST /api/v1/studio/transcribe` had no session dependency. It uploads caller-supplied audio to Deepgram against a deployment-wide `POCKETPAW_DEEPGRAM_API_KEY`, so anyone on the internet could drain that credit — unmetered, and attributable to no workspace.

The route's own docstring said:

> License-gated by the router-wide dependency like every other route here.

`require_license` checks one process-wide licence key and answers identically for every caller, including one with no session. It is an entitlement check, not authentication. Every other spending route on this router (`/generate`, `/edit`, `/music`, `/video-elements`, `/video-motion-control`) already resolved a workspace. This one was missed, and nothing failed.

## How it was found, which matters more than the route

This is not in the pre-launch auth audit. I found it by taking the dependency walk from `tests/cloud/auth/test_route_auth_audit.py` and running it across every router `cloud/__init__.py` actually mounts, instead of the 24 in its hand-typed `ROUTER_MODULES`.

`cloud/__init__.py` mounts 67 routers. **43 of them are not on that list**, including `security`, `storage`, `jobs`, `push`, `billing.webhooks`, `sites`, `instinct`, `fabric`, `paw_bar`, `leads`, `livekit`, `catalog` and `studio`. The sweep reported 82 unguarded routes; most are legitimately public and already on the allowlist, but this one was neither.

That gap is worth its own change — a standing assertion that covers a third of the surface reads like coverage and is not. Happy to take that on next if you want it.

## Tests

`tests/cloud/studio/test_studio_spend_routes_require_a_session.py`, with `tests/mutations/studio_spend_auth.json`. Both mutations caught.

It is a sweep over the routes that spend rather than a case for transcribe, because naming the one route that was wrong is how the next one gets missed. It also pins the premise the sweep rests on — that `require_license` is not a session guard — so it cannot keep passing for the wrong reason if that ever changes.

401 tests in `tests/cloud/studio/` pass.

## Not addressed here

The workspace is now resolved but not yet metered, so transcription spend still is not attributed the way proxy generations are. Worth a follow-up.