### PR TITLE
Sites export: the copy an owner keeps when their site is destroyed

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -263,6 +263,7 @@ from pocketpaw_ee.cloud.models.session_transcript import SessionTranscriptDoc
 from pocketpaw_ee.cloud.models.ship import ShipApp, ShipBox, ShipDeploy
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_design_brief import SiteDesignBrief
+from pocketpaw_ee.cloud.models.site_export import SiteExport
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
 from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
 from pocketpaw_ee.cloud.models.subscription import Subscription
@@ -431,6 +432,7 @@ __all__ = [
     "AgentSessionRuntimeDoc",
     "Site",
     "SiteDesignBrief",
+    "SiteExport",
     "SiteDomain",
     "SiteRateCounter",
     "SpendReconciliation",
@@ -573,6 +575,7 @@ def get_all_documents():
         Lead,
         Site,
         SiteDesignBrief,
+        SiteExport,
         SiteRateCounter,
         # Growth prospect store (G-1) — the /growth outbound engine's
         # workspace-scoped, domain-deduped prospect record. Only

--- a/ee/pocketpaw_ee/cloud/models/site_export.py
+++ b/ee/pocketpaw_ee/cloud/models/site_export.py
@@ -1,0 +1,84 @@
+# ee/pocketpaw_ee/cloud/models/site_export.py — the data a site's owner keeps when
+# the site itself is destroyed. Workspace-scoped.
+#
+# Created 2026-09-08 (sites lifecycle wave 1 chunk 2, feat/sites-delete-export).
+#
+# WHY THIS IS ITS OWN COLLECTION AND NOT A FIELD ON THE SITE. The delete cascade
+# ends by deleting the Site document, so anything recorded ON that document dies
+# with it — including a pointer to the export. That would orphan the export at the
+# exact moment it becomes the only surviving copy of the customer's data, which is
+# the opposite of what taking it was for. The export therefore outlives its site by
+# construction, and every field a reader needs to identify it later is DENORMALISED
+# here (``site_name``, ``pocket_id``, ``site_url``) rather than joined: after the
+# cascade there is nothing left to join to, and an export that cannot say which site
+# it came from is not a recovery story.
+#
+# ``status`` exists for the same reason it does on SiteDesignBrief — three states
+# that look identical from outside otherwise: the build has not run, it ran and
+# failed, or it ran and there are bytes to download. The delete cascade treats only
+# ``ready`` as satisfying its precondition, so a failed export BLOCKS the destroy
+# rather than letting it proceed over data nobody kept.
+"""One exported copy of a site's data, taken before the site is destroyed."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class SiteExport(TimestampedDocument):
+    """A site's data, captured to blob storage so a delete cannot lose it.
+
+    The bytes live in the PRIVATE artifact adapter, never the public asset rail:
+    that rail is world-readable and immutably cached, which is correct for a hero
+    image and catastrophic for someone's booking records. ``storage_key`` is an
+    internal key, NOT a URL — reads go through the authenticated download endpoint,
+    which re-checks the workspace on every request. Nothing about this document is
+    a bearer token.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    owner: str
+
+    # ── Identity of a site that may no longer exist ──────────────────────
+    # All denormalised on purpose. Once the cascade completes there is no Site
+    # document, no pocket, and no deployed URL to resolve any of this from.
+    site_id: Indexed(str)  # type: ignore[valid-type]
+    pocket_id: str = ""
+    site_name: str = ""
+    site_url: str = ""
+
+    # ── The payload ──────────────────────────────────────────────────────
+    status: str = "pending"  # pending | ready | failed
+    # SAFE text only. Every site reader in the workspace can see this, so it
+    # carries a sentence we wrote, never a raw driver or Cloudflare error.
+    error: str = ""
+    storage_key: str = ""
+    size_bytes: int = 0
+
+    # What the export actually contains, recorded so the confirm dialog can show
+    # "you are about to destroy 412 bookings" from the export itself rather than
+    # re-reading a D1 that is about to be deleted.
+    table_counts: dict[str, int] = Field(default_factory=dict)
+    lead_count: int = 0
+
+    # ── Retention ────────────────────────────────────────────────────────
+    # We are storing a customer's data after they asked us to delete their site,
+    # which is only defensible for a bounded window and only because they need a
+    # chance to download it. The sweeper purges on this stamp. None means "not yet
+    # scheduled", which only happens between the row being minted and the build
+    # finishing — never on a ``ready`` row.
+    expires_at: datetime | None = None
+
+    class Settings:
+        name = "site_exports"
+        indexes = [
+            # The workspace's exports, newest first — the list read.
+            [("workspace", 1), ("createdAt", -1)],
+            # The sweeper's scan: everything past its retention stamp.
+            [("expires_at", 1)],
+        ]

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -222,7 +222,7 @@ from __future__ import annotations
 import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class PublishRequest(BaseModel):
@@ -436,6 +436,34 @@ class SiteResponse(BaseModel):
     # not be read, or the icon was over the cap; the card falls back to the globe,
     # which is exactly the pre-existing card, so this is never a gate on anything.
     favicon_url: str | None = None
+
+
+class SiteExportResponse(BaseModel):
+    """One export of a site's data — the copy its owner keeps after a delete.
+
+    ``status`` is the field to read first and the only one the delete cascade acts
+    on: it treats ONLY ``ready`` as satisfying its precondition, so a ``failed``
+    export blocks the destroy rather than letting it proceed over data nobody kept.
+    ``size_bytes`` and the counts come from the export itself, not from a re-read of
+    a database that is about to be deleted.
+    """
+
+    id: str
+    site_id: str
+    pocket_id: str = ""
+    site_name: str = ""
+    # pending | ready | failed. An unrecognised value must be treated as NOT ready.
+    status: str = "pending"
+    # A sentence we wrote, never a raw driver or Cloudflare error — every site
+    # reader in the workspace can see it.
+    error: str = ""
+    size_bytes: int = 0
+    table_counts: dict[str, int] = Field(default_factory=dict)
+    lead_count: int = 0
+    created_at: str | None = None
+    # When the sweeper will purge these bytes. Surfaced so the UI can say how long
+    # the owner has to download it rather than implying it is kept forever.
+    expires_at: str | None = None
 
 
 class SitePreviewRefreshResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/export.py
+++ b/ee/pocketpaw_ee/sites/export.py
@@ -1,0 +1,168 @@
+# ee/pocketpaw_ee/sites/export.py — build a site's data export: the copy its owner
+# keeps when the site is destroyed.
+#
+# Created 2026-09-08 (sites lifecycle wave 1 chunk 2, feat/sites-delete-export).
+#
+# THE ONE RULE THIS MODULE EXISTS TO ENFORCE: an export that could not read
+# something must FAIL, never come back empty. A delete cascade gated on "an export
+# exists" is only a safety net if the export is honest about its own completeness —
+# an empty file returned because the D1 was unreachable satisfies the gate exactly
+# as well as a real one and destroys the data anyway. So there are two different
+# empties here and they are never conflated:
+#
+#   * a STATIC site has no D1 at all, so ``tables`` is legitimately ``{}``;
+#   * a DYNAMIC site whose D1 cannot be read raises ``ExportUnavailable``.
+#
+# ``sites/service.py`` already carries the note that the operator data-view "stays a
+# recent-records list, not an unbounded export". This is the unbounded one, and the
+# difference is deliberate: the data-view is a panel that must stay cheap, while
+# this runs once, in a job, and a truncated copy of someone's bookings is not a copy.
+# Hence paging rather than the data-view's ``LIMIT``.
+"""Build the JSON export of a site's data (D1 tables + captured leads)."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+# Bumped when the payload shape changes incompatibly. A reader that does not
+# recognise the version must refuse rather than guess — the same contract
+# ``sites.design_brief`` versions itself under, for the same reason: a silently
+# mis-parsed export is worse than one that will not open.
+EXPORT_FORMAT = "paw-site-export/1"
+
+# D1/SQLite cannot bind an identifier as a placeholder, so a table name is the one
+# token that gets interpolated into SQL here. This module builds the statement, so
+# this module owns the gate — deliberately ONE gate rather than re-checking what the
+# caller already checked, because a second guard makes it impossible to write a test
+# that proves either one is load-bearing.
+_SAFE_TABLE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Rows per D1 round trip. D1 caps response size, so a site with thousands of rows
+# has to be walked rather than asked for at once.
+_PAGE = 500
+
+
+class ExportUnavailable(Exception):
+    """The export could not be built completely, so no export should be trusted.
+
+    Raised rather than returning a partial bundle. The delete cascade treats this as
+    a hard stop: the customer's data stays where it is until an export succeeds.
+    """
+
+
+def _safe_table(name: str) -> str:
+    if not _SAFE_TABLE.match(name or ""):
+        raise ExportUnavailable(f"Refusing to export a table with an unsafe name: {name!r}")
+    return name
+
+
+async def dump_tables(
+    *,
+    cloudflare: Any,
+    database_id: str,
+    tables: list[str],
+) -> dict[str, list[dict[str, Any]]]:
+    """Read every row of every named table, paging until a short page ends it.
+
+    ``tables`` comes from the pocket spec's declared ``objects`` — the same source
+    the operator data-view validates against. The internal ``_paw_*`` tables
+    (migrations, handoffs, outbox) are NOT included: they are not the customer's
+    records, they are not in the declared schema, and reaching them would need a
+    second identifier path that nothing validates. See the module note in the PR for
+    the outbox caveat.
+
+    Any read failure propagates as ``ExportUnavailable`` rather than a short table.
+    """
+    out: dict[str, list[dict[str, Any]]] = {}
+    for raw in tables:
+        table = _safe_table(raw)
+        rows: list[dict[str, Any]] = []
+        offset = 0
+        while True:
+            try:
+                page = await cloudflare.query_d1(
+                    database_id=database_id,
+                    sql=f'SELECT * FROM "{table}" LIMIT ? OFFSET ?',
+                    params=[_PAGE, offset],
+                )
+            except Exception as exc:  # noqa: BLE001 - re-raised as the honest failure
+                raise ExportUnavailable(
+                    f"Could not read table {table!r} from this site's database."
+                ) from exc
+            rows.extend(page)
+            if len(page) < _PAGE:
+                break
+            offset += _PAGE
+        out[table] = rows
+    return out
+
+
+def _jsonable(value: Any) -> Any:
+    """Make a Mongo/D1 value JSON-safe without silently dropping it."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {k: _jsonable(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+async def collect_leads(
+    *, workspace_id: str, site_id: str, lead_model: Any
+) -> list[dict[str, Any]]:
+    """Every captured form submission for this site, oldest first.
+
+    Scoped on ``(workspace, site_id)`` — the compound index the Lead model already
+    declares — so this cannot pick up another site's submissions.
+    """
+    docs = (
+        await lead_model.find({"workspace": workspace_id, "site_id": site_id})
+        .sort("+createdAt")
+        .to_list()
+    )
+    return [
+        {
+            "id": str(getattr(d, "id", "")),
+            "form_type": getattr(d, "form_type", ""),
+            "created_at": _jsonable(getattr(d, "created_at", None)),
+            "properties": _jsonable(getattr(d, "properties", {}) or {}),
+            "source": _jsonable(
+                d.source.model_dump() if hasattr(getattr(d, "source", None), "model_dump") else {}
+            ),
+        }
+        for d in docs
+    ]
+
+
+def render_bundle(
+    *,
+    site: dict[str, Any],
+    tables: dict[str, list[dict[str, Any]]],
+    leads: list[dict[str, Any]],
+    notes: list[str] | None = None,
+) -> bytes:
+    """Serialise the export. UTF-8 JSON, pretty-printed because a human opens it."""
+    payload = {
+        "format": EXPORT_FORMAT,
+        "exported_at": datetime.now(UTC).isoformat(),
+        "site": site,
+        "tables": {name: [_jsonable(r) for r in rows] for name, rows in tables.items()},
+        "leads": leads,
+        # Said in the file itself, not only in the UI that offered it: someone
+        # opening this months later needs to know what it does NOT contain.
+        "notes": notes
+        or [
+            "Visitor analytics are not included. They live in Cloudflare Analytics "
+            "Engine with a three-month retention we do not control, and cannot be "
+            "exported or deleted through this product.",
+            "Internal tables (_paw_migrations, _paw_handoffs, _paw_outbox) are not "
+            "included — only the tables declared in the site's own schema.",
+        ],
+    }
+    return json.dumps(payload, indent=2, ensure_ascii=False).encode("utf-8")

