### PR TITLE
The delete cascade, ordered so a failure is always survivable

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -529,6 +529,48 @@ class Site(TimestampedDocument):
     # canonical doc per (workspace, pocket_id) active and sets this True on the
     # rest (never deletes). The gallery read filters it so each pocket shows once.
     archived: bool = False
+    # ── The delete cascade's own lifecycle (sites lifecycle wave 1) ────────
+    # Deliberately SEPARATE from build_* and provision_*, for the same reason those
+    # two are separate from each other: a site is provisioned once, rebuilt many
+    # times, and deleted exactly once, so collapsing them would let one overwrite
+    # another's status and make a delete look like a failed build.
+    #
+    # ``delete_status`` — none | queued | exporting | tearing_down | failed.
+    # There is NO terminal success value, because success deletes this row. A reader
+    # that finds no Site has found a completed delete; a reader that finds one of
+    # these has found an unfinished one.
+    delete_status: str = "none"
+    # When the CURRENT delete attempt entered queued (UTC). Same bounded
+    # single-flight reasoning as ``build_started_at`` and ``provision_started_at``,
+    # and the same asymmetry: a row with no stamp reads as STALE, because a
+    # redundant re-enqueue costs one idempotent pass over a ledger that skips
+    # finished steps, while a stuck guard makes a site undeletable forever.
+    delete_started_at: datetime | None = None
+    # PERSISTED, like ``build_job_id`` and unlike the transient provision one. A
+    # delete is exactly the case where the user reloads the page — it is the longest
+    # irreversible thing the product does — and on reload a transient id is gone.
+    delete_job_id: str | None = None
+    # ── THE LEDGER: what makes a partial teardown resumable ────────────────
+    # Step name -> outcome, written as each step completes. A re-entered job SKIPS
+    # every step already recorded here, which is what turns a resume into a skip
+    # rather than a retry — and several of these steps are not safely repeatable in
+    # spirit even where they are idempotent in fact (cancelling a subscription
+    # twice, re-charging a purge over a bucket).
+    #
+    # THIS IS WHY THE SITE DOCUMENT IS DELETED LAST. The ledger lives on the very
+    # row the cascade is destroying, so deleting the row first would make every
+    # later failure both unresumable and invisible. The ordering is a consequence of
+    # where this field lives, not a convention someone has to remember.
+    delete_ledger: dict[str, str] = Field(default_factory=dict)
+    # The SiteExport document holding the customer's data, captured before anything
+    # was destroyed. Its own row outlives this one — see cloud/models/site_export.py
+    # for why it is not stored the other way round.
+    delete_export_id: str = ""
+    # WHY the delete reached ``failed``, as ``"<step>:<cause>"`` — the SAME two-part
+    # shape ``build_reason`` uses, reused verbatim rather than re-minted so a
+    # consumer parses once and can always split on the colon to group by step. A
+    # failure with no reason is not a smaller error, it is an unactionable one.
+    delete_reason: str | None = None
     # SE-2b: the builder origin this site was published with, or "" when it was
     # published as a normal (non-editable) site. When set, the generated page
     # carries the gated edit-bridge keyed on this origin. Persisted so a

