### PR TITLE
Tell the agent what the user just attached

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/studio_editor.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/studio_editor.py
@@ -16,6 +16,31 @@
 # derives addressable kinds from the MCP tool schemas). Ids therefore render as
 # ``…tail``, and the tool's validator resolves tails back through
 # ``pockets.id_resolve``.
+#
+# Changes: 2026-09-10 (feat/studio-editor-gallery-attach) — the user can now type
+# ``@`` in the editor's chat rail and pick an item from their /studio gallery,
+# and the page IMPORTS it into the media rail before the message is even sent.
+# So the preamble grew three things and lost one claim:
+#
+#   * rail rows carry ``attached=yes`` when the asset arrived this turn, so the
+#     agent can tell which of forty rail items the user just pointed at;
+#   * an ATTACHED THIS TURN block (``timeline["attached"]``, a list of asset ids)
+#     names them in the order the user picked, because "add these" resolves to
+#     that list and nothing else;
+#   * an ATTACHMENTS THAT FAILED block (``timeline["attach_failed"]``, already
+#     formatted "<name>: <reason>") — the honesty floor. An import that failed
+#     leaves no asset to place, and the agent must say so rather than place
+#     nothing and describe an arrangement.
+#
+# The claim that went: "You cannot import or generate media from here". Half of
+# it is still true (generation is /studio) and half is now false — attach IS
+# import, so the right answer to "the rail doesn't have that" is to tell the user
+# how to attach it, not to refuse.
+#
+# NO new op, and deliberately so. An attached asset is an ordinary rail asset
+# with a real assetId by the time the agent sees the turn, so ``place_clip`` /
+# ``place_audio`` already place it. The op vocabulary, the contract JSON and the
+# validator are untouched.
 
 from __future__ import annotations
 
@@ -29,6 +54,11 @@ from pocketpaw_ee.cloud.surface.handlers._helpers import content_key
 # otherwise crowd out the procedure block that tells the agent what to do with
 # it. The tail line keeps the agent honest about what it cannot see.
 _MAX_ROWS = 40
+
+# Failure lines are capped harder than rows: they are prose, not entities, and a
+# hundred failed attaches say nothing the first ten do not. Same number the
+# ``last_edit.failures`` block has used since it shipped.
+_MAX_FAILURES = 10
 
 
 def _fmt_ms(value: Any) -> str:
@@ -47,6 +77,66 @@ def _rows(items: list[dict[str, Any]], render) -> list[str]:
         # agent can address.
         out.append(f"  …and {len(items) - _MAX_ROWS} more (ask the user to narrow the request)")
     return out
+
+
+def _asset_row(asset: dict[str, Any]) -> str:
+    """One MEDIA RAIL row.
+
+    ``attached`` is rendered only when it is true. A row carrying ``attached=no``
+    would be a fact about forty items to mark two of them, and the whole point of
+    the marker is that it is scannable.
+    """
+    facts: dict[str, Any] = {
+        "kind": asset.get("kind"),
+        "duration": _fmt_ms(asset.get("duration_ms")),
+        "used": ("yes" if asset.get("in_use") else "no"),
+    }
+    if asset.get("attached"):
+        facts["attached"] = "yes"
+    return entity_line(asset.get("name"), asset.get("id"), **facts)
+
+
+def _attached_block(timeline: dict[str, Any], assets: list[dict[str, Any]]) -> list[str]:
+    """The two attach blocks: what arrived this turn, and what did not.
+
+    ``timeline["attached"]`` is a list of asset ids in the order the user picked
+    them, which is the order they should be placed in — so this renders from that
+    list rather than filtering ``assets``, whose order is the rail's.
+    """
+    lines: list[str] = []
+    by_id = {str(a.get("id")): a for a in assets if a.get("id")}
+
+    attached = [str(a) for a in (timeline.get("attached") or []) if a]
+    if attached:
+        lines.append("")
+        lines.append(
+            "ATTACHED THIS TURN (the user just attached these from their gallery "
+            "and they are already on the rail above):"
+        )
+        lines.extend(
+            _rows(
+                # A picked id with no rail row is not dropped: the id is still
+                # placeable, and silently shortening this list would make "add
+                # all three" quietly arrange two.
+                [by_id.get(aid, {"id": aid}) for aid in attached],
+                lambda a: entity_line(a.get("name"), a.get("id"), kind=a.get("kind")),
+            )
+        )
+        lines.append(
+            "  When the user says 'these clips', 'this' or 'it', they almost "
+            "certainly mean these — place them in the order listed."
+        )
+
+    failed = [str(f) for f in (timeline.get("attach_failed") or []) if f]
+    if failed:
+        lines.append("")
+        lines.append("ATTACHMENTS THAT FAILED (these did NOT reach the rail):")
+        lines.extend(f"  • {f}" for f in failed[:_MAX_FAILURES])
+        if len(failed) > _MAX_FAILURES:
+            lines.append(f"  …and {len(failed) - _MAX_FAILURES} more")
+        lines.append("  Tell the user which ones failed before you arrange anything.")
+
+    return lines
 
 
 def _timeline_block(timeline: dict[str, Any]) -> str:
