### PR TITLE
Sites teardown: remove the Worker and the D1, not just the hostname

### DIFF
--- a/ee/pocketpaw_ee/sites/cloudflare_client.py
+++ b/ee/pocketpaw_ee/sites/cloudflare_client.py
@@ -1,7 +1,24 @@
 # ee/pocketpaw_ee/sites/cloudflare_client.py — async Cloudflare API client for
 # the Sites control plane. Six surfaces:
 #   * Workers for Platforms — PUT a user Worker into our dispatch namespace
-#     (one synchronous call per site; live on 200; no per-account script cap).
+#     (one synchronous call per site; live on 200; no per-account script cap),
+#     and DELETE it again on teardown; see put_worker / delete_worker.
+#
+# Updated 2026-09-08 (sites lifecycle, wave 1 chunk 1 — the teardown primitives):
+# added ``delete_worker``, ``delete_account_script`` and ``delete_database``. Deleting
+# a site had no way to remove the two most expensive things a publish creates: the
+# Worker that serves it and the D1 that holds its data. Only the custom hostname and
+# its route could be torn down, so every other resource was an orphan by construction.
+#
+# THERE ARE TWO WORKER DELETES BECAUSE THERE ARE TWO WORKER CREATES. ``wfp`` mode
+# uploads into the dispatch namespace through ``put_worker`` here; ``workers`` mode
+# deploys an account-level script through a ``bunx wrangler deploy`` SUBPROCESS in
+# ``workers_deploy.py``. They live at different API paths, so one delete cannot serve
+# both, and ``Site.deploy_target`` — which records what the last successful deploy
+# ACTUALLY used rather than what the env is configured for — is what picks between
+# them. Both are implemented against the HTTP API rather than ``wrangler delete``:
+# a teardown driven through a subprocess can only be proven against the real binary,
+# and an API call can be proven against the real resource.
 #   * Cloudflare for SaaS — create a custom hostname, return the single CNAME
 #     the client pastes, poll validation + TLS status, and delete it on teardown.
 #   * Worker routes — bind ``<custom hostname>/*`` to the site's Worker, and
@@ -374,6 +391,55 @@ class CloudflareClient:
         self._unwrap(resp)
         return True
 
+    async def delete_worker(self, script_name: str) -> None:
+        """Remove a user Worker from the dispatch namespace. Idempotent on a 404.
+
+        The inverse of ``put_worker``, and the step in a site teardown that actually
+        stops the page being served: the custom hostname and its route only decide
+        HOW a request reaches this script, so removing them leaves the site reachable
+        on its dispatch address. Nothing deleted a Worker before this existed, which
+        is why a site published under ``wfp`` kept serving after every other trace of
+        it was gone.
+
+        A 404 is SUCCESS, for the same reason it is in ``delete_custom_hostname``:
+        the goal is "this script is not in the namespace", and something already gone
+        satisfies it. Raising there would make a resumed teardown fail on the step it
+        had already completed — turning a recoverable partial teardown into a
+        permanent orphan, which is precisely what this method exists to prevent."""
+        url = (
+            f"{_CF_API}/accounts/{self._account_id}"
+            f"/workers/dispatch/namespaces/{self._namespace}/scripts/{script_name}"
+        )
+        async with self._client() as client:
+            resp = await client.delete(url)
+        if resp.status_code == 404:
+            return
+        self._unwrap(resp)
+
+    async def delete_account_script(self, script_name: str) -> None:
+        """Remove an ACCOUNT-LEVEL Worker script (the ``workers`` deploy mode).
+
+        Sibling of ``delete_worker``, and the difference is the deploy mode, not the
+        caller's preference. ``wfp`` sites live in the dispatch namespace; ``workers``
+        sites were deployed by a ``bunx wrangler deploy`` subprocess to an
+        account-level script at a different API path. Read ``Site.deploy_target`` to
+        choose — it records what the last successful deploy actually did, and its own
+        field comment lists the several ways the configured mode and the deployed
+        reality drift apart.
+
+        Deliberately NOT implemented as ``wrangler delete``. The subprocess would need
+        a project directory that teardown does not have (the artifact may already be
+        purged), and a subprocess seam can only be honestly proven against the real
+        binary. One HTTP call has neither problem.
+
+        Idempotent on a 404, same reasoning as every other delete here."""
+        url = f"{_CF_API}/accounts/{self._account_id}/workers/scripts/{script_name}"
+        async with self._client() as client:
+            resp = await client.delete(url)
+        if resp.status_code == 404:
+            return
+        self._unwrap(resp)
+
     async def create_custom_hostname(
         self, hostname: str, *, features: set[str] | None = None
     ) -> CustomHostname:
