### PR TITLE
A BYOK key can belong to any OpenAI-compatible gateway

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2987,7 +2987,10 @@ threads them into the agent pool's isolated backend. The turn's model must
 belong to the key's provider (402-style `byok.model_provider_mismatch` error
 frame on a mismatch, never a silent upstream 401). A gateway key
 (`openai_compatible`, 2026-09-09) is exempt from that check: a gateway's model
-ids are its own namespace, and the turn is pinned to the stored model anyway.
+ids are its own namespace, so there is no name shape the server could check
+against, and the model that actually runs is the `pydantic_ai_model` the
+credential resolver pins — the pydantic_ai backend, which is the one a gateway
+turn runs on, accepts a per-send `model_override` only to ignore it.
 
 **The gateway address is re-checked on every turn** (2026-09-11). A stored
 `base_url` is resolved again before the turn runs, and every address it

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2971,7 +2971,7 @@ here is local verification, not a production hole.
 
 | Endpoint | Notes |
 |---|---|
-| `POST /auth/guest` | `{api_key, provider?="anthropic"}`. Rate-limited per IP (429). Validates the key against the provider FIRST (422 `byok.key_rejected` / `byok.provider_unavailable` / `byok.provider_unsupported` — Anthropic only in v1); a dead key mints **nothing**. On success mints an anonymous user (`is_guest`) + workspace + default agent, stores the key encrypted (the same per-workspace Fernet store the `/byok` routes use), and answers exactly like `POST /auth/login` (204 + cookies). Public by necessity — a guest has no account yet; on the route-auth-audit allowlist with that reason. |
+| `POST /auth/guest` | `{api_key, provider?="anthropic", base_url?, model?}`. Rate-limited per IP (429). Validates the key against the provider FIRST (422 `byok.key_rejected` / `byok.key_rate_limited` / `byok.provider_unavailable` / `byok.provider_unsupported`); a dead key mints **nothing**. `provider` is `anthropic` or `openai_compatible`; the latter REQUIRES `base_url` and `model` (422 `byok.base_url_required` / `byok.model_required`) and the URL must be https on a non-internal host (422 `byok.base_url_rejected`). On success mints an anonymous user (`is_guest`) + workspace + default agent, stores the key encrypted (the same per-workspace Fernet store the `/byok` routes use), and answers exactly like `POST /auth/login` (204 + cookies). Public by necessity — a guest has no account yet; on the route-auth-audit allowlist with that reason. |
 | `POST /auth/guest/upgrade` | Authenticated guest only. `{email, password}` attaches real credentials to the **same user id** (workspace, sessions, key all stay) and flips `is_guest` off. 409 `auth.email_taken` / `auth.not_a_guest`. The stock `/auth/register` always creates a NEW user, hence the dedicated route. |
 
 Guest limits are server-side and fail-CLOSED: 2 sessions and 40 turns/day by
@@ -2985,7 +2985,25 @@ Turn billing: every workspace with a stored BYOK key (guest or not) now runs
 its chat turns on that key — the executor resolves credentials per turn and
 threads them into the agent pool's isolated backend. The turn's model must
 belong to the key's provider (402-style `byok.model_provider_mismatch` error
-frame on a mismatch, never a silent upstream 401).
+frame on a mismatch, never a silent upstream 401). A gateway key
+(`openai_compatible`, 2026-09-09) is exempt from that check: a gateway's model
+ids are its own namespace, and the turn is pinned to the stored model anyway.
+
+**A gateway turn does not go through the LiteLLM proxy.** An Anthropic key
+rides as a forwarded `x-api-key`, which works because the proxy knows where
+Anthropic is; there is no model group pointing at a URL a user typed, so a
+gateway turn is sent straight to `base_url` through the runtime's own
+`openai_compatible` provider. Those turns therefore produce no spend-log row
+and skip the proxy's guardrails. Weigh that before a paid tier rides the same
+seam.
+
+### BYOK key management
+
+| Endpoint | Notes |
+|---|---|
+| `GET /byok/key` | `ByokStatus` — `configured`, `provider`, `base_url`, `model`, `last4`, `key_hint`, `last_verified_at`, `last_error`. Built from display-only columns; answering never decrypts, and no route ever returns the key. |
+| `PUT /byok/key` | `{provider?="anthropic", api_key, base_url?, model?}`. Validates against the provider (or the gateway's own `/chat/completions`), then encrypts and upserts. Same shape rules and error codes as `POST /auth/guest`. An `anthropic` body carrying `base_url` or `model` is refused rather than silently ignored. |
+| `DELETE /byok/key` | Idempotent. Removing an absent key succeeds. |
 
 ### BYOK key management
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2971,7 +2971,7 @@ here is local verification, not a production hole.
 
 | Endpoint | Notes |
 |---|---|
-| `POST /auth/guest` | `{api_key, provider?="anthropic", base_url?, model?}`. Rate-limited per IP (429). Validates the key against the provider FIRST (422 `byok.key_rejected` / `byok.key_rate_limited` / `byok.provider_unavailable` / `byok.provider_unsupported`); a dead key mints **nothing**. `provider` is `anthropic` or `openai_compatible`; the latter REQUIRES `base_url` and `model` (422 `byok.base_url_required` / `byok.model_required`) and the URL must be https on a non-internal host (422 `byok.base_url_rejected`). On success mints an anonymous user (`is_guest`) + workspace + default agent, stores the key encrypted (the same per-workspace Fernet store the `/byok` routes use), and answers exactly like `POST /auth/login` (204 + cookies). Public by necessity — a guest has no account yet; on the route-auth-audit allowlist with that reason. |
+| `POST /auth/guest` | `{api_key, provider?="anthropic", base_url?, model?}`. Rate-limited per IP (429). Validates the key against the provider FIRST (422 `byok.key_rejected` / `byok.key_rate_limited` / `byok.provider_unavailable` / `byok.provider_unsupported`); a dead key mints **nothing**. `provider` is `anthropic` or `openai_compatible`; the latter REQUIRES `base_url` and `model` (422 `byok.base_url_required` / `byok.model_required`) and the URL must be https on a host that is external **after DNS resolution** — the name is resolved and every address it answers with is checked, so a public hostname pointing at a private range is refused like the private address itself (422 `byok.base_url_rejected`). The request that verifies the key is then sent to that exact resolved address, with redirects off. On success mints an anonymous user (`is_guest`) + workspace + default agent, stores the key encrypted (the same per-workspace Fernet store the `/byok` routes use), and answers exactly like `POST /auth/login` (204 + cookies). Public by necessity — a guest has no account yet; on the route-auth-audit allowlist with that reason. |
 | `POST /auth/guest/upgrade` | Authenticated guest only. `{email, password}` attaches real credentials to the **same user id** (workspace, sessions, key all stay) and flips `is_guest` off. 409 `auth.email_taken` / `auth.not_a_guest`. The stock `/auth/register` always creates a NEW user, hence the dedicated route. |
 
 Guest limits are server-side and fail-CLOSED: 2 sessions and 40 turns/day by
@@ -2988,6 +2988,14 @@ belong to the key's provider (402-style `byok.model_provider_mismatch` error
 frame on a mismatch, never a silent upstream 401). A gateway key
 (`openai_compatible`, 2026-09-09) is exempt from that check: a gateway's model
 ids are its own namespace, and the turn is pinned to the stored model anyway.
+
+**The gateway address is re-checked on every turn** (2026-09-11). A stored
+`base_url` is resolved again before the turn runs, and every address it
+resolves to must be external. A row written before this check existed, or a
+host whose DNS later points inside, gets a terminal
+`byok.base_url_rejected` error frame. The turn is refused, not quietly moved
+onto platform credentials — a tenant's bad address must not spend the
+platform's money.
 
 **A gateway turn does not go through the LiteLLM proxy.** An Anthropic key
 rides as a forwarded `x-api-key`, which works because the proxy knows where

--- a/ee/pocketpaw_ee/cloud/auth/guest.py
+++ b/ee/pocketpaw_ee/cloud/auth/guest.py
@@ -3,6 +3,12 @@
 #
 # Created 2026-09-01 (feat/byok-guest-backend).
 #
+# Updated 2026-09-09 (feat/byok-custom-gateway): a guest may also arrive with a
+# key for an OpenAI-compatible gateway, which brings its own ``base_url`` and
+# ``model``. Both ride through to validation and storage unchanged; the
+# provider gate below is now the only thing deciding what is accepted, and it
+# reads ``byok_service.SUPPORTED_PROVIDERS`` rather than naming a provider.
+#
 # Flow (the order is the security property):
 #   rate-limit -> validate the key against the provider -> mint user ->
 #   provision workspace (default agent + LiteLLM tenant key ride along) ->
@@ -48,7 +54,13 @@ def is_provider_supported(provider: str) -> bool:
     return provider in byok_service.SUPPORTED_PROVIDERS
 
 
-async def mint_guest(api_key: str, *, provider: str = "anthropic") -> User:
+async def mint_guest(
+    api_key: str,
+    *,
+    provider: str = "anthropic",
+    base_url: str | None = None,
+    model: str | None = None,
+) -> User:
     """Validate the key, then mint user + workspace + encrypted key row.
 
     Raises ``ValidationError`` (422) for an unsupported provider and lets
@@ -59,15 +71,26 @@ async def mint_guest(api_key: str, *, provider: str = "anthropic") -> User:
     if not is_provider_supported(provider):
         raise ValidationError(
             "byok.provider_unsupported",
-            "Only Anthropic keys are supported right now — OpenAI and "
-            "OpenRouter are coming. Paste a key from console.anthropic.com.",
+            "That key's provider is not supported yet. Paste an Anthropic key, "
+            "or pick the custom gateway option and give its address.",
         )
+    if provider == "openai_compatible":
+        if not (base_url or "").strip():
+            raise ValidationError(
+                "byok.base_url_required",
+                "A custom gateway needs its address, e.g. https://host/v1.",
+            )
+        if not (model or "").strip():
+            raise ValidationError(
+                "byok.model_required",
+                "A custom gateway needs the model id it serves.",
+            )
     if not api_key or not api_key.strip():
         raise ValidationError("byok.key_missing", "Enter an API key to try Otherhand.")
     api_key = api_key.strip()
 
     # 1. Prove the key works BEFORE anything is created.
-    await byok_service.validate_key(api_key)
+    await byok_service.validate_key(api_key, provider=provider, base_url=base_url, model=model)
 
     # 2. Mint the anonymous user. Synthetic unique email (fastapi-users
     #    requires one), random password nobody knows — the account is only
@@ -105,6 +128,8 @@ async def mint_guest(api_key: str, *, provider: str = "anthropic") -> User:
             ws.id,
             api_key,
             provider=provider,
+            base_url=base_url,
+            model=model,
             user_id=str(user.id),
             validate=False,
         )

--- a/ee/pocketpaw_ee/cloud/auth/guest.py
+++ b/ee/pocketpaw_ee/cloud/auth/guest.py
@@ -9,6 +9,13 @@
 # provider gate below is now the only thing deciding what is accepted, and it
 # reads ``byok_service.SUPPORTED_PROVIDERS`` rather than naming a provider.
 #
+# Updated 2026-09-11 (review S6): ``mint_guest`` now stores the base URL
+# ``validate_key`` hands back rather than the raw body string. The validator
+# normalizes (``strip().rstrip("/")``) before it guards, and writing the
+# un-normalized copy meant the value in the database was not the value that
+# passed the check. This route also does not go through ``ByokSetRequest``, so
+# ``validate_key`` is the whole guard here, not a second opinion on one.
+#
 # Flow (the order is the security property):
 #   rate-limit -> validate the key against the provider -> mint user ->
 #   provision workspace (default agent + LiteLLM tenant key ride along) ->
@@ -89,8 +96,18 @@ async def mint_guest(
         raise ValidationError("byok.key_missing", "Enter an API key to try Otherhand.")
     api_key = api_key.strip()
 
-    # 1. Prove the key works BEFORE anything is created.
-    await byok_service.validate_key(api_key, provider=provider, base_url=base_url, model=model)
+    # 1. Prove the key works BEFORE anything is created. For a gateway this is
+    #    also the ONLY SSRF guard on this path — ``_GuestMintRequest`` carries
+    #    plain ``str`` fields and never touches ``ByokSetRequest`` — and the
+    #    route is unauthenticated, so a stranger picks the address.
+    #    Keep the URL it hands back: it normalized before guarding, and the
+    #    value that reaches the database must be the value that passed
+    #    (review S6). Previously the raw body string was stored instead.
+    canonical_base_url = await byok_service.validate_key(
+        api_key, provider=provider, base_url=base_url, model=model
+    )
+    if canonical_base_url:
+        base_url = canonical_base_url
 
     # 2. Mint the anonymous user. Synthetic unique email (fastapi-users
     #    requires one), random password nobody knows — the account is only

--- a/ee/pocketpaw_ee/cloud/auth/router.py
+++ b/ee/pocketpaw_ee/cloud/auth/router.py
@@ -314,6 +314,11 @@ async def revoke_other_sessions(
 class _GuestMintRequest(BaseModel):
     api_key: str
     provider: str = "anthropic"
+    # Only meaningful for provider "openai_compatible". The URL is checked
+    # against the strict SSRF guard inside ``mint_guest``'s validation call,
+    # not here, so that one guard covers both the guest route and /byok/key.
+    base_url: str | None = None
+    model: str | None = None
 
 
 class _GuestUpgradeRequest(BaseModel):
@@ -334,7 +339,12 @@ async def guest_mint(
     """
     if not guest_mint_limiter.allow(_client_ip(request)):
         raise HTTPException(status_code=429, detail="guest_mint_rate_limited")
-    user = await guest_service.mint_guest(body.api_key, provider=body.provider)
+    user = await guest_service.mint_guest(
+        body.api_key,
+        provider=body.provider,
+        base_url=body.base_url,
+        model=body.model,
+    )
     response = await _mint_and_record(cookie_backend, user, request)
     return response
 

--- a/ee/pocketpaw_ee/cloud/byok/dto.py
+++ b/ee/pocketpaw_ee/cloud/byok/dto.py
@@ -15,6 +15,14 @@
 # shape of an SSRF, so the permissive ``validate_external_url`` is the wrong
 # one here even though it is what the Settings fields use.
 #
+# Updated 2026-09-11 (review B1): that validator is a SHAPE check, not the
+# whole guard — it does not resolve a hostname, so a public name pointing at a
+# private address passes it. It stays here because it is free and it fails a
+# bad paste early; the resolving egress guard lives in ``byok.service``
+# (``assert_gateway_egress``), which every write and every turn goes through.
+# The guest-mint route bypasses this DTO entirely, so a guard that only ran
+# here would not be a guard at all.
+#
 # There is deliberately NO response model carrying the key. ``ByokStatus`` is
 # the ONLY thing this domain returns, and it is built from display-only columns
 # (``last4`` / ``key_hint``) so answering a status call never decrypts anything.
@@ -83,11 +91,15 @@ class ByokSetRequest(BaseModel):
         v = v.strip().rstrip("/")
         if not v:
             return None
