### PR TITLE
fix(guards): per-member action grants never applied, and the fix that looks obvious is worse

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
@@ -400,7 +400,7 @@ async def _gate_admin(tool: str, workspace_id: str, user_id: str | None) -> dict
         return _error_response(f"{tool} could not resolve the calling user for the RBAC check.")
 
     try:
-        check_workspace_action(user, workspace_id, "fabric.admin")
+        await check_workspace_action(user, workspace_id, "fabric.admin")
     except Forbidden as exc:
         logger.info(
             "%s denied: user=%s workspace=%s code=%s", tool, user_id, workspace_id, exc.code

--- a/ee/pocketpaw_ee/agent/mcp_servers/growth.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/growth.py
@@ -185,7 +185,7 @@ async def _gate(tool: str, action: str) -> tuple[str, str, Any] | dict[str, Any]
         return _error_response("could not resolve the calling user for the permission check.")
 
     try:
-        check_workspace_action(user, workspace_id, action)
+        await check_workspace_action(user, workspace_id, action)
     except Forbidden as exc:
         logger.info(
             "%s denied: user=%s workspace=%s code=%s", tool, user_id, workspace_id, exc.code

--- a/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
@@ -379,7 +379,7 @@ async def _gate_read(tool: str, action: str, deny_message: str) -> tuple[str, st
         return _error_response("could not resolve the calling user for the RBAC check.")
 
     try:
-        check_workspace_action(user, workspace_id, action)
+        await check_workspace_action(user, workspace_id, action)
     except Forbidden as exc:
         logger.info(
             "%s denied: user=%s workspace=%s code=%s",
@@ -500,7 +500,7 @@ async def _members_list_handler(args: dict) -> dict:  # noqa: ARG001 — no args
     # as a structured deny envelope (never raised out of the tool). The gate
     # already audits the denial via guards/audit.log_denial.
     try:
-        check_workspace_action(user, workspace_id, _READ_ACTION)
+        await check_workspace_action(user, workspace_id, _READ_ACTION)
     except Forbidden as exc:
         logger.info(
             "members_list denied: user=%s workspace=%s code=%s",
@@ -584,7 +584,7 @@ async def _member_update_role_handler(args: dict) -> dict:
     # deny is enforced BEFORE any proposal/mutation path — a member never
     # reaches the write.
     try:
-        check_workspace_action(user, workspace_id, _ROLE_CHANGE_ACTION)
+        await check_workspace_action(user, workspace_id, _ROLE_CHANGE_ACTION)
     except Forbidden as exc:
         logger.info(
             "member_update_role denied: actor=%s workspace=%s target=%s code=%s",

--- a/ee/pocketpaw_ee/cloud/_core/deps.py
+++ b/ee/pocketpaw_ee/cloud/_core/deps.py
@@ -112,7 +112,7 @@ def require_action(
         workspace_id: str = Depends(workspace_dep),
     ) -> User:
         try:
-            check_workspace_action(user, workspace_id, action)
+            await check_workspace_action(user, workspace_id, action)
         except GuardForbidden as exc:
             raise Forbidden(exc.code, exc.detail or "Access denied") from exc
         return user

--- a/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/admin_proposals/executor.py
@@ -782,7 +782,7 @@ async def _recheck_rbac(workspace_id: str, proposer_user_id: str, rbac_action: s
         )
     # Raises Forbidden if the proposer's CURRENT role is below the action minimum
     # (e.g. demoted to MEMBER since proposing). Audits the denial via log_denial.
-    check_workspace_action(proposer, workspace_id, rbac_action)
+    await check_workspace_action(proposer, workspace_id, rbac_action)
 
 
 async def execute_approved_admin_action(

--- a/ee/pocketpaw_ee/cloud/chat/router.py
+++ b/ee/pocketpaw_ee/cloud/chat/router.py
@@ -118,7 +118,7 @@ async def create_group(
     # are available to any workspace member.
     action = "channel.create" if body.type in ("channel", "public") else "group.create"
     try:
-        check_workspace_action(user, workspace_id, action)
+        await check_workspace_action(user, workspace_id, action)
     except GuardForbidden as exc:
         raise CloudForbidden(exc.code, exc.detail or "Access denied") from exc
     return await group_service.create_group(workspace_id, str(user.id), body)

--- a/ee/pocketpaw_ee/cloud/growth/executor.py
+++ b/ee/pocketpaw_ee/cloud/growth/executor.py
@@ -146,7 +146,7 @@ async def _proposer_still_authorized(workspace_id: str, user_id: str) -> bool:
         if proposer is None:
             return False
         # Raises Forbidden when the CURRENT role is below the action minimum.
-        check_workspace_action(proposer, workspace_id, _GROWTH_RBAC_ACTION)
+        await check_workspace_action(proposer, workspace_id, _GROWTH_RBAC_ACTION)
         return True
     except Exception:  # noqa: BLE001 — denial OR unresolvable proposer fails closed
         logger.warning(

--- a/ee/pocketpaw_ee/cloud/ship/executor.py
+++ b/ee/pocketpaw_ee/cloud/ship/executor.py
@@ -110,7 +110,7 @@ async def _proposer_still_authorized(workspace_id: str, user_id: str) -> bool:
         if proposer is None:
             return False
         # Raises Forbidden when the CURRENT role is below the action minimum.
-        check_workspace_action(proposer, workspace_id, _SHIP_RBAC_ACTION)
+        await check_workspace_action(proposer, workspace_id, _SHIP_RBAC_ACTION)
         return True
     except Exception:  # noqa: BLE001 — denial OR unresolvable proposer fails closed
         logger.warning(

--- a/ee/pocketpaw_ee/cloud/site_plan_requests/executor.py
+++ b/ee/pocketpaw_ee/cloud/site_plan_requests/executor.py
@@ -265,7 +265,7 @@ async def _recheck_approver_may_buy(workspace_id: str, approver_user_id: str) ->
             "sites.plan_purchase_forbidden",
             f"the approving user {approver_user_id} no longer exists",
         )
-    check_workspace_action(approver, workspace_id, "sites.buy_plan")
+    await check_workspace_action(approver, workspace_id, "sites.buy_plan")
 
 
 async def execute_approved_site_plan_request(

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -2237,6 +2237,13 @@ async def set_member_action_permissions(
         {"$set": {"action_permissions": perms}},
     )
 
+    # The guard layer caches this read. Without invalidation an admin's change
+    # would not take effect until the TTL expired, which is exactly the kind of
+    # "I granted it and nothing happened" the broken lookup used to produce.
+    from pocketpaw_ee.guards.deps import invalidate_action_overrides
+
+    invalidate_action_overrides(workspace_id, user_id)
+
     logger.info(
         "action_permissions.set",
         extra={"workspace_id": workspace_id, "user_id": user_id, "actions": clean},
@@ -2259,6 +2266,13 @@ async def clear_member_action_permissions(
     await _WorkspaceDoc.find_one({"_id": doc.id}).update(
         {"$set": {"action_permissions": perms}},
     )
+
+    # The guard layer caches this read. Without invalidation an admin's change
+    # would not take effect until the TTL expired, which is exactly the kind of
+    # "I granted it and nothing happened" the broken lookup used to produce.
+    from pocketpaw_ee.guards.deps import invalidate_action_overrides
+
+    invalidate_action_overrides(workspace_id, user_id)
 
     logger.info(
         "action_permissions.clear",

--- a/ee/pocketpaw_ee/fleet/router.py
+++ b/ee/pocketpaw_ee/fleet/router.py
@@ -144,7 +144,7 @@ def _resolve_actor(spec: ActorSpec | None) -> Any | None:
     return Actor(kind=spec.kind, id=spec.id, scope_context=list(spec.scope_context))
 
 
-def _require_fleet_install(user: User, workspace_id: str) -> None:
+async def _require_fleet_install(user: User, workspace_id: str) -> None:
     """Raise ``HTTPException(403)`` unless ``user`` is allowed to run
     ``fleet.install`` in ``workspace_id``.
 
@@ -161,7 +161,7 @@ def _require_fleet_install(user: User, workspace_id: str) -> None:
     """
 
     try:
-        check_workspace_action(user, workspace_id, "fleet.install")
+        await check_workspace_action(user, workspace_id, "fleet.install")
     except GuardForbidden as exc:
         raise HTTPException(status_code=403, detail=exc.code) from exc
 
@@ -211,7 +211,7 @@ async def post_install(
     # Authz first — never touch the filesystem or the installer before
     # the caller has proven admin+ on the target workspace. A 403 from
     # here does not leak template-loading errors or soul-protocol state.
-    _require_fleet_install(user, req.workspace_id)
+    await _require_fleet_install(user, req.workspace_id)
 
     try:
         fleet = load_fleet(req.template_name)

--- a/ee/pocketpaw_ee/guards/deps.py
+++ b/ee/pocketpaw_ee/guards/deps.py
@@ -180,7 +180,7 @@ def resolve_workspace_role(user: Any, workspace_id: str) -> WorkspaceRole:
     )
 
 
-def check_workspace_action(user: Any, workspace_id: str, action: str) -> WorkspaceRole:
+async def check_workspace_action(user: Any, workspace_id: str, action: str) -> WorkspaceRole:
     """Enforce an ACTIONS entry against a user's workspace role.
 
     Returns the resolved role on success. Raises Forbidden on deny and
@@ -190,14 +190,48 @@ def check_workspace_action(user: Any, workspace_id: str, action: str) -> Workspa
     Also consults per-member ``action_permissions`` overrides stored on the
     workspace document — an explicit grant for ``action`` allows it even
     when the user's base role would not.
+
+    MEMBERSHIP IS RESOLVED FIRST, AND SEPARATELY. That is the shape of this
+    function, not a stylistic choice.
+
+    Both resolution and the action check used to sit in one ``try``, with the
+    override consulted from a single ``except Forbidden``. Two different
+    failures arrived at the same handler:
+
+      * ``check_action`` denied — the user IS a member, their role is just too
+        low. An override is exactly the right thing to consult.
+      * ``resolve_workspace_role`` denied ``workspace.not_member`` — there is
+        no role at all, and ``role`` was never bound.
+
+    The second case was unreachable only because ``_has_action_override``
+    always returned False (see below). Make the lookup work and that same code
+    either raises ``UnboundLocalError`` on ``return role``, or — if somebody
+    "fixes" the UnboundLocalError by giving ``role`` a default — hands a
+    NON-MEMBER of the workspace access on the strength of an override row.
+    Splitting the two checks makes that impossible to write by accident.
     """
+    user_id = str(getattr(user, "id", "") or "")
+
+    # 1. Membership. A non-member is denied outright; no override rescues it.
     try:
         role = resolve_workspace_role(user, workspace_id)
+    except Forbidden as exc:
+        log_denial(
+            actor=user_id,
+            action=action,
+            code=exc.code,
+            workspace_id=workspace_id,
+            detail=exc.detail,
+        )
+        raise
+
+    # 2. The action, against the role just resolved. ``role`` is bound for the
+    #    rest of this function, so the override branch cannot reference an
+    #    unbound name.
+    try:
         check_action(action, role)
     except Forbidden as exc:
-        # Check per-member action overrides before denying.
-        user_id = str(getattr(user, "id", "") or "")
-        if user_id and _has_action_override(workspace_id, user_id, action):
+        if user_id and await _has_action_override(workspace_id, user_id, action):
             return role
         log_denial(
             actor=user_id,
@@ -210,27 +244,75 @@ def check_workspace_action(user: Any, workspace_id: str, action: str) -> Workspa
     return role
 
 
-# In-memory cache for action override lookups. Keyed by (workspace_id, user_id).
-# Lives for process lifetime — fine for a low-cardinality permission store.
-_ACTION_OVERRIDE_CACHE: dict[tuple[str, str], list[str]] = {}
+#: Cached override lookups, keyed by (workspace_id, user_id) -> (expires_at, actions).
+#:
+#: The previous version had no expiry and said so: "Lives for process lifetime
+#: — fine for a low-cardinality permission store". Combined with the broken
+#: lookup below, that meant the FIRST failed read for a pair was cached as "no
+#: overrides", and every later check for that pair short-circuited on the
+#: poisoned entry until the process restarted. A TTL bounds that, and
+#: ``invalidate_action_overrides`` clears a pair the moment an admin changes it,
+#: so a grant made in the UI takes effect immediately rather than within a TTL.
+_ACTION_OVERRIDE_TTL_SECONDS = 60.0
+_ACTION_OVERRIDE_CACHE: dict[tuple[str, str], tuple[float, list[str]]] = {}
 
 
-def _has_action_override(workspace_id: str, user_id: str, action: str) -> bool:
-    """Return True if ``user_id`` has an explicit override for ``action``."""
+def invalidate_action_overrides(workspace_id: str, user_id: str | None = None) -> None:
+    """Drop cached overrides for a member, or for a whole workspace.
+
+    Called by ``workspace.service`` whenever ``action_permissions`` is written,
+    so an admin granting an action does not have to wait out the TTL.
+    """
+    if user_id is not None:
+        _ACTION_OVERRIDE_CACHE.pop((workspace_id, user_id), None)
+        return
+    for key in [k for k in _ACTION_OVERRIDE_CACHE if k[0] == workspace_id]:
+        _ACTION_OVERRIDE_CACHE.pop(key, None)
+
+
+async def _has_action_override(workspace_id: str, user_id: str, action: str) -> bool:
+    """Return True if ``user_id`` has an explicit override for ``action``.
+
+    This is ``async`` because the read it performs is, and that is the bug it
+    exists to fix. It used to be sync and reached the async service through
+    ``asyncio.get_event_loop().run_until_complete(...)``. Every caller is an
+    async request handler, so a loop is already running and that raises
+    ``RuntimeError: This event loop is already running``. A bare
+    ``except Exception`` swallowed it, ``overrides`` became ``[]``, and that
+    empty list was cached forever.
+
+    So every per-member grant an admin made in the UI silently did nothing. It
+    failed CLOSED — denying users an action they had been explicitly granted —
+    which surfaces as a permissions bug rather than a security one.
+
+    Errors are still swallowed, deliberately: a lookup failure must deny rather
+    than grant. It is logged now instead of being silent, and the failure is NOT
+    cached, so a transient database error cannot pin a member to "no overrides"
+    for the life of the process.
+    """
+    import time
+
     cache_key = (workspace_id, user_id)
-    if cache_key not in _ACTION_OVERRIDE_CACHE:
-        try:
-            import asyncio
+    cached = _ACTION_OVERRIDE_CACHE.get(cache_key)
+    now = time.monotonic()
+    if cached is not None and cached[0] > now:
+        return action in cached[1]
 
-            from pocketpaw_ee.cloud.workspace.service import get_member_action_overrides
+    from pocketpaw_ee.cloud.workspace.service import get_member_action_overrides
 
-            overrides = asyncio.get_event_loop().run_until_complete(
-                get_member_action_overrides(workspace_id, user_id)
-            )
-        except Exception:
-            overrides = []
-        _ACTION_OVERRIDE_CACHE[cache_key] = overrides
-    return action in _ACTION_OVERRIDE_CACHE[cache_key]
+    try:
+        overrides = await get_member_action_overrides(workspace_id, user_id)
+    except Exception:
+        logger.warning(
+            "guards: could not read action overrides for %s/%s - denying",
+            workspace_id,
+            user_id,
+            exc_info=True,
+        )
+        return False
+
+    _ACTION_OVERRIDE_CACHE[cache_key] = (now + _ACTION_OVERRIDE_TTL_SECONDS, overrides)
+    return action in overrides
 
 
 def resolve_group_role(
@@ -302,7 +384,7 @@ def make_require_action(
         workspace_id: str = Depends(workspace_dep),
     ) -> Any:
         try:
-            check_workspace_action(user, workspace_id, action)
+            await check_workspace_action(user, workspace_id, action)
         except Forbidden as exc:
             raise HTTPException(status_code=403, detail=exc.code) from exc
         return user

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -294,7 +294,7 @@ router = APIRouter(
 )
 
 
-def _may_buy_site_plan(user: object, workspace_id: str) -> bool:
+async def _may_buy_site_plan(user: object, workspace_id: str) -> bool:
     """May this caller commit the workspace to a recurring site charge?
 
     Asked as a QUESTION rather than enforced as a dependency, because the answer
@@ -311,7 +311,7 @@ def _may_buy_site_plan(user: object, workspace_id: str) -> bool:
     from pocketpaw_ee.guards.deps import check_workspace_action
 
     try:
-        check_workspace_action(user, workspace_id, "sites.buy_plan")
+        await check_workspace_action(user, workspace_id, "sites.buy_plan")
     except CloudError:
         return False
     except Exception:  # noqa: BLE001 — a broken role read must not sell a plan
@@ -354,7 +354,7 @@ async def publish_site(
         user_id=ctx.user_id,
         pocket_id=body.pocket_id,
         site_plan_key=body.site_plan_key,
-        purchase_authorized=_may_buy_site_plan(user, ctx.workspace_id),
+        purchase_authorized=await _may_buy_site_plan(user, ctx.workspace_id),
         prewarm_origin=request.headers.get("origin") or None,
     )
     return sites_service._to_response(doc)

--- a/tests/cloud/meetings/test_router.py
+++ b/tests/cloud/meetings/test_router.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -25,7 +26,7 @@ async def meetings_client(monkeypatch, mongo_db):  # noqa: ARG001 — mongo_db f
     # Pass RBAC checks.
     from pocketpaw_ee.guards import deps as guards_deps
 
-    monkeypatch.setattr(guards_deps, "check_workspace_action", lambda *a, **k: None)
+    monkeypatch.setattr(guards_deps, "check_workspace_action", AsyncMock(return_value=None))
 
     fake_user = SimpleNamespace(
         id="user-1",

--- a/tests/cloud/test_audit_bridge.py
+++ b/tests/cloud/test_audit_bridge.py
@@ -21,6 +21,7 @@ import pytest
 pytest.importorskip("pocketpaw_ee")
 
 from types import SimpleNamespace  # noqa: E402
+from unittest.mock import AsyncMock
 
 import pytest_asyncio  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
@@ -96,7 +97,7 @@ def _build_app(audit_store, *, workspace_id: str = "w1", user_id: str = "u1") ->
     # just need a permissive guard so the handler actually runs.
     from pocketpaw_ee.cloud._core import deps as core_deps
 
-    core_deps.check_workspace_action = lambda *a, **k: None  # type: ignore[assignment]
+    core_deps.check_workspace_action = AsyncMock(return_value=None)  # type: ignore[assignment]
 
     _install_service_seam(audit_store)
     return app

--- a/tests/cloud/test_audit_router.py
+++ b/tests/cloud/test_audit_router.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest_asyncio
 from fastapi import FastAPI
@@ -102,7 +103,9 @@ def _build_app(
 
                 monkeypatch.setattr(core_deps, "check_workspace_action", _deny)
             else:
-                monkeypatch.setattr(core_deps, "check_workspace_action", lambda *a, **k: None)
+                monkeypatch.setattr(
+                    core_deps, "check_workspace_action", AsyncMock(return_value=None)
+                )
 
     # Always inject the tmp store regardless of auth wiring.
     _install_service_seam(audit_store)

--- a/tests/cloud/test_discovery_router.py
+++ b/tests/cloud/test_discovery_router.py
@@ -53,7 +53,7 @@ def _build_app(monkeypatch, *, allow: bool = True) -> FastAPI:
     from pocketpaw_ee.guards.rbac import Forbidden as GuardForbidden
 
     if allow:
-        monkeypatch.setattr(core_deps, "check_workspace_action", lambda *a, **k: None)
+        monkeypatch.setattr(core_deps, "check_workspace_action", AsyncMock(return_value=None))
     else:
 
         def _deny(*_a, **_k):

--- a/tests/cloud/test_fabric_mcp.py
+++ b/tests/cloud/test_fabric_mcp.py
@@ -46,6 +46,8 @@ import pytest
 
 pytest.importorskip("pocketpaw_ee")
 
+from unittest.mock import AsyncMock
+
 import pocketpaw_ee.agent.mcp_servers.fabric as fabric_mcp  # noqa: E402
 from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
     attach_agent_identity,
@@ -357,7 +359,7 @@ def admin_ok(monkeypatch):
 
     monkeypatch.setattr(fabric_mcp, "_load_user", _fake_load_user)
     monkeypatch.setattr(
-        "pocketpaw_ee.guards.deps.check_workspace_action", lambda user, ws, action: None
+        "pocketpaw_ee.guards.deps.check_workspace_action", AsyncMock(return_value=None)
     )
 
 

--- a/tests/cloud/test_knowledge_articles_dedupe.py
+++ b/tests/cloud/test_knowledge_articles_dedupe.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pocketpaw_ee.cloud.kb.knowledge_router as knowledge_router_module
 import pytest
@@ -187,7 +188,7 @@ def _build_client(monkeypatch, rows_by_scope: dict[str, list[dict]]) -> TestClie
 
     from pocketpaw_ee.guards import deps as guards_deps
 
-    monkeypatch.setattr(guards_deps, "check_workspace_action", lambda *a, **k: None)
+    monkeypatch.setattr(guards_deps, "check_workspace_action", AsyncMock(return_value=None))
 
     fake_user = SimpleNamespace(
         id="user-1",

--- a/tests/cloud/test_knowledge_router.py
+++ b/tests/cloud/test_knowledge_router.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pocketpaw_ee.cloud.kb.knowledge_router as knowledge_router_module
 import pytest
@@ -54,7 +55,7 @@ def client(monkeypatch):
     # For routers that DO consume _core.deps, patch the consumer instead — see test_audit_router.py.
     from pocketpaw_ee.guards import deps as guards_deps
 
-    monkeypatch.setattr(guards_deps, "check_workspace_action", lambda *a, **k: None)
+    monkeypatch.setattr(guards_deps, "check_workspace_action", AsyncMock(return_value=None))
 
     # Build a fake user that already has ws-alpha as its active workspace.
     fake_user = SimpleNamespace(

--- a/tests/cloud/test_knowledge_wiki_api.py
+++ b/tests/cloud/test_knowledge_wiki_api.py
@@ -108,7 +108,7 @@ def client(monkeypatch) -> TestClient:
     # Stub RBAC (see test_knowledge_router.py for why this seam works here).
     from pocketpaw_ee.guards import deps as guards_deps
 
-    monkeypatch.setattr(guards_deps, "check_workspace_action", lambda *a, **k: None)
+    monkeypatch.setattr(guards_deps, "check_workspace_action", AsyncMock(return_value=None))
 
     fake_user = SimpleNamespace(
         id="user-1",

--- a/tests/cloud/test_member_action_overrides.py
+++ b/tests/cloud/test_member_action_overrides.py
@@ -1,0 +1,233 @@
+"""Per-member action grants apply, and never substitute for membership.
+
+``_has_action_override`` was sync and reached an async service through::
+
+    asyncio.get_event_loop().run_until_complete(get_member_action_overrides(...))
+
+Every caller is an async request handler, so a loop is already running and that
+raises ``RuntimeError: This event loop is already running``. A bare
+``except Exception`` swallowed it, ``overrides`` became ``[]``, and the empty
+list was cached in a dict with no expiry ("Lives for process lifetime").
+
+So every per-member grant an admin made in the UI silently did nothing, for the
+life of the process. It failed CLOSED — users were denied actions they had been
+explicitly granted — so this is a permissions bug rather than an escalation.
+
+WHY THE OBVIOUS FIX IS WORSE THAN THE BUG
+
+``check_workspace_action`` had both checks in one ``try``::
+
+    try:
+        role = resolve_workspace_role(user, workspace_id)   # may raise not_member
+        check_action(action, role)                          # may raise denied
+    except Forbidden:
+        if _has_action_override(...):
+            return role                                     # role may be UNBOUND
+
+Two different failures arrived at one handler. If ``resolve_workspace_role``
+raised, ``role`` was never bound — and that path was unreachable ONLY because
+the override lookup always returned False. Make the lookup work without
+restructuring and it either raises ``UnboundLocalError``, or, if somebody gives
+``role`` a default to silence that, it hands a NON-MEMBER access on the
+strength of an override row.
+
+Membership is now resolved in its own ``try``, before the override path exists.
+
+Mutations that must fail these tests: putting the two checks back in one try,
+returning True from the override lookup for a non-member, dropping the await,
+and removing the cache invalidation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.guards import deps as guards
+from pocketpaw_ee.guards.rbac import Forbidden
+
+WS = "ws-overrides"
+#: A real entry in both ACTIONS and OVERRIDABLE_ACTIONS that a "member"
+#: role is denied — an invented action name raises KeyError from get_rule
+#: before any of this logic runs, which would test nothing.
+GRANTED = "channel.create"
+
+
+class _Membership:
+    def __init__(self, workspace: str, role: str) -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _User:
+    def __init__(self, user_id: str, role: str | None) -> None:
+        self.id = user_id
+        self.workspaces = [_Membership(WS, role)] if role else []
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    guards._ACTION_OVERRIDE_CACHE.clear()
+    yield
+    guards._ACTION_OVERRIDE_CACHE.clear()
+
+
+@pytest.fixture
+def overrides(monkeypatch):
+    """Stub the service read, recording how many times it is actually awaited."""
+    calls: list[tuple[str, str]] = []
+    table: dict[str, list[str]] = {}
+
+    async def _get(workspace_id: str, user_id: str) -> list[str]:
+        calls.append((workspace_id, user_id))
+        return table.get(user_id, [])
+
+    import sys
+    import types
+
+    module = types.ModuleType("pocketpaw_ee.cloud.workspace.service")
+    module.get_member_action_overrides = _get
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.workspace.service", module)
+    return table, calls
+
+
+async def test_the_lookup_is_actually_awaited(overrides):
+    """The reproduction. Before the fix this raised inside a running loop,
+    was swallowed, and returned False for every caller forever."""
+    table, calls = overrides
+    table["u1"] = [GRANTED]
+
+    assert await guards._has_action_override(WS, "u1", GRANTED) is True
+    assert calls == [(WS, "u1")], "the service read never happened"
+
+
+async def test_a_member_whose_role_is_too_low_is_allowed_by_a_grant(overrides):
+    table, _ = overrides
+    table["u1"] = [GRANTED]
+
+    role = await guards.check_workspace_action(_User("u1", "member"), WS, GRANTED)
+    assert role is not None
+
+
+async def test_a_member_with_no_grant_is_still_denied(overrides):
+    with pytest.raises(Forbidden):
+        await guards.check_workspace_action(_User("u1", "member"), WS, GRANTED)
+
+
+async def test_a_non_member_is_denied_even_with_a_grant_row(overrides):
+    """The escalation the naive fix opens, asserted directly.
+
+    A user who belongs to NO workspace, carrying an override row for the
+    action. Membership is resolved first, so the override is never consulted
+    and the denial is workspace.not_member — not an UnboundLocalError, and
+    certainly not an allow.
+    """
+    table, calls = overrides
+    table["ghost"] = [GRANTED]
+
+    with pytest.raises(Forbidden) as exc:
+        await guards.check_workspace_action(_User("ghost", None), WS, GRANTED)
+
+    assert exc.value.code == "workspace.not_member"
+    assert calls == [], (
+        "the override lookup ran for a non-member; membership must be settled "
+        "before overrides are consulted at all"
+    )
+
+
+async def test_a_lookup_failure_denies_and_is_not_cached(overrides, monkeypatch):
+    """A transient read error must not pin a member to 'no overrides'.
+
+    The old cache stored the failure permanently, which is what turned one bad
+    read into a process-lifetime denial.
+    """
+    import sys
+    import types
+
+    boom = types.ModuleType("pocketpaw_ee.cloud.workspace.service")
+
+    async def _explode(workspace_id: str, user_id: str) -> list[str]:
+        raise RuntimeError("mongo is down")
+
+    boom.get_member_action_overrides = _explode
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.workspace.service", boom)
+
+    assert await guards._has_action_override(WS, "u1", GRANTED) is False
+    assert (WS, "u1") not in guards._ACTION_OVERRIDE_CACHE, (
+        "a failed read was cached; the next call would short-circuit on it"
+    )
+
+
+async def test_a_grant_is_cached_then_invalidated(overrides):
+    """The cache exists, and an admin's change is not stuck behind its TTL."""
+    table, calls = overrides
+    table["u1"] = [GRANTED]
+
+    assert await guards._has_action_override(WS, "u1", GRANTED) is True
+    assert await guards._has_action_override(WS, "u1", GRANTED) is True
+    assert len(calls) == 1, "the second call should have been served from cache"
+
+    guards.invalidate_action_overrides(WS, "u1")
+    assert await guards._has_action_override(WS, "u1", GRANTED) is True
+    assert len(calls) == 2, "invalidation did not force a re-read"
+
+
+async def test_invalidating_a_whole_workspace_clears_every_member(overrides):
+    table, calls = overrides
+    table["u1"] = [GRANTED]
+    table["u2"] = [GRANTED]
+
+    await guards._has_action_override(WS, "u1", GRANTED)
+    await guards._has_action_override(WS, "u2", GRANTED)
+    assert len(calls) == 2
+
+    guards.invalidate_action_overrides(WS)
+    await guards._has_action_override(WS, "u1", GRANTED)
+    await guards._has_action_override(WS, "u2", GRANTED)
+    assert len(calls) == 4
+
+
+def test_the_guard_is_async_so_no_caller_can_silently_drop_the_await():
+    """A sync guard returning a coroutine would be truthy and never checked.
+
+    Asserted because the previous signature was sync: if it stayed sync and
+    grew an async body, every call site would 'pass' while checking nothing.
+    """
+    assert asyncio.iscoroutinefunction(guards.check_workspace_action)
+    assert asyncio.iscoroutinefunction(guards._has_action_override)
+
+
+def test_every_call_site_awaits_the_guard():
+    """A dropped await on an async guard is a silent auth bypass.
+
+    ``check_workspace_action(...)`` without ``await`` builds a coroutine,
+    never runs it, raises nothing, and is discarded. Every route that guards
+    with it would allow. Python only warns ("coroutine was never awaited"), on
+    stderr, at garbage-collection time — which is exactly how the ORIGINAL bug
+    in this module went unnoticed.
+
+    Converting 13 call sites by hand is precisely the change that loses one, so
+    this walks the AST of both packages rather than trusting the conversion.
+    """
+    import ast
+    from pathlib import Path
+
+    repo = Path(__file__).resolve().parents[2]
+    unawaited: list[str] = []
+
+    for package in ("src", "ee"):
+        for path in (repo / package).rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            awaited = {id(node.value) for node in ast.walk(tree) if isinstance(node, ast.Await)}
+            for node in ast.walk(tree):
+                if not (isinstance(node, ast.Call) and not isinstance(node.func, ast.Attribute)):
+                    continue
+                if getattr(node.func, "id", None) != "check_workspace_action":
+                    continue
+                if id(node) not in awaited:
+                    unawaited.append(f"{path.relative_to(repo)}:{node.lineno}")
+
+    assert unawaited == [], (
+        "check_workspace_action is called without await — the guard builds a "
+        "coroutine, never runs, and the route allows:\n  " + "\n  ".join(unawaited)
+    )

--- a/tests/cloud/test_pocket_outcomes.py
+++ b/tests/cloud/test_pocket_outcomes.py
@@ -24,6 +24,8 @@ import pytest
 
 pytest.importorskip("pocketpaw_ee")
 
+from unittest.mock import AsyncMock
+
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 from pocketpaw_ee.cloud._core.realtime.events import Event, PocketOutcomeEvent  # noqa: E402
@@ -297,7 +299,7 @@ def outcomes_client():
     app.dependency_overrides[current_active_user] = _fake_user_dep
 
     _orig = core_deps.check_workspace_action
-    core_deps.check_workspace_action = lambda *a, **k: None
+    core_deps.check_workspace_action = AsyncMock(return_value=None)
 
     with TestClient(app) as client:
         yield client

--- a/tests/cloud/test_rules_router.py
+++ b/tests/cloud/test_rules_router.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -77,7 +78,9 @@ def _build_app(
 
                 monkeypatch.setattr(core_deps, "check_workspace_action", _deny)
             else:
-                monkeypatch.setattr(core_deps, "check_workspace_action", lambda *a, **k: None)
+                monkeypatch.setattr(
+                    core_deps, "check_workspace_action", AsyncMock(return_value=None)
+                )
 
     return app
 

--- a/tests/cloud/test_skills_router.py
+++ b/tests/cloud/test_skills_router.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
@@ -85,7 +86,9 @@ def _build_app(
 
                 monkeypatch.setattr(core_deps, "check_workspace_action", _deny)
             else:
-                monkeypatch.setattr(core_deps, "check_workspace_action", lambda *a, **k: None)
+                monkeypatch.setattr(
+                    core_deps, "check_workspace_action", AsyncMock(return_value=None)
+                )
     return app
 
 

--- a/tests/cloud/test_skills_router_from_url.py
+++ b/tests/cloud/test_skills_router_from_url.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -66,7 +67,7 @@ def _build_app(*, workspace_id: str | None = "w1", monkeypatch=None) -> FastAPI:
     if monkeypatch is not None:
         from pocketpaw_ee.cloud._core import deps as core_deps
 
-        monkeypatch.setattr(core_deps, "check_workspace_action", lambda *a, **k: None)
+        monkeypatch.setattr(core_deps, "check_workspace_action", AsyncMock(return_value=None))
 
     return app
 

--- a/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
+++ b/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -200,7 +201,8 @@ def test_provider_exposes_server_and_tool_ids():
 async def test_members_list_member_allowed_returns_roster(monkeypatch, _patch_user):
     """A MEMBER may read the roster — gate passes, service returns members."""
     monkeypatch.setattr(
-        "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.MEMBER
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        AsyncMock(return_value=WorkspaceRole.MEMBER),
     )
 
     called = {}
@@ -275,7 +277,8 @@ async def test_member_update_role_admin_files_proposal_not_inline(monkeypatch, _
     envelope carrying the action id. The ``update_member_role`` service call is
     spied and asserted NOT called inline (an admin write is human-gated)."""
     monkeypatch.setattr(
-        "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.ADMIN
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        AsyncMock(return_value=WorkspaceRole.ADMIN),
     )
 
     # Spy the propose helper (the tool imports it function-locally).
@@ -355,7 +358,8 @@ async def test_member_update_role_member_denied_no_service_call(monkeypatch, _pa
 async def test_member_update_role_rejects_bad_role(monkeypatch, _patch_user):
     """An out-of-set role is refused before any gate/mutation."""
     monkeypatch.setattr(
-        "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.ADMIN
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        AsyncMock(return_value=WorkspaceRole.ADMIN),
     )
     with _identity(workspace="w1", user="admin1"):
         res = await wa_mcp._member_update_role_handler({"user_id": "u2", "role": "superuser"})
@@ -379,8 +383,13 @@ from types import SimpleNamespace  # noqa: E402
 
 
 def _allow(role=WorkspaceRole.MEMBER):
-    """Patch factory: check_workspace_action passes, returning ``role``."""
-    return lambda *a, **k: role
+    """Patch factory: check_workspace_action passes, returning ``role``.
+
+    Returns a COROUTINE function: check_workspace_action is async (it awaits
+    the per-member override read), so a sync stub makes the production
+    ``await`` raise "object NoneType can't be used in 'await' expression".
+    """
+    return AsyncMock(return_value=role)
 
 
 def _deny_forbidden(code="workspace.insufficient_role", detail="nope"):
@@ -714,7 +723,9 @@ async def test_billing_usage_read_gates_on_the_billing_action(monkeypatch, _patc
     """
     seen: dict = {}
 
-    def _record(user, workspace_id, action):  # noqa: ANN001
+    async def _record(user, workspace_id, action):  # noqa: ANN001
+        # async because check_workspace_action is: it awaits the per-member
+        # override read. A sync stub makes the production await raise.
         seen["action"] = action
         return WorkspaceRole.ADMIN
 
@@ -856,7 +867,8 @@ def _spy_propose(monkeypatch):
 def _admin(monkeypatch):
     """check_workspace_action passes as ADMIN."""
     monkeypatch.setattr(
-        "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.ADMIN
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        AsyncMock(return_value=WorkspaceRole.ADMIN),
     )
 
 
@@ -1177,7 +1189,8 @@ async def test_write_tools_outside_stream_error():
 def _owner(monkeypatch):
     """check_workspace_action passes as OWNER."""
     monkeypatch.setattr(
-        "pocketpaw_ee.guards.deps.check_workspace_action", lambda *a, **k: WorkspaceRole.OWNER
+        "pocketpaw_ee.guards.deps.check_workspace_action",
+        AsyncMock(return_value=WorkspaceRole.OWNER),
     )
 
 

--- a/tests/ee/test_decision_observability.py
+++ b/tests/ee/test_decision_observability.py
@@ -108,7 +108,7 @@ def _make_client(monkeypatch) -> TestClient:
     # underlying guard helper to a no-op.
     import pocketpaw_ee.cloud._core.deps as deps_module
 
-    monkeypatch.setattr(deps_module, "check_workspace_action", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(deps_module, "check_workspace_action", AsyncMock(return_value=None))
 
     user = _FakeUser("admin-1", "ws-A")
     app = FastAPI()

--- a/tests/mutations/member_action_overrides.json
+++ b/tests/mutations/member_action_overrides.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "restore the run_until_complete lookup, the shipped bug",
+    "file": "ee/pocketpaw_ee/guards/deps.py",
+    "find": "    try:\n        overrides = await get_member_action_overrides(workspace_id, user_id)\n    except Exception:",
+    "replace": "    try:\n        import asyncio\n\n        overrides = asyncio.get_event_loop().run_until_complete(\n            get_member_action_overrides(workspace_id, user_id)\n        )\n    except Exception:",
+    "tests": ["tests/cloud/test_member_action_overrides.py"]
+  },
+  {
+    "label": "put membership and the action check back in one try",
+    "file": "ee/pocketpaw_ee/guards/deps.py",
+    "find": "    try:\n        role = resolve_workspace_role(user, workspace_id)\n    except Forbidden as exc:",
+    "replace": "    try:\n        role = resolve_workspace_role(user, workspace_id)\n        check_action(action, role)\n    except Forbidden as exc:\n        if user_id and await _has_action_override(workspace_id, user_id, action):\n            return role",
+    "tests": ["tests/cloud/test_member_action_overrides.py"]
+  },
+  {
+    "label": "cache a failed read, pinning the member for the process lifetime",
+    "file": "ee/pocketpaw_ee/guards/deps.py",
+    "find": "            exc_info=True,\n        )\n        return False\n\n    _ACTION_OVERRIDE_CACHE[cache_key] = (now + _ACTION_OVERRIDE_TTL_SECONDS, overrides)",
+    "replace": "            exc_info=True,\n        )\n        _ACTION_OVERRIDE_CACHE[cache_key] = (now + _ACTION_OVERRIDE_TTL_SECONDS, [])\n        return False\n\n    _ACTION_OVERRIDE_CACHE[cache_key] = (now + _ACTION_OVERRIDE_TTL_SECONDS, overrides)",
+    "tests": ["tests/cloud/test_member_action_overrides.py"]
+  },
+  {
+    "label": "make invalidation a no-op so an admin grant waits out the TTL",
+    "file": "ee/pocketpaw_ee/guards/deps.py",
+    "find": "    if user_id is not None:\n        _ACTION_OVERRIDE_CACHE.pop((workspace_id, user_id), None)\n        return",
+    "replace": "    if user_id is not None:\n        return",
+    "tests": ["tests/cloud/test_member_action_overrides.py"]
+  },
+  {
+    "label": "drop the await at the require_action dependency call site",
+    "file": "ee/pocketpaw_ee/cloud/_core/deps.py",
+    "find": "            await check_workspace_action(user, workspace_id, action)",
+    "replace": "            check_workspace_action(user, workspace_id, action)",
+    "tests": ["tests/cloud/test_member_action_overrides.py::test_every_call_site_awaits_the_guard"]
+  },
+  {
+    "label": "drop the await in the fleet install guard",
+    "file": "ee/pocketpaw_ee/fleet/router.py",
+    "find": "        await check_workspace_action(user, workspace_id, \"fleet.install\")",
+    "replace": "        check_workspace_action(user, workspace_id, \"fleet.install\")",
+    "tests": ["tests/cloud/test_member_action_overrides.py::test_every_call_site_awaits_the_guard"]
+  }
+]

--- a/tests/mutations/site_plan_purchase_authz.json
+++ b/tests/mutations/site_plan_purchase_authz.json
@@ -1,6 +1,6 @@
 [
   {
-    "label": "the purchase gate is deleted — any member charges the company card",
+    "label": "the purchase gate is deleted \u2014 any member charges the company card",
     "file": "ee/pocketpaw_ee/sites/service.py",
     "find": "        and requested_tier.key != _held_tier_key\n        and not purchase_authorized",
     "replace": "        and requested_tier.key != _held_tier_key\n        and False",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "label": "the gate stops exempting a same-tier republish — every content edit needs an admin",
+    "label": "the gate stops exempting a same-tier republish \u2014 every content edit needs an admin",
     "file": "ee/pocketpaw_ee/sites/service.py",
     "find": "        and requested_tier.key != _held_tier_key\n        and not purchase_authorized",
     "replace": "        and not purchase_authorized",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "label": "the gate also refuses a FREE publish — an employee cannot ship at all",
+    "label": "the gate also refuses a FREE publish \u2014 an employee cannot ship at all",
     "file": "ee/pocketpaw_ee/sites/service.py",
     "find": "    if (\n        requested_tier is not None\n        and (is_paid or already_paying)",
     "replace": "    if (\n        requested_tier is not None",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "label": "purchase_authorized defaults True — the MCP path and any new caller buy by omission",
+    "label": "purchase_authorized defaults True \u2014 the MCP path and any new caller buy by omission",
     "file": "ee/pocketpaw_ee/sites/service.py",
     "find": "    purchase_authorized: bool = False,",
     "replace": "    purchase_authorized: bool = True,",
@@ -37,7 +37,7 @@
     ]
   },
   {
-    "label": "buying drops back to the publishing role — the hole reopens",
+    "label": "buying drops back to the publishing role \u2014 the hole reopens",
     "file": "ee/pocketpaw_ee/guards/actions.py",
     "find": "    \"sites.buy_plan\": ActionRule(WorkspaceRole.ADMIN, \"sites.plan_purchase_forbidden\"),",
     "replace": "    \"sites.buy_plan\": ActionRule(WorkspaceRole.MEMBER, \"sites.plan_purchase_forbidden\"),",
@@ -48,14 +48,14 @@
   {
     "label": "the router reports every caller as authorized to buy",
     "file": "ee/pocketpaw_ee/sites/router.py",
-    "find": "    try:\n        check_workspace_action(user, workspace_id, \"sites.buy_plan\")\n    except CloudError:\n        return False",
+    "find": "    try:\n        await check_workspace_action(user, workspace_id, \"sites.buy_plan\")\n    except CloudError:\n        return False",
     "replace": "    try:\n        pass\n    except CloudError:\n        return False",
     "tests": [
       "tests/cloud/sites/test_site_plan_purchase_authz.py::test_the_router_refuses_a_member_and_allows_an_admin"
     ]
   },
   {
-    "label": "the router's helper fails OPEN on an unreadable role — a stranger buys",
+    "label": "the router's helper fails OPEN on an unreadable role \u2014 a stranger buys",
     "file": "ee/pocketpaw_ee/sites/router.py",
     "find": "        return False\n    return True",
     "replace": "        return True\n    return True",


### PR DESCRIPTION
Audit finding H-4.

## What was wrong

`_has_action_override` was sync and reached an async service like this:

```python
overrides = asyncio.get_event_loop().run_until_complete(
    get_member_action_overrides(workspace_id, user_id)
)
```

Every caller is an async request handler, so a loop is already running and that raises `RuntimeError: This event loop is already running`. A bare `except Exception` swallowed it, `overrides` became `[]`, and the empty list went into a dict with no expiry — the comment said "Lives for process lifetime".

So every per-member grant an admin made in the UI silently did nothing, for the life of the process. It fails **closed**: users are denied actions they were explicitly granted. That is a permissions bug, not an escalation — it reads to a customer as "I gave them permission and nothing happened".

## Why the obvious fix is worse than the bug

This is the part worth reviewing carefully. `check_workspace_action` had both checks in one `try`:

```python
try:
    role = resolve_workspace_role(user, workspace_id)   # may raise not_member
    check_action(action, role)                          # may raise denied
except Forbidden:
    if _has_action_override(...):
        return role                                     # role may be UNBOUND
```

Two different failures arrived at one handler. If `resolve_workspace_role` raised, `role` was never bound — and that path was unreachable **only** because the override lookup always returned False.

Make the lookup work without restructuring, and it either raises `UnboundLocalError`, or — if someone gives `role` a default to silence that — it hands a **non-member of the workspace** access on the strength of an override row.

Membership is now resolved in its own `try`, before the override path exists. There is a test that authenticates a user belonging to no workspace, carrying a grant row for the action, and asserts both that it is denied `workspace.not_member` and that the override lookup never ran.

## Also fixed

A failed read is no longer cached — a transient database error used to pin a member to "no overrides" for the process lifetime. The cache has a TTL, and both `action_permissions` writers invalidate it, so an admin's change applies immediately rather than after the TTL.

## The conversion, and the test churn

`check_workspace_action` is now a coroutine function. 13 call sites await it, and two sync helpers (`_require_fleet_install`, `_may_buy_site_plan`) became async along with their single callers.

That also made 22 stubs across 14 test files wrong: a sync stub returning `None` makes the production `await` raise. Those now use `AsyncMock` / `async def`.

The `_deny` stubs are deliberately **untouched** — they raise while `f(x)` is being evaluated, before the `await`, so they still behave correctly.

**Worth a reviewer's eye on the test diff, not just the production diff.** I described this churn as mechanical and it wasn't: my first pass converted lambdas only and silently missed a named `_record` stub, which surfaced as a genuinely failing gate rather than a lint error.

## Tests

`tests/cloud/test_member_action_overrides.py` with `tests/mutations/member_action_overrides.json`. Six mutations, all caught, including both dropped-`await` cases.

That last gate walks the AST of both packages. A dropped `await` on an async guard builds a coroutine, never runs it, raises nothing, and the route allows — Python only warns on stderr at GC time, which is exactly how the original bug in this module stayed invisible.

## What is and is not verified

**Verified like-for-like:** `tests/cloud/test_audit_router.py` + `tests/ee/agent/test_workspace_admin_mcp` give 8 failed / 50 passed on this branch and 8 failed / 50 passed on a clean `dev` checkout. Identical, so those 8 are pre-existing.

**Still running as I open this:** the full `tests/cloud` + `tests/ee` sweep. `tests/cloud` carries substantial pre-existing failures on `dev` and is excluded from CI by `addopts` in `pyproject.toml`, so the totals need a clean-`dev` baseline to mean anything. I will post both numbers here when it lands rather than leave a claim unbacked.

Flagging that exclusion again because it applies to this PR's own gate: `tests/cloud/test_member_action_overrides.py` will not run in CI as things stand.