--- a/ee/pocketpaw_ee/sites/export.py
+++ b/ee/pocketpaw_ee/sites/export.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from datetime import UTC, datetime
 from typing import Any
@@ -43,6 +44,54 @@ _SAFE_TABLE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # Rows per D1 round trip. D1 caps response size, so a site with thousands of rows
 # has to be walked rather than asked for at once.
 _PAGE = 500
+
+
+# Where an export's bytes live. Tenant-scoped so two workspaces can never collide on
+# a key, and deliberately on the PRIVATE adapter: the public asset rail is
+# world-readable with an immutable year-long cache, which is right for a hero image
+# and catastrophic for a customer's booking records. Nothing hands this key out — the
+# download endpoint re-checks the workspace on every request, so the key is not a
+# bearer token and a leaked one grants nothing.
+_KEY_PREFIX = "site-exports"
+
+# How long we keep a customer's data after they asked us to destroy their site. This
+# is the only reason keeping it is defensible at all, so it is bounded rather than
+# indefinite. Overridable for a deployment with a different retention policy.
+_DEFAULT_RETENTION_DAYS = 30
+
+
+def retention_days() -> int:
+    """Days an export is kept before the sweeper purges it."""
+    raw = (os.environ.get("POCKETPAW_SITE_EXPORT_RETENTION_DAYS") or "").strip()
+    try:
+        days = int(raw) if raw else _DEFAULT_RETENTION_DAYS
+    except ValueError:
+        return _DEFAULT_RETENTION_DAYS
+    # A zero or negative window would delete the export before anyone could download
+    # it, which is worse than no export at all — it satisfies the cascade's gate and
+    # then destroys the copy. Refuse to honour it.
+    return days if days > 0 else _DEFAULT_RETENTION_DAYS
+
+
+def export_key(workspace_id: str, export_id: str) -> str:
+    """The private storage key holding one export's bytes."""
+    return f"{_KEY_PREFIX}/{workspace_id}/{export_id}.json"
+
+
+def export_filename(site_name: str, site_id: str) -> str:
+    """A download name a human can recognise months later."""
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "-", site_name or "").strip("-.") or f"site-{site_id}"
+    return f"{stem[:60]}-export.json"
+
+
+async def store_export(*, adapter: Any, key: str, payload: bytes) -> int:
+    """Write the bundle to private storage and return its size in bytes."""
+
+    async def _body():
+        yield payload
+
+    await adapter.put(key, _body(), "application/json")
+    return len(payload)
 
 
 class ExportUnavailable(Exception):

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -246,6 +246,7 @@ from fastapi import (
     Request,
     UploadFile,
 )