-        # ponytail: validated here and resolved again when the request is made,
-        # so a DNS rebind between the two is not closed. The egress guard
-        # (``assert_egress_allowed`` + ``PinnedTransport``) closes it and is the
-        # upgrade path if a gateway URL ever becomes long-lived infrastructure
-        # rather than a thing one guest typed.
+        # The CHEAP half of the guard, on purpose: https, non-empty, and
+        # internal hosts written as IP literals — all decided without touching
+        # DNS, so a junk paste is refused before anything resolves it. It is
+        # NOT sufficient on its own and must never be the only check: a bare
+        # hostname is not resolved here, so a public name with an A record
+        # inside RFC1918 passes this line. ``byok.service`` runs the resolving
+        # egress guard (``assert_gateway_egress``) on every path that stores or
+        # spends the URL, including the guest route, which does not come
+        # through this DTO at all.
         return validate_external_url_strict(v)
 
     @model_validator(mode="after")

--- a/ee/pocketpaw_ee/cloud/byok/dto.py
+++ b/ee/pocketpaw_ee/cloud/byok/dto.py
@@ -2,6 +2,19 @@
 #
 # Created 2026-08-28 (feat/other-hand-byok).
 #
+# Updated 2026-09-09 (feat/byok-custom-gateway): a second provider,
+# ``openai_compatible``, for any gateway that speaks the OpenAI wire
+# (Experiential Labs, OpenRouter, LiteLLM, a local vLLM). It brings its own
+# ``base_url`` and ``model``, and its key has no fixed prefix, so the
+# ``sk-ant-`` check now applies to the anthropic provider only.
+#
+# ``base_url`` goes through ``validate_external_url_strict``, the same guard
+# pocket backend URLs use: https only, and loopback / RFC1918 / link-local /
+# CGNAT hosts blocked with no operator escape hatch. This field is a
+# stranger's input that our server then sends requests to, which is the exact
+# shape of an SSRF, so the permissive ``validate_external_url`` is the wrong
+# one here even though it is what the Settings fields use.
+#
 # There is deliberately NO response model carrying the key. ``ByokStatus`` is
 # the ONLY thing this domain returns, and it is built from display-only columns
 # (``last4`` / ``key_hint``) so answering a status call never decrypts anything.
@@ -12,7 +25,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from pocketpaw.security.url_validators import validate_external_url_strict
 
 # Anthropic keys start with this. Checked at the edge so an obviously-wrong
 # paste (an OpenAI key, a session token, a whole curl command) fails before it
@@ -25,31 +40,78 @@ _MIN_KEY_LEN = 20
 # later inside a generation they paid for.
 _MIN_IMAGE_KEY_LEN = 16
 
+#: Providers a key row may name. Kept in step with
+#: ``byok.service.SUPPORTED_PROVIDERS`` — this is the edge check, that is the
+#: pipeline check, and they must not drift.
+_PROVIDERS = frozenset({"anthropic", "openai_compatible"})
+
 
 class ByokSetRequest(BaseModel):
     """Set or replace this workspace's provider key."""
 
     provider: str = Field(default="anthropic")
     api_key: str = Field(min_length=_MIN_KEY_LEN, max_length=512)
+    #: Required for ``openai_compatible``, rejected for anthropic. Must carry
+    #: the version path the gateway serves (``/v1``): the OpenAI client appends
+    #: only ``/chat/completions``, so a bare host 404s every request.
+    base_url: str | None = Field(default=None, max_length=512)
+    #: Required for ``openai_compatible``, rejected for anthropic.
+    model: str | None = Field(default=None, max_length=200)
 
     @field_validator("provider")
     @classmethod
     def _known_provider(cls, v: str) -> str:
-        if v != "anthropic":
-            raise ValueError("only the 'anthropic' provider is supported today")
+        if v not in _PROVIDERS:
+            raise ValueError(f"provider must be one of {sorted(_PROVIDERS)}")
         return v
 
     @field_validator("api_key")
     @classmethod
-    def _looks_like_a_key(cls, v: str) -> str:
+    def _no_whitespace(cls, v: str) -> str:
         # Whitespace is the single most common paste artefact, and a stray
         # newline inside a header value is worth rejecting on its own merits.
         v = v.strip()
         if any(c.isspace() for c in v):
             raise ValueError("the key contains whitespace — paste the key alone")
-        if not v.startswith(_ANTHROPIC_PREFIX):
-            raise ValueError(f"an Anthropic API key starts with {_ANTHROPIC_PREFIX!r}")
         return v
+
+    @field_validator("base_url")
+    @classmethod
+    def _safe_base_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip().rstrip("/")
+        if not v:
+            return None
+        # ponytail: validated here and resolved again when the request is made,
+        # so a DNS rebind between the two is not closed. The egress guard
+        # (``assert_egress_allowed`` + ``PinnedTransport``) closes it and is the
+        # upgrade path if a gateway URL ever becomes long-lived infrastructure
+        # rather than a thing one guest typed.
+        return validate_external_url_strict(v)
+
+    @model_validator(mode="after")
+    def _provider_shape(self) -> ByokSetRequest:
+        """Each provider carries exactly the fields it can use.
+
+        An anthropic key with a base URL would silently ignore the URL; a
+        gateway key without one has nowhere to spend. Both are the kind of
+        half-configured state that only shows up as a dead first turn.
+        """
+        if self.provider == "anthropic":
+            if not self.api_key.startswith(_ANTHROPIC_PREFIX):
+                raise ValueError(f"an Anthropic API key starts with {_ANTHROPIC_PREFIX!r}")
+            if self.base_url or self.model:
+                raise ValueError(
+                    "base_url and model belong to the 'openai_compatible' provider, "
+                    "not to 'anthropic'"
+                )
+        else:
+            if not self.base_url:
+                raise ValueError("a gateway key needs a base_url, e.g. https://host/v1")
+            if not (self.model or "").strip():
+                raise ValueError("a gateway key needs the model id the gateway serves")
+        return self
 
 
 class ByokImageKeyRequest(BaseModel):
@@ -83,6 +145,11 @@ class ByokStatus(BaseModel):
 
     configured: bool
     provider: str | None = None
+    # Non-secret by construction: a gateway's address and model id are public.
+    # Neither needs a decrypt to read, so the "no field that needs plaintext"
+    # rule above still holds.
+    base_url: str | None = None
+    model: str | None = None
     last4: str | None = None
     key_hint: str | None = None
     last_verified_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/byok/router.py
+++ b/ee/pocketpaw_ee/cloud/byok/router.py
@@ -47,6 +47,8 @@ async def set_byok_key(
         workspace_id,
         body.api_key,
         provider=body.provider,
+        base_url=body.base_url,
+        model=body.model,
         user_id=user_id,
     )
 

--- a/ee/pocketpaw_ee/cloud/byok/service.py
+++ b/ee/pocketpaw_ee/cloud/byok/service.py
@@ -31,6 +31,23 @@
 # talks to the user's base URL directly. That is the price of accepting any
 # base URL, and it costs the proxy's spend log and guardrails for those turns.
 #
+# Updated 2026-09-11 (review B1/B2/S6/S7): the gateway base URL is an SSRF
+# boundary and was only shape-checked. ``validate_external_url_strict`` blocks
+# internal hosts written as IP LITERALS and says in its own helper's docstring
+# that resolving a name is the caller's job — and no caller resolved. So
+# ``https://10-0-0-5.nip.io/v1`` passed both write paths, and ``POST
+# /auth/guest`` puts that behind no authentication at all. Now:
+#
+#   * ``assert_gateway_egress`` runs the real egress guard (DNS + every
+#     resolved address checked, internal rejected unconditionally) and the
+#     validation request goes out pinned to the vetted IP with redirects off.
+#   * ``resolve_turn_credentials`` re-runs it, because a row stored before this
+#     check, or a host whose DNS moved afterwards, is dialed on every turn.
+#     It REFUSES the turn rather than falling back to platform credentials —
+#     falling back would spend our money on the tenant's broken config.
+#   * ``validate_key`` returns the canonical URL so callers store the string
+#     that passed the guard rather than the one that arrived.
+#
 # Created 2026-08-28 (feat/other-hand-byok).
 #
 # Two audiences, deliberately separated:
@@ -52,11 +69,16 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+from urllib.parse import urlsplit
 
 import httpx
 
 from pocketpaw.security.redact import redact_output
+
+if TYPE_CHECKING:
+    from pocketpaw.security.url_validators import EgressTarget
+
 from pocketpaw_ee.cloud._core import crypto
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.byok.dto import ByokStatus
@@ -77,6 +99,78 @@ _VALIDATE_MODEL = "claude-haiku-4-5-20251001"
 # it, and a ``provider_allows_model`` rule. Adding a name here without those is
 # how you mint accounts whose every turn dead-ends.
 SUPPORTED_PROVIDERS = frozenset({"anthropic", "openai_compatible"})
+
+
+class GatewayEgressRejected(ValidationError):
+    """A gateway base URL does not pass the egress guard.
+
+    A ``ValidationError`` subclass, so the two write paths keep answering 422
+    with ``byok.base_url_rejected`` exactly as before. It is a distinct TYPE
+    because the turn path has to tell this apart from everything else that can
+    go wrong while resolving credentials: a generic failure there degrades to
+    platform billing, and doing that here would spend OUR money running a turn
+    whose stored address points somewhere it must not. The turn is refused
+    instead — see ``resolve_turn_credentials``.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__("byok.base_url_rejected", message)
+
+
+async def assert_gateway_egress(base_url: str) -> EgressTarget:
+    """Normalize a gateway base URL and prove it does not point inside.
+
+    Two layers, and the second one is the point:
+
+    * ``validate_external_url_strict`` — the cheap shape check the DTO edge
+      also runs: https only, non-empty, and internal hosts written as IP
+      LITERALS blocked. No DNS, so it is free.
+    * ``assert_egress_allowed`` — resolves the hostname and rejects EVERY
+      resolved address that is internal, then returns the single IP the
+      request must dial.
+
+    The shape check alone was the B1 hole. ``host_is_internal`` says so in its
+    own docstring — "a bare hostname (not an IP literal) returns False — name
+    resolution is the caller's job" — and no caller resolved, so
+    ``https://10-0-0-5.nip.io/v1`` (or any attacker-owned name with an A record
+    in RFC1918) passed both write paths and the server then POSTed to it. The
+    status codes ``_validate_gateway_key`` maps back are a five-way response
+    oracle, and ``POST /auth/guest`` is unauthenticated, so a stranger picked
+    the target.
+
+    ``allow_internal=False`` is passed explicitly rather than inherited.
+    ``assert_egress_allowed`` otherwise honours ``POCKETPAW_ALLOW_INTERNAL_URLS``,
+    and an operator who set that so localhost connectors keep working would
+    reopen this boundary — which is the one boundary here a signed-out stranger
+    can reach.
+
+    The allow-list is the URL's own hostname. There is no registry of gateways
+    a user may name (that is the whole feature), so what this call wants from
+    the guard is the resolution and the pin, not a membership test.
+
+    Returns the ``EgressTarget``: ``.url`` is the canonical (stripped,
+    slash-trimmed) URL to store and request against, ``.pinned_ip`` the address
+    ``PinnedTransport`` must dial so DNS cannot be re-resolved between the check
+    and the connect.
+    """
+    from pocketpaw.security.url_validators import (
+        EgressError,
+        assert_egress_allowed,
+        validate_external_url_strict,
+    )
+
+    try:
+        base = validate_external_url_strict((base_url or "").strip().rstrip("/"))
+    except ValueError as exc:
+        raise GatewayEgressRejected(str(exc)) from exc
+
+    host = urlsplit(base).hostname or ""
+    try:
+        return await assert_egress_allowed(base, {host}, allow_internal=False)
+    except EgressError as exc:
+        raise GatewayEgressRejected(
+            f"That gateway address is not reachable from here: {exc}"
+        ) from exc
 
 
 @dataclass(frozen=True)
@@ -133,7 +227,7 @@ async def validate_key(
     provider: str = "anthropic",
     base_url: str | None = None,
     model: str | None = None,
-) -> None:
+) -> str | None:
     """Prove the key works, or raise ValidationError naming why.
 
     Network trouble is NOT a bad key: a timeout raises the transport error so
@@ -144,10 +238,17 @@ async def validate_key(
     what a turn will actually use. Checking only the key would let a wrong
     model id through to fail on the first turn, which is the failure mode this
     whole function exists to move earlier.
+
+    RETURNS the canonical base URL for a gateway, ``None`` for anthropic
+    (2026-09-11, review S6). Callers must store the returned value, not the one
+    they passed in: this function normalizes (``strip().rstrip("/")``) before
+    guarding, and the guest-mint path used to throw that away and write the raw
+    body value. Today the delta is only whitespace and a trailing slash, which
+    is exactly the size of gap that a later normalization change turns into a
+    stored value that never passed a guard.
     """
     if provider == "openai_compatible":
-        await _validate_gateway_key(api_key, base_url or "", model or "")
-        return
+        return await _validate_gateway_key(api_key, base_url or "", model or "")
 
     payload = {
         "model": _VALIDATE_MODEL,
@@ -180,22 +281,32 @@ async def validate_key(
         )
     # Anything else (200, or a 400 about the tiny payload) means the credential
     # was accepted and the request was understood. That is what we are testing.
+    return None
 
 
-async def _validate_gateway_key(api_key: str, base_url: str, model: str) -> None:
+async def _validate_gateway_key(api_key: str, base_url: str, model: str) -> str:
     """Same proof, against an OpenAI-compatible gateway the user named.
 
-    The URL has already passed ``validate_external_url_strict`` at the DTO
-    edge (https, no internal hosts). It is re-checked here because this
-    function is also reachable from ``set_key``, and a guard that only runs on
-    one of two paths is not a guard.
-    """
-    from pocketpaw.security.url_validators import validate_external_url_strict
+    The URL passed ``validate_external_url_strict`` at the DTO edge, but that
+    is a shape check only. The full egress guard runs HERE because this is the
+    one point both write paths share: the guest-mint route's
+    ``_GuestMintRequest`` has plain ``str`` fields and never touches the DTO,
+    so on the unauthenticated path this is the only guard there is.
 
-    try:
-        base = validate_external_url_strict(base_url.strip().rstrip("/"))
-    except ValueError as exc:
-        raise ValidationError("byok.base_url_rejected", str(exc)) from exc
+    The request then goes out through ``PinnedTransport``, dialing the exact IP
+    the guard vetted, with redirects off. Without the pin, DNS is resolved a
+    second time when the connection opens and a rebinding host can answer with
+    an internal address in the gap (the TOCTOU the guard exists to close).
+    Redirects are pinned OFF rather than inherited from httpx's default: a
+    cooperating gateway could otherwise bounce the request onto an internal
+    host, and that is a security property, not a default worth inheriting.
+
+    Returns the canonical base URL — the caller stores THIS, not its input.
+    """
+    from pocketpaw.security.url_validators import PinnedTransport
+
+    target = await assert_gateway_egress(base_url)
+    base = target.url
 
     payload = {
         "model": model,
@@ -206,7 +317,11 @@ async def _validate_gateway_key(api_key: str, base_url: str, model: str) -> None
         "authorization": f"Bearer {api_key}",
         "content-type": "application/json",
     }
-    async with httpx.AsyncClient(timeout=_VALIDATE_TIMEOUT_S) as client:
+    async with httpx.AsyncClient(
+        timeout=_VALIDATE_TIMEOUT_S,
+        follow_redirects=False,
+        transport=PinnedTransport(target.pinned_ip),
+    ) as client:
         resp = await client.post(f"{base}/chat/completions", json=payload, headers=headers)
 
     if resp.status_code == 401:
@@ -250,6 +365,7 @@ async def _validate_gateway_key(api_key: str, base_url: str, model: str) -> None
             "byok.provider_unavailable",
             "The gateway did not respond. Your key was not saved — try again shortly.",
         )
