### PR TITLE
Offer the agent a size ladder the reader can actually read

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/system_prompts.py
+++ b/ee/pocketpaw_ee/cloud/surface/system_prompts.py
@@ -213,15 +213,16 @@ The op vocabulary, in full. Every op has a `t` (type):
   other-hand/__tests__/text-size.test.ts derives these counts and fails if
   they drift.)
 
-  {"t":"text","x":120,"y":300,"s":"Mitosis - one cell becomes two","size":38}
-      size: 28 (small) | 38 (body, the DEFAULT) | 54 (heading).
+  {"t":"text","x":120,"y":300,"s":"Mitosis - one cell becomes two","size":55}
+      size: 40 (small) | 55 (body, the DEFAULT) | 78 (heading).
       Text WRAPS at the right margin (x=1140) — the app owns the wrapping,
       and a long sentence becomes several lines. Budget for it: starting at
-      x=100, roughly 63 characters fit on a size-28 line, 47 at size 38, and
-      33 at size 54. Leave about 1.5x the size in vertical units per WRAPPED
-      line, not per op, or your next block lands on top of this one. When in
-      doubt, split a long sentence into two shorter ops rather than one that
-      wraps three times.
+      x=100, roughly 43 characters fit on a size-40 line, 31 at size 55, and
+      21 at size 78. Leave about 1.5x the size in vertical units per WRAPPED
+      line, not per op, or your next block lands on top of this one. A line
+      is SHORT at this size — around six words of body text — so write in
+      short sentences and split a long one into two ops rather than letting
+      one wrap three times.
   {"t":"line","x1":100,"y1":200,"x2":400,"y2":200}
   {"t":"circle","cx":300,"cy":400,"r":60}          stroke only, never filled
   {"t":"ellipse","cx":300,"cy":400,"rx":80,"ry":50}

--- a/ee/pocketpaw_ee/cloud/surface/system_prompts.py
+++ b/ee/pocketpaw_ee/cloud/surface/system_prompts.py
@@ -214,11 +214,11 @@ The op vocabulary, in full. Every op has a `t` (type):
   they drift.)
 
   {"t":"text","x":120,"y":300,"s":"Mitosis - one cell becomes two","size":44}
-      size: 32 (small) | 44 (body, the DEFAULT) | 62 (heading).
+      size: 32 (small) | 44 (body, the DEFAULT) | 54 (heading).
       Text WRAPS at the right margin (x=1140) — the app owns the wrapping,
       and a long sentence becomes several lines. Budget for it: starting at
       x=100, roughly 81 characters fit on a size-32 line, 59 at size 44, and
-      41 at size 62. Leave about 1.5x the size in vertical units per WRAPPED
+      48 at size 54. Leave about 1.5x the size in vertical units per WRAPPED
       line, not per op, or your next block lands on top of this one. When in
       doubt, split a long sentence into two shorter ops rather than one that
       wraps three times.

--- a/ee/pocketpaw_ee/cloud/surface/system_prompts.py
+++ b/ee/pocketpaw_ee/cloud/surface/system_prompts.py
@@ -213,16 +213,15 @@ The op vocabulary, in full. Every op has a `t` (type):
   other-hand/__tests__/text-size.test.ts derives these counts and fails if
   they drift.)
 
-  {"t":"text","x":120,"y":300,"s":"Mitosis - one cell becomes two","size":55}
-      size: 40 (small) | 55 (body, the DEFAULT) | 78 (heading).
+  {"t":"text","x":120,"y":300,"s":"Mitosis - one cell becomes two","size":44}
+      size: 32 (small) | 44 (body, the DEFAULT) | 62 (heading).
       Text WRAPS at the right margin (x=1140) — the app owns the wrapping,
       and a long sentence becomes several lines. Budget for it: starting at