@@ -80,23 +170,15 @@ def _timeline_block(timeline: dict[str, Any]) -> str:
     lines.append("")
     if assets:
         lines.append("MEDIA RAIL (what can be placed — nothing else exists):")
-        lines.extend(
-            _rows(
-                assets,
-                lambda a: entity_line(
-                    a.get("name"),
-                    a.get("id"),
-                    kind=a.get("kind"),
-                    duration=_fmt_ms(a.get("duration_ms")),
-                    used=("yes" if a.get("in_use") else "no"),
-                ),
-            )
-        )
+        lines.extend(_rows(assets, _asset_row))
     else:
         lines.append(
-            "MEDIA RAIL: empty. Nothing can be placed until the user imports "
-            "media (drag files onto the rail, or 'Add files')."
+            "MEDIA RAIL: empty. Nothing can be placed until the user adds media — "
+            "they can attach it from their /studio gallery with `@` in the "
+            "composer, or drag files onto the rail."
         )
+
+    lines.extend(_attached_block(timeline, assets))
 
     clips = [c for c in (timeline.get("clips") or []) if isinstance(c, dict)]
     lines.append("")
@@ -178,9 +260,17 @@ Rules that matter:
   clip moves. If a caption belongs to a clip's dialogue, pass
   `anchorClip: <clipId>` and give fromMs/toMs as offsets from that clip's start.
   Absolute times are only right for captions that belong to the timeline itself.
-- ONLY PLACE WHAT EXISTS. assetId must come from the MEDIA RAIL above. You
-  cannot import or generate media from here; if the rail lacks what the user
-  described, say so and ask them to add it.
+- ONLY PLACE WHAT EXISTS. assetId must come from the MEDIA RAIL above;
+  never invent one, and never claim to have generated footage (generation is
+  the /studio surface, not this one). But the rail is not fixed: the user attaches
+  media from their /studio gallery by typing `@` in the composer, and it is
+  imported onto the rail before they even send. So when the rail lacks what they
+  described, tell them to attach it with `@` (or drag the file onto the rail) —
+  do not tell them media cannot be brought in here.
+- WHAT THEY JUST ATTACHED IS WHAT THEY MEAN. When ATTACHED THIS TURN appears
+  above and the user says "add these", "put this on the timeline" or "use it",
+  those assets are the ones — place them in the ORDER LISTED, and place all of
+  them unless the user narrowed it.
 - A TRANSITION IS EXPLICIT. Clips touching or overlapping does not create one.
   Use set_transition, and only when the user asked for one.
 - COPY IDS EXACTLY as they appear above (the `…` prefix and all).
@@ -207,6 +297,9 @@ Honesty (this surface has burned people before):
   edit that did not go through, and never invent a clip, asset or timing.
 - If "YOUR LAST EDIT DID NOT FULLY APPLY" appears above, tell the user which
   parts the editor declined before doing anything else.