+    return base
 
 
 async def set_key(
@@ -279,7 +395,12 @@ async def set_key(
         )
 
     if validate:
-        await validate_key(api_key, provider=provider, base_url=base_url, model=model)
+        # Store what passed the guard, not what arrived (review S6). The
+        # validator normalizes before checking, and writing the un-normalized
+        # copy is the shape a future normalization change turns into a hole.
+        canonical = await validate_key(api_key, provider=provider, base_url=base_url, model=model)
+        if canonical:
+            base_url = canonical
 
     # An anthropic row never carries a gateway address. Writing one through
     # would leave a stale URL behind after a switch back, and the resolver
@@ -393,6 +514,15 @@ async def resolve_turn_credentials(workspace_id: str | None) -> TurnCredentials:
     undecryptable row (the deployment's Fernet key rotated) also degrades to
     platform rather than failing the turn — the user re-enters their key from a
     working product, not from a broken one.
+
+    ONE case raises instead of degrading: a gateway row whose base URL no
+    longer passes the egress guard (review B2). Write-time validation is not a
+    runtime guard — a row stored before this check existed, or a host whose DNS
+    moved inside afterwards, would otherwise be dialed on every turn, with the
+    upstream's answer flowing back to the user. It raises
+    ``GatewayEgressRejected`` rather than returning ``platform`` DELIBERATELY:
+    degrading would run the tenant's turn on our credential, so a tenant's
+    broken (or hostile) configuration would spend our money. Refuse the turn.
     """
     if not workspace_id:
         return TurnCredentials(source="platform")
@@ -413,11 +543,27 @@ async def resolve_turn_credentials(workspace_id: str | None) -> TurnCredentials:
 
     if not plaintext:
         return TurnCredentials(source="platform")
+
+    base_url = doc.base_url
+    if doc.provider == "openai_compatible":
+        # Re-guard at turn time, not just at write time. Raises
+        # ``GatewayEgressRejected``; see this function's docstring for why that
+        # is a raise and not a degrade-to-platform.
+        #
+        # ponytail: this vets the address, it does not pin the connection —
+        # the runtime's own OpenAI client resolves the hostname again when it
+        # dials, so a host that rebinds between here and the connect is still
+        # open. Closing it means plumbing ``target.pinned_ip`` through the
+        # settings override into the backend's transport, which is a change to
+        # the runtime rather than to this seam. The un-resolved-at-all hole
+        # (B1) is what this closes.
+        base_url = (await assert_gateway_egress(base_url or "")).url
+
     return TurnCredentials(
         source="byok",
         api_key=plaintext,
         provider=doc.provider,
-        base_url=doc.base_url,
+        base_url=base_url,
         model=doc.model,
     )
 

--- a/ee/pocketpaw_ee/cloud/byok/service.py
+++ b/ee/pocketpaw_ee/cloud/byok/service.py
@@ -717,9 +717,28 @@ def provider_allows_model(provider: str, model: str | None) -> bool:
 
     ``openai_compatible`` always passes, and deliberately: a gateway's model
     ids are its own namespace, so there is no name shape we could check
-    against. The gateway's own refusal is the only honest judge, and the turn
-    is pinned to the stored model anyway (see ``build_settings_override``), so
-    the model asked for here is not the one that runs.
+    against. The gateway's own refusal is the only honest judge.
+
+    On what the turn actually runs (corrected 2026-09-11, review S7). The old
+    wording here claimed the turn "is pinned to the stored model anyway", as if
+    that were structural. It is not. ``run_core`` asks this function about
+    ``ctx.model_override or agent_model``, and ``AgentPool.run`` forwards a
+    non-None ``model_override`` to WHATEVER backend is running
+    (``agents/pool.py``) — the per-send chip in paw-enterprise #902 and the
+    ``model_override`` field in #2140 both put a client-chosen name on that
+    wire. What makes the stored model win on a gateway turn is narrower: a
+    gateway turn runs on the pydantic_ai backend, and that backend declares
+    ``model_override`` only to ignore it (``agents/pydantic_ai.py``, the
+    ``# noqa: ARG002`` block — "consumed only by the Claude SDK backend"), so
+    the model that runs is the ``pydantic_ai_model`` this service pinned in
+    ``build_settings_override``.
+
+    So the effect holds today, but it rests on one backend's deliberate
+    ignore, not on an invariant anything enforces. If pydantic_ai ever honours
+    ``model_override``, a client could name a model this function never
+    checked. No allowlist is added here on purpose — #2140 owns the per-send
+    model surface and is where a real check belongs; the consequence meanwhile
+    is confined to the tenant's own key against the tenant's own gateway.
 
     Any other provider returns False for every real model name — the pipeline
     cannot serve it end to end (see ``SUPPORTED_PROVIDERS``), and a loud

--- a/ee/pocketpaw_ee/cloud/byok/service.py
+++ b/ee/pocketpaw_ee/cloud/byok/service.py
@@ -19,6 +19,18 @@
 # x-api-key forward, claude model set) is Anthropic-only today, and accepting
 # another provider's key would mint accounts whose every turn dead-ends.
 #
+# Updated 2026-09-09 (feat/byok-custom-gateway): ``openai_compatible`` joins
+# ``anthropic`` in ``SUPPORTED_PROVIDERS``. All three things the old comment
+# said had to widen together did widen: ``validate_key`` now calls the
+# gateway's own ``/chat/completions`` instead of Anthropic, the override
+# builder points the runtime's ``openai_compatible`` provider at the gateway
+# instead of forwarding an ``x-api-key`` through LiteLLM, and
+# ``provider_allows_model`` stops second-guessing model names it cannot know.
+#
+# A gateway turn therefore does NOT go through the LiteLLM proxy: the runtime
+# talks to the user's base URL directly. That is the price of accepting any
+# base URL, and it costs the proxy's spend log and guardrails for those turns.
+#
 # Created 2026-08-28 (feat/other-hand-byok).
 #
 # Two audiences, deliberately separated:
@@ -60,10 +72,11 @@ _VALIDATE_TIMEOUT_S = 15.0
 _VALIDATE_MODEL = "claude-haiku-4-5-20251001"
 
 # The providers this deployment can actually spend a key against, end to end.
-# v1 is Anthropic-only: ``validate_key`` calls Anthropic, the LiteLLM forward
-# targets Anthropic upstreams, and the model set is claude-*. Widening this set
-# means widening ALL THREE, not just this constant.
-SUPPORTED_PROVIDERS = frozenset({"anthropic"})
+# Each entry needs all three of: a ``validate_key`` branch that proves the
+# credential, a ``build_settings_override`` branch that points the runtime at
+# it, and a ``provider_allows_model`` rule. Adding a name here without those is
+# how you mint accounts whose every turn dead-ends.
+SUPPORTED_PROVIDERS = frozenset({"anthropic", "openai_compatible"})
 
 
 @dataclass(frozen=True)
@@ -87,6 +100,10 @@ class TurnCredentials:
     source: Literal["platform", "byok"]
     api_key: str | None = None
     provider: str = "anthropic"
+    #: Only set for ``provider="openai_compatible"`` — where the key spends,
+    #: and which model id that gateway knows it by.
+    base_url: str | None = None
+    model: str | None = None
 
 
 async def get_status(workspace_id: str) -> ByokStatus:
@@ -97,6 +114,8 @@ async def get_status(workspace_id: str) -> ByokStatus:
     return ByokStatus(
         configured=bool(doc.encrypted_key),
         provider=doc.provider,
+        base_url=doc.base_url,
+        model=doc.model,
         last4=doc.last4,
         key_hint=doc.key_hint,
         last_verified_at=doc.last_verified_at,
@@ -108,12 +127,28 @@ async def get_status(workspace_id: str) -> ByokStatus:
     )
 
 
-async def validate_key(api_key: str) -> None:
+async def validate_key(
+    api_key: str,
+    *,
+    provider: str = "anthropic",
+    base_url: str | None = None,
+    model: str | None = None,
+) -> None:
     """Prove the key works, or raise ValidationError naming why.
 
     Network trouble is NOT a bad key: a timeout raises the transport error so
     the caller can decide, rather than telling the user their good key is bad.
+
+    A gateway (``provider="openai_compatible"``) is checked against its own
+    ``/chat/completions`` with the model the user gave, because that pair is
+    what a turn will actually use. Checking only the key would let a wrong
+    model id through to fail on the first turn, which is the failure mode this
+    whole function exists to move earlier.
     """
+    if provider == "openai_compatible":
+        await _validate_gateway_key(api_key, base_url or "", model or "")
+        return
+
     payload = {
         "model": _VALIDATE_MODEL,
         "max_tokens": 1,
@@ -147,11 +182,83 @@ async def validate_key(api_key: str) -> None:
     # was accepted and the request was understood. That is what we are testing.
 
 
+async def _validate_gateway_key(api_key: str, base_url: str, model: str) -> None:
+    """Same proof, against an OpenAI-compatible gateway the user named.
+
+    The URL has already passed ``validate_external_url_strict`` at the DTO
+    edge (https, no internal hosts). It is re-checked here because this
+    function is also reachable from ``set_key``, and a guard that only runs on
+    one of two paths is not a guard.
+    """
+    from pocketpaw.security.url_validators import validate_external_url_strict
+
+    try:
+        base = validate_external_url_strict(base_url.strip().rstrip("/"))
+    except ValueError as exc:
+        raise ValidationError("byok.base_url_rejected", str(exc)) from exc
+
+    payload = {
+        "model": model,
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    headers = {
+        "authorization": f"Bearer {api_key}",
+        "content-type": "application/json",
+    }
+    async with httpx.AsyncClient(timeout=_VALIDATE_TIMEOUT_S) as client:
+        resp = await client.post(f"{base}/chat/completions", json=payload, headers=headers)
+
+    if resp.status_code == 401:
+        # Measured against api.experientiallabs.ai on 2026-09-09: a base URL
+        # missing its version path answers 401, not 404, because auth runs
+        # before routing. So the honest 404 hint below never fires for the
+        # single most likely mistake, and it has to be said here instead.
+        if not base.rstrip("/").rpartition("//")[2].partition("/")[2]:
+            raise ValidationError(
+                "byok.base_url_rejected",
+                f"{base} rejected the key, and it has no path — most gateways "
+                "serve this at /v1. Try adding it before re-checking the key.",
+            )
+        raise ValidationError(
+            "byok.key_rejected",
+            "That gateway rejected the key. Check you copied the whole key, and "
+            "that it has not been revoked.",
+        )
+    if resp.status_code == 403:
+        # A gateway commonly answers 403 for a model the key may not use, or a
+        # model id in the wrong shape. Saying "bad key" here sends the user to
+        # re-copy a key that was fine.
+        raise ValidationError(
+            "byok.key_rejected",
+            f"The gateway refused '{model}' with that key. Check the model id is "
+            "one your gateway serves and that your key is allowed to use it.",
+        )
+    if resp.status_code == 404:
+        raise ValidationError(
+            "byok.base_url_rejected",
+            f"Nothing answered at {base}/chat/completions. The base URL usually "
+            "needs to end in /v1.",
+        )
+    if resp.status_code == 429:
+        raise ValidationError(
+            "byok.key_rate_limited",
+            "That key is rate-limited right now, so we could not verify it. Try again in a minute.",
+        )
+    if resp.status_code >= 500:
+        raise ValidationError(
+            "byok.provider_unavailable",
+            "The gateway did not respond. Your key was not saved — try again shortly.",
+        )
+
+
 async def set_key(
     workspace_id: str,
     api_key: str,
     *,
     provider: str = "anthropic",
+    base_url: str | None = None,
+    model: str | None = None,
     user_id: str | None = None,
     validate: bool = True,
 ) -> ByokStatus:
@@ -172,19 +279,30 @@ async def set_key(
         )
 
     if validate:
-        await validate_key(api_key)
+        await validate_key(api_key, provider=provider, base_url=base_url, model=model)
+
+    # An anthropic row never carries a gateway address. Writing one through
+    # would leave a stale URL behind after a switch back, and the resolver
+    # reads both columns.
+    if provider != "openai_compatible":
+        base_url = None
+        model = None
 
     doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
     if doc is None:
         doc = ByokProviderKey(
             workspace=workspace_id,
             provider=provider,
+            base_url=base_url,
+            model=model,
             encrypted_key=crypto.encrypt(api_key),
             last4=api_key[-4:],
             key_hint=_hint(api_key),
         )
     else:
         doc.provider = provider
+        doc.base_url = base_url
+        doc.model = model
         doc.encrypted_key = crypto.encrypt(api_key)
         doc.last4 = api_key[-4:]
         doc.key_hint = _hint(api_key)
@@ -295,7 +413,13 @@ async def resolve_turn_credentials(workspace_id: str | None) -> TurnCredentials:
 
     if not plaintext:
         return TurnCredentials(source="platform")
-    return TurnCredentials(source="byok", api_key=plaintext, provider=doc.provider)
+    return TurnCredentials(
+        source="byok",
+        api_key=plaintext,
+        provider=doc.provider,
+        base_url=doc.base_url,
+        model=doc.model,
+    )
 
 
 # ── The illustration credential (fal.ai) ────────────────────────────────────
@@ -445,15 +569,23 @@ def provider_allows_model(provider: str, model: str | None) -> bool:
     being broken. Sentinel names ("default" etc.) always pass: the backend's
     own default is provider-correct by construction.
 
-    Anything but ``anthropic`` returns False for every real model name — the
-    pipeline cannot serve another provider end to end today (see
-    ``SUPPORTED_PROVIDERS``), and a loud mismatch beats a silent dead turn.
+    ``openai_compatible`` always passes, and deliberately: a gateway's model
+    ids are its own namespace, so there is no name shape we could check
+    against. The gateway's own refusal is the only honest judge, and the turn
+    is pinned to the stored model anyway (see ``build_settings_override``), so
+    the model asked for here is not the one that runs.
+
+    Any other provider returns False for every real model name — the pipeline
+    cannot serve it end to end (see ``SUPPORTED_PROVIDERS``), and a loud
+    mismatch beats a silent dead turn.
     """
     m = (model or "").strip().lower()
     if m in _MODEL_SENTINELS:
         return True
     if provider == "anthropic":
         return m.startswith("claude") or m.startswith("anthropic/")
+    if provider == "openai_compatible":
+        return True
     return False
 
 
@@ -493,7 +625,31 @@ def build_settings_override(creds: TurnCredentials) -> dict[str, object]:
 
     Returns an EMPTY dict for platform credentials, so the caller can pass it
     unconditionally and get today's behaviour when no key is configured.
+
+    A GATEWAY key (``provider="openai_compatible"``, 2026-09-09) takes the
+    other road. There is no LiteLLM model group pointing at a URL one guest
+    typed, so forwarding a header would send the turn to whatever LiteLLM was
+    already configured for and bill the wrong account. Instead the override
+    points the runtime's own ``openai_compatible`` provider straight at the
+    gateway. Both ``pydantic_ai_provider`` and ``pydantic_ai_model`` are
+    pinned: the provider setting alone leaves ``pydantic_ai_model`` naming
+    whatever the agent was configured with, and that name wins over
+    ``openai_compatible_model`` in ``_parse_provider_model``.
+
+    The cost, stated plainly: a gateway turn does not pass through the LiteLLM
+    proxy, so it produces no spend-log row and skips the proxy's guardrails.
+    The isolation requirement is unchanged and matters just as much — these
+    settings are as tenant-specific as the key.
     """
     if creds.source != "byok" or not creds.api_key:
         return {}
+    if creds.provider == "openai_compatible":
+        return {
+            "pydantic_ai_provider": "openai_compatible",
+            "pydantic_ai_model": creds.model or "",
+            "llm_provider": "openai_compatible",
+            "openai_compatible_base_url": creds.base_url or "",
+            "openai_compatible_api_key": creds.api_key,
+            "openai_compatible_model": creds.model or "",
+        }
     return {"byok_provider_api_key": creds.api_key}

--- a/ee/pocketpaw_ee/cloud/byok/service.py
+++ b/ee/pocketpaw_ee/cloud/byok/service.py
@@ -726,19 +726,27 @@ def provider_allows_model(provider: str, model: str | None) -> bool:
     non-None ``model_override`` to WHATEVER backend is running
     (``agents/pool.py``) — the per-send chip in paw-enterprise #902 and the
     ``model_override`` field in #2140 both put a client-chosen name on that
-    wire. What makes the stored model win on a gateway turn is narrower: a
-    gateway turn runs on the pydantic_ai backend, and that backend declares
-    ``model_override`` only to ignore it (``agents/pydantic_ai.py``, the
-    ``# noqa: ARG002`` block — "consumed only by the Claude SDK backend"), so
-    the model that runs is the ``pydantic_ai_model`` this service pinned in
-    ``build_settings_override``.
+    wire. What makes the stored model win on a gateway turn is narrower: the
+    pydantic_ai backend declares ``model_override`` only to ignore it
+    (``agents/pydantic_ai.py``, the ``# noqa: ARG002`` block — "consumed only
+    by the Claude SDK backend"), so the model that runs is the
+    ``pydantic_ai_model`` this service pinned in ``build_settings_override``.
 
-    So the effect holds today, but it rests on one backend's deliberate
-    ignore, not on an invariant anything enforces. If pydantic_ai ever honours
-    ``model_override``, a client could name a model this function never
-    checked. No allowlist is added here on purpose — #2140 owns the per-send
-    model surface and is where a real check belongs; the consequence meanwhile
-    is confined to the tenant's own key against the tenant's own gateway.
+    That holds while a gateway turn runs on the pydantic_ai backend, which the
+    gateway design assumes but does not enforce:
+    ``AgentRouter.create_isolated_backend`` takes the backend NAME from the
+    agent's own config, not from this override. An agent configured for the
+    Claude SDK backend with a gateway key stored would build a Claude backend,
+    which ignores every ``openai_compatible_*`` setting here and honours
+    ``model_override``. That gap is upstream of this function and is not
+    addressed by this PR — recorded so the paragraph above is not read as a
+    guarantee.
+
+    So the effect holds in the intended configuration, but it rests on one
+    backend's deliberate ignore rather than on anything enforced. No allowlist
+    is added here on purpose — #2140 owns the per-send model surface and is
+    where a real check belongs; the consequence meanwhile is confined to the
+    tenant's own key against the tenant's own gateway.
 
     Any other provider returns False for every real model name — the pipeline
     cannot serve it end to end (see ``SUPPORTED_PROVIDERS``), and a loud

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,15 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-09-11 (feat/byok-custom-gateway, review B2) — ``_iter_agent_events``
+  catches ``byok_service.GatewayEgressRejected`` from
+  ``resolve_turn_credentials`` and yields a terminal
+  ``byok.base_url_rejected`` instead of running the turn. The catch sits ABOVE
+  the existing broad ``except Exception``, which degrades to platform
+  credentials: reaching it with a rejected gateway address would put every
+  such turn on OUR key, so a tenant's bad (or hostile) address would spend our
+  money. A refused turn is the correct answer — the address is theirs to fix.
+
 - 2026-09-08 (fix/attachment-only-turns) — ``_drive_agent_loop`` now runs its
   ``user_content`` through ``agent_service.resolve_user_content`` before
   anything reads it. A send with attachments and no typed text arrives as the
@@ -1714,6 +1723,23 @@ async def _drive_agent_loop(
 
         try:
             byok_creds = await byok_service.resolve_turn_credentials(ctx.workspace_id)
+        except byok_service.GatewayEgressRejected as exc:
+            # The stored gateway address no longer passes the egress guard —
+            # it resolves somewhere this server must not dial (2026-09-11,
+            # review B2). Caught BEFORE the broad handler below on purpose:
+            # that one degrades to platform credentials, which here would run
+            # the tenant's turn on OUR key every time their address is bad.
+            # Refuse the turn and say why; the user fixes the address.
+            logger.warning(
+                "byok: gateway address rejected by the egress guard for workspace=%s — "
+                "refusing the turn",
+                ctx.workspace_id,
+            )
+            yield (
+                "error",
+                {"code": "byok.base_url_rejected", "message": exc.message},
+            )
+            return
         except Exception:
             logger.exception(
                 "byok: resolve_turn_credentials failed for workspace=%s — "

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1740,6 +1740,13 @@ async def _drive_agent_loop(
                 )
                 return
             run_kwargs["byok_api_key"] = byok_creds.api_key
+            # What to substitute, when the answer is more than one key. A
+            # gateway key also carries the address and the model id; the pool
+            # falls back to the key alone when this is empty, so anthropic keys
+            # take exactly the path they took before (2026-09-09).
+            override = byok_service.build_settings_override(byok_creds)
+            if override:
+                run_kwargs["byok_settings_override"] = override
         else:
             from pocketpaw_ee.cloud.auth import guest_budget
 

--- a/ee/pocketpaw_ee/cloud/models/byok_key.py
+++ b/ee/pocketpaw_ee/cloud/models/byok_key.py
@@ -28,6 +28,13 @@
 # Created 2026-08-28 (feat/other-hand-byok): new entity. Registered in
 # ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
 # ``init_beanie`` wires the ``byok_provider_keys`` collection.
+#
+# Updated 2026-09-09 (feat/byok-custom-gateway): two nullable columns,
+# ``base_url`` and ``model``, so a key can belong to an OpenAI-compatible
+# gateway (Experiential Labs, OpenRouter, LiteLLM, vLLM) instead of Anthropic.
+# Both are NON-SECRET and are safe to return in ``ByokStatus`` — the whole
+# point of a gateway is that its address is public. Existing anthropic rows
+# read back as None on both, so no migration.
 
 from __future__ import annotations
 
@@ -55,6 +62,15 @@ class ByokProviderKey(TimestampedDocument):
     # Which provider the key belongs to. Only "anthropic" is accepted today; the
     # column exists so adding a second provider is a value, not a migration.
     provider: str = "anthropic"
+    # Where the key spends, for an ``openai_compatible`` provider only. Always
+    # None for anthropic (the endpoint is api.anthropic.com by definition).
+    # Validated at the DTO edge with ``validate_external_url_strict`` — https
+    # only, no loopback or private ranges — because this URL is a stranger's
+    # input that our server then makes requests to.
+    base_url: str | None = None
+    # The gateway's own model id, e.g. "claude-opus-5" on Experiential Labs.
+    # A gateway's ids are its own, so there is no list to pick from.
+    model: str | None = None
     # Fernet token from cloud._core.crypto.encrypt(). Never returned by the API.
     encrypted_key: str
     # Display-only provenance so status calls never decrypt:

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -686,6 +686,7 @@ class AgentPool:
         surface_preamble: str = "",
         surface_cache_key: str | None = None,
         byok_api_key: str | None = None,
+        byok_settings_override: dict[str, object] | None = None,
     ) -> AsyncIterator[Any]:
         """Run an agent on a message. Yields AgentEvent stream.
 
@@ -772,6 +773,15 @@ class AgentPool:
         the model object it builds. Passing one tenant's key to a shared backend
         would leave it there for the next tenant's turn, billing a stranger's
         account. An isolated instance cannot outlive the run that made it.
+
+        ``byok_settings_override`` (2026-09-09) is what to substitute, when the
+        answer is more than one key. A key for an OpenAI-compatible gateway also
+        needs the gateway's address and model id, and those are as
+        tenant-specific as the key itself. The cloud builds this dict; when it
+        is absent the pool falls back to substituting ``byok_api_key`` alone,
+        which is byte-identical to the 2026-08-28 behaviour.
+
+        ``byok_api_key`` remains the GATE for both: no key, no isolated backend.
 
         None (the default) = the shared cached instance, unchanged for every
         existing run.
@@ -913,7 +923,9 @@ class AgentPool:
                             instance.backend.settings.agent_backend,
                         ),
                         instance.backend.settings,
-                        settings_override={"byok_provider_api_key": byok_api_key},
+                        settings_override=(
+                            byok_settings_override or {"byok_provider_api_key": byok_api_key}
+                        ),
                     )
                 except Exception:
                     logger.warning(

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -7,6 +7,13 @@ self-hosted LiteLLM proxy.
 
 Design source: ``docs/design/drafts/2026-07-29-pydantic-ai-agent-backend-prd.md``.
 
+Changed 2026-09-11 (feat/byok-custom-gateway, review B2/N1): the shared HTTP
+client in ``_get_http_client`` pins ``follow_redirects=False``. It is httpx's
+default, so nothing changes today — but the OpenAI SDK's own client sets it
+True, and this is the client a BYOK gateway turn uses to dial a base URL the
+user supplied. A redirect there would carry the request, and the key in its
+header, to a host no egress guard vetted.
+
 Changed 2026-09-05: this file no longer calls ``logfire.configure`` itself. That
 call is process-global and this file is not — see
 ``_build_instrumentation_capability``. It now delegates to
@@ -1189,6 +1196,15 @@ class PydanticAIBackend:
                     connect=15.0,
                 ),
                 headers=headers,