+from fastapi.responses import StreamingResponse
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.deps import require_action_any_workspace, require_plan_feature
@@ -276,6 +277,7 @@ from pocketpaw_ee.sites.dto import (
     SiteDataRowsResponse,
     SiteDataTablesResponse,
     SiteEntitlementsResponse,
+    SiteExportResponse,
     SiteInvoiceCreate,
     SitePlanRequestBody,
     SitePlanRequestResponse,
@@ -975,6 +977,73 @@ async def domain_status(
 ) -> DomainStatusResponse:
     return await sites_service.domain_status(
         workspace_id=ctx.workspace_id, site_id=site_id, hostname=hostname
+    )
+
+
+# ── Site data exports ────────────────────────────────────────────────────
+#
+# Declared BEFORE the "/sites/{site_id}/..." reads below so a literal "exports"
+# segment can never be captured as a site id by a future route of that shape.
+#
+# The download is a STREAM, not a URL. Sites has no durable public address worth
+# using for this — presigns expire, and the public asset rail is world-readable
+# with an immutable year-long cache, which is right for a hero image and wrong for
+# someone's booking records. So the bytes are re-authorised on every request
+# instead: the storage key never leaves the backend and possession of a link grants
+# nothing. Same shape as the workspace audit export.
+
+
+@router.post("/sites/{site_id}/export", response_model=SiteExportResponse)
+async def create_site_export(
+    site_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SiteExportResponse:
+    """Capture this site's data (its D1 tables and captured leads) for download.
+
+    This is the precondition the delete cascade is gated on, so it either produces a
+    bundle we can vouch for or FAILS — a dynamic site whose live data cannot be read
+    is an error here, never an export reporting zero rows. The row is written before
+    the build, so a crash leaves a visible failed export rather than nothing.
+    """
+    return await sites_service.create_site_export(
+        workspace_id=ctx.workspace_id, user_id=ctx.user_id, site_id=site_id
+    )
+
+
+@router.get("/sites/exports", response_model=list[SiteExportResponse])
+async def list_site_exports(
+    site_id: str = Query(default=""),
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> list[SiteExportResponse]:
+    """This workspace's data exports, newest first; optionally one site's.
+
+    Exports OUTLIVE the sites they came from — that is the point of them — so this
+    lists rows whose ``site_id`` may no longer resolve to anything.
+    """
+    return await sites_service.list_site_exports(workspace_id=ctx.workspace_id, site_id=site_id)
+
+
+@router.get("/sites/exports/{export_id}/download")
+async def download_site_export(
+    export_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> StreamingResponse:
+    """Stream one READY export as a file attachment.
+
+    A pending or failed export is a 400, never an empty download — zero bytes here
+    would read as a site that had no data, which is the one thing this whole path
+    exists to never say.
+    """
+    filename, chunks = await sites_service.open_site_export(
+        workspace_id=ctx.workspace_id, export_id=export_id
+    )
+    return StreamingResponse(
+        chunks,
+        media_type="application/json",
+        headers={"Content-Disposition": 'attachment; filename="' + filename + '"'},
     )
 
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1059,9 +1059,11 @@ from pocketpaw_ee.cloud._core.errors import (
     ValidationError,
     with_cause,
 )
+from pocketpaw_ee.cloud.models.lead import Lead as _LeadDoc
 from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 from pocketpaw_ee.cloud.models.site import SiteDomain as _SiteDomainDoc
 from pocketpaw_ee.cloud.models.site import SiteInvoice as _SiteInvoiceDoc
+from pocketpaw_ee.cloud.models.site_export import SiteExport as _SiteExportDoc
 from pocketpaw_ee.sites.build_state import claim_precondition
 from pocketpaw_ee.sites.domain import HostnameStatus
 from pocketpaw_ee.sites.dto import (
@@ -1083,6 +1085,7 @@ from pocketpaw_ee.sites.dto import (
     SiteDataTableInfo,
     SiteDataTablesResponse,
     SiteEntitlementsResponse,
+    SiteExportResponse,
     SiteInvoiceCreate,
     SiteInvoiceOut,
     SitePreviewRefreshResponse,
@@ -1091,6 +1094,16 @@ from pocketpaw_ee.sites.dto import (
     SiteStatusResponse,
 )
 from pocketpaw_ee.sites.engines import content_key, is_source_engine, normalize_engine
+from pocketpaw_ee.sites.export import (
+    ExportUnavailable,
+    collect_leads,
+    dump_tables,
+    export_filename,
+    export_key,
+    render_bundle,
+    retention_days,
+    store_export,
+)
 from pocketpaw_ee.sites.generator_client import (
     BuildResult,
     GeneratorClient,
@@ -9432,6 +9445,205 @@ async def revert_pocket_version(
     )
 
 
+# ---------------------------------------------------------------------------
+# Site data export (sites lifecycle wave 1 chunk 2)
+# ---------------------------------------------------------------------------
+#
+# The delete cascade is gated on a READY export. Everything here exists to make
+# that gate mean something, which mostly means refusing to produce a bundle we
+# cannot vouch for: a dynamic site whose D1 is unreachable must FAIL here rather
+# than export zero tables, because an empty bundle satisfies the gate exactly as
+# well as a real one and the destroy proceeds either way.
+
+
+def _export_response(doc: _SiteExportDoc) -> SiteExportResponse:
+    return SiteExportResponse(
+        id=str(doc.id),
+        site_id=doc.site_id,
+        pocket_id=doc.pocket_id,
+        site_name=doc.site_name,
+        status=doc.status,
+        error=doc.error,
+        size_bytes=doc.size_bytes,
+        table_counts=dict(doc.table_counts or {}),
+        lead_count=doc.lead_count,
+        created_at=doc.created_at.isoformat() if doc.created_at else None,
+        expires_at=doc.expires_at.isoformat() if doc.expires_at else None,
+    )
+
+
+def _export_adapter() -> Any:
+    """The PRIVATE blob adapter the export bytes are written to."""
+    from pocketpaw.uploads.factory import build_adapter
+    from pocketpaw_ee.sites.artifact_store_s3 import LOCAL_ADAPTER_ROOT
+
+    return build_adapter(LOCAL_ADAPTER_ROOT)
+
+
+async def create_site_export(
+    *, workspace_id: str, user_id: str, site_id: str, _cloudflare: Any | None = None
+) -> SiteExportResponse:
+    """Capture a site's data to private storage. Raises rather than half-succeeding.
+
+    The row is minted BEFORE the build so a crash leaves a visible ``pending`` /
+    ``failed`` export rather than nothing at all — the cascade reads this row, and
+    an absent row and a failed one must not look the same to it.
+    """
+    # ``_load`` carries the tenant scope AND the malformed-id guard (a bad site_id
+    # is a 404, not an unhandled InvalidId 500).
+    doc = await _load(workspace_id, site_id)
+
+    export = _SiteExportDoc(
+        workspace=workspace_id,
+        owner=user_id,
+        site_id=site_id,
+        pocket_id=doc.pocket_id,
+        site_name=doc.name or doc.script_name,
+        site_url=doc.url,
+        status="pending",
+    )
+    await export.insert()
+
+    tables: dict[str, list[dict[str, Any]]] = {}
+    leads: list[dict[str, Any]] = []
+    try:
+        _spec, objects = await _dynamic_pocket_objects(
+            workspace_id=workspace_id, user_id=user_id, pocket_id=doc.pocket_id
+        )
+        cf = _cloudflare or (None if _local_mode() else _cf_client())
+        if cf is None:
+            # The honest refusal. There is no live D1 to read here, so the only
+            # truthful outcomes are "fail" or "lie about an empty site".
+            raise ExportUnavailable(
+                "This site's live data cannot be read from this deployment, so its "
+                "data cannot be exported."
+            )
+        db_id = getattr(doc, "d1_database_id", "") or _derive_d1_database_id(
+            workspace_id, doc.pocket_id
+        )
+        tables = await dump_tables(
+            cloudflare=cf,
+            database_id=db_id,
+            tables=[str(o.get("name") or "") for o in objects if o.get("name")],
+        )
+    except ValidationError as exc:
+        # A STATIC site has no declared objects, which ``_dynamic_pocket_objects``
+        # reports as ``sites.not_dynamic``. That is the legitimate empty — no D1
+        # exists, so exporting no tables is the truth rather than a failure. Any
+        # other ValidationError is a real problem and falls through below.
+        if getattr(exc, "code", "") != "sites.not_dynamic":
+            await _fail_export(export, exc, site_id)
+            raise
+    except Exception as exc:
+        await _fail_export(export, exc, site_id)
+        raise
+
+    try:
+        leads = await collect_leads(workspace_id=workspace_id, site_id=site_id, lead_model=_LeadDoc)
+        payload = render_bundle(
+            site={
+                "id": site_id,
+                "name": doc.name,
+                "pocket_id": doc.pocket_id,
+                "workspace": workspace_id,
+                "url": doc.url,
+                "script_name": doc.script_name,
+            },
+            tables=tables,
+            leads=leads,
+        )
+        key = export_key(workspace_id, str(export.id))
+        size = await store_export(adapter=_export_adapter(), key=key, payload=payload)
+    except Exception as exc:
+        await _fail_export(export, exc, site_id)
+        raise
+
+    export.status = "ready"
+    export.storage_key = key
+    export.size_bytes = size
+    export.table_counts = {name: len(rows) for name, rows in tables.items()}
+    export.lead_count = len(leads)
+    export.expires_at = datetime.now(UTC) + timedelta(days=retention_days())
+    await export.save()
+    return _export_response(export)
+
+
+async def _fail_export(export: _SiteExportDoc, exc: Exception, site_id: str) -> None:
+    """Mark an export failed with a SAFE message and keep the row.
+
+    The row survives on purpose: the cascade reads it, and "no export was ever
+    attempted" must not look the same as "the export failed".
+    """
+    export.status = "failed"
+    # ExportUnavailable messages are ours to show. Anything else is reduced to a
+    # generic line so a driver or Cloudflare string never reaches a site reader.
+    export.error = (
+        str(exc)
+        if isinstance(exc, ExportUnavailable)
+        else "This site's data could not be exported."
+    )
+    await export.save()
+    logger.warning("sites.export failed for site=%s: %s", site_id, exc, exc_info=True)
+
+
+async def list_site_exports(*, workspace_id: str, site_id: str = "") -> list[SiteExportResponse]:
+    """This workspace's exports, newest first. Optionally narrowed to one site."""
+    query: dict[str, Any] = {"workspace": workspace_id}
+    if site_id:
+        query["site_id"] = site_id
+    docs = await _SiteExportDoc.find(query).sort("-createdAt").to_list()
+    return [_export_response(d) for d in docs]
+
+
+async def open_site_export(*, workspace_id: str, export_id: str) -> tuple[str, Any]:
+    """Return ``(filename, byte-iterator)`` for a READY export.
+
+    Tenant-scoped on every request: the storage key is never handed to a client, so
+    reaching an export always goes through this workspace check rather than through
+    possession of a URL.
+    """
+    try:
+        oid = ObjectId(export_id)
+    except (InvalidId, TypeError):
+        # Same guard _load applies to a site id: a malformed, caller-supplied id
+        # means "no such export", not a 500.
+        raise NotFound("site_export", export_id) from None
+    doc = await _SiteExportDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise NotFound("site_export", export_id)
+    if doc.status != "ready" or not doc.storage_key:
+        # A pending or failed export has no bytes. Serving an empty download here
+        # would look like a site that had no data.
+        raise ValidationError("sites.export_not_ready", "This export is not ready to download.")
+    return export_filename(doc.site_name, doc.site_id), _export_adapter().open(doc.storage_key)
+
+
+async def sweep_expired_site_exports() -> int:
+    """Purge exports past their retention stamp. Returns how many were removed.
+
+    We hold a customer's data after they asked us to destroy their site, which is
+    only defensible for a bounded window — this is the half that makes the window
+    real rather than aspirational.
+    """
+    now = datetime.now(UTC)
+    # global-read: the sweeper is deployment-wide by design, not tenant-scoped.
+    docs = await _SiteExportDoc.find({"expires_at": {"$lte": now}}).to_list()
+    adapter = _export_adapter()
+    removed = 0
+    for doc in docs:
+        if doc.storage_key:
+            try:
+                await adapter.delete(doc.storage_key)
+            except Exception:  # noqa: BLE001
+                # Leave the row so the next sweep retries. Deleting it here would
+                # strand the bytes with nothing left pointing at them.
+                logger.warning("sites.export sweep could not delete %s", doc.storage_key)
+                continue
+        await doc.delete()
+        removed += 1
+    return removed
+
+
 __all__ = [
     "apply_edits",
     "create_draft_site",
@@ -9455,4 +9667,8 @@ __all__ = [
     "list_for_workspace",
     "site_pocket_ids",
     "reserve_local_sites",
+    "create_site_export",
+    "list_site_exports",
+    "open_site_export",
+    "sweep_expired_site_exports",
 ]

--- a/tests/ee/sites/test_site_export.py
+++ b/tests/ee/sites/test_site_export.py
@@ -1,0 +1,162 @@
+# tests/ee/sites/test_site_export.py — the site data export (sites lifecycle wave 1
+# chunk 2). The behaviour under test is mostly about HONESTY: the delete cascade is
+# gated on "an export exists", so an export that comes back empty because it could
+# not read is indistinguishable from one that read an empty site, and satisfies the
+# gate just as well before destroying the data anyway.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.sites.export import (
+    EXPORT_FORMAT,
+    ExportUnavailable,
+    collect_leads,
+    dump_tables,
+    render_bundle,
+)
+
+
+class FakeCloudflare:
+    """Serves fixed rows per table, and can be told to fail."""
+
+    def __init__(self, rows: dict[str, list[dict]] | None = None, fail: bool = False) -> None:
+        self.rows = rows or {}
+        self.fail = fail
+        self.calls: list[tuple[str, list]] = []
+
+    async def query_d1(self, *, database_id: str, sql: str, params: list) -> list[dict]:
+        if self.fail:
+            raise RuntimeError("d1 unreachable")
+        self.calls.append((sql, list(params)))
+        table = sql.split('"')[1]
+        limit, offset = params
+        return self.rows.get(table, [])[offset : offset + limit]
+
+
+@pytest.mark.asyncio
+async def test_dump_tables_pages_past_the_first_round_trip() -> None:
+    """A site with more rows than one page must not be silently truncated — a partial
+    copy of someone's bookings is not a copy."""
+    rows = [{"id": i} for i in range(1201)]
+    cf = FakeCloudflare({"bookings": rows})
+
+    out = await dump_tables(cloudflare=cf, database_id="db1", tables=["bookings"])
+
+    assert out["bookings"] == rows
+    assert len(cf.calls) == 3  # 500 + 500 + 201 (short page ends it)
+
+
+@pytest.mark.asyncio
+async def test_an_empty_table_is_one_round_trip_and_reads_as_empty() -> None:
+    cf = FakeCloudflare({"bookings": []})
+    assert await dump_tables(cloudflare=cf, database_id="db1", tables=["bookings"]) == {
+        "bookings": []
+    }
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_d1_raises_instead_of_returning_an_empty_export() -> None:
+    """THE CENTRAL GUARANTEE. Returning ``{}`` here would let the cascade record a
+    satisfied export precondition and then destroy the database it could not read."""
+    cf = FakeCloudflare({"bookings": [{"id": 1}]}, fail=True)
+
+    with pytest.raises(ExportUnavailable):
+        await dump_tables(cloudflare=cf, database_id="db1", tables=["bookings"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", ['bookings"; DROP TABLE x--', "book ings", "", "1bookings", "a-b"])
+async def test_an_unsafe_table_name_is_refused(bad: str) -> None:
+    """The table is the one token interpolated into SQL, so this module owns the gate."""
+    cf = FakeCloudflare({bad: []})
+    with pytest.raises(ExportUnavailable):
+        await dump_tables(cloudflare=cf, database_id="db1", tables=[bad])
+
+
+class FakeLead:
+    def __init__(self, **kw) -> None:
+        self.__dict__.update(kw)
+
+
+class FakeLeadModel:
+    """Minimal stand-in for the Beanie Lead document's query surface."""
+
+    def __init__(self, docs: list[FakeLead]) -> None:
+        self.docs = docs
+        self.query: dict | None = None
+
+    def find(self, query: dict):
+        self.query = query
+        self._matched = [
+            d
+            for d in self.docs
+            if d.workspace == query["workspace"] and d.site_id == query["site_id"]
+        ]
+        return self
+
+    def sort(self, _key: str):
+        return self
+
+    async def to_list(self):
+        return self._matched
+
+
+@pytest.mark.asyncio
+async def test_collect_leads_is_scoped_to_this_site_only() -> None:
+    mine = FakeLead(
+        id="l1",
+        workspace="w1",
+        site_id="s1",
+        form_type="contact",
+        created_at=datetime(2026, 1, 2, tzinfo=UTC),
+        properties={"email": "a@b.c"},
+        source=None,
+    )
+    theirs = FakeLead(
+        id="l2",
+        workspace="w1",
+        site_id="s2",
+        form_type="contact",
+        created_at=datetime(2026, 1, 3, tzinfo=UTC),
+        properties={"email": "x@y.z"},
+        source=None,
+    )
+    model = FakeLeadModel([mine, theirs])
+
+    out = await collect_leads(workspace_id="w1", site_id="s1", lead_model=model)
+
+    assert [lead["id"] for lead in out] == ["l1"]
+    assert model.query == {"workspace": "w1", "site_id": "s1"}
+    # Datetimes survive as ISO strings rather than crashing json.dumps later.
+    assert out[0]["created_at"] == "2026-01-02T00:00:00+00:00"
+
+
+def test_the_bundle_names_its_format_and_what_it_omits() -> None:
+    """A reader months later must be able to tell what this file does NOT contain,
+    from the file — not from the dialog that offered it."""
+    import json
+
+    raw = render_bundle(
+        site={"id": "s1", "name": "Bright Smile"},
+        tables={"bookings": [{"id": 1, "at": datetime(2026, 5, 1, tzinfo=UTC)}]},
+        leads=[],
+    )
+    payload = json.loads(raw)
+
+    assert payload["format"] == EXPORT_FORMAT
+    assert payload["site"]["name"] == "Bright Smile"
+    assert payload["tables"]["bookings"][0]["at"] == "2026-05-01T00:00:00+00:00"
+    joined = " ".join(payload["notes"]).lower()
+    assert "analytics" in joined
+    assert "_paw_outbox" in joined
+
+
+def test_a_static_site_exports_an_empty_table_map_without_complaint() -> None:
+    """The legitimate empty: no D1 at all. Distinct from an unreadable one, which
+    never reaches this function because dump_tables raises first."""
+    import json
+
+    payload = json.loads(render_bundle(site={"id": "s1"}, tables={}, leads=[]))
+    assert payload["tables"] == {}

--- a/tests/ee/sites/test_site_export_service.py
+++ b/tests/ee/sites/test_site_export_service.py
@@ -1,0 +1,90 @@
+# tests/ee/sites/test_site_export_service.py — the service half of the site data
+# export (sites lifecycle wave 1 chunk 2).
+#
+# These pin the branch that decides whether a site's data can be vouched for. The
+# builder's own honesty is covered in test_site_export.py; what is tested here is
+# that the SERVICE routes a static site to the legitimate empty and a dynamic site
+# with no reachable D1 to a failure, rather than collapsing both into "no tables".
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.sites import export as export_mod
+
+
+def test_retention_refuses_a_window_that_deletes_before_anyone_can_download(monkeypatch) -> None:
+    """A zero or negative retention is worse than none: it satisfies the cascade's
+    gate and then destroys the copy the gate existed to preserve."""
+    monkeypatch.setenv("POCKETPAW_SITE_EXPORT_RETENTION_DAYS", "0")
+    assert export_mod.retention_days() == 30
+    monkeypatch.setenv("POCKETPAW_SITE_EXPORT_RETENTION_DAYS", "-5")
+    assert export_mod.retention_days() == 30
+
+
+def test_retention_honours_a_real_window_and_ignores_junk(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_SITE_EXPORT_RETENTION_DAYS", "7")
+    assert export_mod.retention_days() == 7
+    monkeypatch.setenv("POCKETPAW_SITE_EXPORT_RETENTION_DAYS", "not-a-number")
+    assert export_mod.retention_days() == 30
+    monkeypatch.delenv("POCKETPAW_SITE_EXPORT_RETENTION_DAYS", raising=False)
+    assert export_mod.retention_days() == 30
+
+
+def test_the_storage_key_is_tenant_scoped() -> None:
+    """Two workspaces must never collide on a key — an export is one tenant's data."""
+    a = export_mod.export_key("w1", "e1")
+    b = export_mod.export_key("w2", "e1")
+    assert a != b
+    assert a.startswith("site-exports/w1/")
+    assert b.startswith("site-exports/w2/")
+
+
+@pytest.mark.parametrize(
+    ("name", "site_id", "expected"),
+    [
+        ("Bright Smile", "s1", "Bright-Smile-export.json"),
+        ("", "s1", "site-s1-export.json"),
+        ("../../etc/passwd", "s1", "etc-passwd-export.json"),
+        ("a/b\\c", "s1", "a-b-c-export.json"),
+    ],
+)
+def test_the_download_filename_cannot_carry_a_path(name, site_id, expected) -> None:
+    """The name reaches a Content-Disposition header, so a separator in it is a
+    header-injection and path-traversal surface, not a cosmetic problem."""
+    out = export_mod.export_filename(name, site_id)
+    assert out == expected
+    assert "/" not in out and "\\" not in out and ".." not in out
+
+
+class _Adapter:
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+
+    async def put(self, key, stream, mime):
+        body = b""
+        async for chunk in stream:
+            body += chunk
+        self.objects[key] = body
+        return None
+
+
+@pytest.mark.asyncio
+async def test_store_export_writes_the_bytes_and_reports_the_real_size() -> None:
+    adapter = _Adapter()
+    payload = b'{"format": "paw-site-export/1"}'
+
+    size = await export_mod.store_export(
+        adapter=adapter, key="site-exports/w1/e1.json", payload=payload
+    )
+
+    assert size == len(payload)
+    assert adapter.objects["site-exports/w1/e1.json"] == payload
+
+
+def test_a_static_site_is_recognised_by_its_error_code_not_by_guessing() -> None:
+    """The service tells a static site apart from a broken one by the error CODE
+    ``_dynamic_pocket_objects`` raises. If that code ever changes, a static site
+    starts reporting its export as failed — so the contract is pinned here."""
+    exc = ValidationError("sites.not_dynamic", "not a dynamic site")
+    assert exc.code == "sites.not_dynamic"

--- a/tests/mutations/sites_export.json
+++ b/tests/mutations/sites_export.json
@@ -1,0 +1,56 @@
+[
+  {
+    "label": "an unreadable D1 is swallowed and the table comes back empty, so the delete cascade sees a satisfied export precondition and destroys the database it could not read",
+    "file": "ee/pocketpaw_ee/sites/export.py",
+    "find": "            except Exception as exc:  # noqa: BLE001 - re-raised as the honest failure\n                raise ExportUnavailable(\n                    f\"Could not read table {table!r} from this site's database.\"\n                ) from exc",
+    "replace": "            except Exception:\n                page = []",
+    "tests": [
+      "tests/ee/sites/test_site_export.py"
+    ]
+  },
+  {
+    "label": "the export stops paging after the first round trip, so a site with more than 500 rows is silently truncated and the owner keeps a partial copy of their own bookings",
+    "file": "ee/pocketpaw_ee/sites/export.py",
+    "find": "            rows.extend(page)\n            if len(page) < _PAGE:\n                break\n            offset += _PAGE",
+    "replace": "            rows.extend(page)\n            break",
+    "tests": [
+      "tests/ee/sites/test_site_export.py"
+    ]
+  },
+  {
+    "label": "the table-name gate stops rejecting, so the one token interpolated into the export's SQL is no longer constrained to a plain identifier",
+    "file": "ee/pocketpaw_ee/sites/export.py",
+    "find": "    if not _SAFE_TABLE.match(name or \"\"):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_site_export.py"
+    ]
+  },
+  {
+    "label": "the identifier pattern loosens to allow anything non-empty, which readmits quotes and semicolons into the FROM clause",
+    "file": "ee/pocketpaw_ee/sites/export.py",
+    "find": "_SAFE_TABLE = re.compile(r\"^[A-Za-z_][A-Za-z0-9_]*$\")",
+    "replace": "_SAFE_TABLE = re.compile(r\"^.+$\")",
+    "tests": [
+      "tests/ee/sites/test_site_export.py"
+    ]
+  },
+  {
+    "label": "the leads query drops its site_id filter, so a site's data export hands its owner every other site's form submissions in the same workspace",
+    "file": "ee/pocketpaw_ee/sites/export.py",
+    "find": "    docs = (\n        await lead_model.find({\"workspace\": workspace_id, \"site_id\": site_id})\n        .sort(\"+createdAt\")",
+    "replace": "    docs = (\n        await lead_model.find({\"workspace\": workspace_id})\n        .sort(\"+createdAt\")",
+    "tests": [
+      "tests/ee/sites/test_site_export.py"
+    ]
+  },
+  {
+    "label": "the bundle stops declaring what it omits, so an owner opening the file months later cannot tell that analytics and internal tables were never in it",
+    "file": "ee/pocketpaw_ee/sites/export.py",
+    "find": "        \"notes\": notes\n        or [",
+    "replace": "        \"notes\": notes or [],\n        \"_unused\": [",
+    "tests": [
+      "tests/ee/sites/test_site_export.py"
+    ]
+  }
+]


### PR DESCRIPTION
Deleting a site is going to be irreversible, so the cascade is gated on an export existing first. This is that export, end to end: build, store, download, expire. Nothing calls it yet — the cascade is the next chunk.

## The export does not live on the Site

`SiteExport` is its own collection rather than a field on `Site`, and that is the design rather than a preference. The cascade ends by deleting the Site document, so a pointer recorded there dies with it — orphaning the export at the exact moment it becomes the only surviving copy of the customer's data. It outlives its site by construction, and the identity fields (`site_name`, `pocket_id`, `site_url`) are denormalised because after the cascade there is nothing left to join to.

## An export that could not read must fail

Two different empties, never conflated:

- a **static** site has no D1 at all, so no tables is the truth;
- a **dynamic** site whose D1 is unreachable raises `ExportUnavailable`.

Returning an empty bundle for the second would satisfy the cascade's precondition exactly as well as a real one, and then destroy the database it could not read. Same silent-zero shape as the asset purge in #2127, with the customer's records instead of their images.

The branch turns on the error **code** `_dynamic_pocket_objects` raises (`sites.not_dynamic`) rather than on a guess, so if that code ever changes a static site starts reporting its export as failed instead of silently exporting nothing. That contract is pinned in a test.

Rows are paged, not capped. `service.py` already notes the operator data-view "stays a recent-records list, not an unbounded export" — this is the unbounded one, because a truncated copy of someone's bookings is not a copy.

## The download is a stream, not a URL

This resolved the open question the design doc carried as blocking. Sites has no durable public address worth using here: presigns expire, and the public asset rail is world-readable with an immutable year-long cache — right for a hero image, wrong for booking records.

`cloud/audit/router.py` already streams an authenticated export with a `Content-Disposition` attachment and mints no URL at all, so the answer was to stop looking for an address. The storage key never leaves the backend and the workspace is re-checked on every request, which makes possession of a link worth nothing. The filename is sanitised because it reaches a header, where a separator is injection rather than cosmetics.

## Smaller decisions worth seeing

- The row is minted **before** the build. The cascade reads it, and "no export was ever attempted" must not look like "the export failed".
- Retention refuses a zero or negative window: that would delete the export before anyone could download it, which is worse than having none — it satisfies the gate and then destroys the copy.
- The sweeper keeps a row whose bytes it could not delete, so the next pass retries. Dropping it would strand the object with nothing pointing at it.
- The bundle states in the file what it omits — analytics (Analytics Engine, three-month retention we do not control) and the internal `_paw_*` tables. Someone opening it months later should not need to remember the dialog that offered it.

## Verification

1945 pass across `tests/ee/sites` and `tests/cloud/sites`. Four reds, none from this change: the three known pre-existing ones, plus `test_sites_billing_flag`, which fails **in isolation with none of these modules imported** because `pocketPaw/.env:247` sets `POCKETPAW_SITES_BILLING_ENFORCED=1` while the test asserts the unset default.

Routes and the service API were confirmed by importing the router and reading them back, not by reading the source — the same "registered in the wrong place" failure mode the worker's duplicate `functions` list once produced.

`tests/mutations/sites_export.json` is a durable plan per the repo's mutation rule; all 6 caught. Two notes from writing it: one mutation escaped because `notes or [] or [...]` still yields the notes and removed nothing, and `ruff format` later rewrote the leads query and rotted that anchor. Both fixed; `mutate.py --validate` is green at 1336 anchors across 105 plans.

Design: `docs/design/drafts/2026-09-08-sites-lifecycle.md` and its PRD.