+- If "ATTACHMENTS THAT FAILED" appears above, name those files and say they did
+  not make it onto the rail. Placing the ones that worked and staying quiet about
+  the rest looks like the whole request went through.
 
 To render the finished video, call `mcp__pocketpaw_timeline__export_timeline`.
 Never batch an export with edits — it would render a half-built timeline.

--- a/tests/cloud/surface/test_studio_editor_preamble.py
+++ b/tests/cloud/surface/test_studio_editor_preamble.py
@@ -1,0 +1,313 @@
+# tests/cloud/surface/test_studio_editor_preamble.py — the /studio/editor
+# preamble, and specifically the gallery-attach half of it.
+#
+# Created: 2026-09-10 (feat/studio-editor-gallery-attach). The handler shipped
+# 2026-09-08 with no test file of its own; this is it, scoped to the attach
+# contract the paw-enterprise composer now emits.
+#
+# WHAT THE FRONTEND SENDS. The user types `@` in the editor's chat rail, picks a
+# /studio gallery item, and the page imports it into the project's media rail
+# BEFORE the message is sent. By the time the agent reads the turn it is an
+# ordinary asset with a real assetId, so ``SurfaceMeta.timeline`` grows three
+# things and no new op:
+#
+#   timeline["assets"][n]["attached"] -> true on the ones that arrived this turn
+#   timeline["attached"]              -> list[str] of those asset ids, in pick order
+#   timeline["attach_failed"]         -> list[str], already "<name>: <reason>"
+#
+# THE ONE THAT MATTERS is ``test_preamble_no_longer_claims_media_cannot_be_
+# imported``. The old rule read "You cannot import or generate media from here",
+# which is now half false — an agent that believes it would answer "attach the
+# beach clip" with a refusal while the affordance sat in the composer. The other
+# tests guard the rendering; that one guards the claim.
+#
+# Absence is asserted against a fixture that produces the block in a sibling test,
+# so "no ATTACHED heading" cannot pass because the heading was renamed.
+
+from __future__ import annotations
+
+from typing import Any
+
+from pocketpaw_ee.cloud.surface import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import studio_editor
+
+WORKSPACE = "ws-surface-studioeditor"
+USER = "u-studioeditor"
+
+# Realistic ids: 24-char ObjectId-shaped, sharing a head, differing in the tail —
+# a short fixture id would render ~10 chars narrower than production and would
+# also skip ``entity_line``'s tail path entirely (ids at or under 8 chars pass
+# through whole).
+ASSET_BEACH = "68c0f1a2b3c4d5e6f7a1b201"
+ASSET_DRONE = "68c0f1a2b3c4d5e6f7a1b202"
+ASSET_OLD = "68c0f1a2b3c4d5e6f7a1b203"
+
+
+def _asset(asset_id: str, name: str, **extra: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": asset_id,
+        "kind": "video",
+        "name": name,
+        "duration_ms": 4200,
+        "in_use": False,
+    }
+    base.update(extra)
+    return base
+
+
+def _timeline(**over: Any) -> dict[str, Any]:
+    doc: dict[str, Any] = {
+        "name": "Summer reel",
+        "aspect_ratio": "16:9",
+        "fps": 30,
+        "duration_ms": 12000,
+        "tracks": [{"id": "trk-1", "name": "V1", "kind": "video", "role": "main", "clip_count": 0}],
+        "assets": [_asset(ASSET_OLD, "old-intro.mp4")],
+        "clips": [],
+    }
+    doc.update(over)
+    return doc
+
+
+async def _render(timeline: dict[str, Any] | None) -> str:
+    meta = SurfaceMeta(route_path="/studio/editor", timeline=timeline)
+    return (await studio_editor.build_preamble(WORKSPACE, USER, meta)).text
+
+
+def _has_block(preamble: str, heading: str) -> bool:
+    """Is ``heading`` present as a BLOCK, not as prose?
+
+    Both headings are also named inside ``_PROCEDURE`` — the rules tell the agent
+    what to do when each block appears — so a plain ``in`` check can never be
+    false and would make every absence assertion below vacuous. A block heading
+    starts its line; the procedure mentions it mid-sentence."""
+    return any(line.startswith(heading) for line in preamble.splitlines())
+
+
+def _rail_row_for(preamble: str, name: str) -> str:
+    """The MEDIA RAIL row naming ``name``.
+
+    Scoped to the rail block on purpose: the same asset is named again under
+    ATTACHED THIS TURN, and a bare substring search would not tell the two apart
+    — which is exactly the confusion ``test_a_non_attached_asset_gains_no_
+    marker`` exists to rule out.
+    """
+    rail = preamble.split("MEDIA RAIL", 1)[1].split("ATTACHED THIS TURN", 1)[0]
+    rows = [line for line in rail.splitlines() if line.startswith(f"- {name} (")]
+    assert len(rows) == 1, f"expected one rail row for {name!r}, got {rows}"
+    return rows[0]
+
+
+# --- the attached asset reaches both places ---
+
+
+async def test_an_attached_asset_is_marked_on_the_rail_and_listed_below() -> None:
+    """An asset attached this turn renders twice, doing two different jobs.
+
+    On the RAIL it carries ``attached=yes`` so the agent can pick it out of a
+    forty-row list. Under ATTACHED THIS TURN it is named again with its id,
+    because "add these" has to resolve to an ordered list of ids and the rail's
+    order is the rail's, not the user's."""
+    preamble = await _render(
+        _timeline(
+            assets=[
+                _asset(ASSET_OLD, "old-intro.mp4"),
+                _asset(ASSET_BEACH, "beach.mp4", attached=True),
+            ],
+            attached=[ASSET_BEACH],
+        )
+    )
+
+    row = _rail_row_for(preamble, "beach.mp4")
+    assert "attached=yes" in row
+    # The pre-existing facts survive — the marker is additive, not a replacement.
+    assert "kind=video" in row
+    assert "duration=4.2s" in row
+    assert "used=no" in row
+
+    assert _has_block(preamble, "ATTACHED THIS TURN")
+    block = preamble.split("ATTACHED THIS TURN", 1)[1]
+    assert "beach.mp4" in block
+    # Addressable: the id renders as the resolvable tail entity_line produces.
+    assert ASSET_BEACH[-8:] in block
+    lower = block.lower()
+    assert "gallery" in lower
+    assert "order listed" in lower
+
+
+async def test_the_attached_block_keeps_the_users_pick_order() -> None:
+    """Rows follow ``timeline["attached"]``, not the rail.
+
+    The rail is ordered by import; the pick list is ordered by the user. "Add
+    these three" means the second order, so rendering from ``assets`` would
+    quietly arrange the clips in the wrong sequence — a failure that produces a
+    plausible video nobody asked for."""
+    preamble = await _render(
+        _timeline(
+            assets=[
+                _asset(ASSET_BEACH, "beach.mp4", attached=True),
+                _asset(ASSET_DRONE, "drone.mp4", attached=True),
+            ],
+            attached=[ASSET_DRONE, ASSET_BEACH],
+        )
+    )
+
+    block = preamble.split("ATTACHED THIS TURN", 1)[1]
+    assert block.index("drone.mp4") < block.index("beach.mp4")
+
+
+async def test_an_attached_id_with_no_rail_row_is_still_listed() -> None:
+    """A picked id the rail projection did not carry is rendered, not dropped.
+
+    Silently shortening the list would turn "add all three" into an arrangement
+    of two, which reads as success. The id is still placeable, so it goes in."""
+    preamble = await _render(_timeline(attached=[ASSET_BEACH]))
+
+    block = preamble.split("ATTACHED THIS TURN", 1)[1]
+    assert ASSET_BEACH[-8:] in block
+
+
+# --- the negative: an ordinary asset gains nothing ---
+
+
+async def test_a_non_attached_asset_gains_no_marker() -> None:
+    """Assets already on the rail are untouched.
+
+    If everything renders ``attached``, the marker means nothing and the agent
+    picks the wrong clip out of a list where all forty look equally pointed-at."""
+    preamble = await _render(
+        _timeline(
+            assets=[
+                _asset(ASSET_OLD, "old-intro.mp4"),
+                _asset(ASSET_BEACH, "beach.mp4", attached=True),
+            ],
+            attached=[ASSET_BEACH],
+        )
+    )
+
+    assert "attached=" not in _rail_row_for(preamble, "old-intro.mp4")
+    # And not smuggled in as a negative fact either — a row saying attached=no
+    # spends the characters the marker was meant to save.
+    assert "attached=no" not in preamble
+
+
+# --- failures surface ---
+
+
+async def test_a_failed_attach_is_reported_rather_than_swallowed() -> None:
+    """The honesty floor. An import that failed leaves nothing to place, so the
+    agent has to say which file did not arrive — placing the rest quietly looks
+    like the whole request went through."""
+    preamble = await _render(
+        _timeline(
+            assets=[_asset(ASSET_BEACH, "beach.mp4", attached=True)],
+            attached=[ASSET_BEACH],
+            attach_failed=["drone-4k.mp4: network error"],
+        )
+    )
+
+    assert _has_block(preamble, "ATTACHMENTS THAT FAILED")
+    assert "drone-4k.mp4: network error" in preamble
+    lower = preamble.lower()
+    assert "did not" in lower
+    # The procedure has to tell the agent what to DO about it, not just show it.
+    assert "name those files" in lower
+
+
+async def test_failed_attaches_are_capped_like_last_edit_failures() -> None:
+    """Twenty failures do not get twenty lines. Prose, not entities — the cap is
+    the same ``_MAX_FAILURES`` the last-edit block uses, and the overflow is
+    counted so the agent knows it is not seeing all of them."""
+    failures = [f"clip-{n:02d}.mp4: upload rejected" for n in range(20)]
+    preamble = await _render(_timeline(attach_failed=failures))
+
+    block = preamble.split("ATTACHMENTS THAT FAILED", 1)[1]
+    assert "clip-00.mp4" in block
+    assert "clip-09.mp4" in block
+    assert "clip-10.mp4" not in block
+    assert f"…and {20 - studio_editor._MAX_FAILURES} more" in block
+
+
+# --- absence renders nothing ---
+
+
+async def test_no_attachment_renders_no_block_and_no_stray_heading() -> None:
+    """The ordinary turn — no `@`, nothing attached — is byte-identical to what
+    shipped before this feature, so the blocks cost nothing when unused.
+
+    Both the absent key and the explicit empty list are covered: the frontend
+    omits them when there is nothing, but an emitter that sends ``[]`` must not
+    render a heading over an empty list."""
+    for timeline in (
+        _timeline(),
+        _timeline(attached=[], attach_failed=[]),
+    ):
+        preamble = await _render(timeline)
+
+        assert not _has_block(preamble, "ATTACHED THIS TURN")
+        assert not _has_block(preamble, "ATTACHMENTS THAT FAILED")
+        assert "attached=" not in preamble
+        # The rest of the timeline still rendered — the assertions above are not
+        # passing because the whole block went missing.
+        assert "MEDIA RAIL" in preamble
+        assert "old-intro.mp4" in preamble
+
+
+async def test_an_empty_rail_points_at_the_attach_affordance() -> None:
+    """With nothing to place, the preamble names the way media gets there.
+
+    It used to name only 'drag files onto the rail' / 'Add files', neither of
+    which is the affordance sitting in the composer the user is typing into."""
+    preamble = await _render(_timeline(assets=[]))
+
+    assert "MEDIA RAIL: empty" in preamble
+    assert "`@`" in preamble
+    assert "gallery" in preamble.lower()
+
+
+# --- the claim that changed ---
+
+
+async def test_preamble_no_longer_claims_media_cannot_be_imported() -> None:
+    """THE regression this task closes.
+
+    The rule read "You cannot import or generate media from here". Attach IS
+    import, so half of that sentence became false the day the composer shipped —
+    and a false capability claim does not error, it just makes the agent refuse
+    a request the product supports. Generation is still out (that is /studio),
+    and inventing an assetId is still out; only the import claim goes."""
+    preamble = await _render(_timeline())
+    lower = preamble.lower()
+
+    assert "cannot import or generate media" not in lower
+    assert "cannot import" not in lower
+    # The replacement has to tell the user how media actually gets in.
+    assert "`@`" in preamble
+    assert "attach" in lower
+    # Still forbids the two things that were always forbidden.
+    assert "never invent one" in lower
+    assert "/studio surface" in preamble
+    # And the rail is still the only source of an assetId.
+    assert "assetid must come from the media rail" in lower
+
+
+async def test_attach_does_not_add_an_op_to_the_closed_vocabulary() -> None:
+    """No verb was added. An attached asset is an ordinary rail asset by the time
+    the agent sees it, so ``place_clip`` / ``place_audio`` already place it —
+    naming an import op here would advertise a tool the validator rejects."""
+    preamble = await _render(_timeline(attached=[ASSET_BEACH]))
+
+    for invented in ("import_media", "attach_media", "import_asset", "add_media"):
+        assert invented not in preamble
+    assert "this list is closed" in preamble
+    assert "place_clip" in preamble
+
+
+async def test_no_timeline_still_short_circuits() -> None:
+    """With no timeline open there is nothing to attach TO, so none of the new
+    blocks may appear on the no-timeline path."""
+    preamble = await _render(None)
+
+    assert not _has_block(preamble, "ATTACHED THIS TURN")
+    assert not _has_block(preamble, "ATTACHMENTS THAT FAILED")
+    assert "No timeline is open" in preamble

