### PR TITLE
Deleting a pocket must not leave its site running

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -302,7 +302,7 @@ from bson.errors import InvalidId
 from pydantic import ValidationError as PydanticValidationError
 
 from pocketpaw.bundled_templates.schema import RippleSpec
-from pocketpaw_ee.cloud._core.errors import PocketLimitError
+from pocketpaw_ee.cloud._core.errors import ConflictError, PocketLimitError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     PocketCreated,
@@ -2726,6 +2726,43 @@ async def delete(pocket_id: str, user_id: str) -> None:
             resource_id=str(doc.id),
         )
         raise Forbidden("pocket.not_owner", "Only the pocket owner can perform this action")
+    # A pocket may not be deleted out from under a published site.
+    #
+    # Deleting the pocket does not stop the site: architecture-sites Invariant 1 says
+    # a site worker never depends on the box, so the Worker, its D1, the custom
+    # hostname, the R2 assets and the live signed key all keep working with nothing
+    # in the product able to reach them. That is an unreachable site still serving and
+    # still accepting lead ingest against a valid key, and — if it is on a paid plan —
+    # still billing.
+    #
+    # This REFUSES rather than cascading, which is the deliberate half. A cascade from
+    # here would bypass the data export that the sites delete flow takes first, so the
+    # one path that can destroy a site stays the one path that preserves its data
+    # first. Deleting the site is a prerequisite, not an alternative.
+    #
+    # The Site read goes through the sites SERVICE, not the Site model, to respect
+    # entity isolation — and the import is function-local because sites.service reads
+    # pockets, so a module-level import would be a cycle.
+    #
+    # The guard lives in the SERVICE rather than the router on purpose: the router is
+    # not the only caller (bus handlers, MCP tools, CLI and jobs reach this directly),
+    # and a guard they can walk past is not a guard.
+    from pocketpaw_ee.sites import service as sites_service
+
+    live_site = await sites_service.live_site_for_pocket(
+        workspace_id=doc.workspace, pocket_id=pocket_id
+    )
+    if live_site is not None:
+        site_id, site_name = live_site
+        raise ConflictError(
+            "pocket.has_site",
+            (
+                f"This pocket is published as the site {site_name or site_id!r}. "
+                "Delete the site first — deleting the pocket would leave it running "
+                "with no way to reach it."
+            ),
+        )
+
     # Capture audience before delete so receivers can drop the pocket from
     # their list. The wire dict isn't useful here — only the id is.
     delete_payload = {

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -9322,6 +9322,31 @@ async def site_pocket_ids(workspace_id: str) -> set[str]:
     return {doc.pocket_id async for doc in cursor}
 
 
+async def live_site_for_pocket(*, workspace_id: str, pocket_id: str) -> tuple[str, str] | None:
+    """The ACTIVE Site published from this pocket as ``(site_id, name)``, else None.
+
+    The sibling of :func:`site_pocket_ids`, narrowed to one pocket, and it exists for
+    the same entity-isolation reason: the pockets service must be able to ask whether
+    a pocket still has a site WITHOUT importing the Site model, so the Site read stays
+    on this side.
+
+    ``archived: {"$ne": True}`` matches every other gallery read — an archived dedupe
+    tombstone is not a live site, and pre-field docs (no ``archived`` key) still count
+    as active.
+
+    Deliberately does NOT filter on ``deployed``. A Site row that never reached a live
+    deploy can still own a provisioned D1 and a reserved script name, and once the
+    pocket is gone nothing can reach that row to clean it up. "Has a Site at all" is
+    the honest question here; whether it is currently serving is a different one.
+    """
+    doc = await _SiteDoc.find_one(
+        {"workspace": workspace_id, "pocket_id": pocket_id, "archived": {"$ne": True}}
+    )
+    if doc is None:
+        return None
+    return str(doc.id), (doc.name or doc.script_name or "")
+
+
 async def reserve_local_sites(workspace_id: str | None = None) -> int:
     """Re-serve locally-deployed Paw Sites after a backend restart.
 
@@ -9666,6 +9691,7 @@ __all__ = [
     "list_domains",
     "list_for_workspace",
     "site_pocket_ids",
+    "live_site_for_pocket",
     "reserve_local_sites",
     "create_site_export",
     "list_site_exports",

--- a/tests/ee/sites/test_live_site_for_pocket.py
+++ b/tests/ee/sites/test_live_site_for_pocket.py
@@ -1,0 +1,83 @@
+# tests/ee/sites/test_live_site_for_pocket.py — the narrow Site read that the pocket
+# delete guard asks (sites lifecycle wave 2).
+#
+# This is the sibling of ``site_pocket_ids``, and it inherits that read's one
+# non-obvious rule: archived rows are dedupe TOMBSTONES, not sites. The 2026-06-18
+# dedupe migration left archived duplicates behind (one pocket had 14 Site docs), so
+# a lookup that forgets the filter would find a tombstone, call it a live site, and
+# make that pocket permanently undeletable with no live site to explain why.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites import service as sites_service
+
+
+class _Doc:
+    def __init__(self, doc_id="s1", name="Bright Smile", script_name="bright-smile"):
+        self.id = doc_id
+        self.name = name
+        self.script_name = script_name
+
+
+class _FakeSiteDoc:
+    """Records the query it was asked and returns a canned document."""
+
+    query: dict | None = None
+    result: object | None = None
+
+    @classmethod
+    async def find_one(cls, query):
+        cls.query = query
+        return cls.result
+
+
+@pytest.fixture
+def fake_sites(monkeypatch):
+    _FakeSiteDoc.query = None
+    _FakeSiteDoc.result = None
+    monkeypatch.setattr(sites_service, "_SiteDoc", _FakeSiteDoc)
+    return _FakeSiteDoc
+
+
+@pytest.mark.asyncio
+async def test_the_lookup_excludes_archived_dedupe_tombstones(fake_sites) -> None:
+    """Without this filter a pocket whose only Site rows are archived duplicates
+    becomes permanently undeletable, with no live site anywhere to explain it."""
+    fake_sites.result = None
+
+    await sites_service.live_site_for_pocket(workspace_id="w1", pocket_id="pk1")
+
+    assert fake_sites.query == {
+        "workspace": "w1",
+        "pocket_id": "pk1",
+        "archived": {"$ne": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_it_returns_the_site_id_and_a_name_the_refusal_can_show(fake_sites) -> None:
+    fake_sites.result = _Doc()
+    assert await sites_service.live_site_for_pocket(workspace_id="w1", pocket_id="pk1") == (
+        "s1",
+        "Bright Smile",
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unnamed_site_falls_back_to_its_script_name(fake_sites) -> None:
+    """A site published without a display name still has to be identifiable in the
+    refusal — 'the site ""' tells the owner nothing."""
+    fake_sites.result = _Doc(name="")
+    assert await sites_service.live_site_for_pocket(workspace_id="w1", pocket_id="pk1") == (
+        "s1",
+        "bright-smile",
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_site_reads_as_none_not_as_an_empty_tuple(fake_sites) -> None:
+    """The caller branches on ``is not None``; an empty tuple would be falsy in some
+    readings and truthy in others."""
+    fake_sites.result = None
+    assert await sites_service.live_site_for_pocket(workspace_id="w1", pocket_id="pk1") is None

--- a/tests/ee/sites/test_pocket_delete_orphan.py
+++ b/tests/ee/sites/test_pocket_delete_orphan.py
@@ -1,0 +1,131 @@
+# tests/ee/sites/test_pocket_delete_orphan.py — deleting a pocket must not strand
+# the site published from it (sites lifecycle wave 2).
+#
+# The failure this prevents is not a broken page. architecture-sites Invariant 1 says
+# a site worker never depends on the box, so deleting the pocket leaves the Worker,
+# its D1, the custom hostname, the R2 assets and the live signed key all working —
+# an unreachable site still serving, still accepting lead ingest against a valid key,
+# and still billing. Nothing in the product can reach it again.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ConflictError
+
+
+class _FakePocket:
+    def __init__(self) -> None:
+        self.id = "pk1"
+        self.owner = "u1"
+        self.workspace = "w1"
+        self.visibility = "private"
+        self.shared_with: list[str] = []
+        self.deleted = False
+
+    async def delete(self) -> None:
+        self.deleted = True
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Drive pockets_service.delete with the Site lookup and emit stubbed out."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.sites import service as sites_service
+
+    pocket = _FakePocket()
+
+    async def _fetch(_pocket_id):
+        return pocket
+
+    emitted: list = []
+
+    async def _emit(evt):
+        emitted.append(evt)
+
+    monkeypatch.setattr(pockets_service, "_fetch_pocket", _fetch)
+    monkeypatch.setattr(pockets_service, "emit", _emit)
+    return pockets_service, sites_service, pocket, emitted
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_pocket_that_has_a_site_is_refused(wired, monkeypatch) -> None:
+    """The whole point. The pocket must survive so the site stays reachable."""
+    pockets_service, sites_service, pocket, emitted = wired
+
+    async def _live(*, workspace_id, pocket_id):
+        return ("site-123", "Bright Smile")
+
+    monkeypatch.setattr(sites_service, "live_site_for_pocket", _live)
+
+    with pytest.raises(ConflictError) as err:
+        await pockets_service.delete("pk1", "u1")
+
+    assert err.value.code == "pocket.has_site"
+    # The message has to be actionable: it names the site and the way out.
+    assert "Bright Smile" in err.value.message
+    assert "Delete the site first" in err.value.message
+    # And nothing may have happened.
+    assert pocket.deleted is False
+    assert emitted == []
+
+
+@pytest.mark.asyncio
+async def test_a_pocket_with_no_site_still_deletes(wired, monkeypatch) -> None:
+    """The guard must not become a wall. A pocket that was never published, or whose
+    site has already been deleted, deletes exactly as before."""
+    pockets_service, sites_service, pocket, emitted = wired
+
+    async def _live(*, workspace_id, pocket_id):
+        return None
+
+    monkeypatch.setattr(sites_service, "live_site_for_pocket", _live)
+
+    await pockets_service.delete("pk1", "u1")
+
+    assert pocket.deleted is True
+    assert len(emitted) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_site_lookup_is_scoped_to_the_pockets_own_workspace(
+    wired, monkeypatch
+) -> None:
+    """A cross-tenant lookup would let one workspace's site block another's delete —
+    and, worse, leak that the site exists."""
+    pockets_service, sites_service, pocket, _ = wired
+    seen: dict = {}
+
+    async def _live(*, workspace_id, pocket_id):
+        seen["workspace_id"] = workspace_id
+        seen["pocket_id"] = pocket_id
+        return None
+
+    monkeypatch.setattr(sites_service, "live_site_for_pocket", _live)
+
+    await pockets_service.delete("pk1", "u1")
+
+    assert seen == {"workspace_id": "w1", "pocket_id": "pk1"}
+
+
+@pytest.mark.asyncio
+async def test_a_non_owner_is_still_refused_before_the_site_is_ever_looked_up(
+    wired, monkeypatch
+) -> None:
+    """Ownership is checked first. Otherwise the refusal message would tell a
+    non-owner the name of a site in a workspace they cannot see."""
+    pockets_service, sites_service, _pocket, _ = wired
+    called = False
+
+    async def _live(*, workspace_id, pocket_id):
+        nonlocal called
+        called = True
+        return ("site-123", "Bright Smile")
+
+    monkeypatch.setattr(sites_service, "live_site_for_pocket", _live)
+
+    from pocketpaw_ee.cloud.shared.errors import Forbidden
+
+    with pytest.raises(Forbidden):
+        await pockets_service.delete("pk1", "someone-else")
+
+    assert called is False

--- a/tests/ee/sites/test_pocket_delete_orphan.py
+++ b/tests/ee/sites/test_pocket_delete_orphan.py
@@ -87,9 +87,7 @@ async def test_a_pocket_with_no_site_still_deletes(wired, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_the_site_lookup_is_scoped_to_the_pockets_own_workspace(
-    wired, monkeypatch
-) -> None:
+async def test_the_site_lookup_is_scoped_to_the_pockets_own_workspace(wired, monkeypatch) -> None:
     """A cross-tenant lookup would let one workspace's site block another's delete —
     and, worse, leak that the site exists."""
     pockets_service, sites_service, pocket, _ = wired

--- a/tests/mutations/pocket_delete_orphan.json
+++ b/tests/mutations/pocket_delete_orphan.json
@@ -1,0 +1,47 @@
+[
+  {
+    "label": "pocket deletion stops checking for a published site, so deleting the pocket strands a live Worker, its D1, the custom hostname and a valid signed key with nothing in the product able to reach them",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    if live_site is not None:\n        site_id, site_name = live_site\n        raise ConflictError(",
+    "replace": "    if False:\n        site_id, site_name = live_site\n        raise ConflictError(",
+    "tests": [
+      "tests/ee/sites/test_pocket_delete_orphan.py"
+    ]
+  },
+  {
+    "label": "the site lookup reads a workspace supplied by the caller rather than the pocket's own, making the guard cross-tenant",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    live_site = await sites_service.live_site_for_pocket(\n        workspace_id=doc.workspace, pocket_id=pocket_id\n    )",
+    "replace": "    live_site = await sites_service.live_site_for_pocket(\n        workspace_id=\"\", pocket_id=pocket_id\n    )",
+    "tests": [
+      "tests/ee/sites/test_pocket_delete_orphan.py"
+    ]
+  },
+  {
+    "label": "the guard moves ahead of the ownership check, so a non-owner's refusal names a site in a workspace they cannot see",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    doc = await _fetch_pocket(pocket_id)\n    if doc.owner != user_id:",
+    "replace": "    doc = await _fetch_pocket(pocket_id)\n    if False:",
+    "tests": [
+      "tests/ee/sites/test_pocket_delete_orphan.py"
+    ]
+  },
+  {
+    "label": "the refusal loses the site name and the way out, leaving a 409 the owner cannot act on",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "                f\"This pocket is published as the site {site_name or site_id!r}. \"\n                \"Delete the site first — deleting the pocket would leave it running \"\n                \"with no way to reach it.\"",
+    "replace": "                \"This pocket cannot be deleted.\"",
+    "tests": [
+      "tests/ee/sites/test_pocket_delete_orphan.py"
+    ]
+  },
+  {
+    "label": "the Site lookup stops excluding archived dedupe tombstones, so a pocket whose only Site rows are archived duplicates can never be deleted again",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    doc = await _SiteDoc.find_one(\n        {\"workspace\": workspace_id, \"pocket_id\": pocket_id, \"archived\": {\"$ne\": True}}\n    )",
+    "replace": "    doc = await _SiteDoc.find_one({\"workspace\": workspace_id, \"pocket_id\": pocket_id})",
+    "tests": [
+      "tests/ee/sites/test_live_site_for_pocket.py"
+    ]
+  }
+]


### PR DESCRIPTION
`pockets_service.delete` hard-deletes the pocket and emits `PocketDeleted`. Nothing under `sites/` listens. The Site doc, the Worker, its D1, the custom hostname, the Worker route, the R2 assets and the live `signed_key` all survive.

This is not a page that breaks. `architecture-sites` **Invariant 1** — *"a site worker never depends on the box for reads, rule-writes, or payment capture"* — means removing box-side state **cannot** stop a site serving. What's left behind is an unreachable site still serving, still accepting lead ingest against a valid key, and still billing if it's on a paid plan, with nothing in the product able to reach it again.

## It refuses rather than cascading

That's the deliberate half. A cascade from here would bypass the data export the sites delete flow takes first, so the one path that can destroy a site stays the one path that preserves its data first. Deleting the site is a prerequisite, not an alternative — and the 409 names the site and says so.

## The guard is in the service, not the router

The router isn't the only caller: bus handlers, MCP tools, CLI and jobs reach `delete` directly. A guard they can walk past isn't a guard. (The existing cross-entity site read for the pockets gallery lives in the router, which is fine for hiding cards and would not have been fine here.)

The Site read goes through the sites service via a new `live_site_for_pocket` rather than the Site model — the same entity isolation `site_pocket_ids` was built for, and its docstring already spells out. The import is function-local because `sites.service` reads pockets, so a module-level one would be a cycle.

## Two details the tests pin

**Archived rows are excluded.** Those are 2026-06-18 dedupe tombstones, not sites. Counting one would make a pocket permanently undeletable with no live site anywhere to explain why. One pocket in that migration had 14 Site docs.

**Ownership is checked before the site is looked up.** Otherwise a non-owner's refusal would name a site in a workspace they can't see.

`live_site_for_pocket` deliberately does not filter on `deployed`: a Site row that never reached a live deploy can still own a provisioned D1 and a reserved script name, and once the pocket is gone nothing can reach that row to clean it up.

## Verification

`tests/mutations/pocket_delete_orphan.json` — all 5 caught, including the one that removes the guard outright and the one that moves it ahead of the ownership check.

1864 pass across `tests/ee/sites` and `tests/cloud/pockets`. The 16 reds are pre-existing and none are mine: `tests/cloud/pockets` fails 13 on a clean `origin/dev` with these two files reverted, and the other 3 are the known sites reds. `mutate.py --validate` green at 1335 anchors across 105 plans.

Design: `docs/design/drafts/2026-09-08-sites-lifecycle.md` (Wave 2) and its PRD.