### PR TITLE
Attach the page image to the turn, so the agent can see it

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -367,6 +367,7 @@ import uuid
 from collections.abc import AsyncIterator
 from dataclasses import replace
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from pocketpaw.agents.backend import (  # type: ignore[import-untyped]
@@ -1487,6 +1488,77 @@ async def _model_is_unknown_to_gateway(model_id: str) -> bool:
     return not any(entry.id == model_id for entry in entries)
 
 
+#: How much of one turn's attachments we are willing to put on the wire. A page
+#: snapshot is tens of kilobytes; a high-resolution mark crop can be much more,
+#: and every byte is billed to whoever is paying for the turn.
+_MAX_TURN_IMAGE_BYTES = 6 * 1024 * 1024
+_MAX_TURN_IMAGES = 3
+_IMAGE_MEDIA_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
+
+
+def _read_turn_images(ctx: ScopeContext) -> tuple[tuple[bytes, str], ...]:
+    """Read the images the surface handler declared, for THIS turn.
+
+    Reading happens here, in the cloud, and not in the agent backend, for one
+    reason: this is the layer that knows which directory belongs to the tenant
+    asking. The paths come back from the client, which echoes what the snapshot
+    endpoint returned — so they are not secret, and a hostile client can name
+    any string it likes. Every path is therefore resolved and confirmed to sit
+    inside THIS workspace's jail before a byte is read. The OSS backend then
+    receives bytes it cannot use to reach anything.
+
+    Never raises. A missing file, an unreadable one, an oversized one, or one
+    outside the jail is skipped with a warning: the preamble still names the
+    path, so a backend that reads files itself is unaffected, and a turn that
+    loses its picture is far better than a turn that fails.
+    """
+    surface = ctx.surface_context
+    paths = getattr(surface, "preamble_images", ()) if surface else ()
+    if not paths:
+        return ()
+    from pocketpaw_ee.cloud.agent_jail import workspace_jail_root
+
+    try:
+        jail = (workspace_jail_root() / str(ctx.workspace_id)).resolve()
+    except Exception:
+        logger.warning("could not resolve the workspace jail; sending no images this turn")
+        return ()
+
+    out: list[tuple[bytes, str]] = []
+    budget = _MAX_TURN_IMAGE_BYTES
+    for raw in paths[:_MAX_TURN_IMAGES]:
+        try:
+            path = Path(raw).resolve()
+        except Exception:
+            logger.warning("surface image path could not be resolved; skipping it")
+            continue
+        if not path.is_relative_to(jail):
+            # The one case worth a loud line: a path pointing outside the
+            # tenant's own scratch dir is either a bug or an attempt.
+            logger.warning("surface image path is outside the workspace jail; refusing to read it")
+            continue
+        media_type = _IMAGE_MEDIA_TYPES.get(path.suffix.lower())
+        if media_type is None:
+            logger.warning("surface image %s is not an image type we send; skipping", path.suffix)
+            continue
+        try:
+            size = path.stat().st_size
+            if size == 0 or size > budget:
+                logger.warning("surface image is empty or over the turn budget; skipping it")
+                continue
+            out.append((path.read_bytes(), media_type))
+            budget -= size
+        except OSError:
+            logger.warning("surface image could not be read; skipping it", exc_info=True)
+    return tuple(out)
+
+
 async def _drive_agent_loop(
     ctx: ScopeContext,
     *,
@@ -1788,6 +1860,14 @@ async def _drive_agent_loop(
         # older one) produces a byte-identical run.
         if ctx.tools_enabled is False:
             run_kwargs["tools_enabled"] = False
+        # --- Images this turn should LOOK at (feat/other-hand-vision) ----------
+        # The surface handler said which files its preamble is talking about;
+        # read them here, where the tenant's jail is known, and hand the pool
+        # bytes. Withhold-when-empty, so every surface that declares none takes
+        # the identical string path it always has.
+        turn_images = _read_turn_images(ctx)
+        if turn_images:
+            run_kwargs["images"] = turn_images
         # --- BYOK per-turn credentials (feat/byok-guest-backend, 2026-09-01) ----
         # Resolve whose credential pays for THIS turn — the call the byok
         # service's own header always said the turn path makes, wired at last.

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -21,6 +21,17 @@ Changes:
   entitlement check: every model the gateway serves is in the catalog, so a
   per-plan allowlist is still the thing that would put a ceiling on cost, and
   this is the seam it plugs into.
+- 2026-09-11 (feat/other-hand-page-vision) — ``_read_turn_images`` gained a
+  PER-IMAGE ceiling (``_MAX_IMAGE_BYTES``, 5MB) beside the existing per-turn
+  budget. The two answer different questions and both are kept: the budget
+  caps what one turn puts on the wire across up to three images, and until now
+  it was the only check — so a single 5–6MB page snapshot sailed through our
+  guard and was rejected by the provider instead, which the user saw as a
+  failed turn with no useful message. 5MB is Anthropic's documented per-image
+  limit and the safe floor across providers (OpenAI and Gemini allow more), so
+  it is not conditional on which backend the turn runs. An over-size image is
+  skipped exactly like every other bad path here — warn, ``continue``, never
+  raise — so the other images in the turn still ride.
 
 - 2026-09-08 (fix/attachment-only-turns) — ``_drive_agent_loop`` now runs its
   ``user_content`` through ``agent_service.resolve_user_content`` before
@@ -1493,6 +1504,13 @@ async def _model_is_unknown_to_gateway(model_id: str) -> bool:
 #: and every byte is billed to whoever is paying for the turn.
 _MAX_TURN_IMAGE_BYTES = 6 * 1024 * 1024
 _MAX_TURN_IMAGES = 3
+#: How big ONE image may be. The turn budget above answers a different
+#: question — what the whole turn costs — and a single 5MB page snapshot
+#: passes it with room to spare, then gets rejected upstream, which the user
+#: sees as a failed turn with nothing useful said. Anthropic documents 5MB per
+#: image; OpenAI and Gemini allow more, so this is the safe floor across
+#: providers and deliberately NOT provider-conditional.
+_MAX_IMAGE_BYTES = 5 * 1024 * 1024
 _IMAGE_MEDIA_TYPES = {
     ".png": "image/png",
     ".jpg": "image/jpeg",
@@ -1551,6 +1569,13 @@ def _read_turn_images(ctx: ScopeContext) -> tuple[tuple[bytes, str], ...]:
             size = path.stat().st_size
             if size == 0 or size > budget:
                 logger.warning("surface image is empty or over the turn budget; skipping it")
+                continue
+            if size > _MAX_IMAGE_BYTES:
+                logger.warning(
+                    "surface image is %d bytes, over the %d-byte per-image limit; skipping it",
+                    size,
+                    _MAX_IMAGE_BYTES,
+                )
                 continue
             out.append((path.read_bytes(), media_type))
             budget -= size

--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -360,6 +360,15 @@ class SurfacePreamble:
 
     text: str
     cache_key: str | None
+    #: Absolute paths of images this preamble talks about, in the order the
+    #: text mentions them. The chat path reads them and attaches them to the
+    #: turn, so a model that can see gets the picture instead of a path.
+    #:
+    #: The handler owns this because the handler is what knows which files
+    #: carry meaning; nothing downstream can tell a page snapshot from a
+    #: temporary file. Empty for every surface that has no images, which is
+    #: all of them but Otherhand today.
+    images: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if self.cache_key == "":
@@ -401,6 +410,11 @@ class SurfaceContext:
     meta: SurfaceMeta
     preamble: str
     preamble_cache_key: str | None = None
+    #: Absolute image paths the handler declared (see ``SurfacePreamble``).
+    #: The chat path reads these and attaches them to the turn. Paths, not
+    #: bytes: this object is built per request and may be cached or logged,
+    #: and a page PNG has no business in either.
+    preamble_images: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/surface/handlers/other_hand.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/other_hand.py
@@ -7,13 +7,22 @@
 # The preamble's whole job is to hand over two facts the agent cannot obtain any
 # other way, and both arrive on ``SurfaceMeta``:
 #
-#   * ``snapshot_path`` — where the page image is. The agent cannot SEE the page
-#     otherwise: attachments on this pipeline are text-extracted (an image upload
-#     yields an empty stub), and the SDK is invoked with a plain ``prompt: str``,
-#     so there are no content blocks and no vision call. What there IS is
-#     ``Read``, which is in the agent's default SDK tool set and reads images
-#     natively. So the page is written to disk by the snapshot endpoint and the
-#     agent reads it off disk. That is the entire vision path.
+#   * ``snapshot_path`` — where the page image is, and now also WHICH image the
+#     turn carries. The preamble declares it on ``SurfacePreamble.images``; the
+#     chat path reads the file and attaches it to the turn, so a model that can
+#     see gets the picture (2026-09-09, feat/other-hand-vision).
+#
+#     Until then this was Claude-SDK-only by accident. That backend takes a
+#     plain ``prompt: str`` with no content blocks, so the vision path was the
+#     ``Read`` tool in its default set reading the PNG off disk — and the cloud
+#     does not run that backend. Its default is ``pydantic_ai``, which withholds
+#     file tools from tenants, so the only route left was the ``ocr`` tool: a
+#     separate vision call to another provider, on the platform's key, that
+#     flattens a drawing to bad text. The agent was answering about a
+#     transcript of a page it had never seen.
+#
+#     The path is still named in the text, because the SDK backend cannot take
+#     an attachment and reads it off disk exactly as before.
 #   * ``free_y`` — the y below which the page is empty. The one rule that makes
 #     the surface usable rather than destructive: the agent must never write over
 #     the user's own ink. The frontend re-checks this with a placement guard, so
@@ -153,9 +162,9 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
                     )
                 if mark_image_path:
                     parts.append(
-                        "A high-resolution image of just that region is at: "
-                        f"{mark_image_path}\n"
-                        "Read it when the passage is a figure, an equation, a "
+                        "A high-resolution image of just that region is "
+                        f"attached, and on disk at: {mark_image_path}\n"
+                        "Use it when the passage is a figure, an equation, a "
                         "table, or a scan — anything the text above does not "
                         "capture.\n"
                     )
@@ -168,8 +177,9 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
                 # agent should describe what it actually sees rather than
                 # calling a photograph a book page.
                 f"The user has a SOURCE open beside the notebook — a document "
-                f"page or an image — at: {book_path}\n"
-                "Read it too. It is READ-ONLY.\n"
+                f"page or an image. It is attached, and on disk at: "
+                f"{book_path}\n"
+                "Look at it too. It is READ-ONLY.\n"
                 "Everything drawn in RED on that page is the READER'S mark, "
                 "not part of the document: a loop means 'this passage', a line "
                 "under text means 'this line', a line through text means 'I do "
@@ -199,9 +209,11 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
                 f'<surface kind="other_hand" route="{route}" />\n'
                 "You are writing on the user's notebook page with them. "
                 "This is not a chat.\n"
-                f"The page image is at: {snapshot_path}\n"
-                "Read it to see what the user has written and drawn. The image "
-                "is EXACTLY the 1240x1754 coordinate space: a thing at pixel "
+                "The page image is attached to this message, and on disk at: "
+                f"{snapshot_path}\n"
+                "Look at it to see what the user has written and drawn — read "
+                "it off that path if you cannot see attachments. The image is "
+                "EXACTLY the 1240x1754 coordinate space: a thing at pixel "
                 "(x,y) in it is at coordinate (x,y) on the page.\n"
                 f"{book_block}"
                 f"The page below y={free_y} is empty. "
@@ -233,6 +245,11 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
                 mode or "teach",
                 hashlib.md5(scene.encode()).hexdigest()[:8] if scene else "no-scene",
             ),
+            # What the text above says is attached, in the order it says it.
+            # The chat path reads these and puts them on the turn; a path it
+            # cannot read is dropped there, and the sentence naming the path
+            # still stands for a backend that reads files itself.
+            images=tuple(p for p in (snapshot_path, book_path, mark_image_path) if p),
         )
     except Exception:
         # No upstream to fail, so this catch is for the unforeseen only. The

--- a/ee/pocketpaw_ee/cloud/surface/handlers/other_hand.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/other_hand.py
@@ -23,6 +23,13 @@
 #
 #     The path is still named in the text, because the SDK backend cannot take
 #     an attachment and reads it off disk exactly as before.
+#
+#     The preamble also names the INK CONVENTION (2026-09-10): the user's
+#     strokes are blue and the agent's are dark, so an attached page image
+#     carries whose-hand-wrote-this and the agent is told rather than left
+#     to infer it. The other half is paw-enterprise's USER_INK in
+#     src/lib/core/other-hand/types.ts; the word here is "blue", not a hex,
+#     so a shade tweak cannot drift the prompt.
 #   * ``free_y`` — the y below which the page is empty. The one rule that makes
 #     the surface usable rather than destructive: the agent must never write over
 #     the user's own ink. The frontend re-checks this with a placement guard, so
@@ -215,6 +222,11 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
                 "it off that path if you cannot see attachments. The image is "
                 "EXACTLY the 1240x1754 coordinate space: a thing at pixel "
                 "(x,y) in it is at coordinate (x,y) on the page.\n"
+                "Two hands write on this page and they use different pens: "
+                "YOUR ink is dark, the user's is BLUE. Anything blue is theirs "
+                "— their question, their working, their answer to your last "
+                "check-question. Never read your own earlier writing as "
+                "something they said.\n"
                 f"{book_block}"
                 f"The page below y={free_y} is empty. "
                 f"Put everything you add at y >= {free_y}.\n"

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -472,8 +472,9 @@ async def resolve_surface_context(
     # invent for it.
     if isinstance(rendered, SurfacePreamble):
         preamble, cache_key = rendered.text, rendered.cache_key
+        images = rendered.images
     else:
-        preamble, cache_key = (rendered or ""), None
+        preamble, cache_key, images = (rendered or ""), None, ()
 
     return SurfaceContext(
         workspace_id=workspace_id,
@@ -482,6 +483,7 @@ async def resolve_surface_context(
         meta=meta,
         preamble=preamble or "",
         preamble_cache_key=cache_key,
+        preamble_images=images,
     )
 
 

--- a/src/pocketpaw/agents/backend.py
+++ b/src/pocketpaw/agents/backend.py
@@ -148,6 +148,22 @@ def _accepts_prompt_digest_kwarg(func: Any) -> bool:
         return False
 
 
+def _accepts_images_kwarg(func: Any) -> bool:
+    """Does ``func`` name ``images`` in its signature?
+
+    The same question ``_accepts_prompt_digest_kwarg`` asks, for the per-turn
+    picture attachments (2026-09-09, feat/other-hand-vision). It has to be
+    asked, not assumed: seven of the eight backends take a narrower signature
+    with no ``**kwargs``, and the surface that sends images sends them on EVERY
+    turn — so an unconditional forward would not be a rare edge, it would be
+    every Otherhand turn on a self-hosted install dying in a TypeError.
+    """
+    try:
+        return "images" in inspect.signature(func).parameters
+    except (TypeError, ValueError):  # pragma: no cover - exotic callables
+        return False
+
+
 def _accepts_tools_enabled_kwarg(func: Any) -> bool:
     """Does ``func`` name ``tools_enabled`` in its signature?
 

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -178,6 +178,7 @@ from typing import TYPE_CHECKING, Any
 # below and the existing ``from pocketpaw.agents.pool import ...`` importers
 # resolve to the ONE definition.
 from pocketpaw.agents.backend import (
+    _accepts_images_kwarg,
     _accepts_prompt_digest,
     _accepts_prompt_digest_kwarg,
     _accepts_tools_enabled_kwarg,
@@ -687,6 +688,7 @@ class AgentPool:
         surface_cache_key: str | None = None,
         byok_api_key: str | None = None,
         byok_settings_override: dict[str, object] | None = None,
+        images: tuple[tuple[bytes, str], ...] = (),
     ) -> AsyncIterator[Any]:
         """Run an agent on a message. Yields AgentEvent stream.
 
@@ -762,6 +764,11 @@ class AgentPool:
         signature and only the Claude SDK backend acts on it (there it CAPS the MCP
         surface to ``allow_mcp_tool_ids`` alone — no universal grant). ``False``
         (the default) = the unchanged grant-union path.
+
+        ``images`` are the pictures THIS turn should look at, already read into
+        memory as (bytes, media_type). The caller reads them, because the caller
+        is the layer that can prove a path belongs to the tenant asking; nothing
+        below this line touches a filesystem on their behalf.
 
         ``byok_api_key`` is the caller's OWN provider key for this one turn
         (2026-08-28). It does NOT get forwarded to the cached backend — it
@@ -906,6 +913,15 @@ class AgentPool:
             # False = legacy grant-union path, unchanged for every existing run.
             if exclusive_mcp_tools:
                 run_kwargs["exclusive_mcp_tools"] = exclusive_mcp_tools
+            # Images for THIS turn, as (bytes, media_type). Forwarded further
+            # down, once the run's real backend is known — and only to a backend
+            # that DECLARES the parameter. Withhold-when-empty is not enough on
+            # its own here: seven of the eight backends have a narrower
+            # signature with no ``**kwargs``, and the Otherhand surface sends
+            # images on every turn, so an unconditional forward would end each
+            # of those turns in ``TypeError: run() got an unexpected keyword
+            # argument 'images'``. That is the /sites failure this file already
+            # records, one line above, with a different kwarg.
             # BYOK: swap the SHARED backend for a private one, built for this
             # run alone. Anything that fails here (an unregistered backend, a
             # bad settings key) falls back to the shared instance rather than
@@ -935,6 +951,13 @@ class AgentPool:
                         exc_info=True,
                     )
                     run_backend = instance.backend
+
+            # Asked of the signature for the same reason ``_accepts_policy``
+            # and ``_accepts_prompt_digest_kwarg`` are: a backend opts in by
+            # taking the argument. Asked of ``run_backend`` rather than the
+            # cached one because a BYOK run is served by a different object.
+            if images and _accepts_images_kwarg(run_backend.run):
+                run_kwargs["images"] = images
 
             # Per-send tool switch (2026-09-11). TWO gates, and the first one
             # alone was a bug in production.

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -660,6 +660,28 @@ _TENANT_SAFE_TOOLS = frozenset(
 # that removed shell access would run with the full tool set and report success.
 
 
+def _user_prompt(message: str, images: tuple[tuple[bytes, str], ...]) -> Any:
+    """The turn's user prompt: a bare string, or parts when images ride along.
+
+    Returning the STRING when there is nothing to attach is the contract every
+    other surface depends on — a parts list of one text element is not what
+    those runs have been sending, and this file has been bitten before by a
+    change that was "equivalent" on paper.
+
+    An image whose bytes are empty is dropped rather than sent: some providers
+    answer a zero-byte part with an opaque 400, which reads as the model being
+    broken rather than the attachment being empty.
+    """
+    usable = [(data, media_type) for data, media_type in images if data]
+    if not usable:
+        return message
+    from pydantic_ai import BinaryContent
+
+    parts: list[Any] = [message]
+    parts.extend(BinaryContent(data=data, media_type=media_type) for data, media_type in usable)
+    return parts
+
+
 def _normalize_tool_id(tool_id: str) -> str:
     """``mcp__srv__do_thing`` -> ``srv_do_thing``. Other spellings pass through."""
     if tool_id.startswith("mcp__"):
@@ -2276,6 +2298,22 @@ class PydanticAIBackend:
         # ``AgentPool.run`` forwards it only when non-empty, so an empty set
         # means "no per-entity narrowing" and every bundled skill is offered.
         skill_names: frozenset[str] = frozenset(),
+        # Images the caller wants THIS turn to look at, already read into
+        # memory: (bytes, media_type) pairs. Same withhold-when-empty contract
+        # as the kwargs below, so a turn that sends none takes the byte-
+        # identical string path every other surface has always taken.
+        #
+        # Bytes rather than paths, deliberately. The caller is the cloud, which
+        # is the layer that knows a tenant's jail and can prove a path sits
+        # inside it; this backend is OSS and reads no path it was handed. It
+        # also cannot import the cloud to ask.
+        #
+        # pydantic-ai has taken image input for a long time — ``user_prompt``
+        # is ``str | Sequence[UserContent]``. What was missing was anything
+        # here ever passing one, so on the Otherhand surface the page image
+        # never reached the model and the agent fell back to an OCR tool call
+        # that flattens a drawing to bad text.
+        images: tuple[tuple[bytes, str], ...] = (),
         # -- per-surface tool gating (see ``_gate_mcp_toolsets``) ------------
         # These ride the same withhold-when-empty contract, which is why their
         # absence was invisible: the pool forwards them ONLY when a surface
@@ -2481,7 +2519,16 @@ class PydanticAIBackend:
             # a run's accounting cannot live on it.
             kwargs["usage"] = run_usage
 
-            async with agent.run_stream_events(message, **kwargs) as stream:
+            # The user prompt is a plain string unless this turn carries
+            # images, in which case it becomes the parts list pydantic-ai wants.
+            # The images ride the PROMPT, never ``message_history``: history is
+            # replayed from stored text, so an attached page would either be
+            # dropped on the next turn or, worse, serialized into the store.
+            # A fresh snapshot every turn is also the right semantics — the
+            # agent should see the page as it is now, not as it was.
+            prompt = _user_prompt(message, images)
+
+            async with agent.run_stream_events(prompt, **kwargs) as stream:
                 async for event in stream:
                     if handle.stopped:
                         break

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -409,6 +409,18 @@ provider-prefixed one. A spec like ``litellm:anything`` would otherwise resolve
 the deployment's proxy key on a turn that is supposed to run on the tenant's —
 a credential switch wearing a model id, which ``provider_allows_model`` cannot
 catch because a gateway's model ids are its own namespace.
+
+Updated 2026-09-11 (feat/other-hand-page-vision) — **an attached page rode every
+later turn of the session.** Images go on the prompt, which was the whole claim,
+but ``_retain_session`` keeps pydantic-ai's OWN message objects and
+``_session_history`` prefers that transcript over the cloud's stored text. So a
+turn's ``UserPromptPart`` — now ``[text, BinaryContent]`` — came back on turn 2,
+turn 3 and turn 60: N snapshots by turn N, on the one surface that attaches a
+picture to EVERY turn. Cost, real RSS in a process-global map, and a model shown
+every past version of one page with nothing marking the current one.
+``_without_attachments`` rewrites those parts down to their words on the way
+INTO retention, so the guarantee holds for every caller instead of for whichever
+read path someone remembered.
 """
 
 from __future__ import annotations
@@ -419,6 +431,7 @@ import logging
 import re
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Sequence
+from dataclasses import replace
 from typing import Any
 
 from pocketpaw.agents.backend import _DEFAULT_IDENTITY, BackendInfo, Capability
@@ -680,6 +693,49 @@ def _user_prompt(message: str, images: tuple[tuple[bytes, str], ...]) -> Any:
     parts: list[Any] = [message]
     parts.extend(BinaryContent(data=data, media_type=media_type) for data, media_type in usable)
     return parts
+
+
+def _without_attachments(message: Any) -> Any:
+    """A retained message with its attached bytes dropped and its words kept.
+
+    A turn that carried images leaves a ``UserPromptPart`` whose content is
+    ``[text, BinaryContent, ...]``. Retaining that verbatim makes turn N replay
+    every earlier turn's picture: tokens against a feature whose whole point is
+    a per-turn byte budget, raw bytes pinned in a process-global map for the
+    life of the session, and a model shown every past version of one page with
+    nothing to say which is current. The fresh snapshot on THIS turn's prompt is
+    the one the agent is meant to answer about.
+
+    Stripping on the way INTO retention, not on the way out, is what makes the
+    guarantee hold for every caller of ``_retain_session`` rather than for the
+    one read path someone remembered.
+
+    Narrow on purpose. Only ``UserPromptPart`` is rewritten: a ``ToolReturnPart``
+    may legitimately hold a non-string sequence, and filtering that down to its
+    ``str`` elements would destroy tool results — which is the very thing
+    retention exists to preserve.
+    """
+    parts = getattr(message, "parts", None)
+    if not parts:
+        return message
+    from pydantic_ai.messages import UserPromptPart
+
+    rewritten: list[Any] = []
+    stripped = False
+    for part in parts:
+        content = getattr(part, "content", None)
+        if not isinstance(part, UserPromptPart) or isinstance(content, str):
+            rewritten.append(part)
+            continue
+        words = [item for item in content if isinstance(item, str)]
+        if len(words) == len(content):
+            rewritten.append(part)
+            continue
+        stripped = True
+        rewritten.append(replace(part, content="\n".join(words)))
+    if not stripped:
+        return message
+    return replace(message, parts=rewritten)
 
 
 def _normalize_tool_id(tool_id: str) -> str:
@@ -2260,7 +2316,13 @@ class PydanticAIBackend:
         # Trailing window: the head of a conversation is the least useful part
         # to carry and the most expensive, and compaction capabilities already
         # operate inside a run.
-        self._session_messages[session_key] = list(messages)[-_MAX_SESSION_MESSAGES:]
+        #
+        # Attachments are dropped here rather than at the read: a turn's images
+        # belong to that turn only, and keeping them would replay every past
+        # picture on every later turn of the session.
+        self._session_messages[session_key] = [
+            _without_attachments(message) for message in list(messages)[-_MAX_SESSION_MESSAGES:]
+        ]
         self._session_messages.move_to_end(session_key)
         while len(self._session_messages) > _MAX_TRACKED_SESSIONS:
             self._session_messages.popitem(last=False)
@@ -2521,11 +2583,13 @@ class PydanticAIBackend:
 
             # The user prompt is a plain string unless this turn carries
             # images, in which case it becomes the parts list pydantic-ai wants.
-            # The images ride the PROMPT, never ``message_history``: history is
-            # replayed from stored text, so an attached page would either be
-            # dropped on the next turn or, worse, serialized into the store.
-            # A fresh snapshot every turn is also the right semantics — the
-            # agent should see the page as it is now, not as it was.
+            # The images ride the PROMPT, and ONE turn's prompt only: this run's
+            # transcript is retained for the next turn, so ``_retain_session``
+            # strips the attached bytes back out on the way in (see
+            # ``_without_attachments``). Without that, turn N would carry N
+            # snapshots of the same page. A fresh snapshot every turn is also
+            # the right semantics — the agent should see the page as it is now,
+            # not as it was.
             prompt = _user_prompt(message, images)
 
             async with agent.run_stream_events(prompt, **kwargs) as stream:

--- a/tests/cloud/chat/test_turn_images.py
+++ b/tests/cloud/chat/test_turn_images.py
@@ -1,6 +1,10 @@
 # tests/cloud/chat/test_turn_images.py — the images ONE turn looks at.
 #
 # Created 2026-09-09 (feat/other-hand-vision).
+# Updated 2026-09-11 (feat/other-hand-page-vision) — cover the PER-IMAGE cap.
+# The turn budget was the only size check, and it is the wrong shape to catch
+# the case that actually bites: one 5MB page snapshot sits well inside a 6MB
+# turn and is refused by the provider instead of by us.
 #
 # Two things are worth testing here, and neither is "the happy path works":
 #
@@ -111,3 +115,20 @@ class TestALostPictureNeverCostsTheTurn:
             p.write_bytes(PNG)
             paths.append(str(p))
         assert len(run_core._read_turn_images(_ctx(*paths))) == 3
+
+    def test_an_image_over_the_per_image_cap_is_skipped_and_the_rest_still_ride(
+        self, jail: Path
+    ) -> None:
+        # The per-image ceiling is NOT the turn budget, and this is the gap it
+        # closes: at 5MB+1 this page fits the 6MB turn budget with room to
+        # spare, so the budget check passes it and the provider rejects it —
+        # a failed turn with nothing useful said. It must be dropped HERE, and
+        # dropping it must not cost the turn the picture that was fine.
+        big = jail / "big.png"
+        big.write_bytes(PNG)
+        with big.open("r+b") as fh:  # sparse — the bytes are never read
+            fh.truncate(run_core._MAX_IMAGE_BYTES + 1)
+        assert big.stat().st_size < run_core._MAX_TURN_IMAGE_BYTES
+        small = jail / "small.png"
+        small.write_bytes(PNG)
+        assert run_core._read_turn_images(_ctx(str(big), str(small))) == ((PNG, "image/png"),)

--- a/tests/cloud/chat/test_turn_images.py
+++ b/tests/cloud/chat/test_turn_images.py
@@ -1,0 +1,113 @@
+# tests/cloud/chat/test_turn_images.py — the images ONE turn looks at.
+#
+# Created 2026-09-09 (feat/other-hand-vision).
+#
+# Two things are worth testing here, and neither is "the happy path works":
+#
+#   1. The path came back from the CLIENT. It echoes what the snapshot endpoint
+#      returned, so it is not secret and a hostile client can send any string.
+#      Reading happens in the cloud precisely because this is the layer that
+#      knows which directory belongs to the tenant asking, so the jail check is
+#      the reason this function lives here at all.
+#   2. A turn that cannot read its picture must still RUN. The preamble names
+#      the path either way; losing the attachment costs the model its eyes for
+#      one turn, and raising costs the user their turn.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud.chat.runs import run_core
+from pocketpaw_ee.cloud.surface.domain import SurfaceContext, SurfaceKind, SurfaceMeta
+
+WORKSPACE = "ws-images"
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"0" * 64
+
+
+@pytest.fixture()
+def jail(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A workspace jail rooted under tmp_path, as the real one is under $HOME."""
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_JAIL_ROOT", str(tmp_path / "workspaces"))
+    mine = tmp_path / "workspaces" / WORKSPACE / "agent" / "sess"
+    mine.mkdir(parents=True)
+    return mine
+
+
+def _ctx(*images: str) -> object:
+    """A ScopeContext stand-in carrying only what _read_turn_images reads."""
+
+    class _Ctx:
+        workspace_id = WORKSPACE
+        surface_context = SurfaceContext(
+            workspace_id=WORKSPACE,
+            user_id="u1",
+            kind=SurfaceKind.OTHER_HAND,
+            meta=SurfaceMeta(),
+            preamble="x",
+            preamble_images=tuple(images),
+        )
+
+    return _Ctx()
+
+
+class TestTheJailIsTheBoundary:
+    def test_reads_an_image_inside_this_workspace(self, jail: Path) -> None:
+        page = jail / "page.png"
+        page.write_bytes(PNG)
+        assert run_core._read_turn_images(_ctx(str(page))) == ((PNG, "image/png"),)
+
+    def test_refuses_a_path_in_another_workspace(self, jail: Path) -> None:
+        theirs = jail.parent.parent.parent / "ws-someone-else" / "agent" / "s"
+        theirs.mkdir(parents=True)
+        page = theirs / "page.png"
+        page.write_bytes(PNG)
+        assert run_core._read_turn_images(_ctx(str(page))) == ()
+
+    def test_refuses_a_traversal_back_out_of_the_jail(self, jail: Path) -> None:
+        outside = jail.parent.parent.parent.parent / "secret.png"
+        outside.write_bytes(PNG)
+        climb = str(jail / ".." / ".." / ".." / ".." / "secret.png")
+        assert run_core._read_turn_images(_ctx(climb)) == ()
+
+    def test_refuses_a_file_that_is_not_an_image(self, jail: Path) -> None:
+        # The media type is derived from the suffix, so an unknown one has no
+        # honest value to send and is dropped rather than guessed at.
+        secret = jail / "notes.txt"
+        secret.write_bytes(b"whatever")
+        assert run_core._read_turn_images(_ctx(str(secret))) == ()
+
+
+class TestALostPictureNeverCostsTheTurn:
+    def test_a_missing_file_is_skipped_not_raised(self, jail: Path) -> None:
+        assert run_core._read_turn_images(_ctx(str(jail / "gone.png"))) == ()
+
+    def test_an_empty_file_is_skipped(self, jail: Path) -> None:
+        (jail / "empty.png").write_bytes(b"")
+        assert run_core._read_turn_images(_ctx(str(jail / "empty.png"))) == ()
+
+    def test_one_bad_path_does_not_lose_the_good_ones(self, jail: Path) -> None:
+        good = jail / "page.png"
+        good.write_bytes(PNG)
+        out = run_core._read_turn_images(_ctx("/etc/passwd", str(good)))
+        assert out == ((PNG, "image/png"),)
+
+    def test_a_surface_with_no_images_reads_nothing(self, jail: Path) -> None:
+        # The withhold-when-empty guarantee: every other surface keeps the
+        # plain-string prompt path it has always taken.
+        assert run_core._read_turn_images(_ctx()) == ()
+
+    def test_an_oversized_image_is_skipped(self, jail: Path, monkeypatch) -> None:
+        monkeypatch.setattr(run_core, "_MAX_TURN_IMAGE_BYTES", 16)
+        big = jail / "big.png"
+        big.write_bytes(PNG)
+        assert run_core._read_turn_images(_ctx(str(big))) == ()
+
+    def test_at_most_three_images_ride_one_turn(self, jail: Path) -> None:
+        paths = []
+        for i in range(5):
+            p = jail / f"p{i}.png"
+            p.write_bytes(PNG)
+            paths.append(str(p))
+        assert len(run_core._read_turn_images(_ctx(*paths))) == 3

--- a/tests/cloud/surface/test_other_hand_handler.py
+++ b/tests/cloud/surface/test_other_hand_handler.py
@@ -67,6 +67,13 @@ async def test_preamble_carries_snapshot_path_and_free_y() -> None:
     assert "page-ops" in text
     # The page is the surface, not a chat.
     assert "not a chat" in text.lower()
+    # The ink convention. Now that the page image is attached, the two pens are
+    # the agent's only reliable way to tell its own earlier writing from the
+    # user's — and an agent that reads its own check-question as the student's
+    # answer marks itself correct. The other half is paw-enterprise's USER_INK
+    # (src/lib/core/other-hand/types.ts); the word is "blue", never a hex.
+    assert "BLUE" in text
+    assert "YOUR ink is dark" in text
     # A key was claimed, and it names what the preamble depends on.
     assert preamble.cache_key
     assert "820" in preamble.cache_key

--- a/tests/cloud/surface/test_other_hand_handler.py
+++ b/tests/cloud/surface/test_other_hand_handler.py
@@ -56,9 +56,10 @@ async def test_preamble_carries_snapshot_path_and_free_y() -> None:
     text = preamble.text
 
     assert '<surface kind="other_hand"' in text
-    # The path — the agent's only route to seeing the page.
+    # The path, for a backend that reads files itself (the Claude SDK's own
+    # ``Read``). It is no longer the ONLY route: see the attachment tests below.
     assert SNAPSHOT in text
-    assert "Read it" in text
+    assert "attached" in text
     # free_y, as the rule the agent must respect.
     assert "y=820" in text
     assert "y >= 820" in text
@@ -69,6 +70,39 @@ async def test_preamble_carries_snapshot_path_and_free_y() -> None:
     # A key was claimed, and it names what the preamble depends on.
     assert preamble.cache_key
     assert "820" in preamble.cache_key
+    # The page is DECLARED as an attachment. This is the whole vision path on
+    # every backend but the Claude SDK: the cloud reads these and puts them on
+    # the turn. Empty here meant the model got a path it could not open and
+    # fell back to an OCR tool that flattens a drawing to bad text.
+    assert preamble.images == (SNAPSHOT,)
+
+
+async def test_preamble_declares_every_image_it_talks_about() -> None:
+    """Book mode shows three pictures. Naming two of them in the text and
+    attaching one is how an agent ends up describing a page it cannot see."""
+    preamble = await handler.build_preamble(
+        WORKSPACE,
+        USER,
+        SurfaceMeta(
+            route_path="/other-hand",
+            snapshot_path=SNAPSHOT,
+            free_y="820",
+            book_path="/jail/book.png",
+            mark_box="10,10,90,90",
+            mark_image_path="/jail/mark.png",
+        ),
+    )
+    # In the order the text mentions them: the notebook, the source, the crop.
+    assert preamble.images == (SNAPSHOT, "/jail/book.png", "/jail/mark.png")
+    for path in preamble.images:
+        assert path in preamble.text
+
+
+async def test_a_preamble_with_no_page_attaches_nothing() -> None:
+    """The no-snapshot fall-back talks about no images, so it must claim none —
+    an empty tuple is what keeps every other surface on the plain string path."""
+    preamble = await handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/other-hand"))
+    assert preamble.images == ()
 
 
 async def test_preamble_key_moves_when_the_page_does() -> None:

--- a/tests/mutations/other_hand_vision.json
+++ b/tests/mutations/other_hand_vision.json
@@ -1,0 +1,56 @@
+[
+  {
+    "label": "the jail check is dropped \u2014 a client-supplied path reads any file the server can",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "        if not path.is_relative_to(jail):",
+    "replace": "        if False:",
+    "tests": [
+      "tests/cloud/chat/test_turn_images.py::TestTheJailIsTheBoundary"
+    ]
+  },
+  {
+    "label": "a missing image raises instead of being skipped \u2014 one stale path kills every turn",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "            size = path.stat().st_size\n            if size == 0 or size > budget:",
+    "replace": "            size = path.stat().st_size\n            if size > budget:",
+    "tests": [
+      "tests/cloud/chat/test_turn_images.py::TestALostPictureNeverCostsTheTurn"
+    ]
+  },
+  {
+    "label": "the image never reaches the prompt \u2014 the model answers about a page it cannot see",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "    parts.extend(BinaryContent(data=data, media_type=media_type) for data, media_type in usable)",
+    "replace": "    pass",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_a_turn_with_an_image_sends_the_text_and_the_picture"
+    ]
+  },
+  {
+    "label": "an imageless turn sends a parts list \u2014 every other surface changes shape on the wire",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "    if not usable:\n        return message",
+    "replace": "    if False:\n        return message",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_a_turn_with_no_images_sends_a_plain_string"
+    ]
+  },
+  {
+    "label": "the handler stops declaring its images \u2014 the attachment path goes dark and OCR comes back",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/other_hand.py",
+    "find": "            images=tuple(p for p in (snapshot_path, book_path, mark_image_path) if p),",
+    "replace": "            images=(),",
+    "tests": [
+      "tests/cloud/surface/test_other_hand_handler.py"
+    ]
+  },
+  {
+    "label": "images forwarded to any backend \u2014 every Otherhand turn on the Claude SDK dies with TypeError",
+    "file": "src/pocketpaw/agents/backend.py",
+    "find": "        return \"images\" in inspect.signature(func).parameters",
+    "replace": "        return True",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_the_seven_backends_that_cannot_take_images_are_never_handed_one"
+    ]
+  }
+]