+                # Pinned, not inherited (2026-09-11, review B2/N1). httpx already
+                # defaults to False, so this changes nothing today — but the
+                # OpenAI SDK's own client sets it True, and this client is what a
+                # BYOK gateway turn dials a user-supplied base URL with. Following
+                # a redirect there would let a cooperating gateway bounce the
+                # request (and the key in its header) onto a host no guard saw.
+                # A security property is worth a line; a default is not worth
+                # trusting.
+                follow_redirects=False,
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("Could not build HTTP client, using library defaults: %s", exc)

--- a/src/pocketpaw/security/url_validators.py
+++ b/src/pocketpaw/security/url_validators.py
@@ -1,5 +1,15 @@
 # URL validators for Settings fields — guards against SSRF via config.
 # Added: 2026-04-16 for security cluster E (#703).
+# Updated: 2026-09-11 (feat/byok-custom-gateway, review B1) —
+#   ``assert_egress_allowed`` takes a keyword-only ``allow_internal`` that
+#   overrides the ``POCKETPAW_ALLOW_INTERNAL_URLS`` read. ``None`` (default)
+#   keeps every existing caller byte-identical; ``False`` rejects internal
+#   resolved addresses unconditionally. The BYOK gateway base URL needs that:
+#   it is typed by a signed-out stranger through ``POST /auth/guest``, and an
+#   operator who turned the flag on for localhost connectors must not thereby
+#   reopen an unauthenticated SSRF. ``validate_external_url_strict`` already
+#   had no escape hatch for the same reason — this gives the resolving guard
+#   the same property when a caller asks for it.
 # Updated: 2026-05-21 (RFC 04 alpha) — added validate_external_url_strict():
 #   https-only, unconditionally blocks internal/loopback/RFC1918/link-local
 #   hosts (no POCKETPAW_ALLOW_INTERNAL_URLS escape hatch), rejects empty
@@ -289,7 +299,12 @@ def _resolve_ips(host: str) -> list[str]:
     return ips
 
 
-async def assert_egress_allowed(url: str, allowed_hosts: set[str] | frozenset[str]) -> EgressTarget:
+async def assert_egress_allowed(
+    url: str,
+    allowed_hosts: set[str] | frozenset[str],
+    *,
+    allow_internal: bool | None = None,
+) -> EgressTarget:
     """Validate an outbound URL against the egress policy and pin its IP.
 
     Enforces, in order:
@@ -305,6 +320,14 @@ async def assert_egress_allowed(url: str, allowed_hosts: set[str] | frozenset[st
       EXPLICITLY truthy (the dev escape for localhost connectors); when the flag
       is unset the guard rejects — default-closed, matching the EE
       ``_http_guard`` which rejects internal hosts unconditionally.
+
+    ``allow_internal`` overrides that last step. ``None`` (the default) reads
+    the env flag, i.e. every existing caller is unchanged. ``False`` rejects
+    internal addresses UNCONDITIONALLY, for boundaries where a URL arrives from
+    an untrusted caller rather than from an operator-authored connector — the
+    BYOK gateway address is one, and it is reachable from a signed-out stranger
+    through ``POST /auth/guest``, so an operator who set the flag for local
+    connectors must not also reopen that. ``True`` is the explicit dev escape.
 
     Returns an :class:`EgressTarget` carrying the single pinned IP. The caller
     MUST dial that IP via :class:`PinnedTransport` so the connection cannot be
@@ -338,9 +361,9 @@ async def assert_egress_allowed(url: str, allowed_hosts: set[str] | frozenset[st
     if not ips:
         raise EgressError(f"host '{host}' resolved to no addresses")
 
-    allow_internal = _egress_allow_internal()
+    permit_internal = _egress_allow_internal() if allow_internal is None else allow_internal
     for ip in ips:
-        if _ip_is_internal(ip) and not allow_internal:
+        if _ip_is_internal(ip) and not permit_internal:
             raise EgressError(f"host '{host}' resolves to an internal address")
 
     port = parts.port or (443 if parts.scheme == "https" else 80)

--- a/tests/cloud/auth/test_guest.py
+++ b/tests/cloud/auth/test_guest.py
@@ -200,7 +200,7 @@ class TestMintGuest:
     async def test_an_unsupported_provider_is_rejected_before_any_provider_call(
         self, mongo_db, monkeypatch
     ):
-        async def _must_not_run(api_key):
+        async def _must_not_run(api_key, **_kw):
             raise AssertionError("validate_key must not be called for an unsupported provider")
 
         monkeypatch.setattr("pocketpaw_ee.cloud.byok.service.validate_key", _must_not_run)
@@ -209,7 +209,7 @@ class TestMintGuest:
         assert exc.value.code == "byok.provider_unsupported"
 
     async def test_a_dead_key_mints_NOTHING(self, mongo_db, monkeypatch):
-        async def _dead(api_key):
+        async def _dead(api_key, **_kw):
             raise ValidationError("byok.key_rejected", "Anthropic rejected that key.")
 
         monkeypatch.setattr("pocketpaw_ee.cloud.byok.service.validate_key", _dead)
@@ -223,7 +223,7 @@ class TestMintGuest:
     ):
         calls: list[str] = []
 
-        async def _ok(api_key):
+        async def _ok(api_key, **_kw):
             calls.append("validated")
 
         monkeypatch.setattr("pocketpaw_ee.cloud.byok.service.validate_key", _ok)
@@ -258,7 +258,7 @@ class TestMintGuest:
         capture and sweep every record. Break any logger call into including
         the key and this goes red."""
 
