### PR TITLE
A site's title and description can finally be edited

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -285,6 +285,16 @@ class Site(TimestampedDocument):
     pocket_id: str
     owner: str
     name: str = ""
+    # SM-1: the owner's own one-line blurb for this site, shown as the gallery card's
+    # sublabel. EMPTY on every existing row, which reads as "no description" — the
+    # card already falls back to the host or the script name, so there is no
+    # migration and nothing changes for a site nobody has described.
+    #
+    # The frontend has carried a typed ``description`` placeholder since the card was
+    # written, with a comment saying nothing populated it; this is the field it was
+    # waiting for. Capped at the DTO edge rather than here, so an over-long value is
+    # a 422 the form can show instead of a record that silently lost its tail.
+    description: str = ""
     # Workers-for-Platforms script name (== site id) once deployed.
     script_name: str = ""
     deployed: bool = False

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -273,6 +273,10 @@ class SiteResponse(BaseModel):
     id: str
     pocket_id: str
     name: str
+    # SM-1: the owner's blurb, or "" when they have not written one. The card
+    # falls back to the host / script name, so empty is a normal state and not a
+    # missing value.
+    description: str = ""
     script_name: str
     deployed: bool
     signed_key: str
@@ -464,6 +468,42 @@ class SiteExportResponse(BaseModel):
     # When the sweeper will purge these bytes. Surfaced so the UI can say how long
     # the owner has to download it rather than implying it is kept forever.
     expires_at: str | None = None