--- a/tests/mutations/other_hand_vision.json
+++ b/tests/mutations/other_hand_vision.json
@@ -1,6 +1,6 @@
 [
   {
-    "label": "the jail check is dropped \u2014 a client-supplied path reads any file the server can",
+    "label": "the jail check is dropped — a client-supplied path reads any file the server can",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
     "find": "        if not path.is_relative_to(jail):",
     "replace": "        if False:",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "label": "a missing image raises instead of being skipped \u2014 one stale path kills every turn",
+    "label": "a missing image raises instead of being skipped — one stale path kills every turn",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
     "find": "            size = path.stat().st_size\n            if size == 0 or size > budget:",
     "replace": "            size = path.stat().st_size\n            if size > budget:",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "label": "the image never reaches the prompt \u2014 the model answers about a page it cannot see",
+    "label": "the image never reaches the prompt — the model answers about a page it cannot see",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "    parts.extend(BinaryContent(data=data, media_type=media_type) for data, media_type in usable)",
     "replace": "    pass",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "label": "an imageless turn sends a parts list \u2014 every other surface changes shape on the wire",
+    "label": "an imageless turn sends a parts list — every other surface changes shape on the wire",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "    if not usable:\n        return message",
     "replace": "    if False:\n        return message",
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "label": "the handler stops declaring its images \u2014 the attachment path goes dark and OCR comes back",
+    "label": "the handler stops declaring its images — the attachment path goes dark and OCR comes back",
     "file": "ee/pocketpaw_ee/cloud/surface/handlers/other_hand.py",
     "find": "            images=tuple(p for p in (snapshot_path, book_path, mark_image_path) if p),",
     "replace": "            images=(),",
@@ -45,7 +45,7 @@
     ]
   },
   {
-    "label": "images forwarded to any backend \u2014 every Otherhand turn on the Claude SDK dies with TypeError",
+    "label": "images forwarded to any backend — every Otherhand turn on the Claude SDK dies with TypeError",
     "file": "src/pocketpaw/agents/backend.py",
     "find": "        return \"images\" in inspect.signature(func).parameters",
     "replace": "        return True",
@@ -55,12 +55,21 @@
     ]
   },
   {
-    "label": "the pool never forwards the pictures \u2014 the backend can see and is handed nothing",
+    "label": "the pool never forwards the pictures — the backend can see and is handed nothing",
     "file": "src/pocketpaw/agents/pool.py",
     "find": "            if images and _accepts_images_kwarg(run_backend.run):",
     "replace": "            if False:",
     "tests": [
       "tests/test_agent_pool_turn_images.py::test_a_seeing_backend_gets_the_pictures"
+    ]
+  },
+  {
+    "label": "the ink convention is dropped — the agent reads its own check-question as the student's answer",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/other_hand.py",
+    "find": "                \"Two hands write on this page and they use different pens: \"\n                \"YOUR ink is dark, the user's is BLUE. Anything blue is theirs \"",
+    "replace": "                \"Two hands write on this page. \"\n                \"\" ",
+    "tests": [
+      "tests/cloud/surface/test_other_hand_handler.py::test_preamble_carries_snapshot_path_and_free_y"
     ]
   }
 ]