-        async def _ok(api_key):
+        async def _ok(api_key, **_kw):
             return None
 
         monkeypatch.setattr("pocketpaw_ee.cloud.byok.service.validate_key", _ok)

--- a/tests/cloud/auth/test_guest.py
+++ b/tests/cloud/auth/test_guest.py
@@ -15,6 +15,12 @@
 #      server-side).
 #   5. The wire contract (top-level code/kind) is pinned byte-for-byte — the
 #      sibling frontend builds against it.
+#
+# Updated 2026-09-11 (review B1): added the unauthenticated-SSRF case to
+# ``TestMintGuest``. Every other mint test patches ``validate_key`` away, which
+# is right for what they assert and blinding for this one — the guard lives
+# inside that call, and this route never touches the DTO that would otherwise
+# back it up. The new test leaves ``validate_key`` alone and stubs DNS instead.
 
 from __future__ import annotations
 
@@ -246,6 +252,43 @@ class TestMintGuest:
         with pytest.raises(ValidationError) as exc:
             await guest_service.mint_guest("xpl_" + "a" * 40, provider="openai_compatible")
         assert exc.value.code == "byok.base_url_required"
+
+    async def test_a_gateway_address_that_resolves_INSIDE_mints_nothing(
+        self, mongo_db, monkeypatch
+    ):
+        """The unauthenticated SSRF (review B1). /auth/guest is on the
+        route-auth allowlist and rate-limited per IP only, so a signed-out
+        stranger picks this address. ``_GuestMintRequest`` carries plain ``str``
+        fields and never touches ``ByokSetRequest``, so ``validate_key`` is the
+        ONLY guard on this path — which is why ``validate_key`` is deliberately
+        NOT patched here. Patching it is what makes every other test in this
+        class blind to the guard.
+
+        PRE-FIX THIS MINTS A GUEST. ``validate_external_url_strict`` catches
+        internal IP literals and never resolves a name, so a public hostname
+        with an A record in RFC1918 passed, was stored, and was then POSTed to
+        — at mint and again on every turn.
+        """
+        import socket
+
+        def _resolves_inside(host, *_a, **_kw):
+            if host == "10-0-0-5.nip.io":
+                return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.5", 0))]
+            raise socket.gaierror(f"name resolution disabled in test: {host}")
+
+        monkeypatch.setattr(socket, "getaddrinfo", _resolves_inside)
+        # The operator's dev escape must not reach this boundary.
+        monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "true")
+
+        with pytest.raises(ValidationError) as exc:
+            await guest_service.mint_guest(
+                "xpl_" + "a" * 40,
+                provider="openai_compatible",
+                base_url="https://10-0-0-5.nip.io/v1",
+                model="claude-opus-5",
+            )
+        assert exc.value.code == "byok.base_url_rejected"
+        assert await User.find_all().count() == 0, "a rejected address must not mint a user row"
 
     async def test_a_dead_key_mints_NOTHING(self, mongo_db, monkeypatch):
         async def _dead(api_key, **_kw):

--- a/tests/cloud/auth/test_guest.py
+++ b/tests/cloud/auth/test_guest.py
@@ -208,6 +208,45 @@ class TestMintGuest:
             await guest_service.mint_guest(_KEY, provider="openai")
         assert exc.value.code == "byok.provider_unsupported"
 
+    async def test_a_gateway_mint_hands_validation_the_address_and_the_model(
+        self, mongo_db, monkeypatch
+    ):
+        # Drop the kwargs from mint_guest's validate_key call and validation
+        # silently runs as anthropic: an xpl_ key 401s at api.anthropic.com and
+        # the user is told "Anthropic rejected that key" about a key that never
+        # belonged to Anthropic. Nothing else in this file would notice.
+        seen: dict = {}
+
+        async def _capture(api_key, **kw):
+            seen["api_key"] = api_key
+            seen.update(kw)
+            # Stop here: what is under test is the call, not the mint that
+            # follows it, and the mint needs a provisioned realtime bus.
+            raise ValidationError("byok.key_rejected", "stop after capture")
+
+        monkeypatch.setattr("pocketpaw_ee.cloud.byok.service.validate_key", _capture)
+        with pytest.raises(ValidationError):
+            await guest_service.mint_guest(
+                "xpl_" + "a" * 40,
+                provider="openai_compatible",
+                base_url="https://api.experientiallabs.ai/v1",
+                model="claude-opus-5",
+            )
+        assert seen["provider"] == "openai_compatible"
+        assert seen["base_url"] == "https://api.experientiallabs.ai/v1"
+        assert seen["model"] == "claude-opus-5"
+
+    async def test_a_gateway_mint_without_an_address_never_reaches_the_provider(
+        self, mongo_db, monkeypatch
+    ):
+        async def _must_not_run(api_key, **_kw):
+            raise AssertionError("validate_key must not run without a gateway address")
+
+        monkeypatch.setattr("pocketpaw_ee.cloud.byok.service.validate_key", _must_not_run)
+        with pytest.raises(ValidationError) as exc:
+            await guest_service.mint_guest("xpl_" + "a" * 40, provider="openai_compatible")
+        assert exc.value.code == "byok.base_url_required"
+
     async def test_a_dead_key_mints_NOTHING(self, mongo_db, monkeypatch):
         async def _dead(api_key, **_kw):
             raise ValidationError("byok.key_rejected", "Anthropic rejected that key.")

--- a/tests/cloud/auth/test_guest.py
+++ b/tests/cloud/auth/test_guest.py
@@ -300,6 +300,34 @@ class TestMintGuest:
         assert exc.value.code == "byok.key_rejected"
         assert await User.find_all().count() == 0, "a dead key must not mint a user row"
 
+    async def test_a_gateway_mint_stores_the_url_that_passed_the_guard(
+        self, mongo_db, monkeypatch, _resolver_stub
+    ):
+        """Review S6. ``validate_key`` normalizes before it guards, and the
+        value written to the database must be the value that was checked — not
+        the raw body string, which is what this path used to store. The gap is
+        whitespace and a trailing slash today; it is the shape that a later
+        normalization change turns into a stored value nothing vetted."""
+        canonical = "https://api.experientiallabs.ai/v1"
+
+        async def _ok_returning_canonical(api_key, **_kw):
+            return canonical
+
+        monkeypatch.setattr("pocketpaw_ee.cloud.byok.service.validate_key", _ok_returning_canonical)
+
+        user = await guest_service.mint_guest(
+            "xpl_" + "a" * 40,
+            provider="openai_compatible",
+            base_url=f"  {canonical}/  ",
+            model="claude-opus-5",
+        )
+
+        from pocketpaw_ee.cloud.models.byok_key import ByokProviderKey
+
+        row = await ByokProviderKey.find_one(ByokProviderKey.workspace == user.active_workspace)
+        assert row is not None
+        assert row.base_url == canonical, "the stored URL is not the one that passed the guard"
+
     async def test_a_good_key_mints_user_workspace_and_encrypted_key(
         self, mongo_db, monkeypatch, _resolver_stub
     ):

--- a/tests/cloud/byok/test_byok_service.py
+++ b/tests/cloud/byok/test_byok_service.py
@@ -837,9 +837,18 @@ class TestTheTurnPathReGuardsTheStoredUrl:
             socket, "getaddrinfo", _fake_getaddrinfo({"rebind.example.com": ["127.0.0.1"]})
         )
         _stub_row(monkeypatch, _GatewayRow("https://rebind.example.com/v1"))
-        with pytest.raises(byok.GatewayEgressRejected):
+        # Written as try/else rather than pytest.raises deliberately: what is
+        # under test is that it does NOT return, and an assertion placed inside
+        # a raises block never runs when the raise happens, so it would pin
+        # nothing.
+        try:
             creds = await byok.resolve_turn_credentials("ws-1")
