### PR TITLE
Raise guest caps from the environment

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2569,6 +2569,20 @@ default (per-user `guest_limits`). Over-limit responses are 402 with top-level
 or undecryptable gets 402 `{"code": "guest_key_required"}` — guests never fall
 back to platform credentials. `GET /auth/me` carries `is_guest`.
 
+`POCKETPAW_GUEST_SESSIONS` and `POCKETPAW_GUEST_TURNS_PER_DAY` raise those caps
+deployment-wide. They are FLOORS, not replacements: the larger of the env value
+and the guest's own `guest_limits` wins, so a single guest can still be lifted
+by their row. Both are unset in production and both ignore a non-integer, zero
+or negative value rather than applying it — there is deliberately no "disable
+guest limits" switch, because zero is what an operator types when they mean
+unlimited and `try_spend_turn` reads a cap of zero as *refuse every turn*. A dev
+box turns the caps off by setting them past anything it will reach:
+
+```bash
+export POCKETPAW_GUEST_SESSIONS=1000
+export POCKETPAW_GUEST_TURNS_PER_DAY=100000
+```
+
 Turn billing: every workspace with a stored BYOK key (guest or not) now runs
 its chat turns on that key — the executor resolves credentials per turn and
 threads them into the agent pool's isolated backend. The turn's model must

--- a/ee/pocketpaw_ee/cloud/auth/guest_budget.py
+++ b/ee/pocketpaw_ee/cloud/auth/guest_budget.py
@@ -2,6 +2,10 @@
 # accounts (BYOK-first onboarding).
 #
 # Created 2026-09-01 (feat/byok-guest-backend).
+# Updated 2026-09-10 (feat/guest-cap-env-override) — ``limits_for`` now takes
+# a deployment-wide FLOOR from POCKETPAW_GUEST_SESSIONS /
+# POCKETPAW_GUEST_TURNS_PER_DAY, so a dev box can raise both caps out of the
+# way without a migration and without a bypass path in the gate.
 #
 # Guests are anonymous: clearing localStorage loses the guest, it must NOT
 # reset the meter — so both caps live server-side, on the guest's own rows.
@@ -19,7 +23,12 @@
 #     see the long note in comprehension_budget).
 #
 # Everything here fails CLOSED for guests: a broken database must not become
-# an unmetered free tier. Non-guest users are a NO-OP everywhere (the helpers
+# an unmetered free tier. That is also why there is no "disable the limits"
+# boolean: the two env knobs below can only RAISE a cap, never remove the
+# counter, so a typo'd or mis-deployed value costs headroom rather than the
+# whole gate. Dev "switches it off" by raising both to a number nobody reaches.
+#
+# Non-guest users are a NO-OP everywhere (the helpers
 # answer "allowed" without touching the counter), and that no-op includes the
 # lookup failing — an unreadable user row refuses the turn rather than
 # guessing.
@@ -27,6 +36,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from datetime import UTC, datetime
 
 from beanie import PydanticObjectId
@@ -64,8 +74,42 @@ async def load_guest(user_id: str | None) -> User | None:
     return doc
 
 