+
+
+class SiteMetadataUpdate(BaseModel):
+    """PATCH body for a site's own title and blurb.
+
+    THREE-WAY, exactly like ``SiteClientUpdate``: a field absent from the body is
+    left alone, while an explicitly-sent empty string clears it. ``model_fields_set``
+    is what tells the two apart, so the service must read the un-dumped model — a
+    caller editing only the description cannot blank the name it never sent.
+
+    A name of only whitespace is refused rather than accepted-and-trimmed-to-empty.
+    The name is the site's identity in the gallery AND the string the delete
+    confirmation asks the owner to type back; a site that renders as "" there would
+    make the type-to-confirm gate unsatisfiable.
+    """
+
+    name: str | None = None
+    description: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _name_not_blank(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not v.strip():
+            raise ValueError("name cannot be empty")
+        if len(v) > 200:
+            raise ValueError("name must be 200 characters or fewer")
+        return v
+
+    @field_validator("description")
+    @classmethod
+    def _cap_description(cls, v: str | None) -> str | None:
+        if v is not None and len(v) > 500:
+            raise ValueError("description must be 500 characters or fewer")
+        return v
 
 
 class SitePreviewRefreshResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -279,6 +279,7 @@ from pocketpaw_ee.sites.dto import (
     SiteEntitlementsResponse,
     SiteExportResponse,
     SiteInvoiceCreate,
+    SiteMetadataUpdate,
     SitePlanRequestBody,
     SitePlanRequestResponse,
     SitePreviewRefreshResponse,
@@ -1091,6 +1092,29 @@ async def site_analytics(
     """
     return await sites_service.site_analytics(
         workspace_id=ctx.workspace_id, site_id=site_id, window=window
+    )
+
+
+@router.patch("/sites/{site_id}/metadata", response_model=SiteResponse)
+async def update_site_metadata(
+    site_id: str,
+    body: SiteMetadataUpdate,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SiteResponse:
+    """Rename a site or edit its one-line description.
+
+    Three-way: a field the caller omits is left alone, and an explicit empty string
+    clears it — which is how the form deletes a description without a second
+    endpoint. A blank NAME is refused (422) rather than accepted, because the name is
+    both the site's identity in the gallery and the string the delete confirmation
+    asks the owner to type back.
+
+    Tenant-scoped like every sibling per-site write; a missing or cross-tenant site
+    is a 404.
+    """
+    return await sites_service.update_site_metadata(
+        workspace_id=ctx.workspace_id, site_id=site_id, body=body
     )
 
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1088,6 +1088,7 @@ from pocketpaw_ee.sites.dto import (
     SiteExportResponse,
     SiteInvoiceCreate,
     SiteInvoiceOut,
+    SiteMetadataUpdate,
     SitePreviewRefreshResponse,
     SitePreviewResponse,
     SiteResponse,
@@ -2128,6 +2129,11 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         id=str(doc.id),
         pocket_id=doc.pocket_id,
         name=doc.name,
+        # Populated HERE and not only declared on the DTO. SG-9i shipped
+        # ``build_status`` / ``build_job_id`` on the response with nothing ever
+        # passing them, so every site read the field default forever; this builds
+        # the DTO field by field, which is exactly how that gap survived review.
+        description=getattr(doc, "description", "") or "",
         script_name=doc.script_name,
         deployed=doc.deployed,
         signed_key=doc.signed_key,
@@ -5922,6 +5928,38 @@ async def get_site_client(*, workspace_id: str, site_id: str) -> SiteClientRespo
     return _client_response(site)
 
 
+async def update_site_metadata(
+    *, workspace_id: str, site_id: str, body: SiteMetadataUpdate
+) -> SiteResponse:
+    """Patch a site's own title and blurb. THREE-WAY, like the client record.
+
+    Writes through a targeted ``set()`` rather than ``save()``, for the reason
+    ``update_site_client`` documents and which applies harder here: this is a
+    human-paced edit against a document a BUILD also writes to. An owner renaming a
+    site while a publish settles would, under ``save()``, push their whole stale
+    snapshot back and silently roll ``build_status`` — and now ``delete_status`` —
+    backwards. A field-scoped update cannot.
+
+    An empty PATCH is a no-op read rather than an error, so a form that autosaves on
+    blur does not surface a spurious failure.
+    """
+    body = SiteMetadataUpdate.model_validate(body)
+    site = await _load(workspace_id, site_id)
+
+    updates: dict[str, Any] = {}
+    if "name" in body.model_fields_set:
+        # The validator has already refused a blank name, so this strip cannot
+        # produce one.
+        updates["name"] = (body.name or "").strip()
+    if "description" in body.model_fields_set:
+        updates["description"] = (body.description or "").strip()
+
+    if updates:
+        await site.set(updates)
+        site = await _load(workspace_id, site_id)
+    return _to_response(site)
+
+
 async def update_site_client(
     *, workspace_id: str, site_id: str, body: SiteClientUpdate
 ) -> SiteClientResponse:
@@ -9693,6 +9731,7 @@ __all__ = [
     "site_pocket_ids",
     "live_site_for_pocket",
     "reserve_local_sites",
+    "update_site_metadata",
     "create_site_export",
     "list_site_exports",
     "open_site_export",

--- a/tests/ee/sites/test_site_metadata.py
+++ b/tests/ee/sites/test_site_metadata.py
@@ -1,0 +1,97 @@
+# tests/ee/sites/test_site_metadata.py — editable site title and description (SM-1).
+#
+# Two things here are load-bearing beyond ordinary CRUD.
+#
+# The write is field-scoped (``set``) rather than a whole-document ``save``, because
+# this is a human-paced edit against a document a BUILD also writes to. Under
+# ``save()`` an owner renaming a site while a publish settles would push their stale
+# snapshot back and silently roll ``build_status`` — and ``delete_status`` — backwards.
+#
+# And a blank NAME is refused rather than trimmed to empty, because the name is both
+# the site's identity in the gallery and the exact string the delete confirmation
+# asks the owner to type back. A site named "" would make that gate unsatisfiable.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites.dto import SiteMetadataUpdate
+
+
+def test_a_name_of_only_whitespace_is_refused_not_trimmed_to_empty() -> None:
+    """A site named "" cannot be typed back into the delete confirmation."""
+    with pytest.raises(ValueError):
+        SiteMetadataUpdate(name="   ")
+    with pytest.raises(ValueError):
+        SiteMetadataUpdate(name="")
+
+
+def test_an_omitted_name_is_allowed_because_omission_means_leave_alone() -> None:
+    """The blank guard must not become a requirement to resend the name on every
+    description edit."""
+    body = SiteMetadataUpdate(description="A dentist in Leeds.")
+    assert "name" not in body.model_fields_set
+    assert "description" in body.model_fields_set
+
+
+def test_an_explicitly_empty_description_is_allowed_because_that_is_how_you_clear_it() -> None:
+    body = SiteMetadataUpdate(description="")
+    assert "description" in body.model_fields_set
+    assert body.description == ""
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("name", "n" * 201), ("description", "d" * 501)],
+)
+def test_over_long_values_are_refused_at_the_edge(field, value) -> None:
+    """A 422 the form can show beats a record that silently lost its tail on the way
+    to Mongo."""
+    with pytest.raises(ValueError):
+        SiteMetadataUpdate(**{field: value})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("name", "n" * 200), ("description", "d" * 500)],
+)
+def test_the_caps_are_inclusive(field, value) -> None:
+    body = SiteMetadataUpdate(**{field: value})
+    assert getattr(body, field) == value
+
+
+def test_three_way_semantics_distinguish_absent_from_empty() -> None:
+    """``model_fields_set`` is the only thing that tells "leave alone" from "clear",
+    so the service must read the un-dumped model."""
+    only_name = SiteMetadataUpdate(name="Bright Smile")
+    assert only_name.model_fields_set == {"name"}
+    # description is None here, but that is ABSENCE, not a request to clear it.
+    assert only_name.description is None
+
+    clearing = SiteMetadataUpdate(description="")
+    assert clearing.model_fields_set == {"description"}
+
+
+def test_the_response_carries_description_rather_than_only_declaring_it() -> None:
+    """SG-9i declared build_status / build_job_id on SiteResponse and nothing ever
+    passed them, so every site read the default forever. ``_to_response`` builds the
+    DTO field by field, which is exactly how that survived review — so this asserts
+    the field is POPULATED from the document, not merely present on the model."""
+    import inspect
+
+    from pocketpaw_ee.sites import service
+
+    src = inspect.getsource(service._to_response)
+    assert "description=" in src, "_to_response must pass description, not default it"
+
+
+def test_the_service_writes_field_scoped_not_whole_document() -> None:
+    """A ``save()`` here would push a stale snapshot over a concurrent build's status
+    fields. Asserted on the source because the alternative is a live Mongo round trip
+    with a racing writer, which is not something a unit test can stage honestly."""
+    import inspect
+
+    from pocketpaw_ee.sites import service
+
+    src = inspect.getsource(service.update_site_metadata)
+    assert "site.set(" in src
+    assert "site.save(" not in src

--- a/tests/mutations/sites_metadata.json
+++ b/tests/mutations/sites_metadata.json
@@ -1,0 +1,47 @@
+[
+  {
+    "label": "a blank site name is accepted and trimmed to empty, leaving a site whose delete confirmation asks the owner to type a name that renders as nothing",
+    "file": "ee/pocketpaw_ee/sites/dto.py",
+    "find": "        if not v.strip():\n            raise ValueError(\"name cannot be empty\")",
+    "replace": "        if False:\n            raise ValueError(\"name cannot be empty\")",
+    "tests": [
+      "tests/ee/sites/test_site_metadata.py"
+    ]
+  },
+  {
+    "label": "the description cap stops rejecting, so an over-long blurb is silently truncated by Mongo instead of surfacing as a 422 the form can show",
+    "file": "ee/pocketpaw_ee/sites/dto.py",
+    "find": "        if v is not None and len(v) > 500:\n            raise ValueError(\"description must be 500 characters or fewer\")",
+    "replace": "        if False:\n            raise ValueError(\"description must be 500 characters or fewer\")",
+    "tests": [
+      "tests/ee/sites/test_site_metadata.py"
+    ]
+  },
+  {
+    "label": "the name cap stops rejecting, same silent-truncation failure on the field the gallery and the delete gate both read",
+    "file": "ee/pocketpaw_ee/sites/dto.py",
+    "find": "        if len(v) > 200:\n            raise ValueError(\"name must be 200 characters or fewer\")",
+    "replace": "        if False:\n            raise ValueError(\"name must be 200 characters or fewer\")",
+    "tests": [
+      "tests/ee/sites/test_site_metadata.py"
+    ]
+  },
+  {
+    "label": "the metadata write goes back to a whole-document save, so an owner renaming a site mid-publish pushes a stale snapshot over build_status and delete_status",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if updates:\n        await site.set(updates)\n        site = await _load(workspace_id, site_id)\n    return _to_response(site)",
+    "replace": "    if updates:\n        for k, v in updates.items():\n            setattr(site, k, v)\n        await site.save()\n    return _to_response(site)",
+    "tests": [
+      "tests/ee/sites/test_site_metadata.py"
+    ]
+  },
+  {
+    "label": "the response declares description but never passes it, so every site reads the field default forever -- the exact SG-9i failure this field's comment names",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        description=getattr(doc, \"description\", \"\") or \"\",",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_site_metadata.py"
+    ]
+  }
+]


### PR DESCRIPTION
`src/lib/core/sites/types.ts` in paw-enterprise has carried a typed `description` on the site card since the card was written, with a comment saying *"NOTHING populates this today — no /sites response carries it"* and the card falling back to `script_name`. This is the field it was waiting for, plus the endpoint that writes it.

## The contract

`PATCH /sites/{site_id}/metadata` → `SiteResponse`. Three-way, matching `SiteClientUpdate`: a field the caller omits is left alone, an explicit empty string clears it. `model_fields_set` is what tells those apart, so the service reads the un-dumped model — a caller editing only the description can't blank the name it never sent.

## Three decisions worth a look

**A blank name is refused, not trimmed to empty.** The name is both the site's identity in the gallery *and* the exact string the delete confirmation asks the owner to type back. A site rendering as `""` there would make the type-to-confirm gate unsatisfiable. An *omitted* name is still fine — the guard must not become a requirement to resend the name on every description edit.

**The write is field-scoped, not `save()`.** `update_site_client` already documents why, and it applies harder here: this is a human-paced edit against a document a **build** also writes to. Under `save()`, an owner renaming a site while a publish settles would push their whole stale snapshot back and silently roll `build_status` — and now `delete_status` — backwards.

**`_to_response` passes `description` explicitly.** SG-9i declared `build_status` and `build_job_id` on that same response and *nothing ever passed them*, so every site read the field default forever while the frontend polled a value that could not change. The DTO is built field by field, which is exactly how that gap survived review, so one mutation pins it.

Caps live at the DTO edge for the reason the sibling endpoint gives: a 422 the form can show beats a record that silently lost its tail on the way to Mongo.

## Verification

`tests/mutations/sites_metadata.json` — all 5 caught, including the `save()` regression and the "declared but never populated" one.

1754 pass in `tests/ee/sites` with the 3 known pre-existing reds. The route and both model fields were confirmed by importing and reading them back, not by reading source. `mutate.py --validate` green at 1346 anchors across 107 plans.

`cloud/models/site.py` is CRLF in an otherwise-LF tree; it stayed CRLF, so the diff is 113 insertions rather than a whole-file rewrite.

## Not in this PR

The frontend dialog that calls this, and the `description` field on the card. That wiring touches `src/routes/sites/+page.svelte`, where the delete-ui agent is currently working — it lands once that clears, so the two don't collide.