### PR TITLE
fix(media): one gallery was shared by every workspace, with no auth to list it

### DIFF
--- a/ee/pocketpaw_ee/cloud/media/router.py
+++ b/ee/pocketpaw_ee/cloud/media/router.py
@@ -7,9 +7,24 @@ the gallery grid, serves them over HTTP so the frontend can render ``<img>`` /
 ``<video>`` tags, and accepts the canvas editor's "save edited image" upload.
 
 Endpoints:
-  GET  /api/v1/media          — list all generated media files
-  POST /api/v1/media          — upload a generated file (canvas "save edited image")
-  GET  /api/v1/media/{name}   — serve a single media file
+  GET  /api/v1/media          — list the caller's workspace's media (session required)
+  POST /api/v1/media          — upload a generated file (session required)
+  GET  /api/v1/media/{name}   — serve a single media file (capability-based, see below)
+
+Updated: 2026-09-07 — list and upload had NO auth and the key carried no tenant,
+so one gallery was shared by every workspace: the listing returned every
+tenant's filenames and URLs, and anyone on the internet could store bytes on
+this infrastructure and have them served from this origin. Both routes now take
+``current_workspace_id``, and an upload's filename carries an owner token so the
+listing can be scoped.
+
+``serve_media`` is deliberately NOT gated, and that asymmetry is the design
+rather than an omission. Gallery URLs are embedded in ripple specs, and a pocket
+published as a site is served from the edge with no session — enforcing an owner
+on the read would blank every published page showing one. The read stays
+capability-based on an unguessable name, like /uploads. A /browser capture is
+different: it is private to its workspace and never embedded, so serve_media
+does enforce ITS owner token.
 
 Updated: 2026-09-06 (BR-4, feat/browser-surface-extract): /browser screenshots
 are saved through this same storage so they have a URL an image widget can
@@ -37,6 +52,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse, Response, StreamingResponse
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
 from pocketpaw_ee.cloud.auth.core import fastapi_users
 from pocketpaw_ee.cloud.media import storage
 from pocketpaw_ee.cloud.studio.service import tracked_generation_filenames
@@ -77,7 +93,7 @@ _SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]")
 # writes local disk).
 
 
-def _local_entries(generated: Path, sort: str, tracked: set[str]) -> list[dict]:
+def _local_entries(generated: Path, sort: str, tracked: set[str], workspace_id: str) -> list[dict]:
     """List one local generated directory (mtime-sorted, media-only, excluding
     generation-tracked files) as MediaFile dicts."""
     if not generated.exists():
@@ -97,6 +113,8 @@ def _local_entries(generated: Path, sort: str, tracked: set[str]) -> list[dict]:
             continue
         if f.name in tracked or storage.capture_owner_of(f.name):
             continue