--- a/tests/mutations/other_hand_vision.json
+++ b/tests/mutations/other_hand_vision.json
@@ -71,5 +71,23 @@
     "tests": [
       "tests/cloud/surface/test_other_hand_handler.py::test_preamble_carries_snapshot_path_and_free_y"
     ]
+  },
+  {
+    "label": "the page is retained with its bytes — turn N replays every earlier snapshot",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            _without_attachments(message) for message in list(messages)[-_MAX_SESSION_MESSAGES:]",
+    "replace": "            message for message in list(messages)[-_MAX_SESSION_MESSAGES:]",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_a_retained_turn_never_replays_its_page_image"
+    ]
+  },
+  {
+    "label": "the strip takes the words with the bytes — the sentence the picture arrived with is lost",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        words = [item for item in content if isinstance(item, str)]",
+    "replace": "        words = []",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_the_words_of_an_image_turn_survive_into_the_next_one"
+    ]
   }
 ]

--- a/tests/mutations/other_hand_vision.json
+++ b/tests/mutations/other_hand_vision.json
@@ -18,6 +18,15 @@
     ]
   },
   {
+    "label": "the per-image cap is dropped — a 5MB page fits the turn budget and the provider rejects the turn instead",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "            if size > _MAX_IMAGE_BYTES:",
+    "replace": "            if False:",
+    "tests": [
+      "tests/cloud/chat/test_turn_images.py::TestALostPictureNeverCostsTheTurn::test_an_image_over_the_per_image_cap_is_skipped_and_the_rest_still_ride"
+    ]
+  },
+  {
     "label": "the image never reaches the prompt — the model answers about a page it cannot see",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "    parts.extend(BinaryContent(data=data, media_type=media_type) for data, media_type in usable)",

--- a/tests/mutations/other_hand_vision.json
+++ b/tests/mutations/other_hand_vision.json
@@ -50,7 +50,17 @@
     "find": "        return \"images\" in inspect.signature(func).parameters",
     "replace": "        return True",
     "tests": [
-      "tests/test_pydantic_ai_backend.py::test_the_seven_backends_that_cannot_take_images_are_never_handed_one"
+      "tests/test_pydantic_ai_backend.py::test_the_seven_backends_that_cannot_take_images_are_never_handed_one",
+      "tests/test_agent_pool_turn_images.py::test_a_blind_backend_is_never_handed_one"
+    ]
+  },
+  {
+    "label": "the pool never forwards the pictures \u2014 the backend can see and is handed nothing",
+    "file": "src/pocketpaw/agents/pool.py",
+    "find": "            if images and _accepts_images_kwarg(run_backend.run):",
+    "replace": "            if False:",
+    "tests": [
+      "tests/test_agent_pool_turn_images.py::test_a_seeing_backend_gets_the_pictures"
     ]
   }
 ]