-            assert creds.source != "platform", "degrading here spends the platform's money"
+        except byok.GatewayEgressRejected:
+            return
+        pytest.fail(
+            f"returned source={creds.source!r} instead of refusing — a rejected "
+            "gateway address must not fall back to platform credentials"
+        )
 
     async def test_a_still_public_row_resolves_normally(self, monkeypatch):
         monkeypatch.setattr(

--- a/tests/cloud/byok/test_byok_service.py
+++ b/tests/cloud/byok/test_byok_service.py
@@ -17,11 +17,23 @@
 #   2. A stored key round-trips through the Fernet envelope, and a rotated
 #      deployment key degrades to platform credentials instead of failing turns.
 #   3. Two tenants with two keys cannot share a cached agent — the bleed case.
+#
+# Updated 2026-09-11 (review B1/B2/S6): the gateway SSRF tests here all used IP
+# LITERALS, which is precisely why the real hole stayed green — a hostname is
+# never resolved by ``validate_external_url_strict``, so a public name with a
+# private A record passed everything. Two classes added at the end:
+# ``TestAHostnameThatResolvesInsideIsRejected`` (the write path) and
+# ``TestTheTurnPathReGuardsTheStoredUrl`` (the turn path, where the guard did
+# not exist at all). Both stub ``socket.getaddrinfo`` and ``httpx.AsyncClient``,
+# so neither resolves nor sends anything real.
 
 from __future__ import annotations
 
+import socket
+
 import pytest
 from pocketpaw_ee.cloud._core import crypto
+from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.byok import service as byok
 from pocketpaw_ee.cloud.byok.dto import ByokSetRequest, ByokStatus
 from pocketpaw_ee.cloud.models.byok_key import ByokProviderKey
@@ -594,3 +606,279 @@ class TestGatewayTurnIsPointedAtTheGateway:
         assert byok.provider_allows_model("openai_compatible", "gpt-5.5")
         assert byok.provider_allows_model("openai_compatible", "claude-opus-5")
         assert not byok.provider_allows_model("cohere", "command-r")
+
+
+# ── The name that resolves inside (2026-09-11, review B1/B2) ────────────────
+#
+# Everything in TestGatewayUrlIsAnSsrfBoundary above uses an IP LITERAL, which
+# is exactly why the hole survived a green suite: ``validate_external_url_strict``
+# catches literals and says in its own helper's docstring that resolving a NAME
+# is the caller's job — and no caller resolved. ``https://10-0-0-5.nip.io/v1``
+# passed every check and the server POSTed to it, unauthenticated, through
+# POST /auth/guest.
+#
+# The class below is the missing case, on all three paths that touch the URL:
+# validation, storage, and the turn. DNS is stubbed rather than real so the
+# tests neither depend on nip.io nor make an outbound request.
+
+
+def _fake_getaddrinfo(mapping: dict[str, list[str]]):
+    """A ``socket.getaddrinfo`` stub returning the IPs in ``mapping``.
+
+    Same shape as ``tests/connectors/test_egress_guard.py`` — only ``info[4][0]``
+    is ever read. An unmapped host raises ``gaierror``, so a test that forgets
+    to map its host fails loudly instead of reaching the real resolver.
+    """
+
+    def _stub(host, *_a, **_kw):
+        ips = mapping.get(host)
+        if not ips:
+            raise socket.gaierror(f"name resolution disabled in test: {host}")
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0)) for ip in ips]
+
+    return _stub
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+class _RecordingClient:
+    """Stands in for ``httpx.AsyncClient`` so no request leaves the machine.
+
+    Records the kwargs it was constructed with, which is how the redirect
+    policy and the pinned transport get asserted — both are properties of the
+    CLIENT, invisible in the response.
+    """
+
+    last: dict = {}
+
+    def __init__(self, **kwargs):
+        _RecordingClient.last = dict(kwargs)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, url, **_kw):
+        _RecordingClient.last["url"] = url
+        return _FakeResponse(200)
+
+
+class _GatewayRow:
+    """A stored gateway key row, standing in for the Beanie document.
+
+    ``ByokProviderKey`` only grows its queryable ``workspace`` attribute after
+    ``init_beanie``, and what is under test here is the guard, not Mongo.
+    Fields match the real model exactly so the stub cannot be more permissive
+    than the document it replaces.
+    """
+
+    def __init__(self, base_url: str) -> None:
+        self.encrypted_key = crypto.encrypt(_GATEWAY_KEY)
+        self.provider = "openai_compatible"
+        self.base_url = base_url
+        self.model = "claude-opus-5"
+
+
+def _stub_row(monkeypatch, row):
+    class _StubDoc:
+        workspace = "workspace"
+
+        @staticmethod
+        async def find_one(*_a, **_k):
+            return row
+
+    monkeypatch.setattr(byok, "ByokProviderKey", _StubDoc)
+
+
+@pytest.fixture(autouse=True)
+def _no_internal_escape(monkeypatch):
+    """Prove the guard does not inherit the operator's dev escape.
+
+    ``assert_egress_allowed`` honours POCKETPAW_ALLOW_INTERNAL_URLS by default,
+    and an operator who set it so localhost connectors keep working must not
+    thereby reopen an unauthenticated SSRF. Every test in this module runs with
+    the flag ON; the rejections below must happen anyway.
+    """
+    monkeypatch.setenv("POCKETPAW_ALLOW_INTERNAL_URLS", "true")
+
+
+class TestAHostnameThatResolvesInsideIsRejected:
+    """The B1 case. A public DNS name with a private A record — nip.io-style,
+    or any domain the attacker owns. Nothing about the URL looks internal."""
+
+    _INSIDE = "https://10-0-0-5.nip.io/v1"
+    _OUTSIDE = _GATEWAY_URL
+
+    async def test_the_write_path_rejects_it(self, monkeypatch):
+        # PRE-FIX THIS PASSES VALIDATION. ``_validate_gateway_key`` ran only
+        # ``validate_external_url_strict``, which never resolves, so this URL
+        # was stored and then dialed.
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"10-0-0-5.nip.io": ["10.0.0.5"]})
+        )
+        monkeypatch.setattr(byok.httpx, "AsyncClient", _RecordingClient)
+        with pytest.raises(ValidationError) as exc:
+            await byok.validate_key(
+                _GATEWAY_KEY,
+                provider="openai_compatible",
+                base_url=self._INSIDE,
+                model="claude-opus-5",
+            )
+        assert exc.value.code == "byok.base_url_rejected"
+        assert "url" not in _RecordingClient.last, "the request must not be made at all"
+
+    async def test_the_metadata_endpoint_behind_a_public_name_is_rejected(self, monkeypatch):
+        # 169.254.169.254 hands out instance credentials. The literal form was
+        # already blocked; this is the same target wearing a public name.
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"meta.example.com": ["169.254.169.254"]})
+        )
+        with pytest.raises(ValidationError) as exc:
+            await byok.assert_gateway_egress("https://meta.example.com/v1")
+        assert exc.value.code == "byok.base_url_rejected"
+
+    async def test_an_ip_literal_is_still_rejected(self, monkeypatch):
+        # The cheap shape check must survive the new one — and must decide
+        # BEFORE any resolution happens, which the unmapped resolver proves.
+        monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo({}))
+        with pytest.raises(ValidationError) as exc:
+            await byok.assert_gateway_egress("https://10.0.0.5/v1")
+        assert exc.value.code == "byok.base_url_rejected"
+
+    async def test_plain_http_is_still_rejected(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo({}))
+        with pytest.raises(ValidationError):
+            await byok.assert_gateway_egress("http://api.experientiallabs.ai/v1")
+
+    async def test_a_public_host_passes_and_is_pinned(self, monkeypatch):
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            _fake_getaddrinfo({"api.experientiallabs.ai": ["93.184.216.34"]}),
+        )
+        target = await byok.assert_gateway_egress(self._OUTSIDE + "/  ".strip())
+        assert target.url == _GATEWAY_URL
+        assert target.pinned_ip == "93.184.216.34"
+
+    async def test_the_request_is_pinned_and_does_not_follow_redirects(self, monkeypatch):
+        # Both are security properties of the CLIENT. Unpinned, DNS is resolved
+        # a second time at connect and a rebinding host answers with an
+        # internal address in the gap. Following a redirect lets a cooperating
+        # gateway bounce the request — and the key in its header — anywhere.
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            _fake_getaddrinfo({"api.experientiallabs.ai": ["93.184.216.34"]}),
+        )
+        monkeypatch.setattr(byok.httpx, "AsyncClient", _RecordingClient)
+        canonical = await byok.validate_key(
+            _GATEWAY_KEY,
+            provider="openai_compatible",
+            base_url=_GATEWAY_URL,
+            model="claude-opus-5",
+        )
+        assert canonical == _GATEWAY_URL
+        assert _RecordingClient.last["follow_redirects"] is False
+        assert _RecordingClient.last["transport"] is not None
+        assert _RecordingClient.last["url"] == f"{_GATEWAY_URL}/chat/completions"
+
+    async def test_validate_key_returns_the_canonical_url_callers_must_store(self, monkeypatch):
+        # Review S6: the value that reaches the database must be the value that
+        # passed the guard. Pre-fix this returned None and the raw string was
+        # stored instead.
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            _fake_getaddrinfo({"api.experientiallabs.ai": ["93.184.216.34"]}),
+        )
+        monkeypatch.setattr(byok.httpx, "AsyncClient", _RecordingClient)
+        assert (
+            await byok.validate_key(
+                _GATEWAY_KEY,
+                provider="openai_compatible",
+                base_url=f"  {_GATEWAY_URL}/  ",
+                model="claude-opus-5",
+            )
+            == _GATEWAY_URL
+        )
+
+    async def test_an_anthropic_key_returns_no_url(self, monkeypatch):
+        monkeypatch.setattr(byok.httpx, "AsyncClient", _RecordingClient)
+        assert await byok.validate_key(_REAL_KEY) is None
+
+
+class TestTheTurnPathReGuardsTheStoredUrl:
+    """The B2 case. Write-time validation is not a runtime guard: a row stored
+    before the guard existed, or a host whose DNS moved inside afterwards, is
+    dialed on EVERY turn with the answer flowing back to the user."""
+
+    async def test_a_stored_row_that_now_resolves_inside_refuses_the_turn(self, monkeypatch):
+        # PRE-FIX THIS RETURNS source="byok" HAPPILY — ``resolve_turn_credentials``
+        # read the row and handed the URL straight to the runtime.
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"rebind.example.com": ["10.0.0.5"]})
+        )
+        _stub_row(monkeypatch, _GatewayRow("https://rebind.example.com/v1"))
+        with pytest.raises(byok.GatewayEgressRejected) as exc:
+            await byok.resolve_turn_credentials("ws-1")
+        assert exc.value.code == "byok.base_url_rejected"
+
+    async def test_it_refuses_rather_than_degrading_to_platform_credentials(self, monkeypatch):
+        # The distinction that matters for the bill. Degrading would run the
+        # tenant's turn on OUR key every time their address is bad, so a broken
+        # (or hostile) gateway address would spend the platform's money. The
+        # raise is the point; a returned platform credential would be the leak.
+        monkeypatch.setattr(
+            socket, "getaddrinfo", _fake_getaddrinfo({"rebind.example.com": ["127.0.0.1"]})
+        )
+        _stub_row(monkeypatch, _GatewayRow("https://rebind.example.com/v1"))
+        with pytest.raises(byok.GatewayEgressRejected):
+            creds = await byok.resolve_turn_credentials("ws-1")
+            assert creds.source != "platform", "degrading here spends the platform's money"
+
+    async def test_a_still_public_row_resolves_normally(self, monkeypatch):
+        monkeypatch.setattr(
+            socket,
+            "getaddrinfo",
+            _fake_getaddrinfo({"api.experientiallabs.ai": ["93.184.216.34"]}),
+        )
+        _stub_row(monkeypatch, _GatewayRow(_GATEWAY_URL))
+        creds = await byok.resolve_turn_credentials("ws-1")
+        assert creds.source == "byok"
+        assert creds.base_url == _GATEWAY_URL
+        assert creds.api_key == _GATEWAY_KEY
+
+    async def test_an_anthropic_row_never_resolves_anything(self, monkeypatch):
+        # An unmapped resolver: if the gateway branch leaked onto the anthropic
+        # path, gaierror would surface here instead of a clean credential.
+        monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo({}))
+
+        class _Row:
+            encrypted_key = crypto.encrypt(_REAL_KEY)
+            provider = "anthropic"
+            base_url = None
+            model = None
+
+        _stub_row(monkeypatch, _Row())
+        creds = await byok.resolve_turn_credentials("ws-1")
+        assert creds.source == "byok"
+        assert creds.provider == "anthropic"
+
+    def test_the_runtime_client_does_not_follow_redirects(self):
+        # Review N1. httpx defaults to False but the OpenAI SDK's own client
+        # sets it True, and this is the client that dials a user-supplied base
+        # URL. Pinned explicitly, and asserted so it stays pinned.
+        from pocketpaw.agents.pydantic_ai import PydanticAIBackend
+        from pocketpaw.config import Settings
+
+        backend = PydanticAIBackend.__new__(PydanticAIBackend)
+        backend.settings = Settings()
+        backend._http_client = None
+        client = backend._get_http_client()
+        assert client is not None
+        assert client.follow_redirects is False

--- a/tests/cloud/byok/test_byok_service.py
+++ b/tests/cloud/byok/test_byok_service.py
@@ -305,6 +305,8 @@ def _intercepted_row(monkeypatch) -> tuple[ByokProviderKey, dict, list]:
         last4="zzzz",
         key_hint="sk-ant-api03",
         provider="anthropic",
+        base_url="https://gw.example.com/v1",
+        model="some-model",
         last_verified_at=None,
         last_error=None,
         image_encrypted_key="image-token",
@@ -318,6 +320,10 @@ def _intercepted_row(monkeypatch) -> tuple[ByokProviderKey, dict, list]:
         saved["image_encrypted_key"] = self.image_encrypted_key
         saved["last_error"] = self.last_error
         saved["image_last_error"] = self.image_last_error
+        # The gateway half of the LLM credential. Recorded so a delete can be
+        # shown to take the address with the key rather than stranding it.
+        saved["base_url"] = self.base_url
+        saved["model"] = self.model
 
     async def _delete(self):
         deleted.append(True)
@@ -351,6 +357,12 @@ class TestTheTwoCredentialsAreIndependent:
         assert deleted == [], "the row was dropped, taking the image key with it"
         assert saved["encrypted_key"] == "", "the LLM key was not actually removed"
         assert saved["image_encrypted_key"] == "image-token"
+        # The gateway half of the same credential goes with it. Leaving a
+        # stale base_url behind would point a later turn at an address whose
+        # key no longer exists, which reads as "the gateway is broken" rather
+        # than "you deleted the key".
+        assert saved["base_url"] is None, "the gateway address outlived its key"
+        assert saved["model"] is None, "the gateway model outlived its key"
 
     @pytest.mark.asyncio
     async def test_removing_the_image_key_keeps_the_llm_key(self, monkeypatch):
@@ -368,14 +380,21 @@ class TestTheTwoCredentialsAreIndependent:
         ``delete_key`` clears the LLM half of a shared row by assigning each
         of its columns. Naming one the document does not declare is not a
         no-op — pydantic raises, and the delete fails for every workspace that