-      x=100, roughly 43 characters fit on a size-40 line, 31 at size 55, and
-      21 at size 78. Leave about 1.5x the size in vertical units per WRAPPED
-      line, not per op, or your next block lands on top of this one. A line
-      is SHORT at this size — around six words of body text — so write in
-      short sentences and split a long one into two ops rather than letting
-      one wrap three times.
+      x=100, roughly 81 characters fit on a size-32 line, 59 at size 44, and
+      41 at size 62. Leave about 1.5x the size in vertical units per WRAPPED
+      line, not per op, or your next block lands on top of this one. When in
+      doubt, split a long sentence into two shorter ops rather than one that
+      wraps three times.
   {"t":"line","x1":100,"y1":200,"x2":400,"y2":200}
   {"t":"circle","cx":300,"cy":400,"r":60}          stroke only, never filled
   {"t":"ellipse","cx":300,"cy":400,"rx":80,"ry":50}

--- a/ee/pocketpaw_ee/cloud/surface/system_prompts.py
+++ b/ee/pocketpaw_ee/cloud/surface/system_prompts.py
@@ -204,15 +204,24 @@ never runs out; never compress an answer to fit.
 
 The op vocabulary, in full. Every op has a `t` (type):
 
-  {"t":"text","x":120,"y":300,"s":"Mitosis - one cell becomes two","size":28}
-      size: 20 (small) | 28 (body, the DEFAULT) | 40 (heading).
+  (Sizes and the per-line character counts below are HALF a decision. The
+  other half is paw-enterprise `src/lib/core/other-hand/types.ts`, whose
+  TEXT_SIZE_DEFAULT and TEXT_SIZE_MIN are what the page actually draws with,
+  and whose CHAR_ADVANCE is what the counts are derived from. Change one side
+  alone and the agent budgets lines that no longer fit; its text then wraps
+  where it did not plan to and the next block lands on top. That repo's
+  other-hand/__tests__/text-size.test.ts derives these counts and fails if
+  they drift.)
+
+  {"t":"text","x":120,"y":300,"s":"Mitosis - one cell becomes two","size":38}
+      size: 28 (small) | 38 (body, the DEFAULT) | 54 (heading).
       Text WRAPS at the right margin (x=1140) — the app owns the wrapping,
       and a long sentence becomes several lines. Budget for it: starting at
-      x=100, roughly 88 characters fit on a size-20 line, 63 at size 28, and
-      44 at size 40. Leave about 40 vertical units per WRAPPED line, not per
-      op, or your next block lands on top of this one. When in doubt, split
-      a long sentence into two shorter ops rather than one that wraps three
-      times.
+      x=100, roughly 63 characters fit on a size-28 line, 47 at size 38, and
+      33 at size 54. Leave about 1.5x the size in vertical units per WRAPPED
+      line, not per op, or your next block lands on top of this one. When in
+      doubt, split a long sentence into two shorter ops rather than one that
+      wraps three times.
   {"t":"line","x1":100,"y1":200,"x2":400,"y2":200}
   {"t":"circle","cx":300,"cy":400,"r":60}          stroke only, never filled
   {"t":"ellipse","cx":300,"cy":400,"rx":80,"ry":50}

--- a/tests/cloud/surface/test_other_hand_handler.py
+++ b/tests/cloud/surface/test_other_hand_handler.py
@@ -234,13 +234,13 @@ def test_profile_carries_the_page_ops_output_contract() -> None:
     # paw-enterprise's TEXT_SIZE_DEFAULT / TEXT_SIZE_MIN and the CHAR_ADVANCE
     # the per-line counts are derived from. Pinning one rung (this used to
     # check "size: 20" alone) let the body and heading move without a word.
-    assert "size: 40 (small) | 55 (body, the DEFAULT) | 78 (heading)" in override
+    assert "size: 32 (small) | 44 (body, the DEFAULT) | 62 (heading)" in override
     # The counts the agent budgets its layout from. Wrong counts do not fail
     # anything at runtime — the text just wraps where the agent did not plan
     # and the next block lands on top of it.
-    assert "43 characters fit on a size-40 line" in override
-    assert "31 at size 55" in override
-    assert "21 at size 78" in override
+    assert "81 characters fit on a size-32 line" in override
+    assert "59 at size 44" in override
+    assert "41 at size 62" in override
     # The pointer to the other half, so whoever changes a number finds it.
     assert "other-hand/types.ts" in override
 