--- a/tests/mutations/studio_editor_attach.json
+++ b/tests/mutations/studio_editor_attach.json
@@ -1,0 +1,47 @@
+[
+  {
+    "label": "rail row drops the attached marker",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/studio_editor.py",
+    "find": "    if asset.get(\"attached\"):\n        facts[\"attached\"] = \"yes\"",
+    "replace": "    if False:\n        facts[\"attached\"] = \"yes\"",
+    "tests": ["tests/cloud/surface/test_studio_editor_preamble.py::test_an_attached_asset_is_marked_on_the_rail_and_listed_below"]
+  },
+  {
+    "label": "every rail row claims it was attached",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/studio_editor.py",
+    "find": "    if asset.get(\"attached\"):\n        facts[\"attached\"] = \"yes\"",
+    "replace": "    if True:\n        facts[\"attached\"] = \"yes\"",
+    "tests": ["tests/cloud/surface/test_studio_editor_preamble.py::test_a_non_attached_asset_gains_no_marker"]
+  },
+  {
+    "label": "attached block renders in rail order, not pick order",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/studio_editor.py",
+    "find": "                [by_id.get(aid, {\"id\": aid}) for aid in attached],",
+    "replace": "                [a for a in assets if a.get(\"attached\")],",
+    "tests": [
+      "tests/cloud/surface/test_studio_editor_preamble.py::test_the_attached_block_keeps_the_users_pick_order",
+      "tests/cloud/surface/test_studio_editor_preamble.py::test_an_attached_id_with_no_rail_row_is_still_listed"
+    ]
+  },
+  {
+    "label": "failed attaches are swallowed",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/studio_editor.py",
+    "find": "    failed = [str(f) for f in (timeline.get(\"attach_failed\") or []) if f]",
+    "replace": "    failed: list[str] = []",
+    "tests": ["tests/cloud/surface/test_studio_editor_preamble.py::test_a_failed_attach_is_reported_rather_than_swallowed"]
+  },
+  {
+    "label": "failure list is uncapped",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/studio_editor.py",
+    "find": "        lines.extend(f\"  • {f}\" for f in failed[:_MAX_FAILURES])",
+    "replace": "        lines.extend(f\"  • {f}\" for f in failed)",
+    "tests": ["tests/cloud/surface/test_studio_editor_preamble.py::test_failed_attaches_are_capped_like_last_edit_failures"]
+  },
+  {
+    "label": "the procedure goes back to claiming media cannot be imported",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/studio_editor.py",
+    "find": "- ONLY PLACE WHAT EXISTS. assetId must come from the MEDIA RAIL above;",
+    "replace": "- ONLY PLACE WHAT EXISTS. You cannot import media. assetId must come from the MEDIA RAIL above;",
+    "tests": ["tests/cloud/surface/test_studio_editor_preamble.py::test_preamble_no_longer_claims_media_cannot_be_imported"]
+  }
+]