--- a/tests/test_agent_pool_turn_images.py
+++ b/tests/test_agent_pool_turn_images.py
@@ -1,0 +1,101 @@
+# tests/test_agent_pool_turn_images.py — pictures reaching (and not reaching)
+# the backend through ``AgentPool.run``.
+#
+# Created 2026-09-09 (feat/other-hand-vision).
+#
+# The forward is gated on the backend's SIGNATURE, not on truthiness alone, and
+# that is the whole point of this file. Seven of the eight backends take a
+# narrow ``run`` with no ``**kwargs``; the surface that sends images sends them
+# on EVERY turn; and the one that would break is ``claude_agent_sdk``, the
+# self-hosted default. An unconditional forward is not a rare edge there, it is
+# every Otherhand turn.
+#
+# ``**kwargs`` deliberately does NOT count as declaring the parameter. That
+# matches ``_accepts_prompt_digest_kwarg``, and pool.py's own header records
+# what happens when one copy of this question starts counting ``**kwargs``.
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from pocketpaw.agents.pool import AgentPool
+
+pytestmark = pytest.mark.asyncio
+
+PNG = (b"\x89PNG\r\n\x1a\n" + b"page" * 8, "image/png")
+
+
+class _SeeingBackend:
+    """A backend that DECLARES ``images``, as pydantic_ai does."""
+
+    def __init__(self) -> None:
+        self.last_kwargs: dict | None = None
+
+    async def run(self, message: str, *, images=(), **kwargs) -> AsyncIterator[object]:
+        self.last_kwargs = {"images": images, **kwargs}
+        return
+        yield  # pragma: no cover — makes this an async generator
+
+
+class _BlindBackend:
+    """A backend with the narrow signature, as the Claude SDK has. No
+    ``**kwargs``, so an unwanted forward is a TypeError rather than a no-op."""
+
+    def __init__(self) -> None:
+        self.called = False
+
+    async def run(
+        self,
+        message: str,
+        *,
+        system_prompt: str | None = None,
+        history: list[dict] | None = None,
+        session_key: str | None = None,
+    ) -> AsyncIterator[object]:
+        self.called = True
+        return
+        yield  # pragma: no cover
+
+
+async def _drive(monkeypatch, backend, **run_kwargs):
+    inst = SimpleNamespace(
+        backend=backend,
+        soul_manager=None,
+        config={"soul_persona": "P", "system_prompt": ""},
+        last_active=datetime.now(UTC),
+        active_runs=0,
+    )
+    pool = AgentPool()
+
+    async def _fake_get(agent_id):
+        return inst
+
+    monkeypatch.setattr(pool, "get", _fake_get)
+    async for _ in pool.run("a1", "what did I write?", "session:s1", **run_kwargs):
+        pass
+    return backend
+
+
+async def test_a_seeing_backend_gets_the_pictures(monkeypatch) -> None:
+    backend = await _drive(monkeypatch, _SeeingBackend(), images=(PNG,))
+    assert backend.last_kwargs is not None
+    assert backend.last_kwargs["images"] == (PNG,)
+
+
+async def test_a_turn_with_no_pictures_forwards_nothing(monkeypatch) -> None:
+    # Withhold-when-empty: every surface that sends none keeps the call it has
+    # always made, so this change cannot move a single existing turn.
+    backend = await _drive(monkeypatch, _SeeingBackend())
+    assert backend.last_kwargs is not None
+    assert backend.last_kwargs["images"] == ()
+
+
+async def test_a_blind_backend_is_never_handed_one(monkeypatch) -> None:
+    # The regression this file exists for. Without the signature gate this
+    # raises TypeError, which on a self-hosted install is every Otherhand turn.
+    backend = await _drive(monkeypatch, _BlindBackend(), images=(PNG,))
+    assert backend.called, "the turn must still run — just without the picture"

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -3423,3 +3423,79 @@ def test_a_colon_in_a_model_name_is_still_allowed():
 
     assert [e for e in events if e.type == "error"] == []
     assert specs == ["minimax/minimax-m3:free"]
