### PR TITLE
A file with no typed message is still a message

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -9,6 +9,16 @@ handles *what the agent sees*:
 * ``load_history_for_scope`` rehydrates prior chat turns from Mongo so the
   agent carries context across backend restarts and pool evictions.
 
+Changes: 2026-09-08 (fix/attachment-only-turns) — added
+``resolve_user_content`` / ``visible_message_text``: the model's copy of a turn
+that carried attachments and no typed text. The composer sends a zero-width
+space as the body so the row persists and renders blank, and that sentinel was
+being handed to the model as the user's whole message — a pasted brief reached
+the prompt but read as reference material, so the agent asked for a brief it
+already had. The inline-attachment caps moved with it (per-file 8000 -> 40000,
+total 30000 -> 100000): a bulky paste IS an attachment on this path, and the
+old per-file bound cut a normal landing-page brief in half.
+
 Changes: 2026-08-07 (fix/code-delegate-pooled-context) — added the session-keyed
 stream registry (``register_stream_sink`` / ``unregister_stream_sink`` /
 ``stream_sink_for_session``) alongside the ``_sse_event_sink`` ContextVar. The
@@ -2605,9 +2615,70 @@ async def _build_kb_snippets_block(ctx: ScopeContext, query: str) -> str:
 # from eating the budget; total cap keeps a batch of files from blowing the
 # context window. Image/binary attachments typically yield empty text and
 # get a stub entry so the agent at least knows they exist.
+#
+# THE SIZES ARE SET BY WHAT PEOPLE PASTE, not by what a document can weigh.
+# The composer turns any bulky paste into a ``pasted-*.txt`` attachment, so
+# "I pasted my brief into the chat" and "I uploaded a file" are one code path.
+# At the old 8000 (~1200 words) a real landing-page brief was cut in half and
+# the agent reported the paste as truncated and reconstructed the rest from
+# what was left — the user had truncated nothing, we had. 40k chars is roughly
+# 10k tokens: comfortably above any brief someone types, still far below the
+# window. The total cap matters more than ever now that one file may be this
+# large, and it is what keeps five of them from becoming the whole prompt.
 _ATTACHMENT_MAX_FILES = 5