-        also has an image key. The sibling gateway branch adds ``base_url``
-        and ``model``; until it merges they are absent here, so the clear has
-        to ask the document rather than assume.
+        also has an image key.
+
+        Written on the image-key branch, where ``base_url`` was the undeclared
+        name that proved the point, with a note that the sibling gateway
+        branch would add it. That branch has now merged, so the probe moved to
+        a name nothing declares. The assertion below it is the part that
+        matters: every column the clear touches has to be declared, and the
+        set grows as the row takes on more credentials.
         """
         declared = set(ByokProviderKey.model_fields)
         assert {"encrypted_key", "last4", "key_hint", "last_verified_at", "last_error"} <= declared
+        # The gateway branch's two columns, now that it has landed.
+        assert {"base_url", "model"} <= declared
         with pytest.raises(ValueError, match="no field"):
-            ByokProviderKey.model_construct(workspace="ws-1").base_url = None
+            ByokProviderKey.model_construct(workspace="ws-1").not_a_real_column = None
 
 
 class TestStoredErrorTextCarriesNoCredential:
@@ -463,6 +482,7 @@ class TestImageKeyResolution:
 
         monkeypatch.setattr(byok, "ByokProviderKey", _Exploding)
         assert await byok.resolve_image_key(None) is None
+
 
 # ── Custom OpenAI-compatible gateway (2026-09-09, feat/byok-custom-gateway) ──
 #

--- a/tests/cloud/byok/test_byok_service.py
+++ b/tests/cloud/byok/test_byok_service.py
@@ -70,6 +70,11 @@ class TestStatusNeverCarriesTheKey:
         allowed = {
             "configured",
             "provider",
+            # A gateway's address and model id (2026-09-09). Both are public by
+            # construction and neither needs a decrypt to read, which is the
+            # bar this allow-list exists to make people clear.
+            "base_url",
+            "model",
             "last4",
             "key_hint",
             "last_verified_at",
@@ -446,3 +451,146 @@ class TestImageKeyResolution:
 
         monkeypatch.setattr(byok, "ByokProviderKey", _Exploding)
         assert await byok.resolve_image_key(None) is None
+
+# ── Custom OpenAI-compatible gateway (2026-09-09, feat/byok-custom-gateway) ──
+#
+# A gateway key is a stranger's URL that our server then makes requests to, so
+# the tests that matter are the two that stop it being an SSRF, plus the one
+# that proves a gateway turn is actually pointed at the gateway rather than
+# quietly running on the platform's own credentials.
+
+_GATEWAY_KEY = "xpl_" + "a" * 40
+_GATEWAY_URL = "https://api.experientiallabs.ai/v1"
+
+
+class TestGatewayRequestValidation:
+    """The DTO edge is where a bad gateway shape must die."""
+
+    def test_accepts_a_gateway_key_with_a_url_and_a_model(self):
+        req = ByokSetRequest(
+            provider="openai_compatible",
+            api_key=_GATEWAY_KEY,
+            base_url=_GATEWAY_URL,
+            model="claude-opus-5",
+        )
+        assert req.base_url == _GATEWAY_URL
+        assert req.model == "claude-opus-5"
+
+    def test_a_gateway_key_needs_no_anthropic_prefix(self):
+        # The whole point: a gateway mints its own key format.
+        req = ByokSetRequest(
+            provider="openai_compatible",
+            api_key=_GATEWAY_KEY,
+            base_url=_GATEWAY_URL,
+            model="gpt-5.5",
+        )
+        assert req.api_key == _GATEWAY_KEY
+
+    def test_rejects_a_gateway_key_with_no_base_url(self):
+        with pytest.raises(ValueError, match="base_url"):
+            ByokSetRequest(
+                provider="openai_compatible", api_key=_GATEWAY_KEY, model="claude-opus-5"
+            )
+
+    def test_rejects_a_gateway_key_with_no_model(self):
+        with pytest.raises(ValueError, match="model"):
+            ByokSetRequest(
+                provider="openai_compatible", api_key=_GATEWAY_KEY, base_url=_GATEWAY_URL
+            )
+
+    def test_rejects_an_anthropic_key_carrying_a_base_url(self):
+        # A URL that would be silently ignored is worse than a refusal: the
+        # user believes they configured a gateway and every turn goes elsewhere.
+        with pytest.raises(ValueError, match="openai_compatible"):
+            ByokSetRequest(api_key=_REAL_KEY, base_url=_GATEWAY_URL)
+
+    def test_rejects_an_unknown_provider(self):
+        with pytest.raises(ValueError, match="provider must be"):
+            ByokSetRequest(provider="cohere", api_key=_GATEWAY_KEY)
+
+
+class TestGatewayUrlIsAnSsrfBoundary:
+    """The base URL is typed input from a signed-out stranger, and the server
+    dials it. Every one of these is a real target somebody would try."""
+
+    def _with_url(self, url: str):
+        return ByokSetRequest(
+            provider="openai_compatible",
+            api_key=_GATEWAY_KEY,
+            base_url=url,
+            model="claude-opus-5",
+        )
+
+    def test_rejects_the_cloud_metadata_address(self):
+        # 169.254.169.254 hands out instance credentials on most clouds.
+        with pytest.raises(ValueError):
+            self._with_url("https://169.254.169.254/v1")
+
+    def test_rejects_loopback(self):
+        with pytest.raises(ValueError):
+            self._with_url("https://127.0.0.1:8000/v1")
+
+    def test_rejects_a_private_network_address(self):
+        with pytest.raises(ValueError):
+            self._with_url("https://10.0.0.5/v1")
+
+    def test_rejects_plain_http(self):
+        # A key in a header over http is a key on the wire.
+        with pytest.raises(ValueError):
+            self._with_url("http://api.experientiallabs.ai/v1")
+
+    def test_strips_a_trailing_slash_so_the_path_join_is_predictable(self):
+        assert self._with_url(_GATEWAY_URL + "/").base_url == _GATEWAY_URL
+
+
+class TestGatewayTurnIsPointedAtTheGateway:
+    """The override IS the feature. If it is empty or partial the turn runs on
+    platform credentials and the user's key is never spent — a billing
+    surprise for us, and silence for them."""
+
+    def _creds(self):
+        return byok.TurnCredentials(
+            source="byok",
+            api_key=_GATEWAY_KEY,
+            provider="openai_compatible",
+            base_url=_GATEWAY_URL,
+            model="claude-opus-5",
+        )
+
+    def test_the_override_carries_url_key_and_model(self):
+        o = byok.build_settings_override(self._creds())
+        assert o["openai_compatible_base_url"] == _GATEWAY_URL
+        assert o["openai_compatible_api_key"] == _GATEWAY_KEY
+        assert o["openai_compatible_model"] == "claude-opus-5"
+
+    def test_the_override_pins_the_provider_and_the_model(self):
+        # pydantic_ai reads pydantic_ai_model FIRST; leaving it alone lets the
+        # agent's configured claude-* name win and the gateway 404s on a model
+        # it never heard of.
+        o = byok.build_settings_override(self._creds())
+        assert o["pydantic_ai_provider"] == "openai_compatible"
+        assert o["pydantic_ai_model"] == "claude-opus-5"
+
+    def test_a_gateway_turn_does_not_forward_an_x_api_key(self):
+        # That header is the LiteLLM path. Sending both would let the proxy
+        # bill the user for a call that never reached their gateway.
+        assert "byok_provider_api_key" not in byok.build_settings_override(self._creds())
+
+    def test_an_anthropic_turn_is_unchanged(self):
+        creds = byok.TurnCredentials(source="byok", api_key=_REAL_KEY, provider="anthropic")
+        assert byok.build_settings_override(creds) == {"byok_provider_api_key": _REAL_KEY}
+
+    def test_the_settings_the_override_names_all_exist(self):
+        # A typo'd key in the override dict is silently dropped by
+        # create_isolated_backend, and the turn runs on platform credentials.
+        from pocketpaw.config import Settings
+
+        for field in byok.build_settings_override(self._creds()):
+            assert field in Settings.model_fields, field
+
+    def test_a_gateway_model_is_never_second_guessed(self):
+        # A gateway's ids are its own namespace; refusing "gpt-5.5" because it
+        # is not claude-* would dead-end every non-Anthropic gateway.
+        assert byok.provider_allows_model("openai_compatible", "gpt-5.5")
+        assert byok.provider_allows_model("openai_compatible", "claude-opus-5")
+        assert not byok.provider_allows_model("cohere", "command-r")

--- a/tests/cloud/runs/test_run_core_byok_wiring.py
+++ b/tests/cloud/runs/test_run_core_byok_wiring.py
@@ -19,6 +19,18 @@
 #
 # Harness cloned from test_run_core_session_supervisor.py (capture pool +
 # stubbed collaborators; hermetic, no mongod).
+#
+# Updated 2026-09-11 (feat/byok-custom-gateway, review B2): ``_drive`` RAISES a
+# ``creds`` that is an exception, so the resolver's failure branches go through
+# the same harness. Three tests added:
+#
+#   * a GatewayEgressRejected  -> ``byok.base_url_rejected`` frame, no pool.run.
+#   * the same, asserted on the BILL: it must not fall through to the broad
+#     handler's degrade-to-platform, which would run a tenant's bad gateway
+#     address on our credential.
+#   * a generic resolver crash -> still degrades to platform, unchanged. That
+#     one keeps the other two honest: a catch written too wide would start
+#     refusing turns that used to run.
 
 from __future__ import annotations
 
@@ -127,6 +139,11 @@ async def _drive(
         monkeypatch.setattr(run_core, "get_session_supervisor", lambda: SessionSupervisor())
 
     async def _resolve(workspace_id):
+        # An exception passed as ``creds`` is RAISED rather than returned, so a
+        # test can drive the resolver's failure branches through the same
+        # harness. That is how the egress refusal below is exercised.
+        if isinstance(creds, BaseException):
+            raise creds
         return creds
 
     monkeypatch.setattr("pocketpaw_ee.cloud.byok.service.resolve_turn_credentials", _resolve)
@@ -262,6 +279,60 @@ async def test_the_supervisor_still_wires_on_a_platform_turn(monkeypatch):
     assert "session_handle" in pool.run_kwargs, (
         "harness must make the supervisor path viable, or the byok-skip test is vacuous"
     )
+
+
+async def test_a_rejected_gateway_address_refuses_the_turn(monkeypatch):
+    """Review B2. ``resolve_turn_credentials`` raises when the stored gateway
+    address no longer passes the egress guard, and this loop has to turn that
+    into a refusal.
+
+    The distance between fixed and broken here is one deleted ``except``
+    clause: the broad handler immediately below degrades to platform
+    credentials, so losing the typed catch silently runs every turn with a bad
+    gateway address on OUR key. Nothing else in this file would notice."""
+    from pocketpaw_ee.cloud.byok.service import GatewayEgressRejected
+
+    pool, out = await _drive(
+        monkeypatch,
+        _ctx(),
+        creds=GatewayEgressRejected("that gateway address resolves to an internal host"),
+    )
+    assert pool.run_called is False, "a rejected gateway address must never reach the model"
+    errors = [d for name, d in out if name == "error"]
+    assert errors and errors[0]["code"] == "byok.base_url_rejected"
+
+
+async def test_a_rejected_gateway_address_does_not_fall_back_to_platform(monkeypatch):
+    """The cost half of the same guard, kept separate because it is the part a
+    well-meaning refactor removes. Falling through to the broad handler would
+    put the tenant's broken address on the platform's bill, which is exactly
+    what the review retracted its own first suggestion over."""
+    from pocketpaw_ee.cloud.byok.service import GatewayEgressRejected
+
+    pool, out = await _drive(
+        monkeypatch,
+        _ctx(),
+        creds=GatewayEgressRejected("rejected"),
+    )
+    assert pool.run_kwargs is None, (
+        "the turn ran on platform credentials instead of refusing — a tenant's "
+        "bad gateway address must not spend the platform's money"
+    )
+    assert [name for name, _ in out] == ["error"]
+
+
+async def test_an_unrelated_resolver_crash_still_degrades_to_platform(monkeypatch):
+    """The counterpart that keeps the two tests above honest: the broad
+    handler's degrade-to-platform behaviour is UNCHANGED for everything that is
+    not an egress rejection. If the new catch were written too wide, this would
+    start refusing turns that used to run."""
+    pool, out = await _drive(
+        monkeypatch,
+        _ctx(),
+        creds=RuntimeError("mongo blinked"),
+    )
+    assert pool.run_called is True, "a generic resolver crash must still degrade, not refuse"
+    assert "byok_api_key" not in pool.run_kwargs
 
 
 async def test_the_plaintext_key_never_reaches_a_log_record(monkeypatch, caplog):

--- a/tests/mutations/byok.json
+++ b/tests/mutations/byok.json
@@ -1,23 +1,56 @@
 [
   {
-    "label": "credential fingerprint ignores the key — two BYOK tenants share one cached agent",
+    "label": "credential fingerprint ignores the key \u2014 two BYOK tenants share one cached agent",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "        if raw == \"|\":\n            return \"none\"\n        return hashlib.sha256(raw.encode()).hexdigest()[:16]",
     "replace": "        return \"none\"",
-    "tests": ["tests/cloud/byok/test_byok_service.py::TestNoCredentialBleedBetweenTenants"]
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestNoCredentialBleedBetweenTenants"
+    ]
   },
   {
-    "label": "x-api-key attached unconditionally — a platform run carries a stale BYOK header",
+    "label": "x-api-key attached unconditionally \u2014 a platform run carries a stale BYOK header",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "headers = {\"x-api-key\": byok_key} if byok_key else None",
     "replace": "headers = {\"x-api-key\": byok_key}",
-    "tests": ["tests/cloud/byok/test_byok_service.py::TestTheHeaderThatCarriesTheKey"]
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestTheHeaderThatCarriesTheKey"
+    ]
   },
   {
-    "label": "undecryptable stored key raises instead of degrading — every turn fails after a key rotation",
+    "label": "undecryptable stored key raises instead of degrading \u2014 every turn fails after a key rotation",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "        return TurnCredentials(source=\"platform\")\n\n    if not plaintext:",
     "replace": "        raise\n\n    if not plaintext:",
-    "tests": ["tests/cloud/byok/test_byok_service.py::TestEncryptionEnvelope"]
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestEncryptionEnvelope"
+    ]
+  },
+  {
+    "label": "gateway base_url skips the SSRF guard \u2014 a stranger points our server at cloud metadata",
+    "file": "ee/pocketpaw_ee/cloud/byok/dto.py",
+    "find": "        return validate_external_url_strict(v)",
+    "replace": "        return v",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestGatewayUrlIsAnSsrfBoundary"
+    ]
+  },
+  {
+    "label": "gateway override drops the model pin \u2014 the agent's claude-* name wins and every gateway turn 404s",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "            \"pydantic_ai_model\": creds.model or \"\",",
+    "replace": "",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestGatewayTurnIsPointedAtTheGateway"
+    ]
+  },
+  {
+    "label": "gateway shape check dropped \u2014 a key with no base_url is stored and every turn dead-ends",
+    "file": "ee/pocketpaw_ee/cloud/byok/dto.py",
+    "find": "            if not self.base_url:\n                raise ValueError(\"a gateway key needs a base_url, e.g. https://host/v1\")",
+    "replace": "            pass",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestGatewayRequestValidation"
+    ]
   }
 ]

--- a/tests/mutations/byok.json
+++ b/tests/mutations/byok.json
@@ -52,5 +52,14 @@
     "tests": [
       "tests/cloud/byok/test_byok_service.py::TestGatewayRequestValidation"
     ]
+  },
+  {
+    "label": "mint drops the gateway kwargs \u2014 an xpl_ key is validated against Anthropic and reads as a bad key",
+    "file": "ee/pocketpaw_ee/cloud/auth/guest.py",
+    "find": "    await byok_service.validate_key(api_key, provider=provider, base_url=base_url, model=model)",
+    "replace": "    await byok_service.validate_key(api_key)",
+    "tests": [
+      "tests/cloud/auth/test_guest.py::TestMintGuest"
+    ]
   }
 ]

--- a/tests/mutations/byok.json
+++ b/tests/mutations/byok.json
@@ -1,6 +1,6 @@
 [
   {
-    "label": "credential fingerprint ignores the key \u2014 two BYOK tenants share one cached agent",
+    "label": "credential fingerprint ignores the key — two BYOK tenants share one cached agent",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "        if raw == \"|\":\n            return \"none\"\n        return hashlib.sha256(raw.encode()).hexdigest()[:16]",
     "replace": "        return \"none\"",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "label": "x-api-key attached unconditionally \u2014 a platform run carries a stale BYOK header",
+    "label": "x-api-key attached unconditionally — a platform run carries a stale BYOK header",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "headers = {\"x-api-key\": byok_key} if byok_key else None",
     "replace": "headers = {\"x-api-key\": byok_key}",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "label": "undecryptable stored key raises instead of degrading \u2014 every turn fails after a key rotation",
+    "label": "undecryptable stored key raises instead of degrading — every turn fails after a key rotation",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "        return TurnCredentials(source=\"platform\")\n\n    if not plaintext:",
     "replace": "        raise\n\n    if not plaintext:",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "label": "gateway base_url skips the SSRF guard \u2014 a stranger points our server at cloud metadata",
+    "label": "gateway base_url skips the SSRF guard — a stranger points our server at cloud metadata",
     "file": "ee/pocketpaw_ee/cloud/byok/dto.py",
     "find": "        return validate_external_url_strict(v)",
     "replace": "        return v",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "label": "gateway override drops the model pin \u2014 the agent's claude-* name wins and every gateway turn 404s",
+    "label": "gateway override drops the model pin — the agent's claude-* name wins and every gateway turn 404s",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "            \"pydantic_ai_model\": creds.model or \"\",",
     "replace": "",
@@ -45,7 +45,7 @@
     ]
   },
   {
-    "label": "gateway shape check dropped \u2014 a key with no base_url is stored and every turn dead-ends",
+    "label": "gateway shape check dropped — a key with no base_url is stored and every turn dead-ends",
     "file": "ee/pocketpaw_ee/cloud/byok/dto.py",
     "find": "            if not self.base_url:\n                raise ValueError(\"a gateway key needs a base_url, e.g. https://host/v1\")",
     "replace": "            pass",
@@ -54,7 +54,7 @@
     ]
   },
   {
-    "label": "gateway URL is shape-checked but never RESOLVED \u2014 10-0-0-5.nip.io reaches our private network, unauthenticated",
+    "label": "gateway URL is shape-checked but never RESOLVED — 10-0-0-5.nip.io reaches our private network, unauthenticated",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "        return await assert_egress_allowed(base, {host}, allow_internal=False)",
     "replace": "        from pocketpaw.security.url_validators import EgressTarget\n\n        return EgressTarget(url=base, host=host, port=443, pinned_ip=host)",
@@ -64,7 +64,7 @@
     ]
   },
   {
-    "label": "egress guard inherits POCKETPAW_ALLOW_INTERNAL_URLS \u2014 an operator's localhost-connector flag reopens the guest SSRF",
+    "label": "egress guard inherits POCKETPAW_ALLOW_INTERNAL_URLS — an operator's localhost-connector flag reopens the guest SSRF",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "        return await assert_egress_allowed(base, {host}, allow_internal=False)",
     "replace": "        return await assert_egress_allowed(base, {host})",
@@ -74,7 +74,7 @@
     ]
   },
   {
-    "label": "turn path trusts the stored URL \u2014 a row whose DNS moved inside is dialed on every turn",
+    "label": "turn path trusts the stored URL — a row whose DNS moved inside is dialed on every turn",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "        base_url = (await assert_gateway_egress(base_url or \"\")).url",
     "replace": "        pass",
@@ -83,7 +83,7 @@
     ]
   },
   {
-    "label": "a rejected gateway address degrades to platform credentials \u2014 the tenant's bad config spends OUR money every turn",
+    "label": "a rejected gateway address degrades to platform credentials — the tenant's bad config spends OUR money every turn",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "        base_url = (await assert_gateway_egress(base_url or \"\")).url",
     "replace": "        try:\n            base_url = (await assert_gateway_egress(base_url or \"\")).url\n        except GatewayEgressRejected:\n            return TurnCredentials(source=\"platform\")",
@@ -92,7 +92,7 @@
     ]
   },
   {
-    "label": "the validation request is unpinned \u2014 DNS is resolved a second time at connect and a rebinding host answers from inside",
+    "label": "the validation request is unpinned — DNS is resolved a second time at connect and a rebinding host answers from inside",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "        transport=PinnedTransport(target.pinned_ip),",
     "replace": "",
@@ -110,22 +110,32 @@
     ]
   },
   {
-    "label": "the validator stops handing back the canonical URL \u2014 every caller silently stores its own input again",
+    "label": "the validator stops handing back the canonical URL — every caller silently stores its own input again",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
-    "find": "            \"The gateway did not respond. Your key was not saved \u2014 try again shortly.\",\n        )\n    return base",
-    "replace": "            \"The gateway did not respond. Your key was not saved \u2014 try again shortly.\",\n        )\n    return None",
+    "find": "            \"The gateway did not respond. Your key was not saved — try again shortly.\",\n        )\n    return base",
+    "replace": "            \"The gateway did not respond. Your key was not saved — try again shortly.\",\n        )\n    return None",
     "tests": [
       "tests/cloud/byok/test_byok_service.py::TestAHostnameThatResolvesInsideIsRejected::test_validate_key_returns_the_canonical_url_callers_must_store",
       "tests/cloud/auth/test_guest.py::TestMintGuest::test_a_gateway_mint_stores_the_url_that_passed_the_guard"
     ]
   },
   {
-    "label": "mint drops the gateway kwargs \u2014 an xpl_ key is validated against Anthropic and reads as a bad key",
+    "label": "mint drops the gateway kwargs — an xpl_ key is validated against Anthropic and reads as a bad key",
     "file": "ee/pocketpaw_ee/cloud/auth/guest.py",
     "find": "    canonical_base_url = await byok_service.validate_key(\n        api_key, provider=provider, base_url=base_url, model=model\n    )",
     "replace": "    canonical_base_url = await byok_service.validate_key(api_key)",
     "tests": [
       "tests/cloud/auth/test_guest.py::TestMintGuest"
+    ]
+  },
+  {
+    "label": "the typed egress catch is removed — the broad handler degrades every rejected gateway turn onto the platform's bill",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "        except byok_service.GatewayEgressRejected as exc:\n            # The stored gateway address no longer passes the egress guard —\n            # it resolves somewhere this server must not dial (2026-09-11,\n            # review B2). Caught BEFORE the broad handler below on purpose:\n            # that one degrades to platform credentials, which here would run\n            # the tenant's turn on OUR key every time their address is bad.\n            # Refuse the turn and say why; the user fixes the address.\n            logger.warning(\n                \"byok: gateway address rejected by the egress guard for workspace=%s — \"\n                \"refusing the turn\",\n                ctx.workspace_id,\n            )\n            yield (\n                \"error\",\n                {\"code\": \"byok.base_url_rejected\", \"message\": exc.message},\n            )\n            return\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/runs/test_run_core_byok_wiring.py::test_a_rejected_gateway_address_refuses_the_turn",
+      "tests/cloud/runs/test_run_core_byok_wiring.py::test_a_rejected_gateway_address_does_not_fall_back_to_platform"
     ]
   }
 ]

--- a/tests/mutations/byok.json
+++ b/tests/mutations/byok.json
@@ -54,6 +54,62 @@
     ]
   },
   {
+    "label": "gateway URL is shape-checked but never RESOLVED \u2014 10-0-0-5.nip.io reaches our private network, unauthenticated",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "        return await assert_egress_allowed(base, {host}, allow_internal=False)",
+    "replace": "        from pocketpaw.security.url_validators import EgressTarget\n\n        return EgressTarget(url=base, host=host, port=443, pinned_ip=host)",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestAHostnameThatResolvesInsideIsRejected",
+      "tests/cloud/auth/test_guest.py::TestMintGuest::test_a_gateway_address_that_resolves_INSIDE_mints_nothing"
+    ]
+  },
+  {
+    "label": "egress guard inherits POCKETPAW_ALLOW_INTERNAL_URLS \u2014 an operator's localhost-connector flag reopens the guest SSRF",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "        return await assert_egress_allowed(base, {host}, allow_internal=False)",
+    "replace": "        return await assert_egress_allowed(base, {host})",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestAHostnameThatResolvesInsideIsRejected",
+      "tests/cloud/auth/test_guest.py::TestMintGuest::test_a_gateway_address_that_resolves_INSIDE_mints_nothing"
+    ]
+  },
+  {
+    "label": "turn path trusts the stored URL \u2014 a row whose DNS moved inside is dialed on every turn",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "        base_url = (await assert_gateway_egress(base_url or \"\")).url",
+    "replace": "        pass",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestTheTurnPathReGuardsTheStoredUrl"
+    ]
+  },
+  {
+    "label": "a rejected gateway address degrades to platform credentials \u2014 the tenant's bad config spends our money every turn",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "class GatewayEgressRejected(ValidationError):",
+    "replace": "class GatewayEgressRejected(Exception):",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestTheTurnPathReGuardsTheStoredUrl::test_it_refuses_rather_than_degrading_to_platform_credentials"
+    ]
+  },
+  {
+    "label": "the validation request is unpinned \u2014 DNS is resolved a second time at connect and a rebinding host answers from inside",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "        transport=PinnedTransport(target.pinned_ip),",
+    "replace": "",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestAHostnameThatResolvesInsideIsRejected::test_the_request_is_pinned_and_does_not_follow_redirects"
+    ]
+  },
+  {
+    "label": "the stored URL is the raw one, not the one that passed the guard",
+    "file": "ee/pocketpaw_ee/cloud/auth/guest.py",
+    "find": "    if canonical_base_url:\n        base_url = canonical_base_url",
+    "replace": "    pass",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestAHostnameThatResolvesInsideIsRejected::test_validate_key_returns_the_canonical_url_callers_must_store"
+    ]
+  },
+  {
     "label": "mint drops the gateway kwargs \u2014 an xpl_ key is validated against Anthropic and reads as a bad key",
     "file": "ee/pocketpaw_ee/cloud/auth/guest.py",
     "find": "    await byok_service.validate_key(api_key, provider=provider, base_url=base_url, model=model)",

--- a/tests/mutations/byok.json
+++ b/tests/mutations/byok.json
@@ -83,10 +83,10 @@
     ]
   },
   {
-    "label": "a rejected gateway address degrades to platform credentials \u2014 the tenant's bad config spends our money every turn",
+    "label": "a rejected gateway address degrades to platform credentials \u2014 the tenant's bad config spends OUR money every turn",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
-    "find": "class GatewayEgressRejected(ValidationError):",
-    "replace": "class GatewayEgressRejected(Exception):",
+    "find": "        base_url = (await assert_gateway_egress(base_url or \"\")).url",
+    "replace": "        try:\n            base_url = (await assert_gateway_egress(base_url or \"\")).url\n        except GatewayEgressRejected:\n            return TurnCredentials(source=\"platform\")",
     "tests": [
       "tests/cloud/byok/test_byok_service.py::TestTheTurnPathReGuardsTheStoredUrl::test_it_refuses_rather_than_degrading_to_platform_credentials"
     ]
@@ -101,19 +101,29 @@
     ]
   },
   {
-    "label": "the stored URL is the raw one, not the one that passed the guard",
+    "label": "the guest mint stores the raw URL, not the one that passed the guard",
     "file": "ee/pocketpaw_ee/cloud/auth/guest.py",
     "find": "    if canonical_base_url:\n        base_url = canonical_base_url",
-    "replace": "    pass",
+    "replace": "    canonical_base_url = None",
     "tests": [
-      "tests/cloud/byok/test_byok_service.py::TestAHostnameThatResolvesInsideIsRejected::test_validate_key_returns_the_canonical_url_callers_must_store"
+      "tests/cloud/auth/test_guest.py::TestMintGuest::test_a_gateway_mint_stores_the_url_that_passed_the_guard"
+    ]
+  },
+  {
+    "label": "the validator stops handing back the canonical URL \u2014 every caller silently stores its own input again",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "            \"The gateway did not respond. Your key was not saved \u2014 try again shortly.\",\n        )\n    return base",
+    "replace": "            \"The gateway did not respond. Your key was not saved \u2014 try again shortly.\",\n        )\n    return None",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestAHostnameThatResolvesInsideIsRejected::test_validate_key_returns_the_canonical_url_callers_must_store",
+      "tests/cloud/auth/test_guest.py::TestMintGuest::test_a_gateway_mint_stores_the_url_that_passed_the_guard"
     ]
   },
   {
     "label": "mint drops the gateway kwargs \u2014 an xpl_ key is validated against Anthropic and reads as a bad key",
     "file": "ee/pocketpaw_ee/cloud/auth/guest.py",
-    "find": "    await byok_service.validate_key(api_key, provider=provider, base_url=base_url, model=model)",
-    "replace": "    await byok_service.validate_key(api_key)",
+    "find": "    canonical_base_url = await byok_service.validate_key(\n        api_key, provider=provider, base_url=base_url, model=model\n    )",
+    "replace": "    canonical_base_url = await byok_service.validate_key(api_key)",
     "tests": [
       "tests/cloud/auth/test_guest.py::TestMintGuest"
     ]

--- a/tests/mutations/byok_image_key.json
+++ b/tests/mutations/byok_image_key.json
@@ -1,6 +1,6 @@
 [
   {
-    "label": "a self-funded workspace is charged our quota too — pictures stop at 20 a day for someone paying their own bill",
+    "label": "a self-funded workspace is charged our quota too \u2014 pictures stop at 20 a day for someone paying their own bill",
     "file": "ee/pocketpaw_ee/cloud/other_hand/router.py",
     "find": "    if not grant.byok:\n        allowed, spent, cap = await illustration_budget.try_spend(workspace_id)",
     "replace": "    if True:\n        allowed, spent, cap = await illustration_budget.try_spend(workspace_id)",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "label": "the agent's tool ignores the stored key — the more natural way in draws on the platform's account",
+    "label": "the agent's tool ignores the stored key \u2014 the more natural way in draws on the platform's account",
     "file": "ee/pocketpaw_ee/agent/mcp_servers/other_hand.py",
     "find": "    api_key = grant.api_key",
     "replace": "    from pocketpaw_ee.cloud.studio import fal_edit\n\n    api_key = fal_edit.fal_api_key() or grant.api_key",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "label": "the guest refusal moves ahead of the stored key — a guest paying their own way is refused anyway",
+    "label": "the guest refusal moves ahead of the stored key \u2014 a guest paying their own way is refused anyway",
     "file": "ee/pocketpaw_ee/cloud/other_hand/illustration_credentials.py",
     "find": "    own = await byok_service.resolve_image_key(workspace_id)\n    if own:\n        return IllustrationGrant(api_key=own, byok=True)\n\n    if is_guest:",
     "replace": "    if is_guest:\n        return IllustrationRefusal(reason=GUEST_REFUSAL, guest_gate=True)\n\n    own = await byok_service.resolve_image_key(workspace_id)\n    if own:\n        return IllustrationGrant(api_key=own, byok=True)\n\n    if False:",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "label": "the guest refusal is dropped — a keyless guest spends platform money from a signup form that asks for nothing",
+    "label": "the guest refusal is dropped \u2014 a keyless guest spends platform money from a signup form that asks for nothing",
     "file": "ee/pocketpaw_ee/cloud/other_hand/illustration_credentials.py",
     "find": "    if is_guest:\n        return IllustrationRefusal(reason=GUEST_REFUSAL, guest_gate=True)",
     "replace": "    if False:\n        return IllustrationRefusal(reason=GUEST_REFUSAL, guest_gate=True)",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "label": "removing the LLM key drops the whole row — the user rotates one credential and silently loses the other",
+    "label": "removing the LLM key drops the whole row \u2014 the user rotates one credential and silently loses the other",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "    if doc.image_encrypted_key:\n        doc.encrypted_key = \"\"",
     "replace": "    if False:\n        doc.encrypted_key = \"\"",
@@ -45,16 +45,16 @@
     ]
   },
   {
-    "label": "the LLM clear names a column the document does not declare — every delete on a row that also holds an image key raises",
+    "label": "deleting the LLM key strands its gateway address \u2014 a later turn dials a URL whose key is gone",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "        for gateway_field in (\"base_url\", \"model\"):\n            if gateway_field in type(doc).model_fields:\n                setattr(doc, gateway_field, None)",
-    "replace": "        doc.base_url = None\n        doc.model = None",
+    "replace": "        pass",
     "tests": [
       "tests/cloud/byok/test_byok_service.py::TestTheTwoCredentialsAreIndependent::test_removing_the_llm_key_keeps_the_image_key"
     ]
   },
   {
-    "label": "provider error text is stored raw — a gateway that echoes the submitted key writes it into a field the status API hands back",
+    "label": "provider error text is stored raw \u2014 a gateway that echoes the submitted key writes it into a field the status API hands back",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "    return redact_output(message)[:_PROVIDER_ERROR_MAX_LEN]",
     "replace": "    return message[:_PROVIDER_ERROR_MAX_LEN]",
@@ -63,7 +63,7 @@
     ]
   },
   {
-    "label": "the fal hint prints the secret half — a credential is displayed in a settings panel",
+    "label": "the fal hint prints the secret half \u2014 a credential is displayed in a settings panel",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "    return api_key.partition(\":\")[0] if \":\" in api_key else \"\"",
     "replace": "    return api_key",


### PR DESCRIPTION
BYOK took Anthropic keys and nothing else. Otherhand launches to strangers who pay for their own turns, and a stranger's key is as likely to belong to a gateway (Experiential Labs, OpenRouter, LiteLLM, a local vLLM) as to Anthropic direct. The kiosk gate's provider dropdown has listed OpenAI and OpenRouter since it shipped, with a note underneath saying neither works yet.

A gateway key carries two things a provider key does not: an address and a model id. Both sit beside the encrypted key, both are non-secret, and both ride into the turn.

## The turn takes a different road

An Anthropic key rides as an `x-api-key` that LiteLLM forwards upstream. That works because the proxy already knows where Anthropic is. There is no LiteLLM model group pointing at a URL one guest typed, so forwarding a header for a gateway would send the turn wherever the proxy was already configured and bill the wrong account.

A gateway turn goes straight to the gateway instead, through the runtime's own `openai_compatible` provider, which has read a base URL and a key for a long time. The cost, stated plainly: those turns do not pass through the proxy, so they produce no spend-log row and skip its guardrails. That is the price of accepting any base URL, and it should be weighed before this goes to a paid tier.

Both `pydantic_ai_provider` and `pydantic_ai_model` are pinned in the override. Pinning the provider alone leaves `pydantic_ai_model` naming whatever the agent was configured with, and that name wins in `_parse_provider_model`, so every gateway turn would ask for a Claude model the gateway never heard of. There is a mutation for exactly that.

## The base URL is an SSRF boundary

It is typed by a signed-out stranger and this server then dials it. It goes through `validate_external_url_strict`, the same guard pocket backend URLs use: https only, loopback and RFC1918 and link-local and CGNAT refused, and no operator escape hatch. Not `validate_external_url`, which is permissive by design and is what the Settings fields use.

## Validation

The gateway's own `/chat/completions` is called with the user's model, because that pair is what a turn will use. Checking the key alone would let a wrong model id through to fail on the first turn, which is the failure this function exists to move earlier.

Measured against `api.experientiallabs.ai`: a base URL missing its version path answers 401, not 404, because auth runs before routing. So the missing `/v1` gets its own message off the 401 rather than off a 404 that never arrives.

## Verified

- 60 tests green across `tests/cloud/byok` and `tests/cloud/auth/test_guest.py`.
- 6 of 6 mutations caught, including one that strips the SSRF guard and one that drops the model pin.
- Both import-linter configs clean, 36 and 1 contracts kept.
- The validation path run for real against `api.openai.com`, `api.experientiallabs.ai` and `169.254.169.254`. The first two map to `byok.key_rejected`, the metadata address to `byok.base_url_rejected` before any request leaves.
- `ruff check` clean.

## Not verified

No real turn has run on a gateway key. That needs a key, which is the user's to paste. The frontend that collects the two new fields is a separate PR against paw-enterprise.

## Known red, not from this branch

`tests/cloud/auth/test_route_auth_coverage.py` fails at 50 mounted routers against a ceiling of 48. It fails identically on a clean `origin/dev` checkout.