+
+
+_PNG = b"\x89PNG\r\n\x1a\n" + b"0" * 32
+
+
+def test_a_turn_with_no_images_sends_a_plain_string():
+    from pocketpaw.agents.pydantic_ai import _user_prompt
+
+    assert _user_prompt("draw me a cat", ()) == "draw me a cat"
+
+
+def test_a_turn_with_an_image_sends_the_text_and_the_picture():
+    from pydantic_ai import BinaryContent
+
+    from pocketpaw.agents.pydantic_ai import _user_prompt
+
+    prompt = _user_prompt("what did I write?", ((_PNG, "image/png"),))
+    assert isinstance(prompt, list)
+    assert prompt[0] == "what did I write?"
+    assert isinstance(prompt[1], BinaryContent)
+    assert prompt[1].data == _PNG
+    assert prompt[1].media_type == "image/png"
+
+
+def test_every_image_rides_the_same_turn():
+    # Book mode shows three pictures. Dropping the tail would leave the agent
+    # reading about a source page it was never shown.
+    from pocketpaw.agents.pydantic_ai import _user_prompt
+
+    prompt = _user_prompt("x", ((_PNG, "image/png"), (_PNG, "image/jpeg")))
+    assert len(prompt) == 3
+    assert [p.media_type for p in prompt[1:]] == ["image/png", "image/jpeg"]
+
+
+def test_an_empty_image_is_dropped_rather_than_sent():
+    # Some providers answer a zero-byte part with an opaque 400, which reads as
+    # the model being broken rather than the attachment being empty.
+    from pocketpaw.agents.pydantic_ai import _user_prompt
+
+    assert _user_prompt("x", ((b"", "image/png"),)) == "x"
+
+
+def test_the_backend_accepts_the_images_kwarg_the_pool_forwards():
+    import inspect
+
+    from pocketpaw.agents.pool import AgentPool
+    from pocketpaw.agents.pydantic_ai import PydanticAIBackend
+
+    assert "images" in inspect.signature(AgentPool.run).parameters
+    assert "images" in inspect.signature(PydanticAIBackend.run).parameters
+
+
+def test_the_seven_backends_that_cannot_take_images_are_never_handed_one():
+    """The forward is gated on the SIGNATURE, not on truthiness alone.
+
+    Seven backends take a narrower ``run`` with no ``**kwargs``, and the surface
+    that sends images sends them on EVERY turn. An unconditional forward would
+    not be a rare edge — it would be every Otherhand turn on a self-hosted
+    install (whose default backend is the Claude SDK) ending in ``TypeError:
+    run() got an unexpected keyword argument 'images'``. This file already
+    records that exact failure with a different kwarg and a different surface.
+    """
+    import inspect
+
+    from pocketpaw.agents.backend import _accepts_images_kwarg
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+    from pocketpaw.agents.pydantic_ai import PydanticAIBackend
+
+    assert _accepts_images_kwarg(PydanticAIBackend.run)
+    # The one that would break: the OSS/self-hosted default.
+    assert not _accepts_images_kwarg(ClaudeSDKBackend.run)
+    assert "images" not in inspect.signature(ClaudeSDKBackend.run).parameters
+    assert not any(
+        p.kind is inspect.Parameter.VAR_KEYWORD
+        for p in inspect.signature(ClaudeSDKBackend.run).parameters.values()
+    ), "no **kwargs to absorb it, which is why the gate has to exist"

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -34,6 +34,12 @@ moved. ``test_the_usage_event_carries_what_the_meter_actually_reads`` now expect
 be billed as ordinary input and are now billed at Anthropic's 1.25x write
 premium. The difference is a rounding error on that fixture and is not one on a
 write-heavy turn, which is the whole reason the write got its own line.
