### PR TITLE
fix(uploads): the static mount served the whole upload tree, not avatars

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -873,14 +873,45 @@ def mount_cloud(app: FastAPI) -> None:
             for u in users
         ]
 
-    # Serve uploaded avatars from ~/.pocketpaw/uploads/
+    # Serve agent avatars, and ONLY agent avatars.
+    #
+    # This mount used to be rooted at ~/.pocketpaw/uploads — the whole tree —
+    # while its comment said "avatars". Avatars are a subdirectory, so every
+    # other thing any subsystem writes under that root was served too, over a
+    # prefix the auth middleware exempts: the customer "My Files" store, file
+    # versions, websandbox durability, per-project build files, site
+    # screenshots, agent deliverables, meeting artifacts, the thumbnail cache,
+    # the remote-materialisation cache, and _idx.jsonl (an index listing id,
+    # storage_key, filename, mime, size, owner_id and chat_id for every
+    # OSS-path upload and agent-delivered artifact).
+    #
+    # Keys are uuid4 so the bulk of it was capability-based rather than
+    # enumerable, but _idx.jsonl turned that subset into a list, and every URL
+    # that ever leaked was a permanent unrevocable bearer token with no
+    # workspace attached — it ignored the soft-delete tombstone and survived the
+    # user leaving the workspace.
+    #
+    # The mount is now the avatars directory itself. Nothing else is reachable,
+    # and _idx.jsonl stops being served without moving it (which would strand
+    # the indexes on existing deployments). StaticFiles normalises "..' and
+    # compares the realpath against the root, so the narrowed mount cannot be
+    # walked back up.
+    #
+    # Agent avatars are the ONLY consumer: ee/pocketpaw_ee/cloud/agents/router.py
+    # is the one place that builds a root-level "/uploads/..." URL, and it builds
+    # exactly "{base}/uploads/avatars/{filename}". USER avatars are unaffected —
+    # they live in the sibling ~/.pocketpaw/avatars and are served by the
+    # authenticated GET /api/v1/auth/avatar/{filename}. Everything else addresses
+    # bytes through /api/v1/uploads/{id}, which enforces a signed 5-minute grant.
+    #
+    # Gated by tests/cloud/test_uploads_mount_scope.py.
     from pathlib import Path
 
     from fastapi.staticfiles import StaticFiles
 
-    uploads_dir = Path.home() / ".pocketpaw" / "uploads"
-    uploads_dir.mkdir(parents=True, exist_ok=True)
-    app.mount("/uploads", StaticFiles(directory=str(uploads_dir)), name="uploads")
+    avatars_dir = Path.home() / ".pocketpaw" / "uploads" / "avatars"
+    avatars_dir.mkdir(parents=True, exist_ok=True)
+    app.mount("/uploads/avatars", StaticFiles(directory=str(avatars_dir)), name="uploads")
 
     # Paw Bar glass app (A1) — the iframe served by GET /api/v1/paw-bar/frame loads
     # pawbar.js + pawbar.css from THIS root-absolute mount. The dir is configurable