+# Deployment-wide FLOORS under the per-user caps. Unset means "no opinion", so
+# the stored numbers stand — the module's fail-closed default survives a
+# missing env, a broken env, and a fresh container alike.
+SESSIONS_ENV = "POCKETPAW_GUEST_SESSIONS"
+TURNS_ENV = "POCKETPAW_GUEST_TURNS_PER_DAY"
+
+
+def _floor(name: str, stored: int) -> int:
+    """The larger of the stored cap and an env floor. Read per call, not at
+    import, so a container's env and a test's monkeypatch both land.
+
+    A non-integer or <= 0 value is IGNORED rather than applied. Zero is the one
+    number that must never come from config: ``try_spend_turn`` treats cap <= 0
+    as "refuse", so an operator who writes ``0`` meaning "unlimited" would turn
+    every guest turn off — the opposite of what they typed.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return stored
+    try:
+        floor = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an integer; ignoring", name, raw)
+        return stored
+    if floor <= 0:
+        logger.warning("%s=%r must be > 0; ignoring", name, raw)
+        return stored
+    return max(stored, floor)
+
+
 def limits_for(user: User) -> GuestLimits:
-    return user.guest_limits or DEFAULT_LIMITS
+    stored = user.guest_limits or DEFAULT_LIMITS
+    return GuestLimits(
+        sessions=_floor(SESSIONS_ENV, stored.sessions),
+        turns_per_day=_floor(TURNS_ENV, stored.turns_per_day),
+    )
 
 
 async def session_count(user_id: str) -> int:
@@ -138,6 +182,8 @@ async def try_spend_turn(user_id: str, cap: int) -> tuple[bool, int, int]:
 
 __all__ = [
     "DEFAULT_LIMITS",
+    "SESSIONS_ENV",
+    "TURNS_ENV",
     "limits_for",
     "load_guest",
     "session_count",

--- a/tests/cloud/auth/test_guest_cap_env_floor.py
+++ b/tests/cloud/auth/test_guest_cap_env_floor.py
@@ -1,0 +1,80 @@
+# tests/cloud/auth/test_guest_cap_env_floor.py — the env FLOOR under the guest
+# caps (POCKETPAW_GUEST_SESSIONS / POCKETPAW_GUEST_TURNS_PER_DAY).
+#
+# Created 2026-09-10 (feat/guest-cap-env-override).
+#
+# The knob exists so a dev box can raise the caps out of the way. The tests
+# that matter are the ones where it must NOT fire: unset, garbage, zero and
+# negative all have to leave the stored cap standing, because every one of
+# those is a way an operator turns the gate off by accident. Zero has its own
+# test — ``try_spend_turn`` reads cap <= 0 as "refuse", so an operator writing
+# 0 for "unlimited" would block every guest turn.
+#
+# Mutations that must break these: tests/mutations/guest_cap_env_floor.json.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pocketpaw_ee.cloud.auth import guest_budget
+from pocketpaw_ee.cloud.models.user import GuestLimits
+
+
+def _guest(sessions: int = 2, turns: int = 40):
+    """Only ``.guest_limits`` is read here, so a stand-in keeps these tests off
+    the database — constructing a real ``User`` needs beanie initialized, which
+    is a dependency of the fixture and not of the thing under test. The seams
+    that DO drive a real guest row live in test_guest_gates.py."""
+    return SimpleNamespace(guest_limits=GuestLimits(sessions=sessions, turns_per_day=turns))
+
+
+def test_unset_env_keeps_stored_caps(monkeypatch):
+    monkeypatch.delenv(guest_budget.SESSIONS_ENV, raising=False)
+    monkeypatch.delenv(guest_budget.TURNS_ENV, raising=False)
+    limits = guest_budget.limits_for(_guest())
+    assert (limits.sessions, limits.turns_per_day) == (2, 40)
+
+
+def test_no_stored_limits_falls_back_to_defaults(monkeypatch):
+    monkeypatch.delenv(guest_budget.SESSIONS_ENV, raising=False)
+    monkeypatch.delenv(guest_budget.TURNS_ENV, raising=False)
+    user = _guest()
+    user.guest_limits = None
+    limits = guest_budget.limits_for(user)
+    assert limits.sessions == guest_budget.DEFAULT_LIMITS.sessions
+    assert limits.turns_per_day == guest_budget.DEFAULT_LIMITS.turns_per_day
+
+
+def test_env_raises_both_caps(monkeypatch):
+    monkeypatch.setenv(guest_budget.SESSIONS_ENV, "500")
+    monkeypatch.setenv(guest_budget.TURNS_ENV, "9000")
+    limits = guest_budget.limits_for(_guest())
+    assert (limits.sessions, limits.turns_per_day) == (500, 9000)
+
+
+def test_env_is_read_per_call_not_at_import(monkeypatch):
+    """A module-level read would freeze the value at import and this would fail."""
+    monkeypatch.setenv(guest_budget.SESSIONS_ENV, "7")
+    assert guest_budget.limits_for(_guest()).sessions == 7
+    monkeypatch.setenv(guest_budget.SESSIONS_ENV, "9")
+    assert guest_budget.limits_for(_guest()).sessions == 9
+
+
+@pytest.mark.parametrize("bad", ["0", "-1", "", "lots", "40.5", " "])
+def test_unusable_env_leaves_the_stored_cap(monkeypatch, bad):
+    monkeypatch.setenv(guest_budget.SESSIONS_ENV, bad)
+    monkeypatch.setenv(guest_budget.TURNS_ENV, bad)
+    limits = guest_budget.limits_for(_guest())
+    assert (limits.sessions, limits.turns_per_day) == (2, 40), (
+        f"env {bad!r} must be ignored, never applied — 0 and negatives read as "
+        "'refuse every turn' downstream"
+    )
+
+
+def test_env_never_lowers_a_raised_per_user_cap(monkeypatch):
+    """The captain can still lift one guest via their row with env deployed."""
+    monkeypatch.setenv(guest_budget.SESSIONS_ENV, "3")
+    monkeypatch.setenv(guest_budget.TURNS_ENV, "50")
+    limits = guest_budget.limits_for(_guest(sessions=100, turns=1000))
+    assert (limits.sessions, limits.turns_per_day) == (100, 1000)

--- a/tests/mutations/guest_cap_env_floor.json
+++ b/tests/mutations/guest_cap_env_floor.json
@@ -1,0 +1,47 @@
+[
+  {
+    "label": "env floor is read at import — a container's env lands, a later change never does",
+    "file": "ee/pocketpaw_ee/cloud/auth/guest_budget.py",
+    "find": "    raw = os.environ.get(name)\n    if raw is None:\n        return stored",
+    "replace": "    raw = globals().setdefault(\"_FROZEN\", dict(os.environ)).get(name)\n    if raw is None:\n        return stored",
+    "tests": [
+      "tests/cloud/auth/test_guest_cap_env_floor.py::test_env_is_read_per_call_not_at_import"
+    ]
+  },
+  {
+    "label": "a 0 or negative env value is applied — 'unlimited' turns every guest turn OFF",
+    "file": "ee/pocketpaw_ee/cloud/auth/guest_budget.py",
+    "find": "    if floor <= 0:\n        logger.warning(\"%s=%r must be > 0; ignoring\", name, raw)\n        return stored\n    return max(stored, floor)",
+    "replace": "    return floor",
+    "tests": [
+      "tests/cloud/auth/test_guest_cap_env_floor.py::test_unusable_env_leaves_the_stored_cap"
+    ]
+  },
+  {
+    "label": "unparseable env raises instead of degrading — one typo 500s every guest turn",
+    "file": "ee/pocketpaw_ee/cloud/auth/guest_budget.py",
+    "find": "    except ValueError:\n        logger.warning(\"%s=%r is not an integer; ignoring\", name, raw)\n        return stored",
+    "replace": "    except ValueError:\n        raise",
+    "tests": [
+      "tests/cloud/auth/test_guest_cap_env_floor.py::test_unusable_env_leaves_the_stored_cap"
+    ]
+  },
+  {
+    "label": "the floor becomes a ceiling — env silently lowers a per-guest cap raised on the row",
+    "file": "ee/pocketpaw_ee/cloud/auth/guest_budget.py",
+    "find": "    return max(stored, floor)",
+    "replace": "    return floor",
+    "tests": [
+      "tests/cloud/auth/test_guest_cap_env_floor.py::test_env_never_lowers_a_raised_per_user_cap"
+    ]
+  },
+  {
+    "label": "limits_for ignores the env entirely — the dev knob is inert",
+    "file": "ee/pocketpaw_ee/cloud/auth/guest_budget.py",
+    "find": "    stored = user.guest_limits or DEFAULT_LIMITS\n    return GuestLimits(\n        sessions=_floor(SESSIONS_ENV, stored.sessions),\n        turns_per_day=_floor(TURNS_ENV, stored.turns_per_day),\n    )",
+    "replace": "    return user.guest_limits or DEFAULT_LIMITS",
+    "tests": [
+      "tests/cloud/auth/test_guest_cap_env_floor.py::test_env_raises_both_caps"
+    ]
+  }
+]


### PR DESCRIPTION
A guest gets 2 sessions and 40 turns a day. Those numbers live on the guest's
own user row, and the only way to move one was to edit Mongo. That is a bad
place to be when you are testing the BYOK gate and keep minting fresh guests.

`limits_for` now takes a floor from the environment:

```bash
export POCKETPAW_GUEST_SESSIONS=1000
export POCKETPAW_GUEST_TURNS_PER_DAY=100000
```

The larger of the env value and the stored cap wins, so it is a floor and not a
replacement. A captain can still lift one guest by their row with the env
deployed. The read happens per call rather than at import, so a container's env
and a test's monkeypatch both land.

## No off switch, on purpose

`guest_budget`'s header says a broken database must not become an unmetered free
tier, and every path in it refuses rather than guesses. A boolean that skips the
counter is the thing that header exists to prevent, so this raises the numbers
instead. Nothing here can remove the meter.

Zero and negatives are ignored, not applied. Zero is exactly what an operator
writes when they mean unlimited, and `try_spend_turn` reads a cap of zero as
"refuse every turn" — so applying it would block every guest turn while looking
like it had opened the gate. Same for a non-integer: warn and keep the stored
cap, rather than raising and 500-ing every turn on one typo.

## What is not in here

The product question this came out of is still open. A guest on their own key is
paying for their own tokens, so the turns cap protects nothing of ours; the
sessions cap is the signup nudge, and that one is worth keeping. Changing the
defaults is a captain call, so the defaults are untouched and the docstring that
calls them "the captain's launch numbers" stays true.

Worth knowing separately: `session_count` counts every session row the guest
owns, and `ensure_for_agent_scope` creates rows without passing the gate. So an
auto-created session eats into the 2 even though it was never gated.

## Tests

`tests/cloud/auth/test_guest_cap_env_floor.py` — 11 cases, weighted toward the
ones where the knob must NOT fire: unset, empty, whitespace, `40.5`, `lots`, `0`
and `-1` all leave the stored cap standing.

Five mutations in `tests/mutations/guest_cap_env_floor.json`, all caught:

```
uv run python scripts/mutate.py --plan tests/mutations/guest_cap_env_floor.json
all 5 mutations caught
```

`tests/cloud/auth/` is 482 passed, 1 failed. The failure is
`test_route_auth_coverage.py::test_the_coverage_gap_is_measured_and_does_not_grow`,
which is red on clean `origin/dev` and counts routers — this PR adds none.