+
+Updated 2026-09-11 (feat/other-hand-page-vision) — the images section gained the
+two retention tests. ``test_a_retained_turn_never_replays_its_page_image`` is the
+one that matters: it COUNTS the attachments on turn 2 rather than asserting none,
+because turn 2's own picture is supposed to be there and a presence assertion
+would fail on working code. Pre-fix it saw 2.
 """
 
 from __future__ import annotations
@@ -3499,3 +3505,68 @@ def test_the_seven_backends_that_cannot_take_images_are_never_handed_one():
         p.kind is inspect.Parameter.VAR_KEYWORD
         for p in inspect.signature(ClaudeSDKBackend.run).parameters.values()
     ), "no **kwargs to absorb it, which is why the gate has to exist"
+
+
+async def test_a_retained_turn_never_replays_its_page_image():
+    """Turn N must carry ONE page — the one drawn now, not every earlier one.
+
+    ``_retain_session`` keeps pydantic-ai's own message objects, and with images
+    on the prompt that includes a ``UserPromptPart`` whose content is
+    ``[text, BinaryContent]``. ``_session_history`` prefers the retained
+    transcript over the cloud's text history, so without a strip on the way IN,
+    turn N ships N page snapshots: tokens against a feature whose whole point is
+    a per-turn byte budget, raw bytes held in a process-global map, and a model
+    shown every earlier version of the page with no way to tell which is
+    current.
+
+    Counting is what makes this test work. Asserting "no ``BinaryContent`` in
+    the messages" would fail even with the fix, because turn 2's own attachment
+    is supposed to be there.
+    """
+    from pydantic_ai import BinaryContent
+    from pydantic_ai.messages import UserPromptPart
+
+    seen: dict = {}
+
+    async def stream_fn(messages: list[ModelMessage], info: AgentInfo):
+        seen["messages"] = list(messages)
+        yield "ok"
+
+    backend = _backend_with_model(FunctionModel(stream_function=stream_fn))
+
+    await _collect(
+        backend, "what did I write?", images=((_PNG, "image/png"),), session_key="ws1:page"
+    )
+    await _collect(backend, "and now?", images=((_PNG, "image/png"),), session_key="ws1:page")
+
+    attached = [
+        item
+        for message in seen["messages"]
+        for part in getattr(message, "parts", ())
+        if isinstance(part, UserPromptPart) and not isinstance(part.content, str)
+        for item in part.content
+        if isinstance(item, BinaryContent)
+    ]
+    assert len(attached) == 1, f"turn 2 replayed turn 1's page: {len(attached)} images on the wire"
+
+
+async def test_the_words_of_an_image_turn_survive_into_the_next_one():
+    """Stripping the bytes must not strip the sentence they arrived with.
+
+    The retained transcript is what turn 2 reasons over, so dropping the whole
+    part would trade a cost bug for an amnesia bug.
+    """
+    seen: dict = {}
+
+    async def stream_fn(messages: list[ModelMessage], info: AgentInfo):
+        seen["messages"] = str(messages)
+        yield "ok"
+
+    backend = _backend_with_model(FunctionModel(stream_function=stream_fn))
+
+    await _collect(
+        backend, "is this triangle right?", images=((_PNG, "image/png"),), session_key="ws1:page2"
+    )
+    await _collect(backend, "and now?", session_key="ws1:page2")
+
+    assert "is this triangle right?" in seen["messages"]


### PR DESCRIPTION
pydantic-ai has taken image input for a long time. Its user prompt is typed `str | Sequence[UserContent]`. What was missing is that this backend never passed one.

So on Otherhand the page reached the model as OCR text: a separate vision call to another provider, on the platform's own OpenAI key, that flattens a drawing to bad characters. The agent has been answering about a transcript of a page it never saw.

The preamble said "Read it", and that was true only for the Claude Agent SDK, whose native `Read` opens images off disk. The cloud does not run that backend. Its default is `pydantic_ai`, which withholds file tools from tenants, so the only route left was `ocr`. A prompt naming a tool the agent does not have, which is a rule this repo already writes down.

The handler now declares which files its preamble is talking about, and the chat path reads them and puts them on the turn.

## Reading happens in the cloud, not the backend

The paths come back from the client, which echoes what the snapshot endpoint returned. They are not secret and a hostile client can send any string. This is the layer that knows which directory belongs to the tenant asking, so every path is resolved and confirmed inside that workspace's jail before a byte is read. The OSS backend then receives bytes it cannot use to reach anything, and no path-trust decision moves into `src/pocketpaw`.

A missing, oversized, foreign or non-image path is skipped with a warning rather than raised. The preamble still names it, so a backend that opens files itself is unaffected, and a turn that loses its picture beats a turn that fails.

## The bug this nearly shipped with

The forward is gated on the backend's `run` signature, not on truthiness alone. Seven of the eight backends take a narrower signature with no `**kwargs`, and this surface sends images on **every** turn. An unconditional forward would not have been a rare edge. It would have ended every Otherhand turn on a self-hosted install, whose default backend is the Claude SDK, in `TypeError: run() got an unexpected keyword argument 'images'`. `pool.py` already records that exact failure with a different kwarg and a different surface, one comment above.

## The bug that did ship, and is now fixed

An earlier version of this body said images ride the prompt and never `message_history`. That was true of the prompt and false of what happens after it. `_retain_session` keeps pydantic-ai's own message objects off the finished run, so a turn that carried a picture left behind a `UserPromptPart` whose content is `[text, BinaryContent]`, and `_session_history` prefers that retained transcript over the cloud's stored text. Turn 2 sent turn 1's page again. Turn 3 sent both. By turn 60 the retention window held sixty snapshots of one page.

That costs tokens on a feature whose whole point is a per-turn byte budget, it holds raw bytes in a process-global map for up to 200 sessions, and it leaves the model looking at every past version of the page with nothing to mark which one is current.

`_without_attachments` now rewrites those parts down to their words on the way into retention, so the guarantee holds for every caller of `_retain_session` rather than for whichever read path someone remembered. Only `UserPromptPart` is rewritten. A `ToolReturnPart` may legitimately carry a non-string sequence, and filtering that down to its `str` elements would destroy the tool results retention exists to keep.

The test counts attachments on turn 2 instead of asserting there are none, because turn 2's own page is supposed to be there. Pre-fix it counted 2.

A fresh snapshot each turn is still the correct semantics: the agent should see the page as it is now.

## Verified

539 passed and 1 skipped on `-k "pydantic_ai or other_hand or session"`, plus 29 green on the three files this branch adds under `tests/cloud` and `tests/`, which the root `addopts` skips by default. 10 of 10 mutations caught in `tests/mutations/other_hand_vision.json`, including one that strips the jail check, one that forwards to every backend, and the two added for retention.

The wire itself, not the docs: a request captured off a local server carries `"type": "image_url"` with a `data:image/png;base64,` URI to `/v1/chat/completions`. That is what an OpenAI-compatible gateway receives.

## Not verified

No real turn has run end to end against a live gateway. That needs a key.

## Cost, going the right way

These turns stop making the `ocr` call, which was a `gpt-4o` vision request on the platform's OpenAI key, once per turn, per user.

What replaces it is not free. Book mode attaches up to three images, uncached, on every turn, and image parts are not cheap to encode. The retention fix is what keeps that bounded at the current page rather than growing with the length of the session.

## Known red, not from this branch

`test_local_machine_tools_are_never_offered` fails when that file runs after `tests/cloud` in the same session. It fails identically on a clean `origin/dev`.