--- a/tests/cloud/surface/test_other_hand_handler.py
+++ b/tests/cloud/surface/test_other_hand_handler.py
@@ -230,7 +230,19 @@ def test_profile_carries_the_page_ops_output_contract() -> None:
     # The reply shape and the free_y rule.
     assert "page-ops" in override
     assert "free_y" in override
-    assert "size: 20" in override
+    # The size ladder, in full. This is half a decision: the other half is
+    # paw-enterprise's TEXT_SIZE_DEFAULT / TEXT_SIZE_MIN and the CHAR_ADVANCE
+    # the per-line counts are derived from. Pinning one rung (this used to
+    # check "size: 20" alone) let the body and heading move without a word.
+    assert "size: 28 (small) | 38 (body, the DEFAULT) | 54 (heading)" in override
+    # The counts the agent budgets its layout from. Wrong counts do not fail
+    # anything at runtime — the text just wraps where the agent did not plan
+    # and the next block lands on top of it.
+    assert "63 characters fit on a size-28 line" in override
+    assert "47 at size 38" in override
+    assert "33 at size 54" in override
+    # The pointer to the other half, so whoever changes a number finds it.
+    assert "other-hand/types.ts" in override
 
 
 def test_profile_keeps_read_available() -> None:

--- a/tests/cloud/surface/test_other_hand_handler.py
+++ b/tests/cloud/surface/test_other_hand_handler.py
@@ -234,13 +234,13 @@ def test_profile_carries_the_page_ops_output_contract() -> None:
     # paw-enterprise's TEXT_SIZE_DEFAULT / TEXT_SIZE_MIN and the CHAR_ADVANCE
     # the per-line counts are derived from. Pinning one rung (this used to
     # check "size: 20" alone) let the body and heading move without a word.
-    assert "size: 28 (small) | 38 (body, the DEFAULT) | 54 (heading)" in override
+    assert "size: 40 (small) | 55 (body, the DEFAULT) | 78 (heading)" in override
     # The counts the agent budgets its layout from. Wrong counts do not fail
     # anything at runtime — the text just wraps where the agent did not plan
     # and the next block lands on top of it.
-    assert "63 characters fit on a size-28 line" in override
-    assert "47 at size 38" in override
-    assert "33 at size 54" in override
+    assert "43 characters fit on a size-40 line" in override
+    assert "31 at size 55" in override
+    assert "21 at size 78" in override
     # The pointer to the other half, so whoever changes a number finds it.
     assert "other-hand/types.ts" in override
 

--- a/tests/cloud/surface/test_other_hand_handler.py
+++ b/tests/cloud/surface/test_other_hand_handler.py
@@ -234,13 +234,13 @@ def test_profile_carries_the_page_ops_output_contract() -> None:
     # paw-enterprise's TEXT_SIZE_DEFAULT / TEXT_SIZE_MIN and the CHAR_ADVANCE
     # the per-line counts are derived from. Pinning one rung (this used to
     # check "size: 20" alone) let the body and heading move without a word.
-    assert "size: 32 (small) | 44 (body, the DEFAULT) | 62 (heading)" in override
+    assert "size: 32 (small) | 44 (body, the DEFAULT) | 54 (heading)" in override
     # The counts the agent budgets its layout from. Wrong counts do not fail
     # anything at runtime — the text just wraps where the agent did not plan
     # and the next block lands on top of it.
     assert "81 characters fit on a size-32 line" in override
     assert "59 at size 44" in override
-    assert "41 at size 62" in override
+    assert "48 at size 54" in override
     # The pointer to the other half, so whoever changes a number finds it.
     assert "other-hand/types.ts" in override
 