### PR DESCRIPTION
## What this fixes

The `/studio/editor` preamble described a media rail that could only grow by dragging files onto it, and said so outright:

> ONLY PLACE WHAT EXISTS. assetId must come from the MEDIA RAIL above. **You cannot import or generate media from here**; if the rail lacks what the user described, say so and ask them to add it.

Half of that is still true — generation belongs to `/studio`. The other half stops being true with the paired frontend change, where typing `@` in the editor's chat rail picks an item from the user's gallery and imports it onto the rail before the message is even sent. An agent acting on the old claim would refuse a request the product now supports.

## What changed

Rail rows gain an `attached=yes` marker, and two blocks land after the rail and before the clips:

- **ATTACHED THIS TURN** names what the user just attached. It renders from `timeline["attached"]` in *its* order rather than the rail's, because that is pick order and the agent is told to place them in the order listed. Rail order here would quietly turn "add these three" into the wrong cut.
- **ATTACHMENTS THAT FAILED** carries an import that never reached the rail. A failed attach leaves nothing to place, and the agent has to say so rather than arrange what it has and describe the rest. Capped at ten, the number `last_edit.failures` already used.

The `ONLY PLACE WHAT EXISTS` rule keeps its teeth: `assetId` still has to come from the rail, inventing one is still out, generating footage still points at `/studio`. What changed is the answer when the rail lacks what was asked for — now "attach it with `@` or drag it onto the rail", not "media cannot be brought in here".

