### PR TITLE
Free includes a custom domain, and the wire could not say so

### DIFF
--- a/ee/pocketpaw_ee/cloud/entitlements/dto.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/dto.py
@@ -49,6 +49,17 @@
 #   conversation meter and white-label are unenforced claims today and appear only
 #   here, never there.
 
+# Updated 2026-09-08 (fix/sites-plan-domain-allowance): ``SitePlanTierResponse``
+#   now also carries ``max_domained_sites``. It is the field custom-domain
+#   entitlement has actually been resolved from since 2026-08-21
+#   (``site_domain_allowance``), and it was the one capability on the ladder the
+#   wire could not express — so the plan cards answered "does this tier get a
+#   custom domain?" from ``cloudflare_features``. That is a different question:
+#   RESOLD Cloudflare capability BC-10 provisions. The two disagree on exactly the
+#   tier a buyer reads first. FREE grants one domained site and resells no
+#   Cloudflare features, so its card printed "Custom domain ✗" while the backend
+#   was granting it. A card cannot stop guessing until the field ships.
+
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -191,6 +202,20 @@ class SitePlanTierResponse(BaseModel):
     whatever the plain lookup returns — see its docstring. The field is load-bearing
     for the picker and for whatever org-scoped tier the catalog grows next.)
 
+    ``max_domained_sites`` is how many SITES in the workspace may carry a custom
+    domain on this tier (``None`` = uncapped, ``0`` = none at all). THE UNIT IS
+    THE SITE, NOT THE HOSTNAME — apex + ``www`` on one site spend one. READ THIS,
+    not ``cloudflare_features``, to answer "does this tier get a custom domain".
+    The two disagree on the FREE FLOOR and always will: free carries
+    ``max_domained_sites=1`` (the captain's grant of 2026-08-21) beside an empty
+    ``cloudflare_features``, because that collection means only RESOLD Cloudflare
+    capability. ``site_domain_allowance`` — the gate that actually decides whether
+    an attach succeeds — reads this field, so a card reading the other one
+    promises something different from what the gate enforces.
+
+    Unlike the two above it, this is NOT merely a ladder claim: it is the input to
+    a live entitlement, which is why it is worth shipping rather than deriving.
+
     ``conversation_allowance`` and ``conversation_rate_cents`` describe the
     LADDER, not any site's permissions — they are here so a card can state what a
     tier sells. (``white_label`` and ``included_sites`` sat beside them until
@@ -213,6 +238,11 @@ class SitePlanTierResponse(BaseModel):
     key: str
     monthly_price_usd: int
     cloudflare_features: list[str] = Field(default_factory=list)
+    # Defaults to 0 — "no domained sites" — matching ``SitePlanTier``'s own
+    # default and failing closed the same way. A DTO built without the field (a
+    # fixture, an older test) then claims nothing, rather than the "uncapped" a
+    # ``None`` default would claim.
+    max_domained_sites: int | None = 0
     scope: str
     conversation_allowance: int = 0
     conversation_rate_cents: int = 0
@@ -236,6 +266,7 @@ def site_plan_tier_to_dto(tier: SitePlanTier) -> SitePlanTierResponse:
         key=tier.key,
         monthly_price_usd=tier.monthly_price_usd,
         cloudflare_features=sorted(tier.cloudflare_features),
+        max_domained_sites=tier.max_domained_sites,
         scope=tier.scope,
         conversation_allowance=tier.conversation_allowance,
         conversation_rate_cents=tier.conversation_rate_cents,

--- a/tests/cloud/billing/test_site_plan_inclusions.py
+++ b/tests/cloud/billing/test_site_plan_inclusions.py
@@ -228,6 +228,4 @@ def test_the_wire_allowance_agrees_with_the_resolver():
     wrong.
     """
     dto = site_plan_tier_to_dto(catalog.get_site_plan(catalog.BASE_SITE_PLAN_KEY))
-    assert dto.max_domained_sites == site_domain_allowance(
-        plan_tier=None, subscription_status=None
-    )
+    assert dto.max_domained_sites == site_domain_allowance(plan_tier=None, subscription_status=None)

--- a/tests/cloud/billing/test_site_plan_inclusions.py
+++ b/tests/cloud/billing/test_site_plan_inclusions.py
@@ -18,12 +18,26 @@
 #
 # The second is the one worth having. A hand-written "pro is True" assertion
 # passes just as well against a mapper that hardcodes the answer.
+#
+# Updated 2026-09-08 (fix/sites-plan-domain-allowance): added the
+# ``max_domained_sites`` section at the bottom, and corrected a docstring that had
+# gone stale. Same failure as the original, one field later: custom-domain
+# entitlement moved to ``max_domained_sites`` on 2026-08-21 and never reached the
+# wire, so the cards kept answering "custom domain?" from ``cloudflare_features``.
+# The two disagree on the FREE FLOOR — one domained site, zero resold Cloudflare
+# features — so the tier a buyer reads first is the tier the card got wrong. The
+# last test asserts the DTO against ``site_domain_allowance`` rather than a
+# literal, because a card promising what the gate refuses is the real thing to
+# prevent.
 
 from __future__ import annotations
 
 from pocketpaw_ee.cloud.billing import site_plans as catalog
 from pocketpaw_ee.cloud.entitlements.dto import site_plan_tier_to_dto
-from pocketpaw_ee.cloud.entitlements.service import resolve_site_entitlements
+from pocketpaw_ee.cloud.entitlements.service import (
+    resolve_site_entitlements,
+    site_domain_allowance,
+)
 
 # --------------------------------------------------------------------------- #
 # sells_concierge — derived from the floor, not a per-tier mapping
@@ -131,11 +145,16 @@ def test_the_dto_mirrors_every_catalog_row():
 
 
 def test_the_free_tier_card_can_say_what_it_omits():
-    """The free tier's row carries three explicit Falses, not an empty payload.
+    """The free tier's row carries explicit Falses, not an empty payload.
 
-    Its card is the one that has to render "badge shown", "no concierge", "no
-    custom domain" — omissions are only renderable if they arrive as False rather
-    than as absent keys.
+    Its card is the one that has to render "badge shown" and "no concierge" —
+    omissions are only renderable if they arrive as False rather than as absent
+    keys.
+
+    IT DOES NOT OMIT THE CUSTOM DOMAIN, and this docstring used to say it did.
+    That was written on 2026-08-19, two days before the floor grant landed. An
+    empty ``cloudflare_features`` is not that claim: see
+    ``test_the_free_tier_ships_its_domain_grant_on_the_wire`` below.
     """
     dto = site_plan_tier_to_dto(catalog.get_site_plan(catalog.BASE_SITE_PLAN_KEY))
     assert dto.badge_removal is False
@@ -155,3 +174,60 @@ def test_the_top_tier_card_is_the_one_carrying_the_concierge():
     dto = site_plan_tier_to_dto(catalog.get_site_plan("business"))
     assert dto.sells_concierge is True
     assert dto.badge_removal is True
+
+
+# --------------------------------------------------------------------------- #
+# max_domained_sites — the floor grant the wire could not express
+# --------------------------------------------------------------------------- #
+
+
+def test_the_dto_mirrors_the_domain_allowance_for_every_tier():
+    """A sweep, for the same reason the badge sweep above is one.
+
+    Breaks on: a mapper that drops the field, or one that reintroduces the card's
+    old derivation by sending ``"custom_domain" in cloudflare_features`` instead.
+    """
+    for tier in catalog.list_site_plans():
+        dto = site_plan_tier_to_dto(tier)
+        assert dto.max_domained_sites == tier.max_domained_sites, tier.key
+
+
+def test_the_free_tier_ships_its_domain_grant_on_the_wire():
+    """FREE INCLUDES A CUSTOM DOMAIN, and its card has to be able to say so.
+
+    This is the assertion the storefront was missing a field for. The floor grants
+    one domained site with no subscription (captain, 2026-08-21) while reselling no
+    Cloudflare features at all, because that collection means only RESOLD
+    Cloudflare capability. A card reading the feature list to answer "custom
+    domain?" therefore printed an X on the one tier that gets one for nothing.
+
+    The two assertions together are the point: an empty feature list AND a
+    non-zero allowance, on the same row.
+    """
+    dto = site_plan_tier_to_dto(catalog.get_site_plan(catalog.BASE_SITE_PLAN_KEY))
+    assert dto.cloudflare_features == []
+    assert dto.max_domained_sites == 1
+
+
+def test_a_paid_rung_ships_an_uncapped_allowance():
+    """``None`` is uncapped, and it must survive the mapper as ``None``.
+
+    Coerced to 0 on the way out it would read as "no domains" — the opposite
+    claim — on the cheapest tier that actually sells them.
+    """
+    dto = site_plan_tier_to_dto(catalog.get_site_plan("site"))
+    assert dto.max_domained_sites is None
+
+
+def test_the_wire_allowance_agrees_with_the_resolver():
+    """The card and the gate must not answer the same question differently.
+
+    ``site_domain_allowance`` is what actually decides whether a site may attach a
+    domain. A card built off this DTO promises what that resolves — checked here
+    for the floor with no subscription at all, which is the case the old card got
+    wrong.
+    """
+    dto = site_plan_tier_to_dto(catalog.get_site_plan(catalog.BASE_SITE_PLAN_KEY))
+    assert dto.max_domained_sites == site_domain_allowance(
+        plan_tier=None, subscription_status=None
+    )


### PR DESCRIPTION
`SitePlanTierResponse` now carries `max_domained_sites`.

Custom-domain entitlement moved to that field on 2026-08-21, when the free floor
was given one domained site that resolves with no subscription. The field never
reached the wire, so the plan cards answered "does this tier get a custom
domain?" from `cloudflare_features` instead.

That is a different question. `cloudflare_features` means resold Cloudflare
capability that BC-10 provisions, and free resells none. So the free card printed
an X beside Custom domain while `site_domain_allowance` was handing one out. Free
is the first tier anyone looks at.

## Tests

Four new cases in `tests/cloud/billing/test_site_plan_inclusions.py`. The last one
asserts the DTO against `site_domain_allowance` rather than a hardcoded 1, so it
fails if the card would ever promise something the gate refuses.

230 passed across `tests/cloud/billing/` plus the custom-domain and site-billing
suites. Two failures in `test_plans.py` are pre-existing and unrelated: this
machine's `.env` populates `dodo_site_products` where the test asserts it is
unconfigured.

## Follow-up

The frontend half is a separate PR on paw-enterprise, where the cards read the new
field and render the cap ("1 site" on free).