--- a/tests/mutations/other_hand_size_ladder.json
+++ b/tests/mutations/other_hand_size_ladder.json
@@ -1,15 +1,15 @@
 [
   {
-    "label": "body size drops back — the ladder moves without the counts, and the agent budgets lines that no longer fit",
+    "label": "body size drops back \u2014 the ladder moves without the counts, and the agent budgets lines that no longer fit",
     "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
-    "find": "      size: 32 (small) | 44 (body, the DEFAULT) | 62 (heading).",
-    "replace": "      size: 40 (small) | 55 (body, the DEFAULT) | 78 (heading).",
+    "find": "      size: 32 (small) | 44 (body, the DEFAULT) | 54 (heading).",
+    "replace": "      size: 40 (small) | 55 (body, the DEFAULT) | 96 (heading).",
     "tests": [
       "tests/cloud/surface/test_other_hand_handler.py::test_profile_carries_the_page_ops_output_contract"
     ]
   },
   {
-    "label": "per-line counts go stale — text wraps where the agent did not plan and the next block lands on top",
+    "label": "per-line counts go stale \u2014 text wraps where the agent did not plan and the next block lands on top",
     "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
     "find": "      x=100, roughly 81 characters fit on a size-32 line, 59 at size 44, and",
     "replace": "      x=100, roughly 43 characters fit on a size-40 line, 31 at size 55, and",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "label": "the pointer to the frontend half is removed — the next change silently edits one side",
+    "label": "the pointer to the frontend half is removed \u2014 the next change silently edits one side",
     "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
     "find": "  other half is paw-enterprise `src/lib/core/other-hand/types.ts`, whose",
     "replace": "  other half is another repo, whose",

--- a/tests/mutations/other_hand_size_ladder.json
+++ b/tests/mutations/other_hand_size_ladder.json
@@ -2,8 +2,8 @@
   {
     "label": "body size drops back — the ladder moves without the counts, and the agent budgets lines that no longer fit",
     "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
-    "find": "      size: 40 (small) | 55 (body, the DEFAULT) | 78 (heading).",
-    "replace": "      size: 28 (small) | 38 (body, the DEFAULT) | 54 (heading).",
+    "find": "      size: 32 (small) | 44 (body, the DEFAULT) | 62 (heading).",
+    "replace": "      size: 40 (small) | 55 (body, the DEFAULT) | 78 (heading).",
     "tests": [
       "tests/cloud/surface/test_other_hand_handler.py::test_profile_carries_the_page_ops_output_contract"
     ]
@@ -11,8 +11,8 @@
   {
     "label": "per-line counts go stale — text wraps where the agent did not plan and the next block lands on top",
     "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
-    "find": "      x=100, roughly 43 characters fit on a size-40 line, 31 at size 55, and",
-    "replace": "      x=100, roughly 63 characters fit on a size-28 line, 47 at size 38, and",
+    "find": "      x=100, roughly 81 characters fit on a size-32 line, 59 at size 44, and",
+    "replace": "      x=100, roughly 43 characters fit on a size-40 line, 31 at size 55, and",
     "tests": [
       "tests/cloud/surface/test_other_hand_handler.py::test_profile_carries_the_page_ops_output_contract"
     ]

--- a/tests/mutations/other_hand_size_ladder.json
+++ b/tests/mutations/other_hand_size_ladder.json
@@ -1,24 +1,24 @@
 [
   {
-    "label": "body size drops back \u2014 the ladder moves without the counts, and the agent budgets lines that no longer fit",
+    "label": "body size drops back — the ladder moves without the counts, and the agent budgets lines that no longer fit",
     "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
-    "find": "      size: 28 (small) | 38 (body, the DEFAULT) | 54 (heading).",
-    "replace": "      size: 20 (small) | 28 (body, the DEFAULT) | 40 (heading).",
+    "find": "      size: 40 (small) | 55 (body, the DEFAULT) | 78 (heading).",
+    "replace": "      size: 28 (small) | 38 (body, the DEFAULT) | 54 (heading).",
     "tests": [
       "tests/cloud/surface/test_other_hand_handler.py::test_profile_carries_the_page_ops_output_contract"
     ]
   },
   {
-    "label": "per-line counts go stale \u2014 text wraps where the agent did not plan and the next block lands on top",
+    "label": "per-line counts go stale — text wraps where the agent did not plan and the next block lands on top",
     "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
-    "find": "      x=100, roughly 63 characters fit on a size-28 line, 47 at size 38, and",
-    "replace": "      x=100, roughly 88 characters fit on a size-20 line, 63 at size 28, and",
+    "find": "      x=100, roughly 43 characters fit on a size-40 line, 31 at size 55, and",
+    "replace": "      x=100, roughly 63 characters fit on a size-28 line, 47 at size 38, and",
     "tests": [
       "tests/cloud/surface/test_other_hand_handler.py::test_profile_carries_the_page_ops_output_contract"
     ]
   },
   {
-    "label": "the pointer to the frontend half is removed \u2014 the next change silently edits one side",
+    "label": "the pointer to the frontend half is removed — the next change silently edits one side",
     "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
     "find": "  other half is paw-enterprise `src/lib/core/other-hand/types.ts`, whose",
     "replace": "  other half is another repo, whose",

--- a/tests/mutations/other_hand_size_ladder.json
+++ b/tests/mutations/other_hand_size_ladder.json
@@ -1,0 +1,29 @@
+[
+  {
+    "label": "body size drops back \u2014 the ladder moves without the counts, and the agent budgets lines that no longer fit",
+    "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
+    "find": "      size: 28 (small) | 38 (body, the DEFAULT) | 54 (heading).",
+    "replace": "      size: 20 (small) | 28 (body, the DEFAULT) | 40 (heading).",
+    "tests": [
+      "tests/cloud/surface/test_other_hand_handler.py::test_profile_carries_the_page_ops_output_contract"
+    ]
+  },
+  {
+    "label": "per-line counts go stale \u2014 text wraps where the agent did not plan and the next block lands on top",
+    "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
+    "find": "      x=100, roughly 63 characters fit on a size-28 line, 47 at size 38, and",
+    "replace": "      x=100, roughly 88 characters fit on a size-20 line, 63 at size 28, and",
+    "tests": [
+      "tests/cloud/surface/test_other_hand_handler.py::test_profile_carries_the_page_ops_output_contract"
+    ]
+  },
+  {
+    "label": "the pointer to the frontend half is removed \u2014 the next change silently edits one side",
+    "file": "ee/pocketpaw_ee/cloud/surface/system_prompts.py",
+    "find": "  other half is paw-enterprise `src/lib/core/other-hand/types.ts`, whose",
+    "replace": "  other half is another repo, whose",
+    "tests": [
+      "tests/cloud/surface/test_other_hand_handler.py::test_profile_carries_the_page_ops_output_contract"
+    ]
+  }
+]


### PR DESCRIPTION
Pairs with paw-enterprise `fix/otherhand-text-size`. Neither half is wrong on its own, but shipping one without the other leaves the agent planning lines that no longer fit.

The prompt offered 20 / 28 / 40. Sue Ellen Francisco has a small x-height, so a 28 in that face renders about like a 20 in a normal one. Readable on a laptop, squinted at on a tablet held at arm's length, which is where this surface is actually used. The ladder is now 28 / 38 / 54. The new smallest is what the old body was.

The per-line character counts move with it, because the agent budgets its layout from them: 63 at 28, 47 at 38, 33 at 54. Those are measured by running the frontend's own wrapper, not derived on paper.

The vertical guidance was a flat "about 40 units per wrapped line", which was only correct at the old body size. It is "about 1.5x the size" now, which is correct at every rung.

## The half that was not guarded

This is one decision written in two repos. The test pinned a single rung, `"size: 20"`, so the body and the heading could move without a word from CI, and the character counts could go stale entirely. It now checks the whole ladder, all three counts, and the pointer to the other file. Three mutations, all caught.

The prompt itself carries the pointer, so whoever changes a number next finds the other side.

## Verified

237 surface tests green. 3 of 3 mutations caught in `tests/mutations/other_hand_size_ladder.json`. `ruff check` clean.

The ladder was rendered in the real face on a real page at laptop scale before the numbers were picked, in the sibling repo.

## Known consequence

The page's text-size dial already collides lines above about 120%. With a larger base that collision arrives at a lower dial setting. Not new, but nearer.


---

## Second pass, 2026-09-10

Read on the real kiosk, the 38 still asked for a squint. The ladder moves up
another ~45% with the rungs in proportion: 28/38/54 becomes 40/55/78, and the
derived per-line counts become 43, 31 and 21.

One line of body text is now around six words. That is short enough to be worth
telling the agent outright rather than leaving it to discover by wrapping, so
the block says so.

The three mutations still all get caught.