--- a/src/pocketpaw/dashboard_auth.py
+++ b/src/pocketpaw/dashboard_auth.py
@@ -126,10 +126,16 @@ async def verify_token(
     """
     from fastapi import HTTPException
 
-    # SKIP AUTH for static files, uploads, and health checks (if any)
+    # SKIP AUTH for static files, agent avatars, and health checks (if any).
+    #
+    # Narrowed from "/uploads" alongside the StaticFiles mount and the
+    # _auth_dispatch exemptions. This function is currently reachable from
+    # nothing — dashboard.py re-exports it for backward compatibility only — so
+    # the change is consistency rather than a live fix, and it means wiring it
+    # up later cannot reintroduce the broad prefix.
     if (
         request.url.path.startswith("/static")
-        or request.url.path.startswith("/uploads")
+        or request.url.path.startswith("/uploads/avatars")
         or request.url.path.startswith("/pawbar-app")
         or request.url.path == "/favicon.ico"
     ):
@@ -436,7 +442,13 @@ async def _auth_dispatch(request: Request) -> Response | None:
     # webhooks, OAuth callbacks).
     exempt_paths = [
         "/static",
-        "/uploads",
+        # NOT "/uploads" — that exempted the whole prefix while the StaticFiles
+        # mount was rooted at the entire ~/.pocketpaw/uploads tree, so every
+        # subsystem's files were served unauthenticated. The mount is now the
+        # avatars directory alone (ee/pocketpaw_ee/cloud/__init__.py), and this
+        # exemption is narrowed to match so re-widening the mount does not
+        # silently inherit an unauthenticated prefix.
+        "/uploads/avatars",
         "/favicon.ico",
         # Paw Bar glass app bundle (pawbar.js/css) — loaded by the public
         # concierge iframe on published sites; visitors have no session.
@@ -629,11 +641,12 @@ async def _auth_dispatch(request: Request) -> Response | None:
         if _verify_upload_grant(request, current_token):
             is_valid = True
 
-    # Allow frontend assets (/, /static/*, /uploads/*) through for SPA bootstrap.
+    # Allow frontend assets (/, /static/*, /uploads/avatars/*) through for SPA
+    # bootstrap. Narrowed from "/uploads/" for the reason given on exempt_paths.
     if (
         request.url.path == "/"
         or request.url.path.startswith("/static/")
-        or request.url.path.startswith("/uploads/")
+        or request.url.path.startswith("/uploads/avatars/")
     ):
         return None  # allow through
 

--- a/tests/cloud/test_uploads_mount_scope.py
+++ b/tests/cloud/test_uploads_mount_scope.py
@@ -1,0 +1,167 @@
+"""The /uploads static mount serves agent avatars and nothing else.
+
+``mount_cloud`` mounted ``StaticFiles`` at the WHOLE of ``~/.pocketpaw/uploads``
+while the comment above it said "Serve uploaded avatars". Avatars are a
+subdirectory. Everything any subsystem writes under that root was therefore
+served too, over a prefix the auth middleware exempted:
+
+  * the EE customer "My Files" store and its file versions,
+  * websandbox durability and per-project build files,
+  * site screenshots, agent deliverables, meeting artifacts,
+  * the thumbnail cache and the remote-materialisation cache (which streams a
+    copy of every S3 blob an agent has touched back onto local disk, so S3 mode
+    did not empty the directory),
+  * and ``_idx.jsonl`` — an index carrying id, storage_key, filename, mime,
+    size, owner_id and chat_id for every OSS-path upload and agent-delivered
+    artifact.
+
+Storage keys are uuid4, so the bulk of it was capability-based rather than
+enumerable. ``_idx.jsonl`` turned that subset into a list. And every URL that
+ever leaked was a permanent, unrevocable bearer token carrying no workspace: it
+ignored the soft-delete tombstone and survived the user leaving the workspace,
+unlike ``GET /api/v1/uploads/{id}`` which mints a signed 5-minute grant.
+
+THE FIX IS THE MOUNT ROOT, NOT A DENYLIST
+
+Enumerating what must not be served is the version of this that rots. The mount
+is the avatars directory itself, so the set of reachable files is defined by
+where it points rather than by a list somebody has to maintain. ``_idx.jsonl``
+stops being served without being moved, which matters because moving it would
+strand the index on every existing deployment.
+
+WHY NARROWING BREAKS NOTHING
+
+``ee/pocketpaw_ee/cloud/agents/router.py`` is the ONLY place in either package
+that builds a root-level ``/uploads/...`` URL, and it builds exactly
+``{base}/uploads/avatars/{filename}``. User avatars are a different subsystem:
+they live in the sibling ``~/.pocketpaw/avatars`` and are served by the
+authenticated ``GET /api/v1/auth/avatar/{filename}``. Everything else addresses
+bytes through ``/api/v1/uploads/{id}``.
+
+Mutations that must fail these tests: re-rooting the mount at the uploads
+parent, and widening either auth exemption back to the bare ``/uploads``
+prefix.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CLOUD_INIT = REPO / "ee" / "pocketpaw_ee" / "cloud" / "__init__.py"
+DASHBOARD_AUTH = REPO / "src" / "pocketpaw" / "dashboard_auth.py"
+AGENTS_ROUTER = REPO / "ee" / "pocketpaw_ee" / "cloud" / "agents" / "router.py"
+
+
+def _mount_call() -> ast.Call:
+    """The app.mount(...) call whose name is "uploads"."""
+    tree = ast.parse(CLOUD_INIT.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "mount"
+        ):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "name" and getattr(kw.value, "value", None) == "uploads":
+                return node
+    raise AssertionError('no app.mount(..., name="uploads") found in mount_cloud')
+
+
+def test_the_mount_path_is_the_avatars_subtree():
+    call = _mount_call()
+    path = call.args[0].value
+    assert path == "/uploads/avatars", (
+        f"the uploads mount is at {path!r}. At '/uploads' it serves the whole "
+        "~/.pocketpaw/uploads tree, including _idx.jsonl and every tenant's files."
+    )
+
+
+def test_the_mount_directory_is_the_avatars_directory():
+    """The path alone is not enough — the DIRECTORY is what bounds the reach.
+
+    Mounting the parent directory at the '/uploads/avatars' path would serve
+    the whole tree under a narrower-looking URL, and the path assertion above
+    would still pass.
+    """
+    source = open(CLOUD_INIT, encoding="utf-8").read()
+    tree = ast.parse(source)
+
+    target = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and getattr(node.targets[0], "id", None) == "avatars_dir"
+        ):
+            target = ast.get_source_segment(source, node.value)
+    assert target is not None, "expected an avatars_dir assignment feeding the mount"
+    assert '"avatars"' in target, f"avatars_dir does not end at the avatars directory: {target}"
+
+    call = _mount_call()
+    directory = [kw for kw in call.keywords if kw.arg == "directory"]
+    if not directory:
+        static = call.args[1]
+        directory = [kw for kw in static.keywords if kw.arg == "directory"]
+    rendered = ast.get_source_segment(source, directory[0].value)
+    assert "avatars_dir" in rendered, f"the mount does not serve avatars_dir; it serves {rendered}"
+
+
+@pytest.mark.parametrize(
+    "needle",
+    [
+        '"/uploads",',
+        'startswith("/uploads")',
+        'startswith("/uploads/")',
+    ],
+)
+def test_no_auth_exemption_covers_the_bare_uploads_prefix(needle):
+    """Three places exempted '/uploads' from auth. All three are narrowed.
+
+    Left broad, re-rooting the mount later would silently inherit an
+    unauthenticated prefix — which is how this was reachable in the first
+    place.
+    """
+    text = DASHBOARD_AUTH.read_text(encoding="utf-8")
+    live = [
+        line for line in text.splitlines() if needle in line and not line.lstrip().startswith("#")
+    ]
+    assert live == [], f"a broad /uploads auth exemption is still live: {live}"
+
+
+def test_the_only_root_level_uploads_url_is_an_agent_avatar():
+    """The premise the narrowing rests on, asserted rather than assumed.
+
+    If some other module starts handing out a '{base}/uploads/<something-else>'
+    URL, narrowing the mount silently 404s it. This fails when that happens,
+    naming the file, instead of the link just breaking in production.
+    """
+    offenders: list[str] = []
+    for package in ("src", "ee"):
+        for path in (REPO / package).rglob("*.py"):
+            if "test" in path.parts:
+                continue
+            for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if "/uploads/" not in line or "/api/v1/uploads/" in line:
+                    continue
+                if "/uploads/avatars/" in line:
+                    continue
+                # Only flag URL CONSTRUCTION, not prose or path handling.
+                if 'f"' in line and "/uploads/" in line and "base" in line:
+                    offenders.append(f"{path.relative_to(REPO)}:{number} {line.strip()}")
+    assert offenders == [], (
+        "a root-level /uploads/ URL is built outside the avatars path; the "
+        "narrowed mount will 404 it:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_agent_avatar_url_still_matches_the_mount():
+    """The one consumer keeps working — the URL and the mount must agree."""
+    text = AGENTS_ROUTER.read_text(encoding="utf-8")
+    assert "/uploads/avatars/{filename}" in text, (
+        "the agent avatar URL changed; the mount path must change with it"
+    )

--- a/tests/mutations/uploads_mount_scope.json
+++ b/tests/mutations/uploads_mount_scope.json
@@ -1,0 +1,37 @@
+[
+  {
+    "label": "re-root the mount at the whole uploads tree, the shipped state",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "    avatars_dir = Path.home() / \".pocketpaw\" / \"uploads\" / \"avatars\"\n    avatars_dir.mkdir(parents=True, exist_ok=True)\n    app.mount(\"/uploads/avatars\", StaticFiles(directory=str(avatars_dir)), name=\"uploads\")",
+    "replace": "    avatars_dir = Path.home() / \".pocketpaw\" / \"uploads\"\n    avatars_dir.mkdir(parents=True, exist_ok=True)\n    app.mount(\"/uploads\", StaticFiles(directory=str(avatars_dir)), name=\"uploads\")",
+    "tests": ["tests/cloud/test_uploads_mount_scope.py"]
+  },
+  {
+    "label": "keep the narrow path but serve the parent directory",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "    avatars_dir = Path.home() / \".pocketpaw\" / \"uploads\" / \"avatars\"",
+    "replace": "    avatars_dir = Path.home() / \".pocketpaw\" / \"uploads\"",
+    "tests": ["tests/cloud/test_uploads_mount_scope.py"]
+  },
+  {
+    "label": "widen the middleware exempt_paths entry back to /uploads",
+    "file": "src/pocketpaw/dashboard_auth.py",
+    "find": "        \"/uploads/avatars\",\n        \"/favicon.ico\",",
+    "replace": "        \"/uploads\",\n        \"/favicon.ico\",",
+    "tests": ["tests/cloud/test_uploads_mount_scope.py"]
+  },
+  {
+    "label": "widen the SPA-bootstrap allow-through back to /uploads/",
+    "file": "src/pocketpaw/dashboard_auth.py",
+    "find": "        or request.url.path.startswith(\"/uploads/avatars/\")",
+    "replace": "        or request.url.path.startswith(\"/uploads/\")",
+    "tests": ["tests/cloud/test_uploads_mount_scope.py"]
+  },
+  {
+    "label": "widen the verify_token skip back to /uploads",
+    "file": "src/pocketpaw/dashboard_auth.py",
+    "find": "        or request.url.path.startswith(\"/uploads/avatars\")\n        or request.url.path.startswith(\"/pawbar-app\")",
+    "replace": "        or request.url.path.startswith(\"/uploads\")\n        or request.url.path.startswith(\"/pawbar-app\")",
+    "tests": ["tests/cloud/test_uploads_mount_scope.py"]
+  }
+]


### PR DESCRIPTION
## What was wrong

`mount_cloud` mounted `StaticFiles` at the whole of `~/.pocketpaw/uploads`, under a comment that said:

```python
# Serve uploaded avatars from ~/.pocketpaw/uploads/
```

Avatars are a subdirectory. So everything any subsystem writes under that root was served too, over a prefix the auth middleware exempts: the EE customer "My Files" store, file versions, websandbox durability, per-project build files, site screenshots, agent deliverables, meeting artifacts, the thumbnail cache, the remote-materialisation cache, and `_idx.jsonl` — an index carrying id, storage_key, filename, mime, size, owner_id and chat_id for every OSS-path upload and agent-delivered artifact.

Storage keys are uuid4, so the bulk of it was capability-based rather than enumerable. `_idx.jsonl` turned that subset into a list. And every URL that ever leaked was a permanent, unrevocable bearer token carrying no workspace — it ignored the soft-delete tombstone and survived the user leaving the workspace, unlike `GET /api/v1/uploads/{id}` which mints a signed 5-minute grant.

S3 mode did not empty the directory either: `resolver.py` streams a local copy of every S3 blob an agent touches into `_remote_cache` under that same root.

Audit finding H-1.

## What changed

The mount is the avatars directory itself. The reachable set is now defined by where the mount points rather than by a denylist somebody has to maintain — and `_idx.jsonl` stops being served without being moved, which matters because moving it would strand the index on every existing deployment.

All three `/uploads` auth exemptions in `dashboard_auth.py` are narrowed to `/uploads/avatars` alongside it, so re-rooting the mount later cannot silently inherit an unauthenticated prefix. One of the three (`verify_token`) is reachable from nothing today — `dashboard.py` re-exports it for backward compatibility only — so that part is consistency, not a live fix.

## Why this breaks nothing

`ee/pocketpaw_ee/cloud/agents/router.py` is the **only** place in either package that builds a root-level `/uploads/...` URL, and it builds exactly `{base}/uploads/avatars/{filename}`.

User avatars are a different subsystem: they live in the sibling `~/.pocketpaw/avatars` and are served by the authenticated `GET /api/v1/auth/avatar/{filename}`. Everything else addresses bytes through `/api/v1/uploads/{id}`.

There is exactly one `/uploads` mount in the codebase and it is EE-only, so an OSS-only deploy was never exposed by this.

There is a test asserting that premise rather than trusting it: if some other module starts handing out a `{base}/uploads/<something-else>` URL, the suite fails and names the file, instead of the link quietly 404ing in production.

## Tests

`tests/cloud/test_uploads_mount_scope.py` with `tests/mutations/uploads_mount_scope.json`. Five mutations, all caught.

The one worth noting is "keep the narrow path but serve the parent directory" — mounting `uploads/` at the `/uploads/avatars` path serves the whole tree under a narrower-looking URL, and an assertion on the mount path alone passes happily. The directory is asserted separately for that reason.

## On the numbers

The OSS-scope suite reports **78 failed / 7582 passed** with this change, and **78 failed / 7582 passed** on a clean `dev` checkout. Identical, so none of those come from here. They are concentrated in `test_herdr_runtime`, `test_codex_cli_backend` and `test_code_mode_*`, none of which touch uploads or auth.

Worth flagging separately: `tests/cloud/` is excluded by `addopts` in `pyproject.toml`, so this test file will not run in CI as things stand. The mutations were run locally.