### PR TITLE
fix(chat): reactions now land live instead of after a refresh

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/message_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/message_service.py
@@ -14,6 +14,14 @@ transcripts derive from ``ChatRunDoc`` instead, so
 the caller keeps the id and timestamp it needs. Consequence for anything built
 later: a message-id-addressable feature (reactions, thumbs writeback) must key
 off the RUN doc for concierge, because that id has no row behind it.
+
+Updated 2026-09-09: ``MessageReaction`` now carries the post-toggle
+``reactions`` array. The event used to ship only the delta (emoji + user_id),
+which is enough to know something changed but not enough to draw the chips —
+so peers in the room got the event and rendered nothing until they reloaded
+the page. The array is serialized in the same shape as
+``dto.message_to_wire_dict`` so the realtime path and the REST response patch
+a client's message row identically.
 """
 
 from __future__ import annotations
@@ -642,6 +650,9 @@ async def toggle_reaction(message_id: str, user_id: str, emoji: str) -> dict:
                 "group_id": cast(str, domain_msg.group),
                 "emoji": emoji,
                 "user_id": user_id,
+                "reactions": [
+                    {"emoji": r.emoji, "users": list(r.users)} for r in domain_msg.reactions
+                ],
             }
         )
     )

--- a/tests/cloud/chat/test_message_emits.py
+++ b/tests/cloud/chat/test_message_emits.py
@@ -133,6 +133,36 @@ async def test_toggle_reaction_emits_message_reaction(mongo_db, recording_bus):
     assert reacts[0].data["user_id"] == "u1"
 
 
+@pytest.mark.asyncio
+async def test_reaction_event_carries_full_reactions_array(mongo_db, recording_bus):
+    """The event must carry the post-toggle reactions, not just the delta.
+
+    Peers render reaction chips straight off this payload — a delta-only
+    event leaves them with nothing to paint, so the chip only appeared
+    after a manual reload. Shape matches the REST wire dict
+    (``dto.message_to_wire_dict``) so both paths patch identically.
+    """
+    group = await _make_group(owner="u1", members=["u1", "u2"])
+    msg = await _make_message(group_id=str(group.id), sender="u1")
+
+    await message_service.toggle_reaction(str(msg.id), "u2", "\U0001f44d")
+
+    reacts = [e for e in recording_bus.events if isinstance(e, MessageReaction)]
+    assert reacts[-1].data["reactions"] == [{"emoji": "\U0001f44d", "users": ["u2"]}]
+
+    # A second reactor is additive on the same emoji.
+    await message_service.toggle_reaction(str(msg.id), "u1", "\U0001f44d")
+    reacts = [e for e in recording_bus.events if isinstance(e, MessageReaction)]
+    assert reacts[-1].data["reactions"] == [{"emoji": "\U0001f44d", "users": ["u2", "u1"]}]
+
+    # Un-reacting empties the array rather than omitting the key — peers
+    # need the empty list to clear the chip.
+    await message_service.toggle_reaction(str(msg.id), "u2", "\U0001f44d")
+    await message_service.toggle_reaction(str(msg.id), "u1", "\U0001f44d")
+    reacts = [e for e in recording_bus.events if isinstance(e, MessageReaction)]
+    assert reacts[-1].data["reactions"] == []
+
+
 def test_router_no_longer_broadcasts_message_events():
     """Regression guard: the four _ws_message_* handlers must not call manager.broadcast/send."""
     from pathlib import Path


### PR DESCRIPTION
## The bug

React to a message in `/chat` and the other person doesn't see it. Their timeline only picks it up when they reload the page.

## Why

`toggle_reaction` emits `message.reaction` with just the delta:

```python
{"message_id": ..., "group_id": ..., "emoji": "👍", "user_id": "u2"}
```

That's enough to know something changed, but not enough to draw the chips. The client needs the whole reactions array — which it otherwise only gets from the REST response, and the reactor is the only person who makes that call. Everyone else in the room received an event they couldn't render anything from.

## The fix

Put the post-toggle array on the event, serialized the same way `dto.message_to_wire_dict` does it, so a peer patching from the socket and the reactor patching from the REST reply end up with the same row.

An empty list is sent as an empty list, not omitted — that's the state after the last reactor undoes theirs, and the receiver needs it to clear the chip.

## Tests

`test_reaction_event_carries_full_reactions_array` walks the sequence a room actually produces: first reactor, second reactor stacking on the same emoji, then both undoing. Written before the fix and confirmed failing on `KeyError: 'reactions'`.

`tests/cloud/chat/` — 153 passed.

## Paired change

The client half is qbtrix/paw-enterprise `fix/reaction-realtime-payload`. Independent of this one — it stops the old delta-only payload from *clearing* reactions, which is what a client on an older server would do. Either can merge first.