### PR TITLE
Move the studio generation history into Mongo

### DIFF
--- a/docs/deployment/studio-history-mongo-migration.md
+++ b/docs/deployment/studio-history-mongo-migration.md
@@ -1,0 +1,64 @@
+<!-- Operator runbook for moving the Studio generation history off the legacy
+     JSONL file and into Mongo. Created 2026-09-08 (feat/studio-history-store). -->
+# Studio history: JSONL → Mongo
+
+The `/studio` generation history used to live in a single append-only file,
+`~/.pocketpaw/studio/generations.jsonl`, shared by the whole deployment with the
+owning workspace stored as a `_workspace` field filtered in Python on read. It is
+now the `studio_generations` Mongo collection, indexed on `workspace`.
+
+## Do I need to run this?
+
+**Yes, if the deployment has ever generated anything on `/studio`.** The file sits
+on the `backend-data` named volume, so it survived every redeploy and holds real
+galleries. Without the import those galleries render **empty** — nothing errors,
+the tiles are simply gone.
+
+**No, on a fresh install.** There is no file, the migration reports zero and
+exits 0.
+
+## Run it
+
+Containers have no shell, so run it the same way as the credit-wallet migration —
+as a one-off command against the same image:
+
+```bash
+python -m pocketpaw_ee.cloud.studio.migrate_generations_jsonl --dry-run
+python -m pocketpaw_ee.cloud.studio.migrate_generations_jsonl
+```
+
+It reads `CLOUD_MONGODB_URI` (falling back to `POCKETPAW_MONGO_URL`), the same
+variables `init_cloud_db` reads, so the migration and the app cannot point at
+different databases.
+
+**It is idempotent.** A record already present under its `(workspace,
+generation_id)` is counted as "already present" and not rewritten, so a re-run
+converges and an interrupted run can simply be repeated. It does **not** delete
+the JSONL — the file stays as a copy while the change is young.
+
+**Run it once, not per container.** `backend` and `worker` share the volume;
+there is no lock, and the check-then-insert is not atomic, so two simultaneous
+runs could race.
+
+## What it deliberately leaves behind
+
+Records with **no `_workspace` tag** are counted and skipped. They cannot be
+attributed to anyone — and the old reader's `or _workspace is None` clause meant
+they were readable by **every** tenant. Importing one would mean choosing an
+owner, and any choice is wrong.
+
+Their disappearance from the gallery is the leak closing, not data loss. The run
+reports how many it skipped; if that count is large and someone wants them, they
+are still in the JSONL and can be attributed by hand.
+
+Malformed lines are counted separately and stepped over, the same way the old
+reader skipped them, so one bad row cannot strand every record after it.
+
+## Verifying
+
+```
+migration complete: 128 imported, 0 already present, 3 skipped (untagged), 0 skipped (unreadable)
+```
+
+Then open `/studio` as a workspace that had history and confirm the gallery
+renders. A second run should report `0 imported, 128 already present`.

--- a/docs/deployment/studio-history-mongo-migration.md
+++ b/docs/deployment/studio-history-mongo-migration.md
@@ -7,38 +7,43 @@ The `/studio` generation history used to live in a single append-only file,
 owning workspace stored as a `_workspace` field filtered in Python on read. It is
 now the `studio_generations` Mongo collection, indexed on `workspace`.
 
-## Do I need to run this?
+## Do I need to run this? No — it runs itself
 
-**Yes, if the deployment has ever generated anything on `/studio`.** The file sits
-on the `backend-data` named volume, so it survived every redeploy and holds real
-galleries. Without the import those galleries render **empty** — nothing errors,
-the tiles are simply gone.
+The file sits on the `backend-data` named volume, survived every redeploy and
+holds real galleries. Without the import those galleries render **empty** —
+nothing errors, the tiles are simply gone. That failure mode is exactly why this
+is no longer a manual step.
 
-**No, on a fresh install.** There is no file, the migration reports zero and
-exits 0.
+`init_cloud_db` calls `migrate_on_boot()` on every cloud start, beside the
+workspace-VM map import. It is best-effort and never blocks a boot: a missing
+file returns immediately, and any error is logged and swallowed.
 
-## Run it
+That is deliberate. The alternative was a one-off command a human had to
+remember, in an environment with no shell — and forgetting it left every gallery
+silently empty, with nothing in the logs to say why.
 
-Containers have no shell, so run it the same way as the credit-wallet migration —
-as a one-off command against the same image:
+**Running from both containers is safe.** `backend` and `worker` boot
+independently and share the volume. The import does find-then-insert per record
+with no lock, which would once have raced; the unique index on
+`(workspace, generation_id)` closes it, so a concurrent double-insert raises
+`DuplicateKeyError` and the row is applied instead of duplicated.
+
+## Running it by hand
+
+Still useful for a dry run, or to re-run after fixing something:
 
 ```bash
 python -m pocketpaw_ee.cloud.studio.migrate_generations_jsonl --dry-run
 python -m pocketpaw_ee.cloud.studio.migrate_generations_jsonl
 ```
 
+The CLI suppresses the boot import before it initialises the database — without
+that, `--dry-run` would report what it "would" do *after* the automatic import
+had already done it.
+
 It reads `CLOUD_MONGODB_URI` (falling back to `POCKETPAW_MONGO_URL`), the same
 variables `init_cloud_db` reads, so the migration and the app cannot point at
-different databases.
-
-**It is idempotent.** A record already present under its `(workspace,
-generation_id)` is counted as "already present" and not rewritten, so a re-run
-converges and an interrupted run can simply be repeated. It does **not** delete
-the JSONL — the file stays as a copy while the change is young.
-
-**Run it once, not per container.** `backend` and `worker` share the volume;
-there is no lock, and the check-then-insert is not atomic, so two simultaneous
-runs could race.
+different databases. It is idempotent, and it does **not** delete the JSONL.
 
 ## What it deliberately leaves behind
 