@@ -497,6 +563,31 @@ class CloudflareClient:
             resp = await client.post(url, json={"name": name})
         result = self._unwrap(resp)
         return result["uuid"]
+
+    async def delete_database(self, database_id: str) -> None:
+        """Destroy a per-tenant D1 database. Idempotent on a 404. IRREVERSIBLE.
+
+        The inverse of ``create_database``, and the only step in a site teardown that
+        destroys CUSTOMER DATA rather than infrastructure — a dynamic site's D1 holds
+        its bookings, submissions and orders alongside ``_paw_migrations`` /
+        ``_paw_handoffs`` / ``_paw_outbox``. There is no Cloudflare-side undelete and
+        no retention window, so the export that the delete cascade takes BEFORE
+        reaching this step is the only copy that survives it. Do not call this outside
+        that cascade, and do not reorder it ahead of the export.
+
+        Keyed on the database uuid rather than the name because the uuid is what
+        ``Site.d1_database_id`` stores and what the Worker binding points at; a name
+        lookup would be a second way to identify the same database, and the two can
+        disagree once a site is renamed.
+
+        A 404 is SUCCESS — the database is gone, which is the goal. A resumed teardown
+        re-running this step must not fail on it."""
+        url = f"{_CF_API}/accounts/{self._account_id}/d1/database/{database_id}"
+        async with self._client() as client:
+            resp = await client.delete(url)
+        if resp.status_code == 404:
+            return
+        self._unwrap(resp)
 
     async def capture_screenshot(
         self,

--- a/ee/pocketpaw_ee/sites/public_assets.py
+++ b/ee/pocketpaw_ee/sites/public_assets.py
@@ -1,4 +1,14 @@
 # ee/pocketpaw_ee/sites/public_assets.py — the PUBLIC asset rail for Paw Sites.
+#
+# Updated 2026-09-08 (sites lifecycle, wave 1 chunk 1): added ``purge`` — delete every
+# asset under one site's prefix, for the delete cascade — and ``can_list``. A site's
+# assets outlive the record that lists them: once the Site document is gone nothing can
+# enumerate what it left on a world-readable bucket, and these objects are served from
+# bucket origin with an immutable year-long cache, so an orphan is public forever.
+# ``can_list`` exists because ``StorageAdapter.browse`` DEFAULTS to returning ``[]``
+# rather than raising, which makes an adapter that cannot list look identical to a site
+# with no assets — harmless in ``list``, and in ``purge`` the difference between a
+# completed teardown and a merely reported one.
 # Created 2026-08-31 (feat/sites-public-asset-uploads).
 #
 # WHY THIS EXISTS. A site we publish is read by anonymous visitors, so an image it
@@ -302,6 +312,62 @@ class PublicAssetStore:
             # arbitrary-object delete against the whole bucket, across tenants.
             raise PublicAssetError("That asset does not belong to this site.")
         await self._adapter.delete(key)
+
+    def can_list(self) -> bool:
+        """Whether the underlying adapter actually implements prefix listing.
+
+        ``StorageAdapter.browse`` DEFAULTS TO RETURNING ``[]`` — it is a base-class
+        no-op that adapters override, not an abstract method that fails loudly. So an
+        adapter without listing is indistinguishable, from the outside, from a site
+        that has no assets. That ambiguity is harmless in :meth:`list`, which is
+        rendering a panel, and dangerous in :meth:`purge`, which reports what it
+        destroyed: an unlistable adapter would purge nothing, return zero, and the
+        caller would record a completed teardown over a bucket still holding every
+        asset. Checking the override is the only way to tell the two apart, so the
+        distinction lives here rather than in each caller's head."""
+        impl = getattr(type(self._adapter), "browse", None)
+        # Three cases, and only one of them can list: no ``browse`` at all (a
+        # duck-typed adapter), the base class no-op, or a real override.
+        return impl is not None and impl is not StorageAdapter.browse
+
+    async def purge(self, *, workspace_id: str, pocket_id: str) -> int:
+        """Delete EVERY asset under one site's prefix. Returns the number removed.
+
+        The teardown counterpart of :meth:`put`, and the reason it exists separately
+        from :meth:`delete` is that a site's assets outlive the record that lists
+        them: deleting a site removes the Site document, after which nothing can
+        enumerate what it left on a world-readable bucket. Those objects are served
+        with an immutable year-long cache from the bucket origin with no backend hop,
+        so an orphan here is public forever.
+
+        RAISES rather than returning 0 when the adapter cannot list. A silent zero is
+        the specific failure this method must not have — see :meth:`can_list`.
+
+        Deliberately does NOT reuse :meth:`list`. That method skips any item whose
+        ``public_url`` is falsy, which is correct when rendering a panel of openable
+        assets and wrong here: an object we cannot build a URL for is exactly one a
+        purge still has to remove. It also drops the per-key prefix guard, which stays
+        enforced because every key is rebuilt from ``prefix`` rather than taken from
+        the listing.
+
+        Idempotent: a prefix that is already empty returns 0 without erroring, so a
+        resumed teardown can re-run this step safely."""
+        if not self.can_list():
+            raise PublicAssetError(
+                "This deployment's storage adapter cannot list objects, so a site's "
+                "assets cannot be enumerated or removed. Purging would report success "
+                "over a bucket it never touched."
+            )
+        prefix = prefix_for(workspace_id, pocket_id)
+        removed = 0
+        for item in await self._adapter.browse(prefix):
+            if item.is_dir:
+                continue
+            # Rebuilt from the trusted prefix, never taken from the listing, so this
+            # cannot walk outside the site even if the adapter returns odd names.
+            await self._adapter.delete(f"{prefix}{item.name}")
+            removed += 1
+        return removed
 
 
 _MEDIA_EXT: dict[str, str] = {

--- a/tests/ee/sites/test_cloudflare_client.py
+++ b/tests/ee/sites/test_cloudflare_client.py
@@ -696,3 +696,102 @@ async def test_analytics_sql_fails_closed_on_a_2xx_with_no_data_array():
         with pytest.raises(ValidationError) as exc:
             await client.query_analytics_sql("SELECT 1")
         assert exc.value.code == "sites.cloudflare_error", body
+
+
+# ── Teardown primitives (sites lifecycle, wave 1 chunk 1) ────────────────
+#
+# These assert the two things a teardown call can get wrong in a way nothing else
+# notices: the PATH (a delete aimed at the wrong surface silently removes nothing and
+# reports success) and the 404 CONTRACT (a resumed cascade re-runs completed steps, so
+# "already gone" must not raise). The house rule for every delete here is that 404 is
+# success — a teardown that cannot finish leaves exactly the orphan it was called to
+# remove.
+
+
+@pytest.mark.asyncio
+async def test_delete_worker_targets_the_dispatch_namespace_script():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={"success": True, "result": {}})
+
+    await _client(handler).delete_worker("site_abc")
+    assert seen["method"] == "DELETE"
+    assert seen["path"] == (
+        "/client/v4/accounts/acct_1/workers/dispatch/namespaces/paw-sites/scripts/site_abc"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_account_script_targets_the_account_level_path():
+    """The ``workers`` deploy mode's script does NOT live in the dispatch namespace.
+
+    Sending this delete to the namespace path would 404 — and because 404 is success,
+    the cascade would record a completed teardown over a Worker still serving.
+    """
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={"success": True, "result": {}})
+
+    await _client(handler).delete_account_script("site_abc")
+    assert seen["path"] == "/client/v4/accounts/acct_1/workers/scripts/site_abc"
+
+
+@pytest.mark.asyncio
+async def test_delete_database_targets_the_d1_uuid():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={"success": True, "result": {}})
+
+    await _client(handler).delete_database("db-uuid-1")
+    assert seen["method"] == "DELETE"
+    assert seen["path"] == "/client/v4/accounts/acct_1/d1/database/db-uuid-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda c: c.delete_worker("gone"),
+        lambda c: c.delete_account_script("gone"),
+        lambda c: c.delete_database("gone"),
+    ],
+)
+async def test_a_404_is_success_for_every_teardown_delete(call):
+    """A resumed cascade re-runs steps it already finished. If "already gone" raised,
+    a partial teardown could never be completed — the exact orphan these exist to stop.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"success": False, "errors": [{"message": "nope"}]})
+
+    await call(_client(handler))  # must not raise
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda c: c.delete_worker("x"),
+        lambda c: c.delete_account_script("x"),
+        lambda c: c.delete_database("x"),
+    ],
+)
+async def test_a_real_failure_still_raises(call):
+    """404 is the ONLY forgiven status. A 500 means the resource may still exist, and
+    swallowing it would mark the step done while the orphan survives."""
+
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"success": False, "errors": [{"message": "boom"}]})
+
+    with pytest.raises(ValidationError):
+        await call(_client(handler))

--- a/tests/ee/sites/test_public_assets.py
+++ b/tests/ee/sites/test_public_assets.py
@@ -454,3 +454,93 @@ def test_the_video_cap_stays_under_the_adapters_in_memory_ceiling() -> None:
     from pocketpaw.uploads.s3 import _MEM_BUFFER_WARN_BYTES
 
     assert MAX_VIDEO_BYTES < _MEM_BUFFER_WARN_BYTES
+
+
+# ── purge: the teardown sweep (sites lifecycle, wave 1 chunk 1) ──────────
+
+
+async def _store_one(store, *, ws: str, pocket: str, name: str) -> str:
+    asset = await store.put(PNG, filename=name, workspace_id=ws, pocket_id=pocket)
+    return asset.key
+
+
+@pytest.mark.asyncio
+async def test_purge_removes_every_asset_for_the_site_and_counts_them(store) -> None:
+    st, adapter = store
+    await _store_one(st, ws="w1", pocket="p1", name="a.png")
+    await _store_one(st, ws="w1", pocket="p1", name="b.png")
+
+    assert await st.purge(workspace_id="w1", pocket_id="p1") == 2
+    assert adapter.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_purge_leaves_another_sites_assets_untouched(store) -> None:
+    st, adapter = store
+    await _store_one(st, ws="w1", pocket="p1", name="mine.png")
+    survivor = await _store_one(st, ws="w1", pocket="p2", name="theirs.png")
+
+    assert await st.purge(workspace_id="w1", pocket_id="p1") == 1
+    assert list(adapter.objects) == [survivor]
+
+
+@pytest.mark.asyncio
+async def test_purge_of_an_empty_prefix_is_a_no_op(store) -> None:
+    """A resumed teardown re-runs this step. Zero here means "already clean", and it
+    must not raise."""
+    st, _ = store
+    assert await st.purge(workspace_id="w1", pocket_id="never-published") == 0
+
+
+@pytest.mark.asyncio
+async def test_purge_removes_an_asset_even_when_it_has_no_public_url() -> None:
+    """``list`` skips items it cannot build a URL for. ``purge`` must not.
+
+    This is the whole reason purge does not reuse list: an object we cannot address
+    is exactly one that must still be removed, and skipping it would leave bytes on a
+    world-readable bucket that nothing can ever enumerate again.
+    """
+    adapter = FakePublicAdapter(base=None)
+    st = PublicAssetStore(adapter)
+    # Seeded past put(), which refuses an adapter with no public_url by design.
+    adapter.objects[f"{prefix_for('w1', 'p1')}deadbeef-orphan.png"] = (PNG, "image/png")
+
+    assert await st.purge(workspace_id="w1", pocket_id="p1") == 1
+    assert adapter.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_purge_refuses_an_adapter_that_cannot_list_instead_of_reporting_zero() -> None:
+    """THE SILENT ZERO THIS METHOD EXISTS TO AVOID.
+
+    ``StorageAdapter.browse`` is a base-class no-op returning ``[]``, not an abstract
+    method. An adapter that never overrides it therefore looks exactly like a site
+    with no assets — so a purge built on the listing alone would delete nothing,
+    return 0, and let the delete cascade record a completed teardown over a bucket
+    still holding every asset, permanently public and no longer enumerable.
+    """
+    from pocketpaw.uploads.adapter import StorageAdapter
+
+    class Unlistable(StorageAdapter):
+        async def delete(self, key: str) -> None:  # pragma: no cover - never reached
+            raise AssertionError("purge must refuse before deleting anything")
+
+        def public_url(self, key: str) -> str | None:
+            return f"{BASE}/{key}"
+
+    st = PublicAssetStore(Unlistable())
+    assert st.can_list() is False
+    with pytest.raises(PublicAssetError):
+        await st.purge(workspace_id="w1", pocket_id="p1")
+
+
+@pytest.mark.asyncio
+async def test_an_adapter_with_no_browse_attribute_also_cannot_list() -> None:
+    """A duck-typed adapter (not a StorageAdapter subclass) with no ``browse`` at all
+    must read as "cannot list" rather than crashing the capability check."""
+
+    class NoBrowse:
+        def public_url(self, key: str) -> str | None:
+            return None
+
+    assert PublicAssetStore(NoBrowse()).can_list() is False


### PR DESCRIPTION
Deleting a Paw Site has no way to remove the two most expensive things publishing it creates. Only the custom hostname and its Worker route could be torn down, so the Worker that serves the page and the D1 that holds its data were orphans by construction. This is the primitives layer for that, ahead of the cascade that will call it.

## What's here

**`delete_worker`** removes the dispatch-namespace script. **`delete_account_script`** removes the account-level one.

Two deletes because there are two creates. `wfp` mode uploads through `put_worker` in this client; `workers` mode deploys through a `wrangler` subprocess in `workers_deploy.py`. They sit at different API paths, so one delete can't serve both, and `Site.deploy_target` picks between them — it records what the last deploy actually did rather than what the env is configured for, which its own field comment explains is a distinction those two disagree on constantly.

Both go over the HTTP API rather than `wrangler delete`. Teardown has no project directory to run a subprocess in once the artifact is purged, and an API call can be proven against the real resource where a subprocess can only be proven against the real binary.

**`delete_database`** destroys a per-tenant D1. It's the one step that destroys customer data rather than infrastructure, with no Cloudflare-side undelete, so its docstring says plainly that it must not be reordered ahead of the export the cascade takes first.

**`PublicAssetStore.purge`** clears a site's R2 prefix, and **`can_list`** sits underneath it.

`404` is success on all three deletes, matching the two already here. A resumed cascade re-runs steps it finished, and raising on "already gone" would turn a recoverable partial teardown into the permanent orphan these exist to prevent.

## The one that isn't obvious

`StorageAdapter.browse` defaults to returning an empty list rather than raising. So an adapter that can't list is indistinguishable from a site with no assets — harmless when rendering a panel, and in a purge it's the difference between a completed teardown and a merely reported one. Without `can_list`, purge would delete nothing, return zero, and let the caller record success over a bucket still holding every asset — served immutably from bucket origin, and no longer enumerable at all once the Site document is gone.

`purge` also deliberately doesn't reuse `list()`, which skips items it can't build a URL for. Those are exactly the objects a purge still has to remove.

## Verification

1716 pass in `tests/ee/sites`. Three reds in `test_concierge_autoembed` and `test_domain_routing` fail identically on `origin/dev` with these sources reverted — pre-existing, not from this change.

Mutating `can_list` to return `True` kills both guard tests, so they hold the behaviour rather than passing incidentally. `scripts/mutate.py --validate` still resolves 1330 anchors across 104 plans.

Additive only — no existing call sites change, and nothing calls the new methods yet.

Design: `docs/design/drafts/2026-09-08-sites-lifecycle.md` and its PRD in paw-workspace.