### PR TITLE
fix(security): the remaining audit findings — loopback bypass, global settings write, key collision

### DIFF
--- a/ee/pocketpaw_ee/cloud/auth/api_keys.py
+++ b/ee/pocketpaw_ee/cloud/auth/api_keys.py
@@ -331,51 +331,63 @@ async def resolve_bearer(token: str) -> tuple[str, str, list[str]] | None:
     if cached is not None:
         return cached.owner_user_id, cached.workspace, list(cached.scopes)
 
-    doc = await APIKey.find_one(
+    # EVERY live key sharing this prefix, not the first one Mongo happens to
+    # return. The prefix is 8 hex characters carved off the secret, so two live
+    # keys collide by birthday at roughly 65k keys in a deployment. find_one
+    # then returns an arbitrary one of them, its argon2 verify fails against the
+    # other key's secret, and that OTHER key stops authenticating — permanently,
+    # with a 401 that says nothing about why. Availability, not disclosure: the
+    # verify below is what actually authenticates, and it is unchanged.
+    #
+    # The loop costs nothing in the normal case, because the normal case is one
+    # document. It only does a second ~30ms argon2 verify when a collision
+    # genuinely exists, which is the situation it exists to survive.
+    candidates = await APIKey.find(
         APIKey.prefix == prefix,
         APIKey.revoked == False,  # noqa: E712
-    )
-    if doc is None:
+    ).to_list()
+    if not candidates:
         return None
 
-    # Cheap expiry check first — skips the ~30ms argon2 verify when the
-    # key is already dead.
-    if doc.expires_at is not None:
-        exp = doc.expires_at if doc.expires_at.tzinfo else doc.expires_at.replace(tzinfo=UTC)
-        if exp <= now:
-            return None
+    for doc in candidates:
+        # Cheap expiry check first — skips the ~30ms argon2 verify when the
+        # key is already dead.
+        if doc.expires_at is not None:
+            exp = doc.expires_at if doc.expires_at.tzinfo else doc.expires_at.replace(tzinfo=UTC)
+            if exp <= now:
+                continue
 
-    # Argon2id at pwdlib's recommended parameters is ~30ms of CPU and a 64 MB
-    # allocation, by design. That cost is fine; running it INLINE on the event
-    # loop was not. This is one process serving every request, so a synchronous
-    # 30ms burn here freezes every other in-flight request, WebSocket frame and
-    # SSE chunk for those 30ms — not just the caller's. Sustained API-key
-    # traffic therefore caps total server throughput around 1/0.03 ≈ 33 req/s
-    # regardless of how trivial the endpoint being called is.
-    #
-    # to_thread hands it to the default executor so the loop keeps serving.
-    # The verify stays exactly as strict; only where it runs has changed.
-    try:
-        result = await asyncio.to_thread(_password_hash.verify, secret, doc.hashed_secret)
-    except Exception:
-        return None
-    if isinstance(result, tuple):
-        valid = bool(result[0])
-    else:
-        valid = bool(result)
-    if not valid:
-        return None
-
-    _cache_verification(_token_digest(token), doc, now_monotonic)
-
-    if _should_write_last_used(str(doc.id), now_monotonic):
+        # Argon2id at pwdlib's recommended parameters is ~30ms of CPU and a
+        # 64 MB allocation, by design. That cost is fine; running it INLINE on
+        # the event loop was not. This is one process serving every request, so
+        # a synchronous 30ms burn here freezes every other in-flight request,
+        # WebSocket frame and SSE chunk for those 30ms — not just the caller's.
+        #
+        # to_thread hands it to the default executor so the loop keeps serving.
+        # The verify stays exactly as strict; only where it runs has changed.
         try:
-            doc.last_used_at = now
-            await doc.save()
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("last_used_at update failed: %s", exc)
+            result = await asyncio.to_thread(_password_hash.verify, secret, doc.hashed_secret)
+        except Exception:
+            continue
+        if isinstance(result, tuple):
+            valid = bool(result[0])
+        else:
+            valid = bool(result)
+        if not valid:
+            continue
 
-    return doc.owner_user_id, doc.workspace, list(doc.scopes)
+        _cache_verification(_token_digest(token), doc, now_monotonic)
+
+        if _should_write_last_used(str(doc.id), now_monotonic):
+            try:
+                doc.last_used_at = now
+                await doc.save()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("last_used_at update failed: %s", exc)
+
+        return doc.owner_user_id, doc.workspace, list(doc.scopes)
+
+    return None
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -198,6 +198,7 @@ invocation has the same blast radius as a write binding.
 
 from __future__ import annotations
 
+import logging
 import secrets as _secrets
 from typing import Any
 from uuid import uuid4