--- a/ee/pocketpaw_ee/cloud/media/router.py
+++ b/ee/pocketpaw_ee/cloud/media/router.py
@@ -174,7 +174,7 @@ async def list_media(
     tiles. Agent-side generated files (media MCP) are NOT tracked and therefore
     still surface here (in local mode).
     """
-    tracked = tracked_generation_filenames()
+    tracked = await tracked_generation_filenames()
     generated = storage.local_generated_dir()
     entries = (
         _local_entries(generated, sort, tracked, workspace_id)

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -266,6 +266,7 @@ from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
 from pocketpaw_ee.cloud.models.site_export import SiteExport
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
 from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
+from pocketpaw_ee.cloud.models.studio_generation import StudioGeneration
 from pocketpaw_ee.cloud.models.subscription import Subscription
 from pocketpaw_ee.cloud.models.task import Task, TaskAssignee, TaskSource
 from pocketpaw_ee.cloud.models.task_attachment import TaskAttachment
@@ -436,6 +437,7 @@ __all__ = [
     "SiteDomain",
     "SiteRateCounter",
     "SpendReconciliation",
+    "StudioGeneration",
     "Subscription",
     "WorkspaceSensePreference",
     "Task",
@@ -549,6 +551,7 @@ def get_all_documents():
         # Shadow-compare reconciliation rows (WU-F). One per tenant per window
         # during shadow mode. Only ``ee.cloud.llm_provisioning.service`` writes it.
         SpendReconciliation,
+        StudioGeneration,
         Task,
         TaskAttachment,
         TemporalSweepStateDoc,

--- a/ee/pocketpaw_ee/cloud/models/studio_generation.py
+++ b/ee/pocketpaw_ee/cloud/models/studio_generation.py
@@ -33,6 +33,7 @@ from typing import Any
 
 from beanie import Indexed
 from pydantic import Field
+from pymongo import IndexModel
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
@@ -69,8 +70,17 @@ class StudioGeneration(TimestampedDocument):
         indexes = [
             # The gallery: a workspace's history, newest first.
             [("workspace", 1), ("created_at_ms", -1)],
-            # Point lookup + the upsert key, so a retry cannot duplicate a tile.
-            [("workspace", 1), ("generation_id", 1)],
+            # Point lookup AND the dedupe key. UNIQUE deliberately: without it the
+            # find-then-insert in ``record_generation`` is a read-modify-write with
+            # no lock, and `backend` and `worker` both run that code — two concurrent
+            # calls carrying one generation id can both miss and both insert. The
+            # constraint is what actually makes 'a retry cannot duplicate a tile'
+            # true; the application-level check alone only makes it usually true.
+            IndexModel(
+                [("workspace", 1), ("generation_id", 1)],
+                unique=True,
+                name="workspace_generation_id_unique",
+            ),
             # "everything the site agent made", and "everything for this site".
             [("workspace", 1), ("source", 1), ("created_at_ms", -1)],
             [("workspace", 1), ("pocket_id", 1), ("created_at_ms", -1)],

--- a/ee/pocketpaw_ee/cloud/models/studio_generation.py
+++ b/ee/pocketpaw_ee/cloud/models/studio_generation.py
@@ -1,0 +1,77 @@
+# ee/pocketpaw_ee/cloud/models/studio_generation.py — one Studio generation.
+#
+# Created 2026-09-08 (feat/studio-history-store, SM-0). Replaces the
+# ``~/.pocketpaw/studio/generations.jsonl`` history, which was ONE append-only
+# file for the whole deployment with tenancy as a ``_workspace`` field filtered
+# in Python on read. That shape failed four ways:
+#
+#   * every read decoded every tenant's entire history, unindexed and unrotated;
+#   * ``backend`` and ``worker`` both mount the ``backend-data`` volume, so two
+#     processes appended to one file (the reader already swallowed corrupt lines);
+#   * the ``or _workspace is None`` clause in ``list_generations`` showed untagged
+#     rows to EVERY workspace while its docstring claimed the opposite — here
+#     tenancy is a query filter, so there is no untagged branch to fall through;
+#   * append was the only write, so all eight ``_append_history`` call sites wrote
+#     ``status="succeeded"`` and the four-value status enum only ever held one
+#     value. Nothing existed while a job was queued or running and a failure left
+#     no trace, which is why async video had nowhere to record "rendering".
+#
+# The sibling JSONL stores in ee/cloud are NOT precedent for keeping this one:
+# ``outcomes``, ``trust_ledger`` and ``audit`` are append-only ledgers keyed per
+# workspace, and ``trust_ledger`` is on the import-linter "Pockets" allowlist that
+# forbids Beanie writes outright. A gallery listing is none of those — it is
+# mutable content wanting query, filter, pagination and delete.
+#
+# ``created_at_ms`` deliberately does NOT reuse the base class's ``createdAt``:
+# the wire schema (``studio.schemas.Generation.createdAt``) is a unix-ms int the
+# frontend sorts on, while ``TimestampedDocument.createdAt`` is a datetime. Two
+# different types under one name is how a silent coercion bug starts.
+
+from __future__ import annotations
+
+from typing import Any
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class StudioGeneration(TimestampedDocument):
+    """One image / video / audio generation, owned by exactly one workspace."""
+
+    # Tenancy boundary — every read filters on this, no exceptions.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The wire id (``schemas.Generation.id``), unique within a workspace.
+    generation_id: str
+
+    prompt: str
+    # queued | running | succeeded | failed — the full lifecycle, not just the
+    # terminal success the JSONL could express.
+    status: str
+    kind: str  # image | video | audio
+    model: str
+    params: dict[str, Any] = Field(default_factory=dict)
+    assets: list[dict[str, Any]] = Field(default_factory=list)
+    created_at_ms: int
+    error: str | None = None
+    sourceGenerationId: str | None = None
+
+    # Provenance. "studio" is a human on the /studio page; "sites" is the site
+    # authoring agent generating into a page. Without this the linked gallery
+    # mixes a user's own experiments with everything an agent made while
+    # building a site, and reads as clutter rather than as a feature.
+    source: str = "studio"
+    pocket_id: str | None = None
+
+    class Settings:
+        name = "studio_generations"
+        indexes = [
+            # The gallery: a workspace's history, newest first.
+            [("workspace", 1), ("created_at_ms", -1)],
+            # Point lookup + the upsert key, so a retry cannot duplicate a tile.
+            [("workspace", 1), ("generation_id", 1)],
+            # "everything the site agent made", and "everything for this site".
+            [("workspace", 1), ("source", 1), ("created_at_ms", -1)],
+            [("workspace", 1), ("pocket_id", 1), ("created_at_ms", -1)],
+        ]

--- a/ee/pocketpaw_ee/cloud/shared/db.py
+++ b/ee/pocketpaw_ee/cloud/shared/db.py
@@ -333,6 +333,14 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
     # helper swallows its own errors so a migration hiccup never blocks boot.
     await migrate_workspace_vm_map_to_db()
 
+    # One-time import of the legacy studio generation history (the deployment-wide
+    # generations.jsonl) into ``studio_generations``. Same best-effort contract as
+    # the line above: without it, every existing /studio gallery renders EMPTY and
+    # nothing errors to say why.
+    from pocketpaw_ee.cloud.studio.migrate_generations_jsonl import migrate_on_boot
+
+    await migrate_on_boot()
+
     # Flip the memory backend AFTER Beanie is initialized so the
     # MongoMemoryStore's first .insert()/.find() call can never race a
     # not-yet-initialized collection. The bootstrap is a no-op until this

--- a/ee/pocketpaw_ee/cloud/studio/migrate_generations_jsonl.py
+++ b/ee/pocketpaw_ee/cloud/studio/migrate_generations_jsonl.py
@@ -26,7 +26,11 @@ has no file, and a migration that failed there would deadlock the first deploy.
 It also does NOT delete the file: leaving it makes the run repeatable and keeps a
 copy while the change is still young.
 
-RUN IT as a deploy step (Coolify containers have no shell):
+IT RUNS ITSELF. ``init_cloud_db`` calls ``migrate_on_boot`` on every cloud start,
+beside the workspace-VM map import, because the alternative was a one-off command
+a human had to remember in an environment with no shell — and forgetting it left
+every existing gallery silently EMPTY. The CLI remains for a dry run or a manual
+re-run:
 
     python -m pocketpaw_ee.cloud.studio.migrate_generations_jsonl [--dry-run]
 
@@ -54,6 +58,11 @@ logger = logging.getLogger(__name__)
 #: Env vars carrying the Mongo URI, most authoritative first — the same order
 #: ``credits.migrate_micro_credits`` uses, for the same reason.
 _URI_VARS: tuple[str, ...] = ("CLOUD_MONGODB_URI", "POCKETPAW_MONGO_URL")
+
+#: Set by the CLI before it calls ``init_cloud_db``. Without it ``--dry-run``
+#: would be a lie: init_cloud_db now runs ``migrate_on_boot``, so the real import
+#: would already have happened before the dry run reported what it 'would' do.
+_suppress_boot_import = False
 
 
 def legacy_history_path() -> Path:
@@ -117,6 +126,48 @@ async def migrate_file(path: Path, *, dry_run: bool = False) -> Result:
     )
 
 
+async def migrate_on_boot() -> None:
+    """Import the legacy history at cloud startup. Best-effort, never blocks boot.
+
+    WHY THIS RUNS AUTOMATICALLY. Without it the import is a one-off command a human
+    has to remember, in an environment the team's own notes describe as having no
+    shell — and the failure mode is silent: every existing /studio gallery renders
+    EMPTY, nothing errors, the tiles are simply gone. Same shape and same reasoning
+    as ``migrate_workspace_vm_map_to_db`` beside it in ``init_cloud_db``.
+
+    SAFE TO RUN FROM BOTH CONTAINERS. ``backend`` and ``worker`` boot independently
+    and share the volume, which would once have been a race: ``migrate_file`` does
+    find-then-insert per record with no lock. The unique index on
+    ``(workspace, generation_id)`` closes it — a concurrent double-insert raises
+    ``DuplicateKeyError`` and ``record_generation`` applies the row instead.
+
+    CHEAP WHEN THERE IS NOTHING TO DO. A fresh install has no file and this returns
+    immediately; a converged deployment re-reads the file and writes nothing.
+    """
+    if _suppress_boot_import:
+        return
+
+    path = legacy_history_path()
+    if not path.exists():
+        return
+
+    try:
+        result = await migrate_file(path)
+    except Exception:  # noqa: BLE001 — a migration hiccup must never block boot
+        logger.warning("studio: legacy history import failed; run it by hand", exc_info=True)
+        return
+
+    if result.imported or result.skipped_untagged or result.skipped_unreadable:
+        logger.info(
+            "studio: legacy history import — %d imported, %d already present, "
+            "%d skipped (untagged), %d skipped (unreadable)",
+            result.imported,
+            result.already,
+            result.skipped_untagged,
+            result.skipped_unreadable,
+        )
+
+
 def resolve_mongo_uri(env: dict[str, str] | None = None) -> str:
     """The deployed stack sets ``CLOUD_MONGODB_URI``; fall back to the same
     default ``init_cloud_db`` carries so a local run works with no env at all."""
@@ -140,6 +191,8 @@ async def main() -> int:
 
     from pocketpaw_ee.cloud.shared.db import init_cloud_db
 
+    global _suppress_boot_import
+    _suppress_boot_import = True  # this command IS the import; see the flag's note
     await init_cloud_db(resolve_mongo_uri())
 
     path = legacy_history_path()

--- a/ee/pocketpaw_ee/cloud/studio/migrate_generations_jsonl.py
+++ b/ee/pocketpaw_ee/cloud/studio/migrate_generations_jsonl.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+"""Import the legacy Studio generation history into Mongo.
+
+WHAT THIS DOES. Reads ``~/.pocketpaw/studio/generations.jsonl`` — the
+deployment-wide append-only file the history used to live in — and upserts each
+record into the ``studio_generations`` collection, keyed ``(workspace,
+generation_id)``.
+
+WHY IT IS NEEDED AT ALL. The file sits on the ``backend-data`` named volume, so
+it survives redeploys and holds real galleries. Shipping the Mongo store without
+this would silently empty every workspace's /studio page.
+
+UNTAGGED RECORDS ARE SKIPPED, AND THAT IS THE POINT. A record with no
+``_workspace`` cannot be attributed to anyone, and the old reader's
+``or _workspace is None`` clause is exactly why: it showed those rows to EVERY
+tenant. Importing them would mean choosing an owner, and any choice is wrong —
+so they are counted, reported, and left behind. Their disappearance from the
+gallery IS the leak closing.
+
+IDEMPOTENT. A record already present under its ``(workspace, generation_id)`` is
+counted as ``already`` and not rewritten, so a re-run converges and a resumed run
+after an interruption cannot duplicate a tile.
+
+SAFE ON AN EMPTY OR MISSING FILE — it reports zero and exits 0. A fresh install
+has no file, and a migration that failed there would deadlock the first deploy.
+It also does NOT delete the file: leaving it makes the run repeatable and keeps a
+copy while the change is still young.
+
+RUN IT as a deploy step (Coolify containers have no shell):
+
+    python -m pocketpaw_ee.cloud.studio.migrate_generations_jsonl [--dry-run]
+
+CONFIGURATION comes from ``CLOUD_MONGODB_URI``, the same variable
+``init_cloud_db`` reads, so the migration and the app cannot point at different
+databases.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from pocketpaw.config import get_config_dir
+from pocketpaw_ee.cloud.studio import schemas, service
+
+logger = logging.getLogger(__name__)
+
+#: Env vars carrying the Mongo URI, most authoritative first — the same order
+#: ``credits.migrate_micro_credits`` uses, for the same reason.
+_URI_VARS: tuple[str, ...] = ("CLOUD_MONGODB_URI", "POCKETPAW_MONGO_URL")
+
+
+def legacy_history_path() -> Path:
+    """Where the JSONL history lived before this migration."""
+    return get_config_dir() / "studio" / "generations.jsonl"
+
+
+@dataclass(frozen=True)
+class Result:
+    """Counts only — no record content, which may carry a user's prompts."""
+
+    imported: int = 0
+    skipped_untagged: int = 0
+    skipped_unreadable: int = 0
+    already: int = 0
+
+
+async def migrate_file(path: Path, *, dry_run: bool = False) -> Result:
+    """Import one JSONL file. Never raises on a bad line — a corrupt record is
+    counted and stepped over, exactly as the old reader did."""
+    if not path.exists():
+        logger.info("no legacy history at %s — nothing to import", path)
+        return Result()
+
+    imported = untagged = unreadable = already = 0
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except ValueError:
+            unreadable += 1
+            continue
+
+        workspace_id = record.pop("_workspace", None)
+        if not workspace_id:
+            untagged += 1
+            continue
+
+        try:
+            generation = schemas.Generation.model_validate(record)
+        except Exception:  # noqa: BLE001 — a malformed row must not stop the run
+            unreadable += 1
+            continue
+
+        if await service.get_generation(workspace_id, generation.id) is not None:
+            already += 1
+            continue
+
+        if not dry_run:
+            await service.record_generation(workspace_id, generation)
+        imported += 1
+
+    return Result(
+        imported=imported,
+        skipped_untagged=untagged,
+        skipped_unreadable=unreadable,
+        already=already,
+    )
+
+
+def resolve_mongo_uri(env: dict[str, str] | None = None) -> str:
+    """The deployed stack sets ``CLOUD_MONGODB_URI``; fall back to the same
+    default ``init_cloud_db`` carries so a local run works with no env at all."""
+    source = env if env is not None else dict(os.environ)
+    for var in _URI_VARS:
+        value = (source.get(var) or "").strip()
+        if value:
+            return value
+    return "mongodb://localhost:27017/paw-enterprise"
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Import the legacy studio history into Mongo.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be imported without writing anything",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    from pocketpaw_ee.cloud.shared.db import init_cloud_db
+
+    await init_cloud_db(resolve_mongo_uri())
+
+    path = legacy_history_path()
+    result = await migrate_file(path, dry_run=args.dry_run)
+
+    logger.info(
+        "%s: %d imported, %d already present, %d skipped (untagged), %d skipped (unreadable)",
+        "dry run" if args.dry_run else "migration complete",
+        result.imported,
+        result.already,
+        result.skipped_untagged,
+        result.skipped_unreadable,
+    )
+    if result.skipped_untagged:
+        logger.info(
+            "the %d untagged record(s) carry no workspace and were left behind on purpose — "
+            "they were readable by every tenant under the old reader",
+            result.skipped_untagged,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/ee/pocketpaw_ee/cloud/studio/router.py
+++ b/ee/pocketpaw_ee/cloud/studio/router.py
@@ -70,7 +70,7 @@ async def list_generations(
 ) -> schemas.GenerationsResponse:
     """Return the workspace's generation history, newest first (persisted, so it
     survives reloads)."""
-    return schemas.GenerationsResponse(generations=service.list_generations(workspace_id))
+    return schemas.GenerationsResponse(generations=await service.list_generations(workspace_id))
 
 
 @router.post("/generate", response_model=schemas.Generation)
@@ -105,7 +105,7 @@ async def get_generation(
     workspace_id: str = Depends(current_workspace_id),
 ) -> schemas.Generation:
     """Return one generation by id (scoped to the workspace), or 404."""
-    generation = service.get_generation(gen_id, workspace_id)
+    generation = await service.get_generation(workspace_id, gen_id)
     if generation is None:
         raise HTTPException(404, f"Generation '{gen_id}' not found")
     return generation

--- a/ee/pocketpaw_ee/cloud/studio/service.py
+++ b/ee/pocketpaw_ee/cloud/studio/service.py
@@ -53,6 +53,7 @@ from pocketpaw_ee.catalog import config as catalog_config
 from pocketpaw_ee.catalog import service as catalog_service
 from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry
 from pocketpaw_ee.cloud.media import storage as media_storage
+from pocketpaw_ee.cloud.models.studio_generation import StudioGeneration
 
 from . import (
     camera_catalog,
@@ -469,6 +470,137 @@ def get_generation(gen_id: str, workspace_id: str) -> schemas.Generation | None:
             continue
         return schemas.Generation.model_validate(r)
     return None
+
+
+# ── Generation history (Mongo, workspace-scoped) ────────────────────────────
+#
+# House rule (ee/pocketpaw_ee/cloud CLAUDE.md #1/#2): the service IS the
+# repository — there is no repositories.py, and ``models.studio_generation`` is
+# imported HERE and nowhere else in this package.
+#
+# These replace the ``~/.pocketpaw/studio/generations.jsonl`` helpers above.
+# The gallery's default page — the JSONL had no limit and decoded every record
+# every tenant had ever generated on every request.
+DEFAULT_GENERATION_LIMIT = 50
+
+
+def _to_schema(doc: StudioGeneration) -> schemas.Generation:
+    """Document → wire record. The wire shape is what the frontend already reads,
+    so it is deliberately unchanged by the store move."""
+    return schemas.Generation(
+        id=doc.generation_id,
+        prompt=doc.prompt,
+        status=doc.status,
+        kind=doc.kind,
+        model=doc.model,
+        params=schemas.GenerationParams.model_validate(doc.params),
+        assets=[schemas.GeneratedAsset.model_validate(a) for a in doc.assets],
+        createdAt=doc.created_at_ms,
+        error=doc.error,
+        sourceGenerationId=doc.sourceGenerationId,
+    )
+
+
+async def record_generation(
+    workspace_id: str,
+    generation: schemas.Generation,
+    *,
+    source: str = "studio",
+    pocket_id: str | None = None,
+) -> None:
+    """Persist a generation, or replace the record already under its id.
+
+    Upserting on (workspace, generation_id) rather than appending is what stops a
+    retry — or the ordinary queued→succeeded rewrite — from fanning out into
+    duplicate gallery tiles, which an append-only file could not prevent.
+    """
+    existing = await StudioGeneration.find_one(
+        StudioGeneration.workspace == workspace_id,
+        StudioGeneration.generation_id == generation.id,
+    )
+
+    fields = {
+        "prompt": generation.prompt,
+        "status": generation.status,
+        "kind": generation.kind,
+        "model": generation.model,
+        "params": generation.params.model_dump(),
+        "assets": [a.model_dump() for a in generation.assets],
+        "created_at_ms": generation.createdAt,
+        "error": generation.error,
+        "sourceGenerationId": generation.sourceGenerationId,
+        "source": source,
+        "pocket_id": pocket_id,
+    }
+
+    if existing is not None:
+        for key, value in fields.items():
+            setattr(existing, key, value)
+        await existing.save()
+        return
+
+    await StudioGeneration(
+        workspace=workspace_id,
+        generation_id=generation.id,
+        **fields,
+    ).insert()
+
+
+async def update_generation(
+    workspace_id: str,
+    generation_id: str,
+    *,
+    status: str,
+    assets: list[schemas.GeneratedAsset] | None = None,
+    error: str | None = None,
+) -> bool:
+    """Move a generation along its lifecycle. Returns False when the workspace
+    does not own it — a miss, never a cross-tenant write."""
+    doc = await StudioGeneration.find_one(
+        StudioGeneration.workspace == workspace_id,
+        StudioGeneration.generation_id == generation_id,
+    )
+    if doc is None:
+        return False
+
+    doc.status = status
+    if assets is not None:
+        doc.assets = [a.model_dump() for a in assets]
+    if error is not None:
+        doc.error = error
+    await doc.save()
+    return True
+
+
+async def list_stored_generations(
+    workspace_id: str,
+    *,
+    limit: int = DEFAULT_GENERATION_LIMIT,
+    source: str | None = None,
+    pocket_id: str | None = None,
+) -> list[schemas.Generation]:
+    """The workspace's history, newest first.
+
+    ``source`` / ``pocket_id`` are what let the gallery separate a person's own
+    generations from the ones a site agent made while building a page.
+    """
+    query = [StudioGeneration.workspace == workspace_id]
+    if source is not None:
+        query.append(StudioGeneration.source == source)
+    if pocket_id is not None:
+        query.append(StudioGeneration.pocket_id == pocket_id)
+
+    docs = await StudioGeneration.find(*query).sort("-created_at_ms").limit(limit).to_list()
+    return [_to_schema(d) for d in docs]
+
+
+async def get_stored_generation(workspace_id: str, generation_id: str) -> schemas.Generation | None:
+    """One generation, or None. The id is guessable; the workspace is the boundary."""
+    doc = await StudioGeneration.find_one(
+        StudioGeneration.workspace == workspace_id,
+        StudioGeneration.generation_id == generation_id,
+    )
+    return _to_schema(doc) if doc is not None else None
 
 
 def tracked_generation_filenames() -> set[str]:

--- a/ee/pocketpaw_ee/cloud/studio/service.py
+++ b/ee/pocketpaw_ee/cloud/studio/service.py
@@ -163,15 +163,6 @@ _SIZE_MAP: dict[str, str] = {
 _MAX_GENERATED_ASSETS = 4
 
 
-def _history_path() -> Path:
-    """Get (and create) the generation-history JSONL path. History is persisted
-    per-deployment under ``~/.pocketpaw/studio/generations.jsonl`` so the /studio
-    gallery survives process restarts."""
-    d = get_config_dir() / "studio"
-    d.mkdir(parents=True, exist_ok=True)
-    return d / "generations.jsonl"
-
-
 # ── Model catalog mapping ────────────────────────────────────────────────────
 
 
@@ -417,61 +408,6 @@ def list_styles() -> list[schemas.StudioStyle]:
     return quick + curated
 
 
-# ── Generation history (JSONL persistence) ──────────────────────────────────
-
-
-def _load_history() -> list[dict[str, Any]]:
-    """Read the persisted generation records (best-effort — a corrupt/missing
-    file degrades to an empty history, never a crash)."""
-    path = _history_path()
-    if not path.exists():
-        return []
-    records: list[dict[str, Any]] = []
-    try:
-        for line in path.read_text().splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                records.append(json.loads(line))
-            except ValueError:
-                logger.warning("studio: skipping corrupt history line")
-    except OSError:
-        logger.warning("studio: could not read history file", exc_info=True)
-    return records
-
-
-def _append_history(record: dict[str, Any]) -> None:
-    """Append one record to the JSONL history (best-effort)."""
-    try:
-        with _history_path().open("a") as fh:
-            fh.write(json.dumps(record) + "\n")
-    except OSError:
-        logger.warning("studio: could not append history", exc_info=True)
-
-
-def list_generations(workspace_id: str) -> list[schemas.Generation]:
-    """Return the workspace's generation history, newest first. Records are
-    tagged with the owning workspace so multi-tenant deployments never leak."""
-    records = _load_history()
-    mine = [
-        r for r in records if r.get("_workspace") == workspace_id or r.get("_workspace") is None
-    ]
-    mine.sort(key=lambda r: r.get("createdAt", 0), reverse=True)
-    return [schemas.Generation.model_validate(r) for r in mine]
-
-
-def get_generation(gen_id: str, workspace_id: str) -> schemas.Generation | None:
-    """Return one generation by id (scoped to the workspace), or None."""
-    for r in _load_history():
-        if r.get("id") != gen_id:
-            continue
-        if r.get("_workspace") not in (None, workspace_id):
-            continue
-        return schemas.Generation.model_validate(r)
-    return None
-
-
 # ── Generation history (Mongo, workspace-scoped) ────────────────────────────
 #
 # House rule (ee/pocketpaw_ee/cloud CLAUDE.md #1/#2): the service IS the
@@ -572,7 +508,7 @@ async def update_generation(
     return True
 
 
-async def list_stored_generations(
+async def list_generations(
     workspace_id: str,
     *,
     limit: int = DEFAULT_GENERATION_LIMIT,
@@ -594,7 +530,7 @@ async def list_stored_generations(
     return [_to_schema(d) for d in docs]
 
 
-async def get_stored_generation(workspace_id: str, generation_id: str) -> schemas.Generation | None:
+async def get_generation(workspace_id: str, generation_id: str) -> schemas.Generation | None:
     """One generation, or None. The id is guessable; the workspace is the boundary."""
     doc = await StudioGeneration.find_one(
         StudioGeneration.workspace == workspace_id,
@@ -603,15 +539,25 @@ async def get_stored_generation(workspace_id: str, generation_id: str) -> schema
     return _to_schema(doc) if doc is not None else None
 
 
-def tracked_generation_filenames() -> set[str]:
+async def tracked_generation_filenames() -> set[str]:
     """The set of media filenames owned by direct /studio generations. The /media
     list router uses this to EXCLUDE generation outputs so the gallery doesn't
     show a direct generation twice (once via /studio/generations and once via the
     /media file list). Agent-side generated files (media MCP) are NOT tracked here
-    and therefore still surface through /media."""
+    and therefore still surface through /media.
+
+    # global-read: deliberately spans every workspace, and narrowing it would be a
+    # LEAK, not a fix. A generated file's name carries no owner (media_key is a flat
+    # ``generated/<name>``; only /browser captures get an owner prefix), so
+    # ``media.storage.visible_to`` returns True for one — "legacy, untagged". This
+    # global set is therefore the only thing keeping one tenant's studio output off
+    # another tenant's /media listing. Scope it per workspace and those files stop
+    # being excluded and start being shown.
+    """
     names: set[str] = set()
-    for r in _load_history():
-        for asset in r.get("assets") or []:
+    docs = await StudioGeneration.find_all().to_list()
+    for doc in docs:
+        for asset in doc.assets or []:
             url = asset.get("url") or ""
             if url.startswith("/api/v1/media/"):
                 names.add(url.rsplit("/", 1)[-1])
@@ -1135,7 +1081,7 @@ async def generate(req: schemas.GenerateRequest, *, workspace_id: str) -> schema
         status="succeeded",
     )
     # Persist with the owning workspace tag (dropped by the wire model on read).
-    _append_history({**record.model_dump(), "_workspace": workspace_id})
+    await record_generation(workspace_id, record)
     return record
 
 
@@ -1193,7 +1139,7 @@ async def _generate_curated_image(
         assets=assets,
         status="succeeded",
     )
-    _append_history({**record.model_dump(), "_workspace": workspace_id})
+    await record_generation(workspace_id, record)
     return record
 
 
@@ -1259,7 +1205,7 @@ async def _generate_image_edit(
         assets=assets,
         status="succeeded",
     )
-    _append_history({**record.model_dump(), "_workspace": workspace_id})
+    await record_generation(workspace_id, record)
     return record
 
 
@@ -1325,7 +1271,7 @@ async def generate_music(req: schemas.MusicRequest, *, workspace_id: str) -> sch
         assets=assets,
         status="succeeded",
     )
-    _append_history({**record.model_dump(), "_workspace": workspace_id})
+    await record_generation(workspace_id, record)
     return record
 
 
@@ -1462,7 +1408,7 @@ async def _generate_video(req: schemas.GenerateRequest, *, workspace_id: str) ->
         assets=assets,
         status="succeeded",
     )
-    _append_history({**record.model_dump(), "_workspace": workspace_id})
+    await record_generation(workspace_id, record)
     return record
 
 
@@ -1738,7 +1684,7 @@ async def edit(req: schemas.EditRequest, *, workspace_id: str) -> schemas.Genera
         assets=assets,
         status="succeeded",
     )
-    _append_history({**record.model_dump(), "_workspace": workspace_id})
+    await record_generation(workspace_id, record)
     return record
 
 
@@ -1833,7 +1779,7 @@ async def generate_video_elements(
         assets=assets,
         status="succeeded",
     )
-    _append_history({**record.model_dump(), "_workspace": workspace_id})
+    await record_generation(workspace_id, record)
     return record
 
 
@@ -1921,7 +1867,7 @@ async def generate_video_motion(
         assets=assets,
         status="succeeded",
     )
-    _append_history({**record.model_dump(), "_workspace": workspace_id})
+    await record_generation(workspace_id, record)
     return record
 
 

--- a/ee/pocketpaw_ee/cloud/studio/service.py
+++ b/ee/pocketpaw_ee/cloud/studio/service.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+from pymongo.errors import DuplicateKeyError
 
 from pocketpaw.config import get_config_dir
 from pocketpaw_ee.catalog import config as catalog_config
@@ -415,8 +416,13 @@ def list_styles() -> list[schemas.StudioStyle]:
 # imported HERE and nowhere else in this package.
 #
 # These replace the ``~/.pocketpaw/studio/generations.jsonl`` helpers above.
-# The gallery's default page — the JSONL had no limit and decoded every record
-# every tenant had ever generated on every request.
+#
+# ``limit=None`` MEANS NO CAP, and that is the default ON PURPOSE. The JSONL's
+# problem was not the absence of a limit — it was decoding EVERY TENANT's entire
+# history out of one file on every request. A Mongo query filtered on an indexed
+# ``workspace`` already fixes that. Capping on top of it would silently drop the
+# older half of a real gallery, because the /studio page fetches this endpoint
+# once with no cursor and renders whatever comes back.
 DEFAULT_GENERATION_LIMIT = 50
 
 
@@ -475,11 +481,27 @@ async def record_generation(
         await existing.save()
         return
 
-    await StudioGeneration(
-        workspace=workspace_id,
-        generation_id=generation.id,
-        **fields,
-    ).insert()
+    try:
+        await StudioGeneration(
+            workspace=workspace_id,
+            generation_id=generation.id,
+            **fields,
+        ).insert()
+    except DuplicateKeyError:
+        # Lost the race: another process inserted this id between our find and
+        # our insert. The unique index is what turned that into a catchable error
+        # instead of a second tile, and the caller's intent was 'this generation
+        # should be recorded in this state' either way — so apply it to the row
+        # that won rather than failing a write the user already paid for.
+        winner = await StudioGeneration.find_one(
+            StudioGeneration.workspace == workspace_id,
+            StudioGeneration.generation_id == generation.id,
+        )
+        if winner is None:  # pragma: no cover — only if the row vanished again
+            raise
+        for key, value in fields.items():
+            setattr(winner, key, value)
+        await winner.save()
 
 
 async def update_generation(
@@ -508,14 +530,47 @@ async def update_generation(
     return True
 
 
+async def record_generation_best_effort(
+    workspace_id: str,
+    generation: schemas.Generation,
+    *,
+    source: str = "studio",
+    pocket_id: str | None = None,
+) -> None:
+    """Record a generation, but never fail the caller over it.
+
+    The JSONL appender swallowed ``OSError``, so a history failure could not lose
+    a generation the user had already paid for. Swapping it for a bare Mongo write
+    quietly removed that property: a write error would now raise AFTER the image
+    was generated, billed and stored, 500 the request, and orphan the asset with
+    no gallery row. The generation paths want the old semantics back.
+
+    Use this from the generation paths. Use ``record_generation`` where the caller
+    genuinely needs to know the write landed.
+    """
+    try:
+        await record_generation(workspace_id, generation, source=source, pocket_id=pocket_id)
+    except Exception:  # noqa: BLE001 — a history miss must not cost a paid asset
+        logger.warning(
+            "studio: could not record generation %s for workspace %s",
+            generation.id,
+            workspace_id,
+            exc_info=True,
+        )
+
+
 async def list_generations(
     workspace_id: str,
     *,
-    limit: int = DEFAULT_GENERATION_LIMIT,
+    limit: int | None = None,
     source: str | None = None,
     pocket_id: str | None = None,
 ) -> list[schemas.Generation]:
     """The workspace's history, newest first.
+
+    ``limit=None`` returns everything the workspace has. Pass a number only when
+    the caller can actually page — the /studio gallery cannot, so a default cap
+    there would quietly hide the older half of someone's work.
 
     ``source`` / ``pocket_id`` are what let the gallery separate a person's own
     generations from the ones a site agent made while building a page.
@@ -526,7 +581,10 @@ async def list_generations(
     if pocket_id is not None:
         query.append(StudioGeneration.pocket_id == pocket_id)
 
-    docs = await StudioGeneration.find(*query).sort("-created_at_ms").limit(limit).to_list()
+    cursor = StudioGeneration.find(*query).sort("-created_at_ms")
+    if limit is not None:
+        cursor = cursor.limit(limit)
+    docs = await cursor.to_list()
     return [_to_schema(d) for d in docs]
 
 
@@ -555,10 +613,17 @@ async def tracked_generation_filenames() -> set[str]:
     # being excluded and start being shown.
     """
     names: set[str] = set()
-    docs = await StudioGeneration.find_all().to_list()
-    for doc in docs:
-        for asset in doc.assets or []:
-            url = asset.get("url") or ""
+    # PROJECTION, not find_all(): this runs on every GET /api/v1/media, and the
+    # only field it reads is assets[].url. Hydrating whole documents here would
+    # reproduce failure #1 of the JSONL this store replaced — decoding every
+    # tenant's entire history on every request — against Mongo instead of a file.
+    cursor = StudioGeneration.get_pymongo_collection().find(
+        {"assets.url": {"$regex": "^/api/v1/media/"}},
+        {"assets.url": 1, "_id": 0},
+    )
+    async for row in cursor:
+        for asset in row.get("assets") or []:
+            url = (asset or {}).get("url") or ""
             if url.startswith("/api/v1/media/"):
                 names.add(url.rsplit("/", 1)[-1])
     return names
@@ -1081,7 +1146,7 @@ async def generate(req: schemas.GenerateRequest, *, workspace_id: str) -> schema
         status="succeeded",
     )
     # Persist with the owning workspace tag (dropped by the wire model on read).
-    await record_generation(workspace_id, record)
+    await record_generation_best_effort(workspace_id, record)
     return record
 
 
@@ -1139,7 +1204,7 @@ async def _generate_curated_image(
         assets=assets,
         status="succeeded",
     )
-    await record_generation(workspace_id, record)
+    await record_generation_best_effort(workspace_id, record)
     return record
 
 
@@ -1205,7 +1270,7 @@ async def _generate_image_edit(
         assets=assets,
         status="succeeded",
     )
-    await record_generation(workspace_id, record)
+    await record_generation_best_effort(workspace_id, record)
     return record
 
 
@@ -1271,7 +1336,7 @@ async def generate_music(req: schemas.MusicRequest, *, workspace_id: str) -> sch
         assets=assets,
         status="succeeded",
     )
-    await record_generation(workspace_id, record)
+    await record_generation_best_effort(workspace_id, record)
     return record
 
 
@@ -1408,7 +1473,7 @@ async def _generate_video(req: schemas.GenerateRequest, *, workspace_id: str) ->
         assets=assets,
         status="succeeded",
     )
-    await record_generation(workspace_id, record)
+    await record_generation_best_effort(workspace_id, record)
     return record
 
 
@@ -1684,7 +1749,7 @@ async def edit(req: schemas.EditRequest, *, workspace_id: str) -> schemas.Genera
         assets=assets,
         status="succeeded",
     )
-    await record_generation(workspace_id, record)
+    await record_generation_best_effort(workspace_id, record)
     return record
 
 
@@ -1779,7 +1844,7 @@ async def generate_video_elements(
         assets=assets,
         status="succeeded",
     )
-    await record_generation(workspace_id, record)
+    await record_generation_best_effort(workspace_id, record)
     return record
 
 
@@ -1867,7 +1932,7 @@ async def generate_video_motion(
         assets=assets,
         status="succeeded",
     )
-    await record_generation(workspace_id, record)
+    await record_generation_best_effort(workspace_id, record)
     return record
 
 

--- a/tests/cloud/media/test_router.py
+++ b/tests/cloud/media/test_router.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pocketpaw_ee.cloud.media.router as media_module
 import pytest
@@ -41,10 +42,15 @@ def client(tmp_path, monkeypatch) -> TestClient:
     monkeypatch.setattr(
         media_module,
         "tracked_generation_filenames",
-        lambda: {"gen-uuid.png"},
+        AsyncMock(return_value={"gen-uuid.png"}),
     )
     app = FastAPI()
     app.include_router(media_router, prefix="/api/v1")
+    # #2114 put current_workspace_id on list/upload. These fixtures build a bare
+    # app with no session, so without an override every request 401s and the whole
+    # file fails before it reaches what it means to test.
+    app.dependency_overrides[media_module.current_workspace_id] = lambda: "ws-1"
+    app.dependency_overrides[media_module.optional_workspace_id] = lambda: "ws-1"
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -101,25 +107,34 @@ def test_post_media_upload_saves_and_returns_mediafile(client, generated) -> Non
     )
     assert resp.status_code == 200
     body = resp.json()
-    assert body["name"] == "edited.png"
-    assert body["url"] == "/api/v1/media/edited.png"
+    # #2114 makes the owner travel IN the filename (the key cannot carry a
+    # workspace segment), so an uploaded name is prefixed. These tests are about
+    # sanitising and collision handling, so assert the sanitised TAIL rather than
+    # pinning a whole name that predates that change.
+    assert body["name"].endswith("edited.png")
+    assert body["url"] == f"/api/v1/media/{body['name']}"
     assert body["mime"] == "image/png"
     assert body["size"] == len(b"\x89PNG\r\n\x1a\nedit-bytes")
-    assert (generated / "edited.png").read_bytes() == b"\x89PNG\r\n\x1a\nedit-bytes"
+    assert (generated / body["name"]).read_bytes() == b"\x89PNG\r\n\x1a\nedit-bytes"
 
 
 def test_post_media_upload_collision_makes_unique_name(client, generated) -> None:
-    (generated / "edited.png").write_bytes(b"first")
+    # Seed the OWNED name, not the bare one. Since #2114 an upload is stored as
+    # `<owner>-<name>`, so a bare `edited.png` on disk no longer collides with
+    # anything and this test would silently stop exercising the rename it exists
+    # for.
+    first_name = f"{storage.owned_name_prefix('ws-1')}edited.png"
+    (generated / first_name).write_bytes(b"first")
     resp = client.post(
         "/api/v1/media",
         files={"file": ("edited.png", b"second", "image/png")},
     )
     assert resp.status_code == 200
     name = resp.json()["name"]
-    assert name != "edited.png"
-    assert name.startswith("edited-")
+    assert not name.endswith("-edited.png"), "the collision must have renamed it"
+    assert "edited-" in name
     # Both files exist — the original was not overwritten.
-    assert (generated / "edited.png").read_bytes() == b"first"
+    assert (generated / first_name).read_bytes() == b"first"
     assert (generated / name).read_bytes() == b"second"
 
 
@@ -197,10 +212,15 @@ def remote_client(remote_adapter, monkeypatch) -> TestClient:
     monkeypatch.setattr(
         media_module,
         "tracked_generation_filenames",
-        lambda: {"1699999999000-bbbb.png"},
+        AsyncMock(return_value={"1699999999000-bbbb.png"}),
     )
     app = FastAPI()
     app.include_router(media_router, prefix="/api/v1")
+    # #2114 put current_workspace_id on list/upload. These fixtures build a bare
+    # app with no session, so without an override every request 401s and the whole
+    # file fails before it reaches what it means to test.
+    app.dependency_overrides[media_module.current_workspace_id] = lambda: "ws-1"
+    app.dependency_overrides[media_module.optional_workspace_id] = lambda: "ws-1"
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -228,5 +248,10 @@ def test_remote_upload_keys_under_generated_prefix(remote_client, remote_adapter
         files={"file": ("edited.png", b"PNG-BYTES", "image/png")},
     )
     assert resp.status_code == 200
-    assert resp.json()["name"] == "edited.png"
-    assert ("generated/edited.png", b"PNG-BYTES") in remote_adapter.put_calls
+    # #2114 makes the owner travel IN the filename (the key cannot carry a
+    # workspace segment), so an uploaded name is prefixed. These tests are about
+    # sanitising and collision handling, so assert the sanitised TAIL rather than
+    # pinning a whole name that predates that change.
+    name = resp.json()["name"]
+    assert name.endswith("edited.png")
+    assert (f"generated/{name}", b"PNG-BYTES") in remote_adapter.put_calls

--- a/tests/cloud/studio/test_migrate_generations_jsonl.py
+++ b/tests/cloud/studio/test_migrate_generations_jsonl.py
@@ -1,0 +1,137 @@
+# tests/cloud/studio/test_migrate_generations_jsonl.py — the legacy-history import.
+#
+# Created 2026-09-08 (feat/studio-history-store, SM-0). The JSONL lives on the
+# ``backend-data`` named volume, so it survives redeploys and holds real
+# galleries; shipping the Mongo store without this import would silently empty
+# every workspace's /studio page.
+#
+# The behaviour worth pinning is what happens to UNTAGGED records. The old reader
+# admitted rows whose ``_workspace`` was None and showed them to every tenant.
+# They cannot be attributed to anyone, so the migration counts them and leaves
+# them behind rather than picking an owner — their disappearance is the leak
+# closing, not data loss to be quietly patched over.
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pocketpaw_ee.cloud.studio import migrate_generations_jsonl as migration
+from pocketpaw_ee.cloud.studio import service
+
+pytestmark = pytest.mark.asyncio
+
+
+def _record(gen_id: str, workspace: str | None) -> dict:
+    """One legacy JSONL row: a Generation dump plus the ``_workspace`` tag."""
+    record = {
+        "id": gen_id,
+        "prompt": "a quiet reception desk",
+        "status": "succeeded",
+        "kind": "image",
+        "model": "gpt-image-1",
+        "params": {
+            "kind": "image",
+            "model": "gpt-image-1",
+            "aspectRatio": "1:1",
+            "count": 1,
+        },
+        "assets": [],
+        "createdAt": 1_757_000_000_000,
+    }
+    if workspace is not None:
+        record["_workspace"] = workspace
+    return record
+
+
+def _write(path, records) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+
+
+async def test_a_missing_file_is_not_an_error(tmp_path, mongo_db):
+    """A fresh install has no file. If that failed, the first deploy deadlocks."""
+    result = await migration.migrate_file(tmp_path / "nope.jsonl")
+
+    assert result == migration.Result()
+
+
+async def test_an_empty_file_imports_nothing(tmp_path, mongo_db):
+    path = tmp_path / "generations.jsonl"
+    _write(path, [])
+
+    assert (await migration.migrate_file(path)).imported == 0
+
+
+async def test_tagged_records_land_in_their_own_workspace(tmp_path, mongo_db):
+    path = tmp_path / "generations.jsonl"
+    _write(path, [_record("g1", "ws-1"), _record("g2", "ws-2")])
+
+    result = await migration.migrate_file(path)
+    assert result.imported == 2
+
+    assert [g.id for g in await service.list_generations("ws-1")] == ["g1"]
+    assert [g.id for g in await service.list_generations("ws-2")] == ["g2"]
+
+
+async def test_untagged_records_are_counted_and_left_behind(tmp_path, mongo_db):
+    """They were readable by every tenant; importing one means choosing an owner
+    and any choice is wrong."""
+    path = tmp_path / "generations.jsonl"
+    _write(path, [_record("tagged", "ws-1"), _record("orphan", None)])
+
+    result = await migration.migrate_file(path)
+
+    assert result.imported == 1
+    assert result.skipped_untagged == 1
+    assert [g.id for g in await service.list_generations("ws-1")] == ["tagged"]
+
+
+async def test_a_corrupt_line_is_stepped_over_not_fatal(tmp_path, mongo_db):
+    """The old reader skipped corrupt lines; a migration that dies on one would
+    strand every record after it."""
+    path = tmp_path / "generations.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(_record("g1", "ws-1"))
+        + "\n"
+        + "{not json at all\n"
+        + json.dumps(_record("g2", "ws-1"))
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = await migration.migrate_file(path)
+
+    assert result.imported == 2
+    assert result.skipped_unreadable == 1
+
+
+async def test_rerunning_converges_and_does_not_duplicate(tmp_path, mongo_db):
+    path = tmp_path / "generations.jsonl"
+    _write(path, [_record("g1", "ws-1")])
+
+    first = await migration.migrate_file(path)
+    second = await migration.migrate_file(path)
+
+    assert (first.imported, first.already) == (1, 0)
+    assert (second.imported, second.already) == (0, 1)
+    assert len(await service.list_generations("ws-1")) == 1
+
+
+async def test_dry_run_reports_without_writing(tmp_path, mongo_db):
+    path = tmp_path / "generations.jsonl"
+    _write(path, [_record("g1", "ws-1")])
+
+    result = await migration.migrate_file(path, dry_run=True)
+
+    assert result.imported == 1
+    assert await service.list_generations("ws-1") == []
+
+
+async def test_the_uri_comes_from_the_same_var_the_app_reads(tmp_path):
+    assert migration.resolve_mongo_uri({"CLOUD_MONGODB_URI": "mongodb://m:27017/x"}) == (
+        "mongodb://m:27017/x"
+    )
+    # No env at all still resolves, so a local run needs no setup.
+    assert migration.resolve_mongo_uri({}).startswith("mongodb://")

--- a/tests/cloud/studio/test_migrate_generations_jsonl.py
+++ b/tests/cloud/studio/test_migrate_generations_jsonl.py
@@ -135,3 +135,62 @@ async def test_the_uri_comes_from_the_same_var_the_app_reads(tmp_path):
     )
     # No env at all still resolves, so a local run needs no setup.
     assert migration.resolve_mongo_uri({}).startswith("mongodb://")
+
+
+# ── The boot hook: it has to run itself, and never block a boot ─────────────
+
+
+async def test_boot_import_runs_without_being_asked(tmp_path, mongo_db, monkeypatch):
+    """The whole point: forgetting a manual command left every existing gallery
+    silently EMPTY, in an environment with no shell to run it from.
+
+    MUTATION: make migrate_on_boot return before calling migrate_file.
+    """
+    path = tmp_path / "generations.jsonl"
+    _write(path, [_record("g1", "ws-1")])
+    monkeypatch.setattr(migration, "legacy_history_path", lambda: path)
+
+    await migration.migrate_on_boot()
+
+    assert [g.id for g in await service.list_generations("ws-1")] == ["g1"]
+
+
+async def test_boot_import_is_a_no_op_on_a_fresh_install(tmp_path, mongo_db, monkeypatch):
+    """No file, no work, no error — this runs on every cloud start."""
+    monkeypatch.setattr(migration, "legacy_history_path", lambda: tmp_path / "absent.jsonl")
+
+    await migration.migrate_on_boot()  # must not raise
+
+
+async def test_boot_import_never_blocks_a_boot(tmp_path, mongo_db, monkeypatch):
+    """A migration hiccup must not take the cloud down with it.
+
+    MUTATION: drop the try/except around migrate_file.
+    """
+    path = tmp_path / "generations.jsonl"
+    _write(path, [_record("g1", "ws-1")])
+    monkeypatch.setattr(migration, "legacy_history_path", lambda: path)
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("mongo is having a day")
+
+    monkeypatch.setattr(migration, "migrate_file", _boom)
+
+    await migration.migrate_on_boot()  # must swallow and carry on
+
+
+async def test_the_cli_suppresses_the_boot_import(tmp_path, mongo_db, monkeypatch):
+    """init_cloud_db now runs the import, so without this flag `--dry-run` would
+    be a lie: the real import would already have happened before the dry run
+    reported what it 'would' do.
+
+    MUTATION: ignore _suppress_boot_import in migrate_on_boot.
+    """
+    path = tmp_path / "generations.jsonl"
+    _write(path, [_record("g1", "ws-1")])
+    monkeypatch.setattr(migration, "legacy_history_path", lambda: path)
+    monkeypatch.setattr(migration, "_suppress_boot_import", True)
+
+    await migration.migrate_on_boot()
+
+    assert await service.list_generations("ws-1") == []

--- a/tests/cloud/studio/test_router.py
+++ b/tests/cloud/studio/test_router.py
@@ -107,7 +107,7 @@ def test_list_styles_returns_envelope(client):
 def test_list_generations_is_workspace_scoped(client, monkeypatch):
     seen: dict = {}
 
-    def _list(workspace_id):
+    async def _list(workspace_id):
         seen["workspace"] = workspace_id
         return [_generation()]
 
@@ -181,7 +181,7 @@ def test_post_generate_proxy_failure_is_502(client, monkeypatch):
 
 
 def test_get_generation_found(client, monkeypatch):
-    def _get(gen_id, workspace_id):
+    async def _get(workspace_id, gen_id):
         assert gen_id == "gen_abc"
         assert workspace_id == "ws-1"
         return _generation()
@@ -193,7 +193,10 @@ def test_get_generation_found(client, monkeypatch):
 
 
 def test_get_generation_not_found_is_404(client, monkeypatch):
-    monkeypatch.setattr(studio_service, "get_generation", lambda gen_id, workspace_id: None)
+    async def _missing(workspace_id, gen_id):
+        return None
+
+    monkeypatch.setattr(studio_service, "get_generation", _missing)
     resp = client.get("/api/v1/studio/generations/nope")
     assert resp.status_code == 404
 

--- a/tests/cloud/studio/test_service.py
+++ b/tests/cloud/studio/test_service.py
@@ -4,8 +4,8 @@
 # (``service._PROXY_TRANSPORT`` → httpx.MockTransport) so the full request
 # shape — path, model, prompt, size, count, the OpenAI ``user`` tenant tag, and
 # the Bearer key — is asserted end-to-end without a live proxy. The media
-# storage adapter and ``_history_path`` are redirected to tmp dirs so nothing
-# touches the developer's real ``~/.pocketpaw``. Coverage:
+# storage adapter is redirected to a tmp dir so nothing touches the developer's
+# real ``~/.pocketpaw``; generation history is Mongo (the ``mongo_db`` fixture). Coverage:
 #   * list_models — catalog image/video entries map onto StudioModel shapes,
 #     first image model is the catalog default, chat entries are excluded.
 #   * generate (image) — happy path (b64_json): POSTs the right payload, saves a
@@ -81,8 +81,8 @@ def proxy_env(monkeypatch):
 
 
 @pytest.fixture
-def studio_env(tmp_path, monkeypatch):
-    """Redirect media storage + history persistence + flow-project persistence
+def studio_env(tmp_path, monkeypatch, mongo_db):
+    """Redirect media storage + flow-project persistence
     into tmp dirs so tests never touch the real ~/.pocketpaw, and resolve the
     tenant key to a fixed value.
 
@@ -94,9 +94,10 @@ def studio_env(tmp_path, monkeypatch):
     generated = media_root / "generated"
     generated.mkdir(exist_ok=True)
     monkeypatch.setattr(media_storage, "_ADAPTER", LocalStorageAdapter(root=media_root))
+    # History is Mongo now (the ``mongo_db`` fixture inits Beanie); this path is
+    # kept only so callers can keep unpacking a 2-tuple.
     history = tmp_path / "studio" / "generations.jsonl"
     history.parent.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(service, "_history_path", lambda: history)
     projects = tmp_path / "studio" / "flow-projects.jsonl"
     projects.parent.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(service, "_projects_path", lambda: projects)
@@ -345,17 +346,16 @@ async def test_generate_image_happy_path(monkeypatch, proxy_env, studio_env) -> 
     assert len(captured["requests"]) == 1
 
     # History: one record, scoped to ws-1, re-readable as a wire Generation.
-    records = service._load_history()
+    records = await service.list_generations("ws-1")
     assert len(records) == 1
-    assert records[0]["_workspace"] == "ws-1"
-    listed = service.list_generations("ws-1")
+    listed = await service.list_generations("ws-1")
     assert [g.id for g in listed] == [gen.id]
-    assert service.get_generation(gen.id, "ws-1") is not None
+    assert await service.get_generation("ws-1", gen.id) is not None
     # A different workspace does not see it.
-    assert service.list_generations("ws-other") == []
-    assert service.get_generation(gen.id, "ws-other") is None
+    assert await service.list_generations("ws-other") == []
+    assert await service.get_generation("ws-other", gen.id) is None
     # The media router exclusion sees the saved file.
-    assert name in service.tracked_generation_filenames()
+    assert name in await service.tracked_generation_filenames()
 
 
 async def test_generate_image_url_path(monkeypatch, proxy_env, studio_env) -> None:
@@ -452,7 +452,7 @@ async def test_generate_video_happy_path(monkeypatch, studio_env) -> None:
     assert any(p.suffix == ".mp4" for p in saved)
     assert any(p.suffix == ".png" for p in saved)
     # The persisted record is scoped to the workspace.
-    assert service.list_generations("ws-1")[0].id == gen.id
+    assert (await service.list_generations("ws-1"))[0].id == gen.id
 
 
 async def test_generate_video_alias_resolves_endpoint(monkeypatch, studio_env) -> None:
@@ -510,7 +510,7 @@ async def test_generate_video_fal_failure_is_upstream_error(monkeypatch, studio_
     req = schemas.GenerateRequest(prompt="a clip", kind="video", model="m", aspectRatio="16:9")
     with pytest.raises(service.StudioUpstreamError, match="bad key"):
         await service.generate(req, workspace_id="ws-1")
-    assert service._load_history() == []
+    assert await service.list_generations("ws-1") == []
 
 
 async def test_generate_video_image_to_video_passes_all_images(monkeypatch, studio_env) -> None:
@@ -756,7 +756,7 @@ async def test_generate_music_happy_path(monkeypatch, studio_env) -> None:
     assert gen.assets and gen.assets[0].mime == "audio/mpeg"
     assert gen.assets[0].url.startswith("/api/v1/media/")
     assert any(p.suffix == ".mp3" for p in generated.iterdir())
-    assert service.list_generations("ws-1")[0].id == gen.id
+    assert (await service.list_generations("ws-1"))[0].id == gen.id
 
 
 async def test_generate_music_missing_prompt_is_valueerror(monkeypatch, studio_env) -> None:
@@ -778,7 +778,7 @@ async def test_generate_proxy_failure_is_upstream_error(monkeypatch, proxy_env, 
     req = schemas.GenerateRequest(prompt="x", model="fal_ai/fal-ai/flux/schnell", aspectRatio="1:1")
     with pytest.raises(service.StudioUpstreamError):
         await service.generate(req, workspace_id="ws-1")
-    assert service._load_history() == []
+    assert await service.list_generations("ws-1") == []
 
 
 # ── edit (direct fal.ai dispatch) ────────────────────────────────────────────
@@ -812,10 +812,9 @@ async def test_edit_happy_path(monkeypatch, studio_env) -> None:
     assert (generated / name).read_bytes() == png
 
     # History: one record, scoped to ws-1, excluded from the /media list.
-    records = service._load_history()
+    records = await service.list_generations("ws-1")
     assert len(records) == 1
-    assert records[0]["_workspace"] == "ws-1"
-    assert name in service.tracked_generation_filenames()
+    assert name in await service.tracked_generation_filenames()
 
 
 async def test_edit_op_routes_curated_model_through_fal_image(monkeypatch, studio_env) -> None:
@@ -953,7 +952,7 @@ async def test_edit_fal_failure_is_upstream_error(monkeypatch, studio_env) -> No
     req = schemas.EditRequest(op="upscale", sourceUrl=_DATA_URL)
     with pytest.raises(service.StudioUpstreamError):
         await service.edit(req, workspace_id="ws-1")
-    assert service._load_history() == []
+    assert await service.list_generations("ws-1") == []
 
 
 async def test_edit_missing_prompt_is_valueerror(monkeypatch, studio_env) -> None:
@@ -963,7 +962,7 @@ async def test_edit_missing_prompt_is_valueerror(monkeypatch, studio_env) -> Non
     req = schemas.EditRequest(op="edit", sourceUrl=_DATA_URL)
     with pytest.raises(ValueError, match="prompt is required"):
         await service.edit(req, workspace_id="ws-1")
-    assert service._load_history() == []
+    assert await service.list_generations("ws-1") == []
 
 
 async def test_edit_no_output_is_upstream_error(monkeypatch, studio_env) -> None:
@@ -977,7 +976,7 @@ async def test_edit_no_output_is_upstream_error(monkeypatch, studio_env) -> None
     req = schemas.EditRequest(op="upscale", sourceUrl=_DATA_URL)
     with pytest.raises(service.StudioUpstreamError, match="no output images"):
         await service.edit(req, workspace_id="ws-1")
-    assert service._load_history() == []
+    assert await service.list_generations("ws-1") == []
 
 
 # ── video elements (direct fal.ai Kling Elements dispatch) ───────────────────
@@ -1023,7 +1022,7 @@ async def test_generate_video_elements_happy_path(monkeypatch, studio_env) -> No
     assert seen["input_image_urls"] == [_DATA_URL, _DATA_URL]
     assert seen["video_url"] == _DATA_URL
     assert seen["duration_sec"] == 5
-    assert service.list_generations("ws-1")[0].id == gen.id
+    assert (await service.list_generations("ws-1"))[0].id == gen.id
 
 
 async def test_generate_video_elements_prompt_only(monkeypatch, studio_env) -> None:
@@ -1073,7 +1072,7 @@ async def test_generate_video_elements_fal_failure_is_upstream_error(
     req = schemas.VideoElementsRequest(prompt="a scene")
     with pytest.raises(service.StudioUpstreamError, match="bad key"):
         await service.generate_video_elements(req, workspace_id="ws-1")
-    assert service._load_history() == []
+    assert await service.list_generations("ws-1") == []
 
 
 # ── motion control (direct fal.ai Kling Motion Control dispatch) ─────────────
@@ -1112,7 +1111,7 @@ async def test_generate_video_motion_happy_path(monkeypatch, studio_env) -> None
     assert seen["image_url"] == _DATA_URL
     assert seen["video_url"] == _DATA_URL
     assert seen["character_orientation"] == "video"
-    assert service.list_generations("ws-1")[0].id == gen.id
+    assert (await service.list_generations("ws-1"))[0].id == gen.id
 
 
 async def test_generate_video_motion_requires_image(monkeypatch, studio_env) -> None:
@@ -1135,7 +1134,7 @@ async def test_generate_video_motion_fal_failure_is_upstream_error(monkeypatch, 
     req = schemas.VideoMotionRequest(imageUrl=_DATA_URL, videoUrl=_DATA_URL)
     with pytest.raises(service.StudioUpstreamError, match="bad key"):
         await service.generate_video_motion(req, workspace_id="ws-1")
-    assert service._load_history() == []
+    assert await service.list_generations("ws-1") == []
 
 
 async def test_generate_video_motion_validation_error_is_value_error(
@@ -1152,7 +1151,7 @@ async def test_generate_video_motion_validation_error_is_value_error(
     req = schemas.VideoMotionRequest(imageUrl=_DATA_URL, videoUrl=_DATA_URL)
     with pytest.raises(ValueError, match="dimensions are too small"):
         await service.generate_video_motion(req, workspace_id="ws-1")
-    assert service._load_history() == []
+    assert await service.list_generations("ws-1") == []
 
 
 async def test_generate_video_motion_passes_public_video_url_through(

--- a/tests/cloud/studio/test_store.py
+++ b/tests/cloud/studio/test_store.py
@@ -55,8 +55,8 @@ async def test_a_generation_is_invisible_to_another_workspace(mongo_db):
 
     await store.record_generation("w1", _generation("g1"))
 
-    assert [g.id for g in await store.list_stored_generations("w1")] == ["g1"]
-    assert await store.list_stored_generations("w2") == []
+    assert [g.id for g in await store.list_generations("w1")] == ["g1"]
+    assert await store.list_generations("w2") == []
 
 
 async def test_get_generation_is_scoped_to_the_owning_workspace(mongo_db):
@@ -64,9 +64,9 @@ async def test_get_generation_is_scoped_to_the_owning_workspace(mongo_db):
 
     await store.record_generation("w1", _generation("g1"))
 
-    assert (await store.get_stored_generation("w1", "g1")) is not None
+    assert (await store.get_generation("w1", "g1")) is not None
     # The id is guessable; the workspace is the boundary.
-    assert (await store.get_stored_generation("w2", "g1")) is None
+    assert (await store.get_generation("w2", "g1")) is None
 
 
 async def test_updating_from_a_foreign_workspace_does_not_touch_the_record(mongo_db):
@@ -76,7 +76,7 @@ async def test_updating_from_a_foreign_workspace_does_not_touch_the_record(mongo
 
     assert await store.update_generation("w2", "g1", status="succeeded") is False
 
-    still_mine = await store.get_stored_generation("w1", "g1")
+    still_mine = await store.get_generation("w1", "g1")
     assert still_mine is not None
     assert still_mine.status == "running"
 
@@ -91,7 +91,7 @@ async def test_a_queued_generation_is_persisted_before_it_completes(mongo_db):
 
     await store.record_generation("w1", _generation("vid1", status="queued", kind="video"))
 
-    listed = await store.list_stored_generations("w1")
+    listed = await store.list_generations("w1")
     assert [(g.id, g.status) for g in listed] == [("vid1", "queued")]
 
 
@@ -101,7 +101,7 @@ async def test_a_generation_transitions_queued_to_running_to_succeeded(mongo_db)
     await store.record_generation("w1", _generation("vid1", status="queued", kind="video"))
 
     assert await store.update_generation("w1", "vid1", status="running") is True
-    assert (await store.get_stored_generation("w1", "vid1")).status == "running"
+    assert (await store.get_generation("w1", "vid1")).status == "running"
 
     asset = schemas.GeneratedAsset(
         id="a1",
@@ -110,7 +110,7 @@ async def test_a_generation_transitions_queued_to_running_to_succeeded(mongo_db)
     )
     assert await store.update_generation("w1", "vid1", status="succeeded", assets=[asset]) is True
 
-    done = await store.get_stored_generation("w1", "vid1")
+    done = await store.get_generation("w1", "vid1")
     assert done.status == "succeeded"
     assert [a.url for a in done.assets] == [asset.url]
 
@@ -126,11 +126,11 @@ async def test_a_failed_generation_persists_with_its_error(mongo_db):
         is True
     )
 
-    failed = await store.get_stored_generation("w1", "g1")
+    failed = await store.get_generation("w1", "g1")
     assert failed.status == "failed"
     assert failed.error == "upstream quota exceeded"
     # A failure is still part of the workspace's history, not swallowed.
-    assert [g.id for g in await store.list_stored_generations("w1")] == ["g1"]
+    assert [g.id for g in await store.list_generations("w1")] == ["g1"]
 
 
 # ── 3. Provenance ───────────────────────────────────────────────────────────
@@ -144,13 +144,13 @@ async def test_source_and_pocket_round_trip_and_filter(mongo_db):
         "w1", _generation("site1"), source="sites", pocket_id="pocket-abc"
     )
 
-    from_sites = await store.list_stored_generations("w1", source="sites")
+    from_sites = await store.list_generations("w1", source="sites")
     assert [g.id for g in from_sites] == ["site1"]
 
-    for_pocket = await store.list_stored_generations("w1", pocket_id="pocket-abc")
+    for_pocket = await store.list_generations("w1", pocket_id="pocket-abc")
     assert [g.id for g in for_pocket] == ["site1"]
 
-    assert len(await store.list_stored_generations("w1")) == 2
+    assert len(await store.list_generations("w1")) == 2
 
 
 # ── 4. Listing shape ────────────────────────────────────────────────────────
@@ -164,14 +164,14 @@ async def test_list_is_newest_first_and_honours_limit(mongo_db):
         gen.createdAt = 1_757_000_000_000 + i
         await store.record_generation("w1", gen)
 
-    assert [g.id for g in await store.list_stored_generations("w1")] == [
+    assert [g.id for g in await store.list_generations("w1")] == [
         "g4",
         "g3",
         "g2",
         "g1",
         "g0",
     ]
-    assert [g.id for g in await store.list_stored_generations("w1", limit=2)] == ["g4", "g3"]
+    assert [g.id for g in await store.list_generations("w1", limit=2)] == ["g4", "g3"]
 
 
 async def test_recording_the_same_id_twice_does_not_duplicate(mongo_db):
@@ -181,5 +181,5 @@ async def test_recording_the_same_id_twice_does_not_duplicate(mongo_db):
     await store.record_generation("w1", _generation("g1", status="queued"))
     await store.record_generation("w1", _generation("g1", status="succeeded"))
 
-    listed = await store.list_stored_generations("w1")
+    listed = await store.list_generations("w1")
     assert [(g.id, g.status) for g in listed] == [("g1", "succeeded")]

--- a/tests/cloud/studio/test_store.py
+++ b/tests/cloud/studio/test_store.py
@@ -1,0 +1,185 @@
+# tests/cloud/studio/test_store.py — contract for the Mongo-backed Studio
+# generation store (SM-0).
+#
+# Created 2026-09-08 (feat/studio-history-store). These tests pin the three
+# properties the JSONL history could not hold, and which the sites media layer
+# depends on:
+#
+#   1. TENANCY IS A QUERY, NOT A POST-FILTER. The JSONL kept one file for the
+#      whole deployment and filtered a `_workspace` field on read, with an
+#      `or _workspace is None` clause that showed untagged rows to EVERY tenant
+#      while its docstring claimed the opposite. A record here is reachable only
+#      from the workspace that wrote it — there is no untagged branch to fall
+#      through.
+#   2. THE STATUS LIFECYCLE IS REPRESENTABLE. All eight `_append_history` call
+#      sites in service.py write `status="succeeded"`, so a four-value enum only
+#      ever held one value: nothing was persisted while a generation was queued
+#      or running, and a failure left no trace at all. Async video therefore had
+#      nowhere to record that it was rendering, and a page reload lost the job.
+#   3. PROVENANCE ROUND-TRIPS. `source` / `pocket_id` distinguish a site
+#      agent's generations from a human's, which is what stops the linked
+#      gallery reading as clutter.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.studio import schemas
+
+pytestmark = pytest.mark.asyncio
+
+
+def _generation(gen_id: str, *, status: str = "queued", kind: str = "image") -> schemas.Generation:
+    """A minimal but schema-valid Generation record."""
+    return schemas.Generation(
+        id=gen_id,
+        prompt="a calm nordic reception desk, morning light",
+        status=status,
+        kind=kind,
+        model="gpt-image-1",
+        params=schemas.GenerationParams(
+            kind=kind,
+            model="gpt-image-1",
+            aspectRatio="16:9",
+            count=1,
+        ),
+        assets=[],
+        createdAt=1_757_000_000_000,
+    )
+
+
+# ── 1. Tenancy ──────────────────────────────────────────────────────────────
+
+
+async def test_a_generation_is_invisible_to_another_workspace(mongo_db):
+    from pocketpaw_ee.cloud.studio import service as store
+
+    await store.record_generation("w1", _generation("g1"))
+
+    assert [g.id for g in await store.list_stored_generations("w1")] == ["g1"]
+    assert await store.list_stored_generations("w2") == []
+
+
+async def test_get_generation_is_scoped_to_the_owning_workspace(mongo_db):
+    from pocketpaw_ee.cloud.studio import service as store
+
+    await store.record_generation("w1", _generation("g1"))
+
+    assert (await store.get_stored_generation("w1", "g1")) is not None
+    # The id is guessable; the workspace is the boundary.
+    assert (await store.get_stored_generation("w2", "g1")) is None
+
+
+async def test_updating_from_a_foreign_workspace_does_not_touch_the_record(mongo_db):
+    from pocketpaw_ee.cloud.studio import service as store
+
+    await store.record_generation("w1", _generation("g1", status="running"))
+
+    assert await store.update_generation("w2", "g1", status="succeeded") is False
+
+    still_mine = await store.get_stored_generation("w1", "g1")
+    assert still_mine is not None
+    assert still_mine.status == "running"
+
+
+# ── 2. The status lifecycle ─────────────────────────────────────────────────
+
+
+async def test_a_queued_generation_is_persisted_before_it_completes(mongo_db):
+    """The JSONL wrote nothing until success, so an in-flight video job did not
+    exist and a reload lost it. A queued record must be listable immediately."""
+    from pocketpaw_ee.cloud.studio import service as store
+
+    await store.record_generation("w1", _generation("vid1", status="queued", kind="video"))
+
+    listed = await store.list_stored_generations("w1")
+    assert [(g.id, g.status) for g in listed] == [("vid1", "queued")]
+
+
+async def test_a_generation_transitions_queued_to_running_to_succeeded(mongo_db):
+    from pocketpaw_ee.cloud.studio import service as store
+
+    await store.record_generation("w1", _generation("vid1", status="queued", kind="video"))
+
+    assert await store.update_generation("w1", "vid1", status="running") is True
+    assert (await store.get_stored_generation("w1", "vid1")).status == "running"
+
+    asset = schemas.GeneratedAsset(
+        id="a1",
+        url="https://cdn.example.com/sites-assets/w1/p1/abc123-hero.mp4",
+        mime="video/mp4",
+    )
+    assert await store.update_generation("w1", "vid1", status="succeeded", assets=[asset]) is True
+
+    done = await store.get_stored_generation("w1", "vid1")
+    assert done.status == "succeeded"
+    assert [a.url for a in done.assets] == [asset.url]
+
+
+async def test_a_failed_generation_persists_with_its_error(mongo_db):
+    """Failures left no trace at all, so failed spend could not be audited."""
+    from pocketpaw_ee.cloud.studio import service as store
+
+    await store.record_generation("w1", _generation("g1", status="running"))
+
+    assert (
+        await store.update_generation("w1", "g1", status="failed", error="upstream quota exceeded")
+        is True
+    )
+
+    failed = await store.get_stored_generation("w1", "g1")
+    assert failed.status == "failed"
+    assert failed.error == "upstream quota exceeded"
+    # A failure is still part of the workspace's history, not swallowed.
+    assert [g.id for g in await store.list_stored_generations("w1")] == ["g1"]
+
+
+# ── 3. Provenance ───────────────────────────────────────────────────────────
+
+
+async def test_source_and_pocket_round_trip_and_filter(mongo_db):
+    from pocketpaw_ee.cloud.studio import service as store
+
+    await store.record_generation("w1", _generation("studio1"))
+    await store.record_generation(
+        "w1", _generation("site1"), source="sites", pocket_id="pocket-abc"
+    )
+
+    from_sites = await store.list_stored_generations("w1", source="sites")
+    assert [g.id for g in from_sites] == ["site1"]
+
+    for_pocket = await store.list_stored_generations("w1", pocket_id="pocket-abc")
+    assert [g.id for g in for_pocket] == ["site1"]
+
+    assert len(await store.list_stored_generations("w1")) == 2
+
+
+# ── 4. Listing shape ────────────────────────────────────────────────────────
+
+
+async def test_list_is_newest_first_and_honours_limit(mongo_db):
+    from pocketpaw_ee.cloud.studio import service as store
+
+    for i in range(5):
+        gen = _generation(f"g{i}")
+        gen.createdAt = 1_757_000_000_000 + i
+        await store.record_generation("w1", gen)
+
+    assert [g.id for g in await store.list_stored_generations("w1")] == [
+        "g4",
+        "g3",
+        "g2",
+        "g1",
+        "g0",
+    ]
+    assert [g.id for g in await store.list_stored_generations("w1", limit=2)] == ["g4", "g3"]
+
+
+async def test_recording_the_same_id_twice_does_not_duplicate(mongo_db):
+    """Retries and status rewrites must not fan out into duplicate tiles."""
+    from pocketpaw_ee.cloud.studio import service as store
+
+    await store.record_generation("w1", _generation("g1", status="queued"))
+    await store.record_generation("w1", _generation("g1", status="succeeded"))
+
+    listed = await store.list_stored_generations("w1")
+    assert [(g.id, g.status) for g in listed] == [("g1", "succeeded")]

--- a/tests/cloud/studio/test_store.py
+++ b/tests/cloud/studio/test_store.py
@@ -183,3 +183,68 @@ async def test_recording_the_same_id_twice_does_not_duplicate(mongo_db):
 
     listed = await store.list_generations("w1")
     assert [(g.id, g.status) for g in listed] == [("g1", "succeeded")]
+
+
+# ── 5. The gallery must not silently lose the older half ────────────────────
+
+
+async def test_the_gallery_is_not_silently_capped(mongo_db):
+    """REGRESSION. The reader briefly defaulted to a 50-row cap. The /studio page
+    fetches this once with NO cursor and renders whatever comes back, so a
+    workspace with more history than the cap would simply stop seeing the older
+    part of its own gallery — data present in Mongo, unreachable in the product,
+    and invisible to every test that used fewer rows than the cap.
+
+    MUTATION: give ``list_generations`` a non-None default ``limit``.
+    """
+    from pocketpaw_ee.cloud.studio import service as store
+
+    for i in range(60):
+        gen = _generation(f"g{i:02d}")
+        gen.createdAt = 1_757_000_000_000 + i
+        await store.record_generation("w1", gen)
+
+    assert len(await store.list_generations("w1")) == 60
+
+
+async def test_a_caller_that_can_page_may_still_ask_for_one(mongo_db):
+    """The cap is opt-in, for callers that can actually page."""
+    from pocketpaw_ee.cloud.studio import service as store
+
+    for i in range(10):
+        gen = _generation(f"g{i:02d}")
+        gen.createdAt = 1_757_000_000_000 + i
+        await store.record_generation("w1", gen)
+
+    assert len(await store.list_generations("w1", limit=3)) == 3
+
+
+# ── 6. The dedupe key is a constraint, not just a lookup ────────────────────
+
+
+def test_the_dedupe_key_is_declared_unique():
+    """``record_generation`` does find-then-insert with no lock, and `backend` and
+    `worker` both run it — so the application check alone makes duplicate tiles
+    merely unlikely. The UNIQUE index is what makes them impossible.
+
+    Asserted on the DECLARATION, not the behaviour, because mongomock does not
+    enforce unique indexes — a behavioural test would pass whether or not the
+    constraint shipped, which is worse than no test.
+
+    KNOWN GAP: the ``DuplicateKeyError`` recovery in ``record_generation`` is
+    therefore NOT covered here. It cannot be exercised without a real mongod, and
+    faking the error only proves the fake raises. Verify it against a real
+    instance before trusting the recovery, and do not read this test as coverage
+    of it.
+
+    MUTATION: drop unique=True from the index.
+    """
+    from pocketpaw_ee.cloud.models.studio_generation import StudioGeneration
+    from pymongo import IndexModel
+
+    unique_keys = [
+        tuple(k for k, _ in idx.document["key"].items())
+        for idx in StudioGeneration.Settings.indexes
+        if isinstance(idx, IndexModel) and idx.document.get("unique")
+    ]
+    assert ("workspace", "generation_id") in unique_keys

--- a/tests/cloud/studio/test_store.py
+++ b/tests/cloud/studio/test_store.py
@@ -248,3 +248,52 @@ def test_the_dedupe_key_is_declared_unique():
         if isinstance(idx, IndexModel) and idx.document.get("unique")
     ]
     assert ("workspace", "generation_id") in unique_keys
+
+
+# ── 7. A history miss must not cost a paid generation ───────────────────────
+
+
+async def test_a_history_failure_does_not_fail_the_caller(mongo_db, monkeypatch):
+    """The JSONL appender swallowed OSError, so a history failure could never lose
+    a generation the user had already paid for. A bare Mongo write removed that:
+    an error would raise AFTER the image was generated, billed and stored.
+
+    MUTATION: narrow the except in record_generation_best_effort.
+    """
+    from pocketpaw_ee.cloud.studio import service as store
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("mongo is having a day")
+
+    monkeypatch.setattr(store, "record_generation", _boom)
+
+    await store.record_generation_best_effort("w1", _generation("g1"))  # must not raise
+
+
+async def test_tracked_filenames_asks_for_a_projection(mongo_db, monkeypatch):
+    """It runs on every GET /api/v1/media and reads ONE field. Hydrating whole
+    documents reproduces, against Mongo, the failure that made the JSONL
+    untenable — every tenant's entire history decoded on every request.
+
+    Asserted on the QUERY, not on behaviour, because behaviour is identical
+    either way: this is a cost property, and a mutation that drops the projection
+    escapes every behavioural test. That is exactly why this test looks odd.
+    """
+    from pocketpaw_ee.cloud.studio import service as store
+
+    seen: dict = {}
+    real = store.StudioGeneration.get_pymongo_collection()
+
+    class _Spy:
+        def find(self, *args):
+            seen["args"] = args
+            return real.find(*args)
+
+    monkeypatch.setattr(
+        store.StudioGeneration, "get_pymongo_collection", classmethod(lambda cls: _Spy())
+    )
+
+    await store.tracked_generation_filenames()
+
+    assert len(seen["args"]) == 2, "no projection was passed — whole documents hydrate"
+    assert seen["args"][1].get("assets.url") == 1

--- a/tests/cloud/test_browser_mcp.py
+++ b/tests/cloud/test_browser_mcp.py
@@ -257,8 +257,15 @@ def media_client(media_store):
 
     def _as(workspace_id: str | None):
         app.dependency_overrides[media_router_module.optional_workspace_id] = lambda: workspace_id
+        # list_media takes the STRICT dep (#2114); without this it 401s before it
+        # reaches the capture-exclusion logic these tests are about. serve_media
+        # keeps the optional one, so the anonymous-read tests still mean something.
+        app.dependency_overrides[media_router_module.current_workspace_id] = lambda: (
+            workspace_id or "ws-anon"
+        )
 
     app.dependency_overrides[media_router_module.optional_workspace_id] = lambda: None
+    app.dependency_overrides[media_router_module.current_workspace_id] = lambda: "ws-anon"
     client = TestClient(app)
     client.as_workspace = _as  # type: ignore[attr-defined]
     return client

--- a/tests/cloud/test_browser_mcp.py
+++ b/tests/cloud/test_browser_mcp.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -339,7 +339,9 @@ async def test_captures_stay_out_of_the_studio_gallery(media_client, media_store
     (media_store / "1700000000000-abc123.png").write_bytes(_PNG)
     capture_url = _url_from(await _capture("ws-1"))
 
-    with patch.object(media_router_module, "tracked_generation_filenames", return_value=set()):
+    with patch.object(
+        media_router_module, "tracked_generation_filenames", AsyncMock(return_value=set())
+    ):
         media_client.as_workspace("ws-1")
         names = [e["name"] for e in media_client.get("/api/v1/media").json()["media"]]
 

--- a/tests/mutations/studio_history.json
+++ b/tests/mutations/studio_history.json
@@ -1,0 +1,65 @@
+[
+  {
+    "label": "cap the gallery again (silently hides the older half)",
+    "file": "ee/pocketpaw_ee/cloud/studio/service.py",
+    "find": "    limit: int | None = None,\n    source: str | None = None,",
+    "replace": "    limit: int | None = DEFAULT_GENERATION_LIMIT,\n    source: str | None = None,",
+    "tests": [
+      "tests/cloud/studio/test_store.py::test_the_gallery_is_not_silently_capped"
+    ]
+  },
+  {
+    "label": "drop unique=True from the dedupe index",
+    "file": "ee/pocketpaw_ee/cloud/models/studio_generation.py",
+    "find": "                unique=True,",
+    "replace": "                sparse=False,",
+    "tests": [
+      "tests/cloud/studio/test_store.py::test_the_dedupe_key_is_declared_unique"
+    ]
+  },
+  {
+    "label": "let a history write failure 500 a paid generation",
+    "file": "ee/pocketpaw_ee/cloud/studio/service.py",
+    "find": "    except Exception:  # noqa: BLE001 \u2014 a history miss must not cost a paid asset",
+    "replace": "    except _NeverRaised:  # noqa: BLE001",
+    "tests": [
+      "tests/cloud/studio/test_store.py::test_a_history_failure_does_not_fail_the_caller"
+    ]
+  },
+  {
+    "label": "never import the legacy history at boot",
+    "file": "ee/pocketpaw_ee/cloud/studio/migrate_generations_jsonl.py",
+    "find": "    if _suppress_boot_import:\n        return",
+    "replace": "    if True:\n        return",
+    "tests": [
+      "tests/cloud/studio/test_migrate_generations_jsonl.py::test_boot_import_runs_without_being_asked"
+    ]
+  },
+  {
+    "label": "let a migration hiccup block the boot",
+    "file": "ee/pocketpaw_ee/cloud/studio/migrate_generations_jsonl.py",
+    "find": "    except Exception:  # noqa: BLE001 \u2014 a migration hiccup must never block boot",
+    "replace": "    except _NeverRaised:  # noqa: BLE001",
+    "tests": [
+      "tests/cloud/studio/test_migrate_generations_jsonl.py::test_boot_import_never_blocks_a_boot"
+    ]
+  },
+  {
+    "label": "ignore the CLI suppression flag (makes --dry-run a lie)",
+    "file": "ee/pocketpaw_ee/cloud/studio/migrate_generations_jsonl.py",
+    "find": "    if _suppress_boot_import:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/studio/test_migrate_generations_jsonl.py::test_the_cli_suppresses_the_boot_import"
+    ]
+  },
+  {
+    "label": "hydrate whole documents in tracked_generation_filenames",
+    "file": "ee/pocketpaw_ee/cloud/studio/service.py",
+    "find": "        {\"assets.url\": 1, \"_id\": 0},\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/studio/test_store.py::test_tracked_filenames_asks_for_a_projection"
+    ]
+  }
+]


### PR DESCRIPTION
## What this changes

The `/studio` generation history moves off `~/.pocketpaw/studio/generations.jsonl` and into a `studio_generations` Mongo collection.

That file was one append-only log for the whole deployment, with the owning workspace stored as a `_workspace` field filtered in Python after the read. It is not ephemeral (it sits on the `backend-data` named volume), it was just the wrong shape:

* Every read decoded every tenant's entire history. No index, no pagination, no rotation.
* `backend` and `worker` both mount that volume, so two processes appended to one file. The reader already swallowed corrupt lines, which reads like someone saw this coming.
* `list_generations` admitted records whose `_workspace` was None and showed them to every tenant, while the docstring directly above it claimed records are tagged "so multi-tenant deployments never leak".
* Append was the only write, so all eight call sites wrote `status="succeeded"`. A four-value status enum only ever held one value.

That last point is why this is a prerequisite rather than cleanup. Nothing was persisted until a job succeeded, so an async video render had nowhere to record that it was running, a page reload lost it, and a failure left no trace to audit spend against.

The sibling JSONL stores are not a precedent for keeping this one. `outcomes`, `trust_ledger` and `audit` are append-only ledgers keyed per workspace, and `trust_ledger` is on the import-linter allowlist that forbids Beanie writes outright. A gallery listing is none of those.

## Commits

1. The `StudioGeneration` document and the persistence functions, with tests written first.
2. The swap: eight write sites, both readers, the two studio routes, and the JSONL helpers deleted.
3. The legacy import, plus a runbook at `docs/deployment/studio-history-mongo-migration.md`.

Persistence lives in `service.py` rather than a `store.py`, per the cloud rule that the service is the repository and `models.<entity>` is imported from one place per entity.

## Three decisions worth a look

**`tracked_generation_filenames` stays global on purpose**, with a `# global-read:` note explaining why. Narrowing it to a workspace looks like a tenancy fix but is a leak: a generated file's name carries no owner (`media_key` is a flat `generated/<name>`, and only `/browser` captures get an owner prefix), so `media.storage.visible_to` answers True for one on its "legacy, untagged" branch. This global set is the only thing keeping one tenant's studio output off another tenant's `/media` listing.

**`get_generation` takes the workspace first now**, instead of trailing it after the id. Tenancy should not be the last argument in a signature.

**The migration skips untagged records** rather than guessing an owner. They were readable by every tenant under the old reader, so importing one means picking a workspace and any pick is wrong. The run counts and reports them, and they stay in the file. Their disappearance from the gallery is the leak closing.

## Migration

**It runs itself.** `init_cloud_db` calls `migrate_on_boot()` on every cloud
start, beside the workspace-VM map import. Best-effort: a missing file returns
immediately, any error is logged and swallowed, and a converged deployment
re-reads the file and writes nothing.

That changed during review. It was a one-off command a human had to remember, in
an environment with no shell, and forgetting it left every existing gallery
silently empty with nothing in the logs to say why.

Running it from both containers is safe, which it would not have been a commit
earlier: the import is find-then-insert per record with no lock, and the unique
index on `(workspace, generation_id)` is what turns a concurrent double-insert
into a `DuplicateKeyError` the recovery path handles.

The CLI is still there for a dry run or a manual re-run, and it suppresses the
boot import first. Otherwise `init_cloud_db` would do the real import before
`--dry-run` reported what it "would" do.

```bash
python -m pocketpaw_ee.cloud.studio.migrate_generations_jsonl --dry-run
```

## What a self-review changed

Five findings, four of them mine, all fixed on this branch:

- **The gallery was silently capped at 50.** `/studio` fetches once with no
  cursor, so a workspace with 200 generations would have lost access to 150 of
  them: present in Mongo, unreachable in the product, and invisible to every
  test because none used more rows than the cap. `limit=None` by default now,
  with the cap opt-in for callers that can page.
- **The dedupe index was not a constraint.** Its comment claimed a retry could
  not duplicate a tile; the index was not unique and the write is
  find-then-insert. It is unique now, and losing the race applies the caller's
  intent to the winning row rather than failing a write the user paid for.
- **The generation paths lost best-effort history.** The JSONL appender swallowed
  `OSError`, so a history failure could not cost a generation. A bare Mongo write
  would have raised *after* the image was generated, billed and stored. All eight
  paths go through `record_generation_best_effort` again.
- **`tracked_generation_filenames` read every tenant's documents** on every
  `GET /api/v1/media`, reproducing against Mongo the exact failure the new
  model's header lists as reason one for leaving the JSONL. It takes a
  projection now.

It also fixes the eight media tests that were red on `dev` before this branch,
because they were masking a real defect: two fixtures still patched
`tracked_generation_filenames` with a sync lambda after it became async. They
failed earlier on a 401 (#2114 put `current_workspace_id` on list/upload while
the fixtures only override the optional dep), and once auth was overridden three
upload assertions turned out to predate #2114 too.

## Testing

687 tests pass across studio / media / browser-mcp / surface, ruff clean, and all
36 import-linter contracts hold. **7 mutations, all caught**
(`tests/mutations/studio_history.json`). Two escaped on the first pass: one
pointed at a line no test exercised, and one could not be caught behaviourally
at all, since dropping a projection changes cost rather than output. 17 new tests cover cross-workspace invisibility, a foreign-workspace update returning False without touching the record, a queued job being listable before it completes, a failure persisting with its error, and the migration's untagged/corrupt/idempotent paths.

## Already red on dev, unrelated to this

Flagging so the CI signal is not confusing:

* 8 tests in `tests/cloud/media/test_router.py` and `tests/cloud/test_browser_mcp.py` fail with 401. #2114 put `current_workspace_id` on `list_media` and `upload_media`, but their fixture only overrides `optional_workspace_id`. Every one of those failures is that 401.
* 15 tests in `tests/cloud/pockets` fail with `Entitlements.__init__() missing 3 required positional arguments`, from 2253186a.

Both look like merged PRs that did not update their callers. Happy to pick them up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