+        if not storage.visible_to(f.name, workspace_id):
+            continue
         entries.append(
             {
                 "name": f.name,
@@ -109,7 +127,7 @@ def _local_entries(generated: Path, sort: str, tracked: set[str]) -> list[dict]:
     return entries
 
 
-async def _remote_entries(sort: str, tracked: set[str]) -> list[dict]:
+async def _remote_entries(sort: str, tracked: set[str], workspace_id: str) -> list[dict]:
     """List S3 keys under the media prefix as MediaFile dicts. Remote listings
     carry no mtime, so ``modified`` comes from the timestamp baked into generated
     filenames (``<ms>-<uuid>.png``); uploads without one report 0."""
@@ -124,6 +142,8 @@ async def _remote_entries(sort: str, tracked: set[str]) -> list[dict]:
         if mime is None:
             continue
         if item.name in tracked or storage.capture_owner_of(item.name):
+            continue
+        if not storage.visible_to(item.name, workspace_id):
             continue
         entries.append(
             {
@@ -142,6 +162,7 @@ async def _remote_entries(sort: str, tracked: set[str]) -> list[dict]:
 async def list_media(
     sort: str = Query("newest", description="Sort order: 'newest' or 'oldest'"),
     limit: int = Query(50, description="Max items to return"),
+    workspace_id: str = Depends(current_workspace_id),
 ) -> Response:
     """List all generated media files with metadata.
 
@@ -156,9 +177,9 @@ async def list_media(
     tracked = tracked_generation_filenames()
     generated = storage.local_generated_dir()
     entries = (
-        _local_entries(generated, sort, tracked)
+        _local_entries(generated, sort, tracked, workspace_id)
         if generated is not None
-        else await _remote_entries(sort, tracked)
+        else await _remote_entries(sort, tracked, workspace_id)
     )
     return Response(
         content=json.dumps({"media": entries[:limit]}),
@@ -167,7 +188,10 @@ async def list_media(
 
 
 @router.post("")
-async def upload_media(file: UploadFile = File(...)) -> Response:
+async def upload_media(
+    file: UploadFile = File(...),
+    workspace_id: str = Depends(current_workspace_id),
+) -> Response:
     """Upload a generated file into the gallery (used by the canvas editor's
     "save edited image"). Returns the MediaFile JSON so the frontend can select
     it after re-listing.
@@ -188,7 +212,11 @@ async def upload_media(file: UploadFile = File(...)) -> Response:
         safe_name = f"{stem}{suffix}"
 
     adapter = storage.get_adapter()
-    name = safe_name
+    # The owner travels in the filename, because the key cannot carry a
+    # workspace segment (serve_media refuses any name with a slash). This makes
+    # the file attributable so the LISTING can be scoped; the read stays
+    # capability-based so a published site that embeds the URL keeps working.
+    name = f"{storage.owned_name_prefix(workspace_id)}{safe_name}"
     while await adapter.exists(storage.media_key(name)):
         stem = Path(name).stem
         name = f"{stem}-{uuid4().hex[:8]}{suffix}"

--- a/ee/pocketpaw_ee/cloud/media/storage.py
+++ b/ee/pocketpaw_ee/cloud/media/storage.py
@@ -102,6 +102,59 @@ def capture_owner_of(name: str) -> str | None:
     return token if _CAPTURE_TOKEN_RE.match(token) else None
 
 
+# --- Uploaded gallery files -------------------------------------------------
+# The SAME problem as a capture, and a deliberately different answer.
+#
+# ``POST /api/v1/media`` had no auth and ``media_key`` carried no tenant, so one
+# gallery was shared by every workspace on the deployment: GET /api/v1/media
+# returned every tenant's filenames and URLs, and anyone on the internet could
+# add to it. The key cannot grow a workspace segment — ``serve_media`` refuses
+# any name containing a slash — so, as with captures, the owner travels in the
+# filename.
+#
+# Where this DIFFERS from a capture, and the difference is the whole design:
+# ``serve_media`` does NOT enforce this token. A capture is private to its
+# workspace; a gallery image is embedded in ripple specs, and a pocket
+# published as a site is served from the edge with no session, so enforcing an
+# owner on the read would blank every published page that shows one. The token
+# makes a file ATTRIBUTABLE so the LISTING can be scoped. Reads stay
+# capability-based on an unguessable name, exactly like /uploads.
+#
+# Files written before this existed carry no token. They stay visible to every
+# workspace's listing, which matches what ``studio.service.list_generations``
+# already does with untagged history records (``_workspace is None`` is shown
+# to everyone). Consistency with the neighbouring subsystem beats a private
+# rule here, and hiding them instead would empty existing galleries.
+OWNED_PREFIX = "ws-"
+_OWNED_TOKEN_RE = re.compile(r"[0-9a-f]{16}\Z")
+
+
+def owned_name_prefix(workspace_id: str) -> str:
+    """Filename prefix marking a gallery upload as owned by ``workspace_id``."""
+    return f"{OWNED_PREFIX}{capture_owner_token(workspace_id)}-"
+
+
+def owner_of(name: str) -> str | None:
+    """The owner token in an uploaded filename, or None when it carries none.
+
+    Shape-checked rather than prefix-checked: a user's own file called
+    "ws-holiday.png" is not an owned upload, and treating it as one would hide
+    it from every listing including its owner's.
+    """
+    if not name.startswith(OWNED_PREFIX):
+        return None
+    token = name[len(OWNED_PREFIX) :].split("-", 1)[0]
+    return token if _OWNED_TOKEN_RE.match(token) else None
+
+
+def visible_to(name: str, workspace_id: str | None) -> bool:
+    """Whether ``name`` belongs in ``workspace_id``'s gallery listing."""
+    owner = owner_of(name)
+    if owner is None:
+        return True  # legacy, untagged — see the note above
+    return workspace_id is not None and owner == capture_owner_token(workspace_id)
+
+
 async def save_generated(data: bytes, *, mime: str, ext: str = "png", name_prefix: str = "") -> str:
     """Persist a freshly generated blob (image / audio / …) through the media
     adapter and return its backend-relative ``/api/v1/media/<name>`` URL.
@@ -137,6 +190,7 @@ def local_generated_dir() -> Path | None:
 
 __all__ = [
     "CAPTURE_PREFIX",
+    "OWNED_PREFIX",
     "MEDIA_ROOT",
     "MEDIA_KEY_PREFIX",
     "media_key",

--- a/tests/cloud/test_media_gallery_tenancy.py
+++ b/tests/cloud/test_media_gallery_tenancy.py
@@ -1,0 +1,195 @@
+"""The media gallery was one global namespace with no auth on list or upload.
+
+``ee/pocketpaw_ee/cloud/media/router.py`` declared
+``APIRouter(prefix="/media", ...)`` with no dependencies, and ``media_key``
+was ``f"generated/{name}"`` — no tenant anywhere. So:
+
+  * ``GET /api/v1/media`` returned every workspace's filenames and URLs to
+    anyone on the internet, and every listed URL then served;
+  * ``POST /api/v1/media`` let an anonymous caller store arbitrary image or
+    video bytes on this infrastructure and have them served from this origin.
+
+THE ASYMMETRY IS THE DESIGN, NOT AN OVERSIGHT
+
+``serve_media`` is still reachable without a session, and that is deliberate.
+Gallery URLs are embedded in ripple specs, and a pocket published as a site is
+served from the edge with no cookie — gating the read would blank every
+published page that shows a generated image. Reads stay capability-based on an
+unguessable name, exactly like /uploads. A /browser capture is the exception
+already in the code: private to its workspace, never embedded, and serve_media
+does enforce its owner token.
+
+So the fix is: authenticate the two routes that do not need to be public, and
+make files ATTRIBUTABLE so the listing can be scoped. The key cannot carry a
+workspace segment — serve_media refuses any name containing a slash — so the
+owner travels in the filename, reusing the mechanism captures already use.
+
+LEGACY FILES STAY VISIBLE, ON PURPOSE
+
+A file written before this carries no token and appears in every workspace's
+listing. That matches what ``studio.service.list_generations`` already does with
+untagged history records (``_workspace is None`` is shown to everyone), and
+hiding them instead would empty existing galleries. It is a bounded residue that
+stops growing, not a hole that stays open.
+
+Mutations that must fail these tests: dropping either dependency, dropping the
+owner prefix from an upload, and making ``visible_to`` return True for another
+workspace's file.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from fastapi.routing import APIRoute
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
+from pocketpaw_ee.cloud.media import storage
+
+ROUTER = "pocketpaw_ee.cloud.media.router"
+
+WS_A = "ws-alpha"
+WS_B = "ws-beta"
+
+
+@pytest.fixture
+def router_module():
+    return importlib.import_module(ROUTER)
+
+
+def _route(module, method: str, path: str) -> APIRoute:
+    for r in module.router.routes:
+        if isinstance(r, APIRoute) and r.path == path and method in (r.methods or set()):
+            return r
+    raise AssertionError(f"no {method} {path} on the media router")
+
+
+# ---------------------------------------------------------------------------
+# Auth, per route, because they do not all want the same answer.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("method", "path"), [("GET", "/media"), ("POST", "/media")])
+def test_list_and_upload_require_a_session(router_module, method, path):
+    route = _route(router_module, method, path)
+    assert any(d.call is current_workspace_id for d in route.dependant.dependencies), (
+        f"{method} {path} does not resolve a workspace from the caller; it "
+        "listed and accepted writes for one global namespace"
+    )
+
+
+def test_serving_stays_reachable_without_a_session(router_module):
+    """Asserted so nobody 'finishes the job' and breaks every published site.
+
+    If this ever needs to change, the ripple specs that embed
+    ``/api/v1/media/<name>`` have to change with it.
+    """
+    route = _route(router_module, "GET", "/media/{name:path}")
+    assert not any(d.call is current_workspace_id for d in route.dependant.dependencies)
+
+
+# ---------------------------------------------------------------------------
+# Attribution.
+# ---------------------------------------------------------------------------
+
+
+def test_an_owned_name_round_trips_to_its_workspace():
+    name = storage.owned_name_prefix(WS_A) + "edit.png"
+    assert storage.owner_of(name) == storage.capture_owner_token(WS_A)
+    assert storage.visible_to(name, WS_A) is True
+    assert storage.visible_to(name, WS_B) is False
+
+
+def test_the_workspace_id_is_not_recoverable_from_the_name():
+    """The token is a digest, so a URL in an image widget does not leak a tenant id."""
+    name = storage.owned_name_prefix(WS_A) + "edit.png"
+    assert WS_A not in name
+
+
+def test_a_file_merely_named_like_an_owned_one_is_not_treated_as_owned():
+    """Shape-checked, not prefix-checked.
+
+    A user's own upload called "ws-holiday.png" is not an owned file, and
+    treating it as one would hide it from every listing including its owner's.
+    """
+    assert storage.owner_of("ws-holiday.png") is None
+    assert storage.visible_to("ws-holiday.png", WS_A) is True
+
+
+def test_an_untagged_legacy_file_stays_visible():
+    """Deliberate, and it matches studio.service.list_generations.
+
+    Change this and existing galleries empty out; that is a product decision,
+    not a refactor.
+    """
+    assert storage.owner_of("1700000000000-abc123.png") is None
+    assert storage.visible_to("1700000000000-abc123.png", WS_A) is True
+    assert storage.visible_to("1700000000000-abc123.png", None) is True
+
+
+def test_a_capture_is_not_mistaken_for_an_owned_upload():
+    """The two mechanisms share a token but not a prefix, and must not collide.
+
+    A capture is enforced on READ; an owned upload is not. Confusing them
+    either exposes a private capture or 404s a published site's image.
+    """
+    capture = storage.capture_name_prefix(WS_A) + "1700000000000-abc.png"
+    assert storage.capture_owner_of(capture) == storage.capture_owner_token(WS_A)
+    assert storage.owner_of(capture) is None
+
+
+# ---------------------------------------------------------------------------
+# The listing actually applies it.
+# ---------------------------------------------------------------------------
+
+
+def test_the_local_listing_excludes_another_workspaces_file(tmp_path, router_module):
+    mine = storage.owned_name_prefix(WS_A) + "mine.png"
+    theirs = storage.owned_name_prefix(WS_B) + "theirs.png"
+    legacy = "1700000000000-legacy.png"
+    for name in (mine, theirs, legacy):
+        (tmp_path / name).write_bytes(b"x")
+
+    names = {e["name"] for e in router_module._local_entries(tmp_path, "newest", set(), WS_A)}
+    assert mine in names
+    assert legacy in names
+    assert theirs not in names, "another workspace's file appeared in the listing"
+
+
+async def test_an_upload_is_stamped_with_the_callers_workspace(router_module, monkeypatch):
+    """The route must APPLY the prefix, not merely have one available.
+
+    This test exists because a mutation escaped without it. Dropping the stamp
+    leaves uploads untagged, untagged files are visible to everyone by the
+    legacy rule above, and every other test in this file still passed — the
+    listing filter was correct and had nothing to filter on.
+    """
+    written: list[str] = []
+
+    class _Stored:
+        size = 1
+
+    class _Adapter:
+        async def exists(self, key: str) -> bool:
+            return False
+
+        async def put(self, key: str, stream, mime: str):
+            written.append(key)
+            return _Stored()
+
+    monkeypatch.setattr(storage, "get_adapter", lambda: _Adapter())
+
+    class _File:
+        filename = "edit.png"
+
+        async def read(self) -> bytes:
+            return b"x"
+
+    await router_module.upload_media(file=_File(), workspace_id=WS_A)
+
+    assert written, "the upload never reached the adapter"
+    name = storage.name_from_key(written[0])
+    assert storage.owner_of(name) == storage.capture_owner_token(WS_A), (
+        f"the stored name carries no owner token: {name!r}"
+    )
+    assert storage.visible_to(name, WS_B) is False

--- a/tests/mutations/media_gallery_tenancy.json
+++ b/tests/mutations/media_gallery_tenancy.json
@@ -1,0 +1,51 @@
+[
+  {
+    "label": "drop the session from the listing, the shipped state",
+    "file": "ee/pocketpaw_ee/cloud/media/router.py",
+    "find": "    limit: int = Query(50, description=\"Max items to return\"),\n    workspace_id: str = Depends(current_workspace_id),\n) -> Response:",
+    "replace": "    limit: int = Query(50, description=\"Max items to return\"),\n    workspace_id: str = \"\",\n) -> Response:",
+    "tests": ["tests/cloud/test_media_gallery_tenancy.py"]
+  },
+  {
+    "label": "drop the session from the upload route",
+    "file": "ee/pocketpaw_ee/cloud/media/router.py",
+    "find": "    file: UploadFile = File(...),\n    workspace_id: str = Depends(current_workspace_id),\n) -> Response:",
+    "replace": "    file: UploadFile = File(...),\n    workspace_id: str = \"\",\n) -> Response:",
+    "tests": ["tests/cloud/test_media_gallery_tenancy.py"]
+  },
+  {
+    "label": "gate the serve route too, blanking every published site",
+    "file": "ee/pocketpaw_ee/cloud/media/router.py",
+    "find": "    workspace_id: str | None = Depends(optional_workspace_id),\n) -> Response:",
+    "replace": "    workspace_id: str | None = Depends(current_workspace_id),\n) -> Response:",
+    "tests": ["tests/cloud/test_media_gallery_tenancy.py"]
+  },
+  {
+    "label": "stop stamping the owner onto an upload",
+    "file": "ee/pocketpaw_ee/cloud/media/router.py",
+    "find": "    name = f\"{storage.owned_name_prefix(workspace_id)}{safe_name}\"",
+    "replace": "    name = safe_name",
+    "tests": ["tests/cloud/test_media_gallery_tenancy.py"]
+  },
+  {
+    "label": "show every workspace's file in the listing",
+    "file": "ee/pocketpaw_ee/cloud/media/storage.py",
+    "find": "    owner = owner_of(name)\n    if owner is None:\n        return True  # legacy, untagged — see the note above\n    return workspace_id is not None and owner == capture_owner_token(workspace_id)",
+    "replace": "    return True",
+    "tests": ["tests/cloud/test_media_gallery_tenancy.py"]
+  },
+  {
+    "label": "match the owner prefix without checking the token shape",
+    "file": "ee/pocketpaw_ee/cloud/media/storage.py",
+    "find": "    token = name[len(OWNED_PREFIX) :].split(\"-\", 1)[0]\n    return token if _OWNED_TOKEN_RE.match(token) else None",
+    "replace": "    return name[len(OWNED_PREFIX) :].split(\"-\", 1)[0]",
+    "tests": ["tests/cloud/test_media_gallery_tenancy.py"]
+  },
+  {
+    "label": "skip the visibility filter in the local listing",
+    "file": "ee/pocketpaw_ee/cloud/media/router.py",
+    "find": "        if not storage.visible_to(f.name, workspace_id):\n            continue",
+    "replace": "        pass",
+    "tests": ["tests/cloud/test_media_gallery_tenancy.py"]
+  }
+]


### PR DESCRIPTION
## What was wrong

`ee/pocketpaw_ee/cloud/media/router.py` declared `APIRouter(prefix="/media", ...)` with no dependencies, and `media_key` was `f"generated/{name}"` — no tenant anywhere.

`GET /api/v1/media` returned every workspace's filenames and URLs to anyone on the internet, and every listed URL then served. `POST /api/v1/media` let an anonymous caller store arbitrary image or video bytes on this infrastructure and have them served from this origin.

Audit finding H-2.

## What changed

List and upload now take `current_workspace_id`. An upload's stored filename carries an opaque per-workspace owner token, so the listing can be scoped to the caller.

The owner travels in the filename because the key cannot carry a workspace segment — `serve_media` refuses any name containing a slash. That is the same constraint the `/browser` capture mechanism already solved, so this reuses it rather than inventing a second scheme.

## serve_media is deliberately still public

This is the part worth reviewing carefully, because it looks like an unfinished fix and is not.

Gallery URLs are embedded in ripple specs, and a pocket published as a site is served from the edge with no session. Gating the read would blank every published page that shows a generated image. Reads stay capability-based on an unguessable name, exactly like `/uploads`.

A `/browser` capture is the existing exception: private to its workspace, never embedded, and `serve_media` does enforce its token. The two mechanisms share a token derivation but not a prefix, and a test asserts they cannot be confused — mixing them up would either expose a private capture or 404 a published site's image.

There is a test asserting the serve route stays ungated, so that nobody "finishes the job" later without also changing the specs that embed the URLs.

## Legacy files stay visible, on purpose

A file written before this carries no token and appears in every workspace's listing. That matches what `studio.service.list_generations` already does with untagged history records (`_workspace is None` is shown to everyone), and hiding them instead would empty existing galleries. It is a bounded residue that stops growing rather than a hole left open. Flagging it explicitly because it is a product call, not a technical one — say the word and I will make untagged files invisible instead.

## Known cosmetic consequence

An upload's stored name now begins with `ws-<token>-`, and `downloadMedia` in paw-enterprise derives the download filename from the URL. So saving an edited image and downloading it gives `ws-3f9a…-edit.png`. The clean fix is a `display_name` in the upload response that `downloadMedia` prefers, which is frontend work in the other repo. Worth doing, not worth blocking this.

## Tests

`tests/cloud/test_media_gallery_tenancy.py` with `tests/mutations/media_gallery_tenancy.json`. Seven mutations, all caught — including one that gates the serve route, which must fail.

One escaped on the first run and is worth knowing about: nothing asserted that the upload route *applies* the prefix. Dropping the stamp left uploads untagged, untagged files are visible to everyone by the legacy rule, and every other test still passed — the listing filter was correct and had nothing to filter on. There is now a test that drives the upload route and inspects the stored key.

Media, studio and browser suites pass locally. A full `tests/cloud/ tests/ee/` sweep was still running when I opened this; CI is the gate and I will follow up if it turns anything up.