@@ -256,6 +257,8 @@ from pocketpaw_ee.cloud.shared.deps import (
     require_pocket_edit,
     require_pocket_owner,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/pockets", tags=["Pockets"], dependencies=[Depends(require_license)])
 
@@ -562,6 +565,31 @@ def _loopback_bypass_active(
 
     Any missing factor → bypass denied; the caller falls through to
     the standard cookie/bearer auth dependency.
+
+    AND IT IS REFUSED OUTRIGHT IN MULTI-TENANT CLOUD.
+
+    The loopback half of this contract provides nothing behind a reverse
+    proxy. The docstring on ``_is_localhost`` says so itself: with nginx or
+    Caddy on the same box, ``request.client.host`` is ``127.0.0.1`` for every
+    external client, so factor 1 passes for the whole internet. That leaves
+    the process token as the entire gate — and the remaining factors are the
+    workspace id and the user id, both read from attacker-supplied headers.
+
+    So a leaked internal token is any-tenant, any-user impersonation across
+    pocket reads, spec merges and both reconcile routes. The token is minted
+    per process and never rotated within it, and the code that describes it
+    calls the arrangement "interim, dev-grade".
+
+    ``is_multi_tenant_cloud()`` is the signal, not an env flag anybody has to
+    remember to set: it is exactly "there is a cloud DB, so more than one
+    tenant lives here". A local desktop install, where this bypass is how the
+    agent talks to its own backend, has no cloud DB and is unaffected.
+
+    ``POCKETPAW_INTERNAL_BYPASS_ENABLED=1`` re-enables it in cloud for a
+    deployment that genuinely needs it, and says so in the log every time it
+    fires. Silence is safe; leniency is deliberate.
+
+    Gated by tests/cloud/test_pocket_loopback_bypass.py.
     """
     if not _is_localhost(request):
         return False
@@ -571,6 +599,46 @@ def _loopback_bypass_active(
         return False
     if not workspace_header or not user_header:
         return False
+    if not _bypass_allowed_here():
+        return False
+    return True
+
+
+def _bypass_allowed_here() -> bool:
+    """Whether the internal bypass may fire in THIS deployment at all.
+
+    Off in multi-tenant cloud unless explicitly re-enabled, because the
+    workspace and user it trusts both come from request headers — see
+    ``_loopback_bypass_active``.
+    """
+    import os
+
+    if os.environ.get("POCKETPAW_INTERNAL_BYPASS_ENABLED", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    ):
+        logger.warning(
+            "POCKETPAW_INTERNAL_BYPASS_ENABLED is set — honouring the pocket "
+            "internal bypass, which takes its workspace and user from request "
+            "headers. Unset this unless a component genuinely needs it."
+        )
+        return True
+
+    try:
+        from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
+
+        if is_multi_tenant_cloud():
+            return False
+    except Exception:  # noqa: BLE001 — an unreadable signal must not open the gate
+        logger.warning(
+            "guards: could not determine whether this is multi-tenant cloud — "
+            "refusing the pocket internal bypass",
+            exc_info=True,
+        )
+        return False
+
     return True
 
 

--- a/src/pocketpaw/api/v1/settings.py
+++ b/src/pocketpaw/api/v1/settings.py
@@ -72,10 +72,66 @@ async def get_settings():
     return data
 
 
+def _refuse_global_write_in_cloud(request: Request) -> None:
+    """404 the settings write when more than one tenant lives on this box.
+
+    ``Settings.load()`` / ``.save()`` is the single on-disk config for the whole
+    PROCESS. There is no workspace anywhere in this handler, and the update is a
+    blind ``setattr`` loop over whatever keys the body carries, bounded only by
+    ``hasattr`` and ``_IMMUTABLE_FIELDS``. So one caller who passes the gate
+    rewrites model routing, provider keys, channel wiring and budget for EVERY
+    tenant on the deployment — while the product presents this as workspace
+    settings.
+
+    The gate in front of it is currently sound: ``require_scope`` fails closed,
+    and the EE bridge grants ``full_access`` only to ``is_superuser``, so a
+    workspace owner cannot reach it. This is not a fix for a broken gate. It is
+    removing the reason one narrow superuser check is the only thing standing
+    between a self-service tenant and everyone else's provider keys.
+
+    HOW "CLOUD" IS DETECTED FROM THE OSS PACKAGE
+
+    This module is in ``pocketpaw``, which must never import ``pocketpaw_ee`` —
+    an import-linter contract enforces it — so ``is_multi_tenant_cloud()`` is
+    out of reach. ``request.state.workspace_id`` is the seam: the EE auth bridge
+    stamps it from the caller's own JWT, and nothing else sets it. If it is
+    present, a cloud session reached this route, which means this deployment has
+    cloud mounted.
+
+    ``POCKETPAW_ALLOW_GLOBAL_SETTINGS_WRITE=1`` re-opens it for an operator who
+    genuinely needs to drive a single-tenant cloud install through this route.
+
+    404 rather than 403: a surface a deployment has turned off should not
+    announce itself.
+
+    Per-workspace settings is the real fix and a real project. This is the
+    launch-week posture, not the end state.
+    """
+    import os
+
+    if not getattr(request.state, "workspace_id", None):
+        return
+    if os.environ.get("POCKETPAW_ALLOW_GLOBAL_SETTINGS_WRITE", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    ):
+        logger.warning(
+            "POCKETPAW_ALLOW_GLOBAL_SETTINGS_WRITE is set — honouring a write to "
+            "the PROCESS-WIDE settings from a cloud session. This changes config "
+            "for every tenant on this deployment."
+        )
+        return
+    raise HTTPException(status_code=404, detail="Not Found")
+
+
 @router.put("/settings", dependencies=[Depends(require_scope("settings:write"))])
 async def update_settings(request: Request):
     """Update settings fields. Only provided fields are changed."""
     from pocketpaw.config import Settings, get_settings, validate_api_key
+
+    _refuse_global_write_in_cloud(request)
 
     data = await request.json()
     settings_data = data.get("settings", data)

--- a/tests/cloud/auth/test_api_key_prefix_collision.py
+++ b/tests/cloud/auth/test_api_key_prefix_collision.py
@@ -1,0 +1,104 @@
+"""Two live keys sharing a prefix must both keep working.
+
+``resolve_bearer`` looked its key up with::
+
+    doc = await APIKey.find_one(APIKey.prefix == prefix, APIKey.revoked == False)
+
+The prefix is 8 hex characters carved off the secret, so two live keys collide
+by birthday at roughly 65k keys in one deployment. ``find_one`` then returns an
+arbitrary one of them, the argon2 verify fails against the other key's secret,
+and that OTHER key stops authenticating — permanently, with a 401 that explains
+nothing.
+
+Availability rather than disclosure: the argon2 verify is what actually
+authenticates and it is unchanged, so a collision could never let the wrong key
+in. It could only lock a legitimate key out.
+
+The loop costs nothing in the normal case, because the normal case is one
+document. It performs a second ~30ms verify only when a collision genuinely
+exists, which is the situation it exists to survive.
+
+Mutations that must fail these tests: going back to ``find_one``, and returning
+after the first candidate instead of continuing past a failed verify.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.auth import api_keys
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    api_keys._reset_caches_for_tests()
+    yield
+    api_keys._reset_caches_for_tests()
+
+
+async def test_a_colliding_prefix_does_not_lock_the_other_key_out(mongo_db, monkeypatch):  # noqa: ARG001
+    """The reproduction: two live keys, same prefix, both must resolve.
+
+    Their secrets are forced to share the first 8 characters so the lookup
+    returns two documents. Before the fix, whichever one Mongo did not return
+    first was dead.
+    """
+    created: list[tuple[str, str]] = []
+    for workspace in ("ws-alpha", "ws-beta"):
+        doc, full_key = await api_keys.create_api_key(
+            workspace_id=workspace,
+            owner_user_id=f"owner-{workspace}",
+            name=f"key for {workspace}",
+            scopes=["chat.read"],
+        )
+        created.append((workspace, full_key))
+
+    # Force the collision: give the second key the first key's prefix. Both
+    # rows stay live, and each still verifies only against its OWN secret.
+    first_prefix = (await api_keys.APIKey.find_one(APIKey_owner("owner-ws-alpha"))).prefix
+    other = await api_keys.APIKey.find_one(APIKey_owner("owner-ws-beta"))
+    other.prefix = first_prefix
+    await other.save()
+
+    api_keys._reset_caches_for_tests()
+
+    for workspace, full_key in created:
+        # The colliding key's token still carries its own prefix in the body,
+        # so rewrite the lookup prefix the same way the row was rewritten.
+        token = full_key
+        if workspace == "ws-beta":
+            body = full_key[4:]
+            token = "paw_" + first_prefix + body[len(first_prefix) :]
+            # The secret is the whole body, so changing the prefix changes the
+            # secret; re-point the row's hash at the token we will present.
+            other.hashed_secret = api_keys._password_hash.hash(token[4:])
+            await other.save()
+            api_keys._reset_caches_for_tests()
+
+        resolved = await api_keys.resolve_bearer(token)
+        assert resolved is not None, (
+            f"{workspace}'s key stopped authenticating because another live key "
+            "shares its prefix"
+        )
+        assert resolved[1] == workspace
+
+
+def APIKey_owner(owner: str):  # noqa: N802 — reads as a query helper at call sites
+    return api_keys.APIKey.owner_user_id == owner
+
+
+async def test_an_unknown_prefix_is_still_refused(mongo_db):  # noqa: ARG001
+    assert await api_keys.resolve_bearer("paw_" + "0" * 40) is None
+
+
+async def test_a_wrong_secret_on_a_known_prefix_is_still_refused(mongo_db):  # noqa: ARG001
+    """The verify still decides. Iterating candidates must not weaken it."""
+    doc, full_key = await api_keys.create_api_key(
+        workspace_id="ws-1",
+        owner_user_id="owner-1",
+        name="k",
+        scopes=["chat.read"],
+    )
+    api_keys._reset_caches_for_tests()
+
+    tampered = full_key[:-4] + ("0000" if not full_key.endswith("0000") else "1111")
+    assert await api_keys.resolve_bearer(tampered) is None

--- a/tests/cloud/auth/test_api_key_prefix_collision.py
+++ b/tests/cloud/auth/test_api_key_prefix_collision.py
@@ -76,8 +76,7 @@ async def test_a_colliding_prefix_does_not_lock_the_other_key_out(mongo_db, monk
 
         resolved = await api_keys.resolve_bearer(token)
         assert resolved is not None, (
-            f"{workspace}'s key stopped authenticating because another live key "
-            "shares its prefix"
+            f"{workspace}'s key stopped authenticating because another live key shares its prefix"
         )
         assert resolved[1] == workspace
 

--- a/tests/cloud/auth/test_route_auth_audit.py
+++ b/tests/cloud/auth/test_route_auth_audit.py
@@ -102,6 +102,13 @@ ROUTER_MODULES = [
     ("audit", "pocketpaw_ee.cloud.audit.router"),
     ("auth", "pocketpaw_ee.cloud.auth.router"),
     ("billing", "pocketpaw_ee.cloud.billing.router"),
+    # Added 2026-09-08. Both mounted while the coverage pin was being
+    # written against an older base, so dev merged at 50 unaudited
+    # routers against a pin of 48. Every route on both carries a session
+    # guard, so auditing them brings the count back down rather than
+    # raising the pin — which is the point of the pin.
+    ("byok", "pocketpaw_ee.cloud.byok.router"),
+    ("other_hand", "pocketpaw_ee.cloud.other_hand.router"),
     ("chat", "pocketpaw_ee.cloud.chat.router"),
     ("chat_runs", "pocketpaw_ee.cloud.chat.runs.router"),
     ("codeagent", "pocketpaw_ee.cloud.codeagent.router"),

--- a/tests/cloud/test_pocket_loopback_bypass.py
+++ b/tests/cloud/test_pocket_loopback_bypass.py
@@ -1,0 +1,217 @@
+"""The pocket internal bypass is refused in multi-tenant cloud.
+
+``_loopback_bypass_active`` lets a caller skip cookie/bearer auth on
+``GET /pockets/{id}``, ``POST /pockets/{id}/spec/merge`` and both reconcile
+routes, taking the workspace AND the user from request headers
+(``X-PocketPaw-Workspace-Id``, ``X-PocketPaw-User-Id``).
+
+Four factors are required, and three of them are attacker-supplied. The fourth,
+"the request came from loopback", provides nothing behind a reverse proxy — the
+code says so itself, in ``_is_localhost``:
+
+    Security contract: we deliberately do NOT honor ``X-Forwarded-For`` here.
+    If a future deployment puts a reverse proxy in front of the dashboard,
+    ``request.client.host`` will resolve to the proxy's address (also loopback
+    if the proxy runs on the same box), making every external client appear
+    loopback. This bypass MUST be disabled in that deployment, or this contract
+    revisited.
+
+Production behind nginx or Caddy on the same host is precisely that deployment.
+So the process token is the entire gate, and a leaked token is any-tenant,
+any-user impersonation across pocket reads and writes. The module's own
+docstring calls the arrangement "interim, dev-grade".
+
+WHY A SIGNAL RATHER THAN AN ENV FLAG
+
+An env flag defaults to whatever an operator remembers to set, and the audit
+that found this also found ``RECALL_WEBHOOK_SECRET`` — a variable that appeared
+in no template, so the warning telling operators to set it was addressed to
+nobody. ``is_multi_tenant_cloud()`` is not a thing to remember: it means "there
+is a cloud DB, so more than one tenant lives here", and it is the same signal
+the agent jail and the storage boot guard already use.
+
+A local desktop install has no cloud DB and is unaffected — which matters,
+because that is the deployment where this bypass is how the local agent reaches
+its own backend.
+
+Mutations that must fail these tests: dropping the ``_bypass_allowed_here``
+call from ``_loopback_bypass_active``, returning True when the signal cannot be
+read, and treating any present value of the opt-in variable as truthy.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+ROUTER = "pocketpaw_ee.cloud.pockets.router"
+
+
+@pytest.fixture
+def router_module():
+    return importlib.import_module(ROUTER)
+
+
+@pytest.fixture
+def in_cloud(monkeypatch):
+    """Make ``is_multi_tenant_cloud()`` report a multi-tenant deployment."""
+    import sys
+    import types
+
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+    module.is_multi_tenant_cloud = lambda: True
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+
+
+def test_the_bypass_is_refused_in_multi_tenant_cloud(router_module, in_cloud, monkeypatch):
+    """The finding. One leaked process token was any-tenant impersonation."""
+    monkeypatch.delenv("POCKETPAW_INTERNAL_BYPASS_ENABLED", raising=False)
+    assert router_module._bypass_allowed_here() is False
+
+
+def test_a_local_install_is_unaffected(router_module, monkeypatch):
+    """No cloud DB means one tenant, and the local agent still reaches itself."""
+    import sys
+    import types
+
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+    module.is_multi_tenant_cloud = lambda: False
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+    monkeypatch.delenv("POCKETPAW_INTERNAL_BYPASS_ENABLED", raising=False)
+
+    assert router_module._bypass_allowed_here() is True
+
+
+def test_an_unreadable_signal_refuses(router_module, monkeypatch):
+    """If we cannot tell whether this is cloud, we do not open the gate."""
+    import sys
+    import types
+
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+
+    def _explode():
+        raise RuntimeError("no db")
+
+    module.is_multi_tenant_cloud = _explode
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+    monkeypatch.delenv("POCKETPAW_INTERNAL_BYPASS_ENABLED", raising=False)
+
+    assert router_module._bypass_allowed_here() is False
+
+
+def test_the_escape_hatch_re_enables_it(router_module, in_cloud, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_INTERNAL_BYPASS_ENABLED", "1")
+    assert router_module._bypass_allowed_here() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+def test_only_an_explicit_opt_in_re_enables_it(router_module, in_cloud, monkeypatch, value):
+    """``...=0`` must not mean yes.
+
+    ``"VAR" in os.environ`` is the easy wrong check and would make every value
+    an opt-in, including the one an operator sets to turn it off.
+    """
+    monkeypatch.setenv("POCKETPAW_INTERNAL_BYPASS_ENABLED", value)
+    assert router_module._bypass_allowed_here() is False
+
+
+def test_the_full_bypass_check_consults_the_gate(router_module, in_cloud, monkeypatch):
+    """End to end through ``_loopback_bypass_active``, with every OTHER factor
+    satisfied — so the only thing that can deny is the new gate.
+
+    Written this way on purpose: a test that fails because the token is wrong
+    would pass with the gate deleted.
+    """
+    from types import SimpleNamespace
+
+    monkeypatch.delenv("POCKETPAW_INTERNAL_BYPASS_ENABLED", raising=False)
+    monkeypatch.setattr(router_module, "_is_localhost", lambda request: True)
+    monkeypatch.setattr(router_module, "_bypass_token_matches", lambda supplied: True)
+
+    request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+
+    assert (
+        router_module._loopback_bypass_active(
+            request,
+            internal_header="true",
+            internal_token="whatever",
+            workspace_header="ws-victim",
+            user_header="u-victim",
+        )
+        is False
+    )
+
+
+def test_every_other_factor_still_denies_on_its_own(router_module, monkeypatch):
+    """The pre-existing factors are untouched — this change only ADDS one."""
+    import sys
+    import types
+    from types import SimpleNamespace
+
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+    module.is_multi_tenant_cloud = lambda: False
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+    monkeypatch.setattr(router_module, "_is_localhost", lambda request: True)
+    monkeypatch.setattr(router_module, "_bypass_token_matches", lambda supplied: True)
+
+    request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+    base = {
+        "internal_header": "true",
+        "internal_token": "t",
+        "workspace_header": "w",
+        "user_header": "u",
+    }
+    assert router_module._loopback_bypass_active(request, **base) is True
+
+    for missing, value in (
+        ("internal_header", "no"),
+        ("workspace_header", ""),
+        ("user_header", ""),
+    ):
+        assert (
+            router_module._loopback_bypass_active(request, **{**base, missing: value}) is False
+        ), f"{missing} no longer denies on its own"
+
+
+def test_a_non_loopback_request_is_denied_with_the_real_check(router_module, monkeypatch):
+    """The loopback factor itself, with ``_is_localhost`` NOT stubbed.
+
+    The test above monkeypatches ``_is_localhost`` to True so the new gate is
+    the only thing that can deny — which is right for that test and useless for
+    this one. A mutation deleting the loopback factor escaped the whole file
+    until this case existed, because every other test had stubbed it away.
+    """
+    import sys
+    import types
+    from types import SimpleNamespace
+
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+    module.is_multi_tenant_cloud = lambda: False
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+    monkeypatch.setattr(router_module, "_bypass_token_matches", lambda supplied: True)
+    monkeypatch.delenv("POCKETPAW_INTERNAL_BYPASS_ENABLED", raising=False)
+
+    off_box = SimpleNamespace(client=SimpleNamespace(host="203.0.113.7"))
+    assert (
+        router_module._loopback_bypass_active(
+            off_box,
+            internal_header="true",
+            internal_token="t",
+            workspace_header="w",
+            user_header="u",
+        )
+        is False
+    )
+
+    loopback = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+    assert (
+        router_module._loopback_bypass_active(
+            loopback,
+            internal_header="true",
+            internal_token="t",
+            workspace_header="w",
+            user_header="u",
+        )
+        is True
+    )

--- a/tests/mutations/api_key_prefix_collision.json
+++ b/tests/mutations/api_key_prefix_collision.json
@@ -1,0 +1,23 @@
+[
+  {
+    "label": "go back to find_one — one colliding key stops authenticating",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "    candidates = await APIKey.find(\n        APIKey.prefix == prefix,\n        APIKey.revoked == False,  # noqa: E712\n    ).to_list()\n    if not candidates:\n        return None",
+    "replace": "    _one = await APIKey.find_one(\n        APIKey.prefix == prefix,\n        APIKey.revoked == False,  # noqa: E712\n    )\n    candidates = [_one] if _one is not None else []\n    if not candidates:\n        return None",
+    "tests": ["tests/cloud/auth/test_api_key_prefix_collision.py"]
+  },
+  {
+    "label": "stop after the first candidate whose verify fails",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "        if not valid:\n            continue",
+    "replace": "        if not valid:\n            return None",
+    "tests": ["tests/cloud/auth/test_api_key_prefix_collision.py"]
+  },
+  {
+    "label": "accept a candidate without verifying it",
+    "file": "ee/pocketpaw_ee/cloud/auth/api_keys.py",
+    "find": "        if isinstance(result, tuple):\n            valid = bool(result[0])\n        else:\n            valid = bool(result)",
+    "replace": "        valid = True",
+    "tests": ["tests/cloud/auth/test_api_key_prefix_collision.py"]
+  }
+]

--- a/tests/mutations/pocket_loopback_bypass.json
+++ b/tests/mutations/pocket_loopback_bypass.json
@@ -1,0 +1,37 @@
+[
+  {
+    "label": "drop the deployment gate — the shipped state, any tenant by header",
+    "file": "ee/pocketpaw_ee/cloud/pockets/router.py",
+    "find": "    if not _bypass_allowed_here():\n        return False\n    return True",
+    "replace": "    return True",
+    "tests": ["tests/cloud/test_pocket_loopback_bypass.py"]
+  },
+  {
+    "label": "fail OPEN when the multi-tenant signal cannot be read",
+    "file": "ee/pocketpaw_ee/cloud/pockets/router.py",
+    "find": "            \"refusing the pocket internal bypass\",\n            exc_info=True,\n        )\n        return False",
+    "replace": "            \"refusing the pocket internal bypass\",\n            exc_info=True,\n        )\n        return True",
+    "tests": ["tests/cloud/test_pocket_loopback_bypass.py"]
+  },
+  {
+    "label": "treat any present opt-in value as truthy, so =0 means yes",
+    "file": "ee/pocketpaw_ee/cloud/pockets/router.py",
+    "find": "    if os.environ.get(\"POCKETPAW_INTERNAL_BYPASS_ENABLED\", \"\").strip().lower() in (\n        \"1\",\n        \"true\",\n        \"yes\",\n        \"on\",\n    ):",
+    "replace": "    if \"POCKETPAW_INTERNAL_BYPASS_ENABLED\" in os.environ:",
+    "tests": ["tests/cloud/test_pocket_loopback_bypass.py"]
+  },
+  {
+    "label": "stop refusing in multi-tenant cloud",
+    "file": "ee/pocketpaw_ee/cloud/pockets/router.py",
+    "find": "        if is_multi_tenant_cloud():\n            return False",
+    "replace": "        if False:\n            return False",
+    "tests": ["tests/cloud/test_pocket_loopback_bypass.py"]
+  },
+  {
+    "label": "drop the loopback factor while keeping the new gate",
+    "file": "ee/pocketpaw_ee/cloud/pockets/router.py",
+    "find": "    if not _is_localhost(request):\n        return False\n    if internal_header != \"true\":",
+    "replace": "    if internal_header != \"true\":",
+    "tests": ["tests/cloud/test_pocket_loopback_bypass.py"]
+  }
+]

--- a/tests/mutations/settings_global_write_gate.json
+++ b/tests/mutations/settings_global_write_gate.json
@@ -1,0 +1,30 @@
+[
+  {
+    "label": "drop the gate from the handler — the shipped state",
+    "file": "src/pocketpaw/api/v1/settings.py",
+    "find": "    _refuse_global_write_in_cloud(request)\n\n    data = await request.json()",
+    "replace": "    data = await request.json()",
+    "tests": ["tests/v1/test_settings_global_write_gate.py"]
+  },
+  {
+    "label": "treat any present override value as truthy, so =0 means yes",
+    "file": "src/pocketpaw/api/v1/settings.py",
+    "find": "    if os.environ.get(\"POCKETPAW_ALLOW_GLOBAL_SETTINGS_WRITE\", \"\").strip().lower() in (\n        \"1\",\n        \"true\",\n        \"yes\",\n        \"on\",\n    ):",
+    "replace": "    if \"POCKETPAW_ALLOW_GLOBAL_SETTINGS_WRITE\" in os.environ:",
+    "tests": ["tests/v1/test_settings_global_write_gate.py"]
+  },
+  {
+    "label": "announce the surface with a 403 instead of a 404",
+    "file": "src/pocketpaw/api/v1/settings.py",
+    "find": "    raise HTTPException(status_code=404, detail=\"Not Found\")",
+    "replace": "    raise HTTPException(status_code=403, detail=\"Forbidden\")",
+    "tests": ["tests/v1/test_settings_global_write_gate.py"]
+  },
+  {
+    "label": "let a cloud session through by ignoring the stamped workspace",
+    "file": "src/pocketpaw/api/v1/settings.py",
+    "find": "    if not getattr(request.state, \"workspace_id\", None):\n        return",
+    "replace": "    return",
+    "tests": ["tests/v1/test_settings_global_write_gate.py"]
+  }
+]

--- a/tests/v1/test_settings_global_write_gate.py
+++ b/tests/v1/test_settings_global_write_gate.py
@@ -1,0 +1,106 @@
+"""A cloud session cannot rewrite the process-wide settings.
+
+``PUT /api/v1/settings`` calls ``Settings.load()`` / ``.save()`` — the single
+on-disk config for the whole PROCESS. There is no ``workspace_id`` anywhere in
+the handler, and the update is a blind ``setattr`` loop over whatever keys the
+body carries, bounded only by ``hasattr`` and ``_IMMUTABLE_FIELDS`` (which
+covers seven security fields and nothing else — provider keys, model routing and
+channel credentials are all writable).
+
+So one caller who passes the gate rewrites config for EVERY tenant on the
+deployment, while the product presents this as workspace settings.
+
+THIS IS NOT A FIX FOR A BROKEN GATE
+
+``require_scope`` fails closed, and the EE bridge grants ``full_access`` only to
+``is_superuser`` — the 2026-06-10 escalation fix, which is holding. A workspace
+owner cannot reach this route today. What this removes is the situation where
+one narrow superuser check is the only thing between a self-service tenant and
+everyone else's provider keys.
+
+DETECTING CLOUD FROM THE OSS PACKAGE
+
+``pocketpaw`` must never import ``pocketpaw_ee`` (an import-linter contract
+enforces it), so ``is_multi_tenant_cloud()`` is unavailable here.
+``request.state.workspace_id`` is the seam: the EE auth bridge stamps it from
+the caller's own JWT and nothing else sets it, so its presence means a cloud
+session reached this route.
+
+404 rather than 403, because a surface a deployment has turned off should not
+announce itself.
+
+Mutations that must fail these tests: dropping the call from the handler,
+treating any present value of the override as truthy, and raising 403 instead
+of 404.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from pocketpaw.api.v1.settings import _refuse_global_write_in_cloud
+
+
+def _request(**state) -> Request:
+    request = Request({"type": "http", "method": "PUT", "path": "/", "headers": []})
+    for key, value in state.items():
+        setattr(request.state, key, value)
+    return request
+
+
+def test_a_cloud_session_is_refused(monkeypatch):
+    """The finding: a cloud caller must not rewrite every tenant's config."""
+    monkeypatch.delenv("POCKETPAW_ALLOW_GLOBAL_SETTINGS_WRITE", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        _refuse_global_write_in_cloud(_request(workspace_id="ws-1"))
+    assert exc.value.status_code == 404
+
+
+def test_a_local_install_is_unaffected(monkeypatch):
+    """No cloud session means one tenant, and the dashboard still works."""
+    monkeypatch.delenv("POCKETPAW_ALLOW_GLOBAL_SETTINGS_WRITE", raising=False)
+    _refuse_global_write_in_cloud(_request())  # must not raise
+
+
+def test_the_override_re_opens_it(monkeypatch):
+    monkeypatch.setenv("POCKETPAW_ALLOW_GLOBAL_SETTINGS_WRITE", "1")
+    _refuse_global_write_in_cloud(_request(workspace_id="ws-1"))  # must not raise
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+def test_only_an_explicit_override_re_opens_it(monkeypatch, value):
+    """``...=0`` must not mean yes."""
+    monkeypatch.setenv("POCKETPAW_ALLOW_GLOBAL_SETTINGS_WRITE", value)
+    with pytest.raises(HTTPException) as exc:
+        _refuse_global_write_in_cloud(_request(workspace_id="ws-1"))
+    assert exc.value.status_code == 404
+
+
+def test_the_handler_actually_calls_the_gate():
+    """A helper nobody calls is documentation.
+
+    Asserted against the parsed handler rather than by driving the route,
+    because the route needs the whole dashboard middleware stack to reach a
+    state where request.state.workspace_id is set.
+    """
+    import ast
+    import inspect
+
+    import pocketpaw.api.v1.settings as module
+
+    tree = ast.parse(inspect.getsource(module))
+    handler = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "update_settings"
+    )
+    called = {
+        node.func.id
+        for node in ast.walk(handler)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "_refuse_global_write_in_cloud" in called, (
+        "update_settings does not call the cloud gate; the process-wide write is open"
+    )


### PR DESCRIPTION
The remaining findings from the pre-launch auth audit, bundled as asked. Four separate commits, readable one at a time.

---

## 1. `test(auth)` — the coverage pin is honest again

The gate from #2116 pins how many mounted routers sit outside the auth audit, so the number can only shrink. **It went red on `dev` almost immediately, and that was my error**: I computed the pin (48) against my branch's base, and by the time it merged, work landing in parallel had mounted `byok` and `other_hand`, putting `dev` at 50. Nothing caught it because `tests/cloud` is excluded from CI by `addopts` in `pyproject.toml`.

Every route on both routers already carries a session guard, so the fix is to **audit** them rather than raise the pin. The count returns to 48 by covering more of the surface, which is the only direction that pin is meant to move.

## 2. `fix(pockets)` — M-3, the internal bypass

`_loopback_bypass_active` skips cookie/bearer auth on `GET /pockets/{id}`, `POST /pockets/{id}/spec/merge` and both reconcile routes, taking the workspace **and the user** from request headers.

Four factors are required and three are attacker-supplied. The fourth — "came from loopback" — provides nothing behind a reverse proxy, and the code says so itself in `_is_localhost`: with nginx or Caddy on the same box, `request.client.host` is `127.0.0.1` for every external client. Production is exactly that deployment. So the process token was the entire gate, and a leaked token is any-tenant, any-user impersonation. The module's own docstring calls it "interim, dev-grade".

Now refused when `is_multi_tenant_cloud()` reports more than one tenant. **That signal rather than a bare env flag on purpose**: a flag defaults to whatever an operator remembers to set, and this same audit turned up `RECALL_WEBHOOK_SECRET` — a variable that appeared in no template, so the warning telling operators to set it was addressed to nobody.

A local desktop install has no cloud DB and is unaffected, which matters because that is the deployment where this bypass is how the local agent reaches its own backend.

## 3. `fix(api-keys)` — L-2, the prefix collision

`resolve_bearer` used `find_one` on an 8-hex prefix. Two live keys collide by birthday at roughly 65k keys; `find_one` returns an arbitrary one, its argon2 verify fails against the other key's secret, and that **other** key stops authenticating permanently, with a 401 that explains nothing.

Availability, not disclosure — the verify is unchanged, so a collision could never let the wrong key in, only lock a legitimate one out. Now iterates every live candidate, which costs nothing in the normal case of one document.

## 4. `fix(settings)` — H-3, the process-wide write

`PUT /api/v1/settings` writes the single on-disk config for the whole process. No `workspace_id` anywhere in the handler, and the update is a blind `setattr` loop bounded only by `hasattr` and seven immutable fields — provider keys, model routing and channel credentials are all writable.

**This is not a fix for a broken gate.** `require_scope` fails closed and the EE bridge grants `full_access` only to `is_superuser`; that 2026-06-10 escalation fix is holding, so a workspace owner cannot reach this today. What it removes is one narrow superuser check being the only thing between a self-service tenant and everyone else's provider keys.

`pocketpaw` cannot import `pocketpaw_ee`, so `is_multi_tenant_cloud()` is unavailable. `request.state.workspace_id` is the seam — stamped by the EE auth bridge from the caller's own JWT, set by nothing else.

Per-workspace settings is the real fix and a real project. This is the launch-week posture, not the end state.

---

## Tests

Four mutation plans, **15 mutations, all caught**. Repo-wide: 1342 anchors across 107 plans all resolve.

Two of them only after the tests grew a case, which is the part worth reading:

- The M-3 plan's "delete the loopback factor" **escaped the entire file**, because every test had monkeypatched `_is_localhost` to True — while the suite claimed to assert the pre-existing factors still hold. There is now a case that exercises the real check with an off-box address.
- The L-2 plan's "go back to `find_one`" is what proves the collision test reproduces the bug rather than passing alongside it. Without that mutation I would have had a green test and no evidence.

`tests/v1` is 268 green; `tests/cloud/auth` plus the new bypass tests are 485 green.

## Standing caveat

Three of these four test files live under `tests/cloud/`, which `addopts` excludes from CI. They will not run on anyone's PR as things stand — the same gap that let this batch of findings ship, and the reason item 1 above was needed at all.