-_ATTACHMENT_PER_FILE_CHARS = 8000
-_ATTACHMENT_TOTAL_CHARS = 30000
+_ATTACHMENT_PER_FILE_CHARS = 40000
+_ATTACHMENT_TOTAL_CHARS = 100000
+
+
+# The composer sends a zero-width space as the message body when the user
+# attaches files and types nothing. That is deliberate on both ends it was
+# written for: the row has to be non-empty or the backend drops the message,
+# and every renderer strips the character so no placeholder text shows in the
+# transcript. The model is the end nobody wrote it for.
+_INVISIBLE_BODY_CHARS = "\u200b\u200c\u200d\ufeff"
+_INVISIBLE_BODY_TABLE = {ord(c): None for c in _INVISIBLE_BODY_CHARS}
+
+# What the model is told instead. It names ``<uploaded-files>`` on purpose: the
+# instruction is only actionable if it points at the block the text landed in.
+_ATTACHMENT_ONLY_MESSAGE = (
+    "The user sent this turn with no typed message. The attached file(s) ARE "
+    "the message: their contents are inlined in the <uploaded-files> block of "
+    "your context. Read that block and act on it as the user's request. Do not "
+    "ask them what they want when the file already says, and do not treat it "
+    "as background reference for some other question."
+)
+
+
+def visible_message_text(content: str | None) -> str:
+    """``content`` with the composer's invisible sentinel removed, trimmed."""
+    return (content or "").translate(_INVISIBLE_BODY_TABLE).strip()
+
+
+def resolve_user_content(
+    content: str | None,
+    attachments: list[dict[str, Any]] | None,
+) -> str:
+    """The user's turn as the MODEL should receive it.
+
+    A files-only send reaches us as the invisible sentinel above, and handing
+    that to the model is handing it an empty turn: the attachment's text is
+    inlined into the knowledge/system channel, which reads as reference
+    material, so the model sees a system block it was given no reason to act on
+    and a user who said nothing. Its most reasonable move is to ask what they
+    wanted — which is what a user who pasted a full brief and pressed send got
+    back, with the brief already in the prompt. Typing one character alongside
+    the attachment made it work, and that asymmetry is the bug.
+
+    So substitute a real message for the empty one. Only for the empty one:
+    anything with visible text is returned BYTE-IDENTICALLY, sentinel included,
+    because rewriting what someone actually wrote is not this function's job.
+    With no attachments there is nothing to point at, so nothing is invented.
+    """
+    if visible_message_text(content):
+        return content or ""
+    if attachments:
+        return _ATTACHMENT_ONLY_MESSAGE
+    return content or ""
 
 
 # Surfaces whose attachments may be republished to the WORLD-READABLE bucket.

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,16 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-09-08 (fix/attachment-only-turns) — ``_drive_agent_loop`` now runs its
+  ``user_content`` through ``agent_service.resolve_user_content`` before
+  anything reads it. A send with attachments and no typed text arrives as the
+  composer's invisible sentinel, which the model reads as an empty turn while
+  the attachment's text sits in the knowledge channel looking like reference
+  material; the resolver replaces that one case with a message saying the
+  files ARE the request. Placed at the top of the loop because three things
+  downstream consume the string — the KB query, the session titler, and the
+  prompt handed to ``pool.run``. A turn with real text is untouched.
+
 - 2026-09-01 (feat/byok-guest-backend) — the turn path finally CALLS
   ``byok.service.resolve_turn_credentials`` (the seam its own header always
   promised): ``_iter_agent_events`` resolves the workspace's stored key per
