### PR TITLE
A failed export answered with a 500 and said nothing

### DIFF
--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -9561,7 +9561,7 @@ async def create_site_export(
             raise
     except Exception as exc:
         await _fail_export(export, exc, site_id)
-        raise
+        raise _export_error(exc) from exc
 
     try:
         leads = await collect_leads(workspace_id=workspace_id, site_id=site_id, lead_model=_LeadDoc)
@@ -9581,7 +9581,7 @@ async def create_site_export(
         size = await store_export(adapter=_export_adapter(), key=key, payload=payload)
     except Exception as exc:
         await _fail_export(export, exc, site_id)
-        raise
+        raise _export_error(exc) from exc
 
     export.status = "ready"
     export.storage_key = key
@@ -9591,6 +9591,30 @@ async def create_site_export(
     export.expires_at = datetime.now(UTC) + timedelta(days=retention_days())
     await export.save()
     return _export_response(export)
+
+
+def _export_error(exc: Exception) -> Exception:
+    """Turn a failed export into something the HTTP layer can actually render.
+
+    ``ExportUnavailable`` is a plain ``Exception``, and the cloud error handler maps
+    ``CloudError`` only — so re-raising it unchanged answered the request with a bare
+    500 and the safe sentence we had just written to the export row never reached the
+    caller at all. That is the same shape as the ``InvalidId`` cast this module
+    already guards: an ordinary exception escaping a CloudError-only handler.
+
+    A ``CloudError`` (including the ``sites.not_dynamic`` path above) is already
+    renderable and passes through untouched, so this only ever promotes the plain
+    ones. The message is the same safe text ``_fail_export`` records, never a driver
+    or Cloudflare string — every site reader in the workspace can see it.
+    """
+    if isinstance(exc, CloudError):
+        return exc
+    message = (
+        str(exc)
+        if isinstance(exc, ExportUnavailable)
+        else "This site's data could not be exported."
+    )
+    return ValidationError("sites.export_unavailable", message)
 
 
 async def _fail_export(export: _SiteExportDoc, exc: Exception, site_id: str) -> None:

--- a/tests/ee/sites/test_export_error_envelope.py
+++ b/tests/ee/sites/test_export_error_envelope.py
@@ -1,0 +1,60 @@
+# tests/ee/sites/test_export_error_envelope.py — a failed export must reach the
+# client as a renderable envelope, not a bare 500.
+#
+# Found by the frontend agent building the export panel: ``ExportUnavailable`` is a
+# plain ``Exception``, and the cloud error handler maps ``CloudError`` only, so the
+# POST answered with an unhandled 500 and the safe sentence the same failure had
+# just written to the export row never reached the caller. The panel could not tell
+# "your site's data is unreachable" from "the backend fell over", and had to reload
+# the list to find out what happened.
+#
+# This is the same shape as the ``InvalidId`` cast ``sites/service.py`` already
+# guards, and the module header there says why it matters: an ordinary exception
+# escaping a CloudError-only handler surfaces as a 500 with nothing useful in it.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound, ValidationError
+from pocketpaw_ee.sites.export import ExportUnavailable
+from pocketpaw_ee.sites.service import _export_error
+
+
+def test_export_unavailable_is_not_renderable_on_its_own() -> None:
+    """The premise. If this ever becomes a CloudError subclass, the converter can go
+    — but silently leaving both in place would be worse than either."""
+    assert not issubclass(ExportUnavailable, CloudError)
+
+
+def test_a_plain_export_failure_is_promoted_to_a_renderable_error() -> None:
+    err = _export_error(ExportUnavailable("This site's live data cannot be read."))
+
+    assert isinstance(err, CloudError)
+    assert err.code == "sites.export_unavailable"
+    # Our own sentence survives — it is the whole reason the export said anything.
+    assert "live data cannot be read" in err.message
+
+
+def test_an_unexpected_failure_does_not_leak_provider_text() -> None:
+    """A driver or Cloudflare string here would reach every site reader in the
+    workspace. Only ``ExportUnavailable`` messages are ours to show."""
+    err = _export_error(RuntimeError("mongo: connection refused to 10.0.0.4:27017"))
+
+    assert isinstance(err, ValidationError)
+    assert err.code == "sites.export_unavailable"
+    assert "10.0.0.4" not in err.message
+    assert "mongo" not in err.message.lower()
+    assert err.message == "This site's data could not be exported."
+
+
+@pytest.mark.parametrize(
+    "original",
+    [
+        NotFound("site", "s1"),
+        ValidationError("sites.not_dynamic", "not a dynamic site"),
+    ],
+)
+def test_an_error_that_was_already_renderable_passes_through_untouched(original) -> None:
+    """Promoting these would flatten a 404 into a 422 and lose the code the client
+    branches on."""
+    assert _export_error(original) is original

--- a/tests/mutations/sites_export_envelope.json
+++ b/tests/mutations/sites_export_envelope.json
@@ -1,0 +1,29 @@
+[
+  {
+    "label": "a failed export re-raises the plain exception again, so the CloudError-only handler lets it escape as a bare 500 and the safe sentence never reaches the caller",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if isinstance(exc, CloudError):\n        return exc",
+    "replace": "    if False:\n        return exc",
+    "tests": [
+      "tests/ee/sites/test_export_error_envelope.py"
+    ]
+  },
+  {
+    "label": "the converter forwards the provider's own exception text, putting a driver or Cloudflare string in front of every site reader in the workspace",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    message = (\n        str(exc)\n        if isinstance(exc, ExportUnavailable)\n        else \"This site's data could not be exported.\"\n    )",
+    "replace": "    message = str(exc)",
+    "tests": [
+      "tests/ee/sites/test_export_error_envelope.py"
+    ]
+  },
+  {
+    "label": "the converter swallows our own ExportUnavailable sentence too, so the panel is told nothing more useful than that something went wrong",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    message = (\n        str(exc)\n        if isinstance(exc, ExportUnavailable)\n        else \"This site's data could not be exported.\"\n    )",
+    "replace": "    message = \"This site's data could not be exported.\"",
+    "tests": [
+      "tests/ee/sites/test_export_error_envelope.py"
+    ]
+  }
+]


### PR DESCRIPTION
Found by the agent building the export panel in paw-enterprise, which couldn't tell "your site's data is unreachable" from "the backend fell over" and had to reload the list to discover what had happened.

## The bug

`ExportUnavailable` is a plain `Exception`. The cloud error handler maps `CloudError` only, so re-raising it unchanged escaped as an **unhandled 500** — and the safe sentence that the *same failure* had just written to the export row never reached the caller. The one piece of the design that exists to explain a refusal was only reachable by fetching a different resource.

This is the same shape as the `InvalidId` cast `sites/service.py` already guards, and that module header says why it matters: an ordinary exception escaping a CloudError-only handler surfaces as a 500 with nothing useful in it. The export path reintroduced the pattern one function over.

## The fix

`_export_error` promotes a plain failure to `ValidationError("sites.export_unavailable")` carrying our own message.

An **already-renderable `CloudError` passes through untouched** — promoting those would flatten a 404 into a 422 and lose the code the client branches on, including the `sites.not_dynamic` path the static-site branch depends on.

Only `ExportUnavailable` messages are forwarded. Anything else is reduced to a fixed sentence, because a driver or Cloudflare string here reaches every site reader in the workspace. There's a test asserting a Mongo connection string doesn't survive the conversion.

## Verification

`tests/mutations/sites_export_envelope.json` — all 3 caught, including the one that restores the original bug by removing the passthrough.

1749 pass in `tests/ee/sites` with the 3 known pre-existing reds. `mutate.py --validate` green at 1344 anchors across 107 plans. `ruff check` and `ruff format --check` clean repo-wide.

Follow-up to #2132.