--- a/ee/pocketpaw_ee/sites/delete_cascade.py
+++ b/ee/pocketpaw_ee/sites/delete_cascade.py
@@ -1,0 +1,278 @@
+# ee/pocketpaw_ee/sites/delete_cascade.py — the ordered, idempotent teardown of one
+# published site.
+#
+# Created 2026-09-09 (sites lifecycle wave 1 chunk 3, feat/sites-delete-cascade).
+#
+# THE ORDER IS THE DESIGN. Every step here can fail, and the sequence is chosen so
+# that a failure at ANY point leaves the site LESS live than before and never still
+# charging:
+#
+#   1. billing off   — a failed teardown must never keep taking money;
+#   2. auth off      — the signed key dies next, at near-zero cost and before
+#                      anything irreversible, so lead ingest and the concierge stop
+#                      even if every later step fails;
+#   3. serving off   — routes, hostnames, then the Worker script itself;
+#   4. reclaim       — D1, R2, artifacts: the things that cost money once nothing
+#                      serves;
+#   5. records       — the dependent rows;
+#   6. the Site doc  — LAST, and not by convention.
+#
+# The Site document carries the ledger (``delete_ledger``), so it is the only thing
+# that knows which steps finished. Deleting it earlier would make every subsequent
+# failure both unresumable and invisible — the ordering is a consequence of where
+# the ledger lives.
+#
+# EVERY STEP IS SKIPPED IF THE LEDGER ALREADY RECORDS IT. That is what makes a
+# resume a skip rather than a retry, which matters because several steps are
+# idempotent in fact but not in spirit: cancelling a subscription twice, or
+# re-running a purge, is not free even when it is safe.
+#
+# WHAT THIS DELIBERATELY DOES NOT DO: it does not take the export. The export is a
+# PRECONDITION resolved before the cascade is ever enqueued, because an export taken
+# inside the cascade could fail after the first destructive step has already run.
+"""The delete cascade: tear one site down, in an order that survives failure."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Ledger keys, in execution order. Named rather than positional so a step inserted
+# later cannot silently renumber a half-finished cascade's record of itself.
+STEP_SUBSCRIPTION = "subscription"
+STEP_REVOKE = "revoke"
+STEP_ROUTES = "routes"
+STEP_HOSTNAMES = "hostnames"
+STEP_SCRIPT = "script"
+STEP_D1 = "d1"
+STEP_R2 = "r2"
+STEP_RECORDS = "records"
+
+CASCADE_STEPS: tuple[str, ...] = (
+    STEP_SUBSCRIPTION,
+    STEP_REVOKE,
+    STEP_ROUTES,
+    STEP_HOSTNAMES,
+    STEP_SCRIPT,
+    STEP_D1,
+    STEP_R2,
+    STEP_RECORDS,
+)
+
+# Recorded in the ledger when a step had nothing to do — a static site's D1, a site
+# with no custom domains, a free site's subscription. Distinct from "done" on
+# purpose: "there was nothing here" and "I removed it" are different facts, and an
+# operator reading a stalled cascade needs to tell them apart.
+OUTCOME_DONE = "done"
+OUTCOME_SKIPPED = "nothing-to-do"
+# The subscription we cannot cancel because the row predates the activation webhook
+# and holds a checkout SESSION id the gateway rejects. Recorded rather than raised:
+# refusing to delete would trap the customer's site forever over a subscription we
+# can no longer reach either way, so the cascade continues and says so.
+OUTCOME_UNCANCELLABLE = "uncancellable"
+
+
+class CascadeStepFailed(Exception):
+    """One step failed. Carries ``"<step>:<cause>"`` for ``Site.delete_reason``."""
+
+    def __init__(self, step: str, cause: str) -> None:
+        self.step = step
+        self.cause = cause
+        super().__init__(f"{step}:{cause}")
+
+    @property
+    def reason(self) -> str:
+        return f"{self.step}:{self.cause}"
+
+
+def _is_session_id(subscription_id: str) -> bool:
+    """Whether this is a checkout SESSION id rather than a real subscription id.
+
+    ``service.py`` records that rows created before the ``subscription.active``
+    webhook learned to persist the authoritative id still hold a ``cks_`` checkout
+    session id, and that "a session id cannot cancel a subscription and cannot
+    change its plan — the gateway rejects it." Those subscriptions are unreachable
+    from our side, so the cascade records the fact and continues rather than
+    trapping the site.
+    """
+    return subscription_id.startswith("cks_")
+
+
+async def run_cascade(
+    *,
+    site: Any,
+    deps: Any,
+    save: Any,
+) -> None:
+    """Tear the site down in order, recording each step in ``site.delete_ledger``.
+
+    ``deps`` supplies the side effects (cancel_subscription, cloudflare, assets,
+    purge_records) so the ordering and the ledger can be tested without Cloudflare,
+    a gateway, or a database. ``save`` persists the ledger after every step — a
+    ledger only written at the end would record nothing about the crash it exists
+    to survive.
+
+    Raises :class:`CascadeStepFailed` at the first failing step, leaving every
+    earlier step recorded so a re-run resumes rather than repeats.
+    """
+    ledger: dict[str, str] = dict(site.delete_ledger or {})
+
+    async def record(step: str, outcome: str) -> None:
+        ledger[step] = outcome
+        site.delete_ledger = dict(ledger)
+        await save(site)
+
+    for step in CASCADE_STEPS:
+        if step in ledger:
+            # Already done on an earlier attempt. Skipping is the point of the
+            # ledger; re-running would re-charge purges and re-cancel subscriptions.
+            continue
+        try:
+            outcome = await _run_step(step, site=site, deps=deps)
+        except CascadeStepFailed:
+            raise
+        except Exception as exc:  # noqa: BLE001 - classified, then re-raised
+            logger.warning("sites.delete step %s failed: %s", step, exc, exc_info=True)
+            raise CascadeStepFailed(step, _classify(exc)) from exc
+        await record(step, outcome)
+
+
+def _classify(exc: Exception) -> str:
+    """A short, machine-readable cause. Never raw provider text.
+
+    ``delete_reason`` is surfaced, so it carries a fixed token exactly the way
+    ``build_reason`` does. A stderr string here would be the one place a Cloudflare
+    or driver message reaches a customer.
+    """
+    name = type(exc).__name__
+    return "".join(c.lower() if c.isalnum() else "_" for c in name).strip("_") or "error"
+
+
+async def _run_step(step: str, *, site: Any, deps: Any) -> str:
+    if step == STEP_SUBSCRIPTION:
+        return await _cancel_subscription(site=site, deps=deps)
+    if step == STEP_REVOKE:
+        return await _revoke_key(site=site, deps=deps)
+    if step == STEP_ROUTES:
+        return await _delete_routes(site=site, deps=deps)
+    if step == STEP_HOSTNAMES:
+        return await _delete_hostnames(site=site, deps=deps)
+    if step == STEP_SCRIPT:
+        return await _delete_script(site=site, deps=deps)
+    if step == STEP_D1:
+        return await _delete_d1(site=site, deps=deps)
+    if step == STEP_R2:
+        return await _purge_assets(site=site, deps=deps)
+    if step == STEP_RECORDS:
+        return await _purge_records(site=site, deps=deps)
+    raise CascadeStepFailed(step, "unknown_step")
+
+
+async def _cancel_subscription(*, site: Any, deps: Any) -> str:
+    """FIRST, so a teardown that fails later never keeps billing."""
+    sub_id = (getattr(site, "subscription_id", "") or "").strip()
+    status = getattr(site, "subscription_status", "none")
+    if not sub_id or status in ("none", "cancelled"):
+        return OUTCOME_SKIPPED
+    if _is_session_id(sub_id):
+        # Unreachable from our side. Say so in the ledger and keep going — refusing
+        # here would trap the site permanently over a subscription that cannot be
+        # cancelled through this product either way.
+        logger.warning(
+            "sites.delete: subscription %s is a checkout session id and cannot be "
+            "cancelled; continuing the cascade",
+            sub_id,
+        )
+        return OUTCOME_UNCANCELLABLE
+    await deps.cancel_subscription(sub_id)
+    return OUTCOME_DONE
+
+
+async def _revoke_key(*, site: Any, deps: Any) -> str:
+    """SECOND, and the cheapest meaningful step in the cascade.
+
+    Clearing the signed key stops lead ingest and the concierge immediately. It is
+    reversible-ish, costs one write, and happens before anything irreversible — so
+    even a cascade that fails at the very next step has already closed the surface
+    that accepts data from the public internet.
+    """
+    if not (getattr(site, "signed_key", "") or ""):
+        return OUTCOME_SKIPPED
+    site.signed_key = ""
+    site.revoked = True
+    return OUTCOME_DONE
+
+
+async def _delete_routes(*, site: Any, deps: Any) -> str:
+    routes = [d for d in (getattr(site, "domains", None) or []) if getattr(d, "cf_route_id", "")]
+    if not routes:
+        return OUTCOME_SKIPPED
+    for domain in routes:
+        await deps.cloudflare.delete_worker_route(domain.cf_route_id)
+    return OUTCOME_DONE
+
+
+async def _delete_hostnames(*, site: Any, deps: Any) -> str:
+    hosts = [d for d in (getattr(site, "domains", None) or []) if getattr(d, "cf_hostname_id", "")]
+    if not hosts:
+        return OUTCOME_SKIPPED
+    for domain in hosts:
+        await deps.cloudflare.delete_custom_hostname(domain.cf_hostname_id)
+    return OUTCOME_DONE
+
+
+async def _delete_script(*, site: Any, deps: Any) -> str:
+    """THE STEP THAT ACTUALLY STOPS THE PAGE BEING SERVED.
+
+    Which delete to call is decided by ``deploy_target`` — what the last successful
+    deploy ACTUALLY did — and not by the configured mode, because that field's own
+    comment lists the several ways the two disagree. Sending a wfp site's delete to
+    the account-level path (or the reverse) would 404, and 404 is success for these
+    calls, so the cascade would record a completed teardown over a live Worker.
+    """
+    script = (getattr(site, "script_name", "") or "").strip()
+    target = (getattr(site, "deploy_target", "") or "").strip()
+    if not script or target in ("", "local"):
+        # Never deployed, or deployed to the local static server, which owns no
+        # Cloudflare Worker to remove.
+        return OUTCOME_SKIPPED
+    if target == "wfp":
+        await deps.cloudflare.delete_worker(script)
+    else:
+        await deps.cloudflare.delete_account_script(script)
+    return OUTCOME_DONE
+
+
+async def _delete_d1(*, site: Any, deps: Any) -> str:
+    """IRREVERSIBLE, and the step the forced export exists for.
+
+    Runs only after the site has stopped serving, so a failure here leaves a
+    database that costs money rather than one still reachable from the internet.
+    """
+    db_id = (getattr(site, "d1_database_id", "") or "").strip()
+    if not db_id:
+        return OUTCOME_SKIPPED
+    await deps.cloudflare.delete_database(db_id)
+    return OUTCOME_DONE
+
+
+async def _purge_assets(*, site: Any, deps: Any) -> str:
+    if deps.assets is None:
+        # No public rail configured on this deployment, so there is nothing on a
+        # bucket to remove. Distinct from an adapter that cannot list, which
+        # ``PublicAssetStore.purge`` raises on rather than reporting zero.
+        return OUTCOME_SKIPPED
+    await deps.assets.purge(workspace_id=site.workspace, pocket_id=site.pocket_id)
+    return OUTCOME_DONE
+
+
+async def _purge_records(*, site: Any, deps: Any) -> str:
+    """The dependent rows: leads, transcripts, briefs, counters.
+
+    NOT the Site document — that is deleted by the caller after this returns, so the
+    ledger survives every step it records.
+    """
+    await deps.purge_records(workspace_id=site.workspace, site_id=str(site.id))
+    return OUTCOME_DONE

--- a/tests/ee/sites/test_delete_cascade.py
+++ b/tests/ee/sites/test_delete_cascade.py
@@ -1,0 +1,293 @@
+# tests/ee/sites/test_delete_cascade.py — the ordered teardown (sites lifecycle
+# wave 1 chunk 3).
+#
+# What is under test is mostly the ORDER and the LEDGER, because those are what make
+# an irreversible multi-step destroy survivable. A cascade that does the right eight
+# things in the wrong order is not a smaller bug than one that does seven.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites.delete_cascade import (
+    CASCADE_STEPS,
+    OUTCOME_DONE,
+    OUTCOME_SKIPPED,
+    OUTCOME_UNCANCELLABLE,
+    CascadeStepFailed,
+    run_cascade,
+)
+
+
+class _Domain:
+    def __init__(self, route="rt1", host="hn1"):
+        self.cf_route_id = route
+        self.cf_hostname_id = host
+
+
+class _Site:
+    def __init__(self, **kw):
+        self.id = "s1"
+        self.workspace = "w1"
+        self.pocket_id = "pk1"
+        self.script_name = "site-s1"
+        self.deploy_target = "wfp"
+        self.d1_database_id = "db1"
+        self.signed_key = "key-abc"
+        self.revoked = False
+        self.subscription_id = "sub_live"
+        self.subscription_status = "active"
+        self.domains = [_Domain()]
+        self.delete_ledger: dict[str, str] = {}
+        self.__dict__.update(kw)
+
+
+class _CF:
+    def __init__(self, fail_on: str | None = None):
+        self.calls: list[str] = []
+        self.fail_on = fail_on
+
+    async def _rec(self, name):
+        if self.fail_on == name:
+            raise RuntimeError("cloudflare said no")
+        self.calls.append(name)
+
+    async def delete_worker_route(self, _id):
+        await self._rec("delete_worker_route")
+
+    async def delete_custom_hostname(self, _id):
+        await self._rec("delete_custom_hostname")
+
+    async def delete_worker(self, _name):
+        await self._rec("delete_worker")
+
+    async def delete_account_script(self, _name):
+        await self._rec("delete_account_script")
+
+    async def delete_database(self, _id):
+        await self._rec("delete_database")
+
+
+class _Assets:
+    def __init__(self):
+        self.purged: list[tuple[str, str]] = []
+
+    async def purge(self, *, workspace_id, pocket_id):
+        self.purged.append((workspace_id, pocket_id))
+        return 3
+
+
+class _Deps:
+    def __init__(self, cf=None, assets=None, fail_cancel=False):
+        self.cloudflare = cf or _CF()
+        self.assets = assets if assets is not None else _Assets()
+        self.cancelled: list[str] = []
+        self.records: list[tuple[str, str]] = []
+        self.fail_cancel = fail_cancel
+
+    async def cancel_subscription(self, sub_id):
+        if self.fail_cancel:
+            raise RuntimeError("gateway down")
+        self.cancelled.append(sub_id)
+
+    async def purge_records(self, *, workspace_id, site_id):
+        self.records.append((workspace_id, site_id))
+
+
+def _saver(saves):
+    async def save(site):
+        # Snapshot, not a reference — otherwise every entry is the final ledger and
+        # the test cannot see what was persisted at each point.
+        saves.append(dict(site.delete_ledger))
+
+    return save
+
+
+@pytest.mark.asyncio
+async def test_every_step_runs_and_is_recorded_in_order() -> None:
+    site, deps, saves = _Site(), _Deps(), []
+
+    await run_cascade(site=site, deps=deps, save=_saver(saves))
+
+    assert list(site.delete_ledger) == list(CASCADE_STEPS)
+    assert all(v in (OUTCOME_DONE, OUTCOME_SKIPPED) for v in site.delete_ledger.values())
+
+
+@pytest.mark.asyncio
+async def test_billing_stops_before_anything_else_happens() -> None:
+    """A teardown that fails partway must never keep taking money, so the cancel is
+    step one and nothing destructive precedes it."""
+    site, deps, saves = _Site(), _Deps(), []
+
+    await run_cascade(site=site, deps=deps, save=_saver(saves))
+
+    # The first thing ever persisted is the subscription step, alone.
+    assert saves[0] == {"subscription": OUTCOME_DONE}
+    assert deps.cancelled == ["sub_live"]
+
+
+@pytest.mark.asyncio
+async def test_the_key_dies_before_the_site_stops_serving() -> None:
+    """Revoking is cheap and reversible-ish; deleting a Worker is neither. Doing it
+    second means even a cascade that fails immediately after has already closed the
+    surface that accepts data from the public internet."""
+    site, deps, saves = _Site(), _Deps(), []
+
+    await run_cascade(site=site, deps=deps, save=_saver(saves))
+
+    order = list(site.delete_ledger)
+    assert order.index("revoke") < order.index("script")
+    assert site.signed_key == ""
+    assert site.revoked is True
+
+
+@pytest.mark.asyncio
+async def test_resources_are_only_reclaimed_after_the_site_stops_serving() -> None:
+    """A failure between these two leaves a database that costs money, rather than
+    one still reachable from the internet."""
+    site, deps, saves = _Site(), _Deps(), []
+
+    await run_cascade(site=site, deps=deps, save=_saver(saves))
+
+    order = list(site.delete_ledger)
+    assert order.index("script") < order.index("d1") < order.index("r2")
+    assert order.index("records") == len(order) - 1
+
+
+@pytest.mark.asyncio
+async def test_a_failure_stops_the_cascade_and_keeps_what_finished() -> None:
+    """THE RESUME CONTRACT. Everything before the failure stays recorded, so a
+    re-run skips it; nothing after it ran."""
+    site = _Site()
+    deps = _Deps(cf=_CF(fail_on="delete_worker"))
+
+    with pytest.raises(CascadeStepFailed) as err:
+        await run_cascade(site=site, deps=deps, save=_saver([]))
+
+    assert err.value.step == "script"
+    assert err.value.reason.startswith("script:")
+    assert set(site.delete_ledger) == {"subscription", "revoke", "routes", "hostnames"}
+    # The reclaim steps must not have run behind a site that is still serving.
+    assert "delete_database" not in deps.cloudflare.calls
+    assert deps.records == []
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_cascade_skips_finished_steps_instead_of_repeating_them() -> None:
+    """Several steps are idempotent in fact but not in spirit — re-cancelling a
+    subscription or re-charging a purge is not free even when it is safe."""
+    site = _Site(delete_ledger={"subscription": OUTCOME_DONE, "revoke": OUTCOME_DONE})
+    deps = _Deps()
+
+    await run_cascade(site=site, deps=deps, save=_saver([]))
+
+    assert deps.cancelled == []  # not cancelled a second time
+    assert list(site.delete_ledger) == list(CASCADE_STEPS)
+
+
+@pytest.mark.asyncio
+async def test_an_uncancellable_subscription_is_recorded_and_does_not_block() -> None:
+    """A row predating the activation webhook holds a checkout SESSION id the
+    gateway rejects. Refusing to delete would trap the customer's site forever over
+    a subscription we cannot reach either way."""
+    site = _Site(subscription_id="cks_legacy")
+    deps = _Deps()
+
+    await run_cascade(site=site, deps=deps, save=_saver([]))
+
+    assert site.delete_ledger["subscription"] == OUTCOME_UNCANCELLABLE
+    assert deps.cancelled == []
+    assert list(site.delete_ledger) == list(CASCADE_STEPS)
+
+
+@pytest.mark.asyncio
+async def test_the_worker_delete_follows_deploy_target_not_the_configured_mode() -> None:
+    """404 is success for these calls, so aiming the delete at the wrong API path
+    would record a completed teardown over a Worker that is still serving."""
+    wfp, deps_wfp = _Site(deploy_target="wfp"), _Deps()
+    await run_cascade(site=wfp, deps=deps_wfp, save=_saver([]))
+    assert "delete_worker" in deps_wfp.cloudflare.calls
+    assert "delete_account_script" not in deps_wfp.cloudflare.calls
+
+    acct, deps_acct = _Site(deploy_target="workers"), _Deps()
+    await run_cascade(site=acct, deps=deps_acct, save=_saver([]))
+    assert "delete_account_script" in deps_acct.cloudflare.calls
+    assert "delete_worker" not in deps_acct.cloudflare.calls
+
+
+@pytest.mark.asyncio
+async def test_a_local_site_owns_no_cloudflare_worker_to_delete() -> None:
+    site = _Site(deploy_target="local")
+    deps = _Deps()
+
+    await run_cascade(site=site, deps=deps, save=_saver([]))
+
+    assert site.delete_ledger["script"] == OUTCOME_SKIPPED
+    assert deps.cloudflare.calls.count("delete_worker") == 0
+
+
+@pytest.mark.asyncio
+async def test_a_static_site_has_no_d1_and_says_so_rather_than_claiming_it_deleted_one() -> None:
+    """ "Nothing was here" and "I removed it" are different facts. An operator reading
+    a stalled cascade needs to tell them apart."""
+    site = _Site(d1_database_id="", domains=[])
+    deps = _Deps()
+
+    await run_cascade(site=site, deps=deps, save=_saver([]))
+
+    # Compared against the LITERAL, not the imported constant. Asserting
+    # ``== OUTCOME_SKIPPED`` cannot detect the constant being collapsed into
+    # "done", because the assertion moves with it.
+    assert site.delete_ledger["d1"] == "nothing-to-do"
+    assert site.delete_ledger["routes"] == "nothing-to-do"
+    assert site.delete_ledger["hostnames"] == "nothing-to-do"
+    assert "delete_database" not in deps.cloudflare.calls
+
+
+@pytest.mark.asyncio
+async def test_the_failure_reason_never_carries_provider_text() -> None:
+    """``delete_reason`` is surfaced, so it holds a fixed token the way
+    ``build_reason`` does — not a Cloudflare or driver sentence."""
+    deps = _Deps(fail_cancel=True)
+
+    with pytest.raises(CascadeStepFailed) as err:
+        await run_cascade(site=_Site(), deps=deps, save=_saver([]))
+
+    assert err.value.reason == "subscription:runtimeerror"
+    assert "gateway down" not in err.value.reason
+
+
+@pytest.mark.asyncio
+async def test_the_ledger_is_persisted_after_every_step_not_only_at_the_end() -> None:
+    """A ledger written once at the end would record nothing about the crash it
+    exists to survive."""
+    saves: list[dict] = []
+
+    await run_cascade(site=_Site(), deps=_Deps(), save=_saver(saves))
+
+    assert len(saves) == len(CASCADE_STEPS)
+    # Each save is strictly larger than the one before it.
+    assert [len(s) for s in saves] == list(range(1, len(CASCADE_STEPS) + 1))
+
+
+@pytest.mark.asyncio
+async def test_a_deployment_with_no_public_asset_rail_skips_the_purge() -> None:
+    site = _Site()
+    deps = _Deps(assets=None)
+    deps.assets = None
+
+    await run_cascade(site=site, deps=deps, save=_saver([]))
+
+    assert site.delete_ledger["r2"] == OUTCOME_SKIPPED
+
+
+def test_nothing_to_do_and_done_stay_distinguishable() -> None:
+    """The two outcomes must never collapse into one value.
+
+    "There was no D1" and "I deleted the D1" are different facts, and an operator
+    reading a stalled cascade has only the ledger to tell them apart. Pinned as
+    literals so this survives someone redefining the constants.
+    """
+    assert OUTCOME_DONE == "done"
+    assert OUTCOME_SKIPPED == "nothing-to-do"
+    assert OUTCOME_UNCANCELLABLE == "uncancellable"
+    assert len({OUTCOME_DONE, OUTCOME_SKIPPED, OUTCOME_UNCANCELLABLE}) == 3

--- a/tests/mutations/sites_delete_cascade.json
+++ b/tests/mutations/sites_delete_cascade.json
@@ -1,0 +1,83 @@
+[
+  {
+    "label": "the cascade stops skipping steps the ledger already records, so a resumed delete re-cancels a subscription and re-runs purges that already ran",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "        if step in ledger:",
+    "replace": "        if False:",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py"
+    ]
+  },
+  {
+    "label": "the ledger is only persisted once the whole cascade finishes, so a crash records nothing about the steps it already ran and the resume repeats every destructive one",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "        ledger[step] = outcome\n        site.delete_ledger = dict(ledger)\n        await save(site)",
+    "replace": "        ledger[step] = outcome\n        site.delete_ledger = dict(ledger)",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py"
+    ]
+  },
+  {
+    "label": "billing is cancelled last instead of first, so every teardown that fails partway keeps charging the customer for a site that no longer serves",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "CASCADE_STEPS: tuple[str, ...] = (\n    STEP_SUBSCRIPTION,\n    STEP_REVOKE,",
+    "replace": "CASCADE_STEPS: tuple[str, ...] = (\n    STEP_REVOKE,",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py"
+    ]
+  },
+  {
+    "label": "the D1 is destroyed before the site stops serving, so a failure leaves a live page reading a database that no longer exists",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "    STEP_SCRIPT,\n    STEP_D1,",
+    "replace": "    STEP_D1,\n    STEP_SCRIPT,",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py"
+    ]
+  },
+  {
+    "label": "the signed key is revoked last, so a cascade that fails early leaves a public lead-ingest surface open on a site being torn down",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "    STEP_SUBSCRIPTION,\n    STEP_REVOKE,\n    STEP_ROUTES,",
+    "replace": "    STEP_SUBSCRIPTION,\n    STEP_ROUTES,",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py"
+    ]
+  },
+  {
+    "label": "the worker delete ignores deploy_target and always uses the dispatch path, so a workers-mode site 404s (which is success here) and the cascade records a completed teardown over a Worker still serving",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "    if target == \"wfp\":\n        await deps.cloudflare.delete_worker(script)\n    else:\n        await deps.cloudflare.delete_account_script(script)",
+    "replace": "    await deps.cloudflare.delete_worker(script)",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py"
+    ]
+  },
+  {
+    "label": "an uncancellable checkout-session subscription raises instead of being recorded, trapping the customer's site permanently over a subscription nothing can cancel",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "        return OUTCOME_UNCANCELLABLE",
+    "replace": "        raise CascadeStepFailed(STEP_SUBSCRIPTION, \"uncancellable\")",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py"
+    ]
+  },
+  {
+    "label": "a step that had nothing to do is recorded as done, so an operator reading a stalled cascade cannot tell an absent D1 from one we claim to have deleted",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "OUTCOME_SKIPPED = \"nothing-to-do\"",
+    "replace": "OUTCOME_SKIPPED = \"done\"",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py"
+    ]
+  },
+  {
+    "label": "the failure reason carries the provider's own exception text, putting a raw Cloudflare or driver sentence into a field that is surfaced to the customer",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "    name = type(exc).__name__\n    return \"\".join(c.lower() if c.isalnum() else \"_\" for c in name).strip(\"_\") or \"error\"",
+    "replace": "    return str(exc)",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py"
+    ]
+  }
+]


### PR DESCRIPTION
The ordered teardown of one published site, plus the `Site` fields that record it. Nothing calls it yet — the job and the endpoint are the next slice. Builds on #2127 (the primitives) and #2132 (the export).

## The order is the design

Every step can fail. The sequence is chosen so a failure *anywhere* leaves the site **less live than before** and **never still charging**:

1. **billing off** — a teardown that dies halfway must never keep taking money
2. **auth off** — the signed key goes next: near-zero cost, before anything irreversible, so even an immediate failure has already closed the public lead-ingest surface
3. **serving off** — routes, hostnames, then the Worker script
4. **reclaim** — D1, R2: the things that cost money once nothing serves
5. **records**, then **the Site document last**

That last one is a consequence, not a convention. The ledger lives on the row being destroyed, so deleting it earlier would make every later failure both unresumable and invisible.

## The ledger is what makes a partial teardown recoverable

Every step is skipped when the ledger already records it, so a resume is a **skip**, not a retry. That matters because several steps are idempotent in fact but not in spirit — re-cancelling a subscription or re-running a purge isn't free even when it's safe.

It's persisted after **every** step. A ledger written only at the end records nothing about the crash it exists to survive.

## Three decisions worth seeing

**"Nothing to do" is a distinct outcome from "done."** An operator reading a stalled cascade has only the ledger to tell an absent D1 from one we claim to have deleted.

**The worker delete follows `deploy_target`, not the configured mode.** 404 is success for these calls (deliberately — see #2127), so aiming at the wrong API path would record a completed teardown over a Worker that's still serving.

**An uncancellable subscription is recorded, not raised.** `service.py:7027` documents that rows predating the activation webhook hold a `cks_` checkout session id the gateway rejects, and are "unreachable from our side." Refusing to delete would trap the customer's site forever over a subscription nothing can cancel either way — so the cascade records the fact and continues.

`delete_reason` carries a fixed `"<step>:<cause>"` token, the same shape as `build_reason`, never provider text. That field is surfaced, so a raw Cloudflare or driver sentence there would reach a customer.

## Verification

`tests/mutations/sites_delete_cascade.json` — all 9 caught, including every reordering (billing last, D1 before the script, revoke last).

One escaped on the first run, and it was my test that was wrong: asserting `== OUTCOME_SKIPPED` can't detect that constant being collapsed into `"done"`, because the assertion moves with it. The outcomes are now pinned as literals.

1750 pass in `tests/ee/sites`; the 3 reds are the known pre-existing ones. `mutate.py --validate` green at 1345 anchors across 106 plans.

Design: `docs/design/drafts/2026-09-08-sites-lifecycle.md` and its PRD.