@@ -365,6 +375,7 @@ from pocketpaw_ee.cloud.chat.agent_service import (
     mark_cloud_chat_run,
     push_sse_event,
     register_stream_sink,
+    resolve_user_content,
     session_key_for,
     unbind_pawbar_run,
     unregister_stream_sink,
@@ -1305,6 +1316,14 @@ async def _drive_agent_loop(
     surface: str | None = None,
 ) -> AsyncIterator[tuple[str, dict[str, Any]]]:
     """Drive ``AgentPool.run`` and yield ``(event_name, event_data)`` tuples."""
+    # A files-only send arrives as the composer's invisible sentinel — a turn
+    # that persists and renders correctly but says nothing to the model, while
+    # the attachment's text sits in the knowledge channel looking like
+    # reference material. Resolve it HERE, before anything downstream reads it:
+    # the knowledge context uses this string as its KB query, the session
+    # titler names the thread from it, and the pool hands it to the model as
+    # the user's turn. A turn with real text passes through untouched.
+    user_content = resolve_user_content(user_content, attachments_in)
     pool = get_agent_pool()
     try:
         instance = await pool.get(ctx.target_agent_id)

--- a/tests/cloud/chat/test_attachment_inline_budget.py
+++ b/tests/cloud/chat/test_attachment_inline_budget.py
@@ -1,0 +1,131 @@
+# tests/cloud/chat/test_attachment_inline_budget.py
+# Created: 2026-09-08 (fix/attachment-only-turns) — pins the size of a pasted
+# brief that survives the trip into the prompt intact.
+#
+# Under test: ``chat.agent_service._build_attachments_block`` and the two caps
+# it enforces.
+#
+# WHY. The composer converts any bulky paste into a ``pasted-*.txt``
+# attachment, so "I pasted my brief into the chat" and "I uploaded a file" are
+# the SAME code path. The per-file cap was 8000 chars (~1200 words), which a
+# real landing-page brief clears easily, and the agent dutifully reported that
+# the paste "was truncated mid Section 1" and reconstructed the rest. The user
+# had not truncated anything; we had. The caps still exist — one huge PDF must
+# not eat the window — they are just set above the size of the thing people
+# actually paste.
+#
+# What these prove:
+#   * a 30k-char brief arrives whole, with no truncation marker;
+#   * something genuinely enormous IS still cut, and says so;
+#   * the total cap still bounds a batch, so the per-file rise cannot be
+#     multiplied by five files into an unbounded prompt.
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+
+import pytest
+from pocketpaw_ee.cloud.chat import agent_service
+
+
+@dataclass
+class FakeRec:
+    id: str
+    filename: str
+    mime: str
+    size: int
+
+
+@dataclass
+class FakeCtx:
+    workspace_id: str = "ws1"
+    user_id: str = "u1"
+    pocket_id: str | None = "pk1"
+
+
+class _FakeResolver:
+    """Hands back a record per url without touching S3 or the filesystem."""
+
+    def __init__(self, texts: dict[str, str]) -> None:
+        self._texts = texts
+
+    def open_local_for_url(self, url, *, workspace):  # noqa: ARG002
+        text = self._texts[url]
+
+        @contextlib.asynccontextmanager
+        async def _cm():
+            yield (
+                FakeRec(id=url, filename=f"{url}.txt", mime="text/plain", size=len(text)),
+                url,
+            )
+
+        return _cm()
+
+
+class _FakeChain:
+    def __init__(self, texts: dict[str, str]) -> None:
+        self._texts = texts
+
+    async def run(self, path, _mime):
+        return type("R", (), {"text": self._texts[path]})()
+
+
+def _install(monkeypatch, texts: dict[str, str]) -> None:
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.uploads.resolver.default_resolver",
+        lambda: _FakeResolver(texts),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.extraction.build_chain",
+        lambda _settings: _FakeChain(texts),
+        raising=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_long_pasted_brief_is_inlined_whole(monkeypatch) -> None:
+    """30k chars is a big brief, not an abusive upload. It goes in intact."""
+    brief = "SECTION 1. " + ("the hero copy goes here. " * 1200) + "END."
+    assert len(brief) > 30_000
+    _install(monkeypatch, {"upload://brief": brief})
+
+    block = await agent_service._build_attachments_block(
+        FakeCtx(), [{"url": "upload://brief"}], surface="sites"
+    )
+
+    assert "[truncated]" not in block
+    assert brief in block
+    assert "treat them as part of the user's message" in block
+
+
+@pytest.mark.asyncio
+async def test_something_genuinely_enormous_is_still_cut_and_says_so(monkeypatch) -> None:
+    """The cap is raised, not removed — and the marker stays, so the agent can
+    tell the user it only saw part of the file instead of quietly inventing the
+    rest."""
+    huge = "x" * (agent_service._ATTACHMENT_PER_FILE_CHARS + 5_000)
+    _install(monkeypatch, {"upload://huge": huge})
+
+    block = await agent_service._build_attachments_block(
+        FakeCtx(), [{"url": "upload://huge"}], surface="sites"
+    )
+
+    assert "[truncated]" in block
+    assert len(block) < len(huge)
+
+
+@pytest.mark.asyncio
+async def test_the_total_cap_still_bounds_a_batch(monkeypatch) -> None:
+    """Five files at the per-file cap must not multiply into the whole window."""
+    each = "y" * agent_service._ATTACHMENT_PER_FILE_CHARS
+    texts = {f"upload://f{i}": each for i in range(5)}
+    _install(monkeypatch, texts)
+
+    block = await agent_service._build_attachments_block(
+        FakeCtx(), [{"url": u} for u in texts], surface="sites"
+    )
+
+    # Headers and the wrapper add a little; the inlined TEXT is what is bounded.
+    assert len(block) < agent_service._ATTACHMENT_TOTAL_CHARS + 2_000

--- a/tests/cloud/runs/test_run_core_attachment_only_turn.py
+++ b/tests/cloud/runs/test_run_core_attachment_only_turn.py
@@ -1,0 +1,155 @@
+# tests/cloud/runs/test_run_core_attachment_only_turn.py
+# Created: 2026-09-08 (fix/attachment-only-turns) — pins that a turn carrying
+# ONLY attachments reaches the model as a real request instead of as an empty
+# one.
+#
+# The bug this file exists for: the composer sends a zero-width space (U+200B)
+# as the message body when the user attaches files and types nothing — the row
+# has to be non-empty to persist, and every renderer strips it so no
+# placeholder shows. The backend then handed that sentinel to ``AgentPool.run``
+# verbatim. The attached file's text DOES reach the prompt, but it lands in the
+# knowledge/system channel, so the model saw a system block of reference
+# material and a user turn that said nothing, and answered the only way that
+# leaves: by asking what the user wanted. Pasting a long brief (which the
+# composer converts to a .txt attachment) and pressing send therefore produced
+# "I don't have a brief yet — what's the site for?" while the brief sat in the
+# prompt. Typing any character alongside the attachment made it work, which is
+# exactly the tell.
+#
+# What these prove:
+#   * an attachment-only turn is given a user message that says the files ARE
+#     the message, so the model acts on the inlined text;
+#   * the substitute reaches BOTH ``AgentPool.run`` and
+#     ``build_knowledge_context`` (the latter uses it as the KB query — a
+#     zero-width char is a useless one);
+#   * an ordinary typed turn is passed through BYTE-IDENTICALLY, sentinel or
+#     not — this must not start rewriting messages people actually wrote;
+#   * an empty turn with NO attachments invents nothing.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+
+pytestmark = pytest.mark.asyncio
+
+# What the composer actually sends for a files-only message.
+SENTINEL = "\u200b"
+
+ATTACHMENTS = [{"url": "upload://f1", "filename": "pasted-20260908-101500.txt"}]
+
+
+class _CapturingPool:
+    def __init__(self) -> None:
+        self.prompt: str | None = None
+
+    async def get(self, _agent_id):
+        return type("Inst", (), {"config": {"backend": "claude_agent_sdk"}})()
+
+    def run(self, _agent_id, prompt, _session_key, **_kwargs):
+        self.prompt = prompt
+
+        async def _empty():
+            return
+            yield  # pragma: no cover
+
+        return _empty()
+
+    async def prewarm(self, *a, **k):  # pragma: no cover - not exercised here
+        return None
+
+
+def _ctx() -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+
+
+async def _drive(
+    monkeypatch,
+    *,
+    content: str,
+    attachments: list[dict[str, Any]] | None,
+) -> tuple[_CapturingPool, dict[str, Any]]:
+    pool = _CapturingPool()
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: pool)
+
+    seen: dict[str, Any] = {}
+
+    async def _fake_knowledge(_ctx, **kwargs):
+        seen.update(kwargs)
+        return "KB"
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda *a, **k: "INSTR")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda *a, **k: None, raising=False)
+
+    async def _is_cancelled():
+        return False
+
+    gen = run_core._drive_agent_loop(
+        _ctx(),
+        user_content=content,
+        attachments_in=attachments,
+        mentions_in=None,
+        history=[{"role": "user", "content": "earlier"}],
+        is_cancelled=_is_cancelled,
+        emit_stream_start=False,
+    )
+    async for _ in gen:
+        pass
+    return pool, seen
+
+
+async def test_an_attachment_only_turn_reaches_the_model_as_a_request(monkeypatch):
+    """The whole bug in one assertion: the model must not be handed a message
+    that says nothing while the user's brief sits in the system prompt."""
+    pool, seen = await _drive(monkeypatch, content=SENTINEL, attachments=ATTACHMENTS)
+
+    assert pool.prompt is not None
+    assert SENTINEL not in pool.prompt
+    assert pool.prompt.strip() != ""
+    # It has to name the block the text was inlined into, or the instruction is
+    # just an assertion the model cannot check.
+    assert "<uploaded-files>" in pool.prompt
+    # And the KB query gets the same substitute, not a zero-width char.
+    assert seen["user_message"] == pool.prompt
+
+
+async def test_whitespace_only_content_with_attachments_is_treated_the_same(monkeypatch):
+    """A client that sends spaces (or nothing at all) instead of the sentinel is
+    the same situation and must not fall through to the empty-prompt path."""
+    for content in ("", "   ", "\n\t", "\ufeff"):
+        pool, _ = await _drive(monkeypatch, content=content, attachments=ATTACHMENTS)
+        assert pool.prompt and "<uploaded-files>" in pool.prompt
+
+
+async def test_a_typed_message_is_passed_through_byte_for_byte(monkeypatch):
+    """The substitution is only for turns with nothing to say. A real message —
+    including one that happens to carry the sentinel next to real text — must
+    arrive exactly as the user wrote it."""
+    pool, _ = await _drive(monkeypatch, content="build me a landing page", attachments=ATTACHMENTS)
+    assert pool.prompt == "build me a landing page"
+
+    pool, _ = await _drive(
+        monkeypatch, content=f"{SENTINEL}build me a landing page", attachments=ATTACHMENTS
+    )
+    assert pool.prompt == f"{SENTINEL}build me a landing page"
+
+
+async def test_an_empty_turn_with_no_attachments_invents_nothing(monkeypatch):
+    """Nothing was attached, so there is no file to point the model at. Say
+    nothing rather than describing files that do not exist."""
+    pool, _ = await _drive(monkeypatch, content=SENTINEL, attachments=None)
+    assert pool.prompt == SENTINEL


### PR DESCRIPTION
Attach a file, type nothing, send. The agent asks what you wanted — with the answer already in its prompt.

## What was happening

The composer puts a zero-width space in the message body when you attach files and type nothing. That is right for the two ends it was written for: the row has to be non-empty or the backend drops the message, and every renderer strips the character so no placeholder shows in the transcript.

The model is the end nobody wrote it for. It received a user turn that said nothing, plus the file's extracted text inlined into the knowledge channel — where it reads as reference material rather than as the request. The only reasonable move left is to ask what the user wanted. Typing a single character alongside the attachment made it work, which is the tell that the attachment was never the problem.

This bites hardest on the paste path, because the composer converts any bulky paste into a `pasted-*.txt` attachment. So "I pasted my brief into the chat" and "I uploaded a file" are the same code path, and pasting a full site brief produced `I don't have a brief yet — what's the site for?`.

## The fix

`_drive_agent_loop` resolves that one case before anything downstream reads the string — the KB query, the session titler, and the prompt handed to `pool.run` all consume it. The substitute names `<uploaded-files>` so the instruction points at the block the text actually landed in.

A turn with visible text is returned byte-identically, sentinel included. With no attachments nothing is invented.

## Second cut on the same trip

The per-file inline cap was 8000 chars, around 1200 words. A real landing-page brief clears that easily, so the agent was reporting the paste as truncated and reconstructing the rest from what survived — the user had truncated nothing, we had. Per-file goes to 40000 and the total to 100000. Still capped, just set by what people paste rather than by what a document can weigh; the total cap is what keeps five large files from becoming the whole prompt.

## Tests

Two new files, both red before the change:

- `tests/cloud/runs/test_run_core_attachment_only_turn.py` — the attachment-only turn reaches the model as a request; the substitute reaches both `pool.run` and the KB query; a typed message passes through byte-for-byte; an empty turn with no attachments invents nothing.
- `tests/cloud/chat/test_attachment_inline_budget.py` — a 30k-char brief inlines whole; something genuinely enormous is still cut and still says so; the total cap still bounds a batch.

`tests/cloud/runs`, `tests/cloud/chat` and `tests/ee/agent`: 1003 passed. Six failures in `test_run_core.py` and `test_run_core_entity_profile.py` are pre-existing — verified failing identically on a clean `origin/dev` worktree, and they concern surface/entity profile resolution, not this path.