## No new op

An attached asset is an ordinary rail asset with a real `assetId` by the time the agent sees the turn, so `place_clip` and `place_audio` already place it. **`timeline_ops.py`, `timeline.py`, the contract JSON and the validator are untouched.** This closes open question 2 of the agentic-editor PRD, which parked agent-driven import because a twelfth verb would have put an async download inside the atomic undo batch.

## Wire contract

Consumed from `SurfaceMeta.timeline`, which is already a free-form dict — no schema change in `domain.py` or `dto.py`:

| Key | Shape |
|---|---|
| `assets[n].attached` | `true`, present only on attached rows (never `false`) |
| `attached` | list of asset ids, in the user's pick order, deduped |
| `attach_failed` | list of pre-formatted `"<name>: <reason>"` strings |

## Testing

- 11 new tests in `tests/cloud/surface/test_studio_editor_preamble.py` — the marker, the block, pick order, an attached id with no rail row, the non-attached negative, `attach_failed` surfacing and capping, the absent *and* explicitly-empty cases, the empty rail, the no-timeline path, and a regression test that the old "cannot import" claim stays gone.
- 6 mutations in `tests/mutations/studio_editor_attach.json`, all caught — including marker dropped, marker on every row, rail order instead of pick order, and failures swallowed.
- `tests/cloud/surface/` + `tests/ee/agent/test_timeline_ops.py`: 290 passed. With `test_entity_id_contract.py` + `tests/ee/agent/`: 702 passed.
- The entity-id contract passes with no allow-list entry: attached rows go through `entity_line`, and failure lines use the `  • ` bullet shape.
- `ruff check` and `ruff format --check` clean.

## Review notes

Ships first of a pair with qbtrix/paw-enterprise#897, which adds the `@` gallery picker that stamps these fields. The Pydantic side ignores unknown fields, so this is safe to land ahead of the paw-enterprise PR that starts stamping them — until that merges, the new blocks simply never render.

Two behaviours this handler depends on, both guaranteed and separately tested on the emitter side: `attached` arrives in pick order (not download-completion order, which is size order in practice), and the marker is cleared every turn so it keeps distinguishing what it exists to distinguish.