### PR TITLE
Offer the notebook agent the two tools its prompt names

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -158,6 +158,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import NamedTuple
 
+from pocketpaw.agents.pydantic_ai import _TENANT_SAFE_TOOLS
 from pocketpaw_ee.agent.mcp_servers.other_hand import ILLUSTRATE_TOOL_ID
 from pocketpaw_ee.cloud.surface.domain import (
     SurfaceKind,
@@ -314,6 +315,30 @@ _OTHER_HAND_POCKET_DENY: frozenset[str] = frozenset(
         "mcp__pocketpaw_pocket_planner__plan_pocket",
     }
 )
+
+# Every BRIDGED builtin the Otherhand agent is never told about (2026-09-10).
+#
+# The notebook prompt names exactly two tools, ``illustrate`` and
+# ``image_generate``. The pydantic_ai backend nonetheless offered every
+# tenant-safe builtin the bridge could build — 34 on a dev box, ~26.5k chars of
+# JSON schema, about 6.6k tokens — on every turn. Tool schemas are the one part
+# of the request the upstream prompt cache has been measured NOT to cover
+# (``agents/pydantic_ai.py``, module header: same prompt, tools attached,
+# ``cache_read_tokens`` of zero on every turn). So this was the largest
+# uncacheable block in an Otherhand request, and every byte of it was a tool
+# the prompt never mentions.
+#
+# DERIVED from the backend's own classification rather than written out, so
+# a newly classified tool is denied here by default instead of leaking in
+# until someone notices. The two names kept are the two the prompt commands.
+#
+# Bare names, not ``mcp__`` ids, on purpose: the backend's deny filter
+# subtracts ANY matching name from the bridged list before the agent is built
+# (the route ``_SITES_BUILTIN_DENY`` takes to remove Bash). An allow-list would
+# be the cleaner shape, but the backend applies its allow to MCP toolsets only
+# and says why; a deny is the lever that exists.
+_OTHER_HAND_TOOLS: frozenset[str] = frozenset({"illustrate", "image_generate"})
+_OTHER_HAND_BRIDGED_DENY: frozenset[str] = _TENANT_SAFE_TOOLS - _OTHER_HAND_TOOLS
 
 # Built-in SDK tools the /sites agent never needs. It authors sites through the
 # sites_manager + design MCP tools (the source map / copy is a tool ARGUMENT), so
@@ -1070,7 +1095,10 @@ SURFACES: list[SurfaceSpec] = [
         # Static profile: no lazily-loaded ids, not meta-aware.
         profile=SurfaceProfile(
             ripple_mode="off",
-            deny_mcp_tool_ids=_OTHER_HAND_POCKET_DENY,
+            # Two deny sets, one field: the pocket MCP ids that make a pocket
+            # unreachable, and the bridged builtins the prompt never names
+            # (``_OTHER_HAND_BRIDGED_DENY`` — the token cut).
+            deny_mcp_tool_ids=_OTHER_HAND_POCKET_DENY | _OTHER_HAND_BRIDGED_DENY,
             allow_mcp_tool_ids=frozenset({ILLUSTRATE_TOOL_ID}),
             system_message_override=OTHER_HAND_SYSTEM_PROMPT,
         ),

--- a/tests/cloud/surface/test_other_hand_handler.py
+++ b/tests/cloud/surface/test_other_hand_handler.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+from pocketpaw_ee.agent.mcp_servers.other_hand import ILLUSTRATE_TOOL_ID
 from pocketpaw_ee.cloud.surface import (
     SurfaceKind,
     SurfaceMeta,
@@ -231,6 +232,28 @@ def test_profile_carries_the_page_ops_output_contract() -> None:
     assert "page-ops" in override
     assert "free_y" in override
     assert "size: 20" in override
+
+
+def test_profile_offers_only_the_tools_the_prompt_names() -> None:
+    """The bridged tool surface is derived from the OSS allow-list and pinned.
+
+    Otherhand's prompt names two tools, ``illustrate`` and ``image_generate``,
+    and every other bridged builtin was still offered on every turn: ~6.6k
+    tokens of schema, the one block the upstream prompt cache has been measured
+    not to cover. What is LEFT after the deny is computed from the backend's
+    own ``_TENANT_SAFE_TOOLS`` and pinned to those two names. Mutations: drop
+    ``_OTHER_HAND_BRIDGED_DENY`` from the profile and 70 names are offered;
+    widen the deny by one and the prompt commands a tool the agent lacks.
+    """
+    from pocketpaw.agents.pydantic_ai import _TENANT_SAFE_TOOLS
+
+    profile = resolve_profile(SurfaceKind.OTHER_HAND, SurfaceMeta())
+    offered = _TENANT_SAFE_TOOLS - profile.deny_mcp_tool_ids
+    assert offered == {"illustrate", "image_generate"}, sorted(offered)
+    # The pocket MCP deny is still in the same field — one union, both halves.
+    assert "mcp__pocketpaw_pocket_specialist__create" in profile.deny_mcp_tool_ids
+    # And the illustration tool is still the ONE permitted MCP id.
+    assert profile.allow_mcp_tool_ids == frozenset({ILLUSTRATE_TOOL_ID})
 
 
 def test_profile_keeps_read_available() -> None:

--- a/tests/mutations/other_hand_tool_surface.json
+++ b/tests/mutations/other_hand_tool_surface.json
@@ -1,0 +1,20 @@
+[
+  {
+    "label": "bridged builtins offered again — every tenant-safe schema, ~6.6k uncacheable tokens, back on every Otherhand turn",
+    "file": "ee/pocketpaw_ee/cloud/surface/surface_registry.py",
+    "find": "            deny_mcp_tool_ids=_OTHER_HAND_POCKET_DENY | _OTHER_HAND_BRIDGED_DENY,",
+    "replace": "            deny_mcp_tool_ids=_OTHER_HAND_POCKET_DENY,",
+    "tests": [
+      "tests/cloud/surface/test_other_hand_handler.py::test_profile_offers_only_the_tools_the_prompt_names"
+    ]
+  },
+  {
+    "label": "the deny swallows illustrate too — the prompt commands a tool the agent no longer has",
+    "file": "ee/pocketpaw_ee/cloud/surface/surface_registry.py",
+    "find": "_OTHER_HAND_TOOLS: frozenset[str] = frozenset({\"illustrate\", \"image_generate\"})",
+    "replace": "_OTHER_HAND_TOOLS: frozenset[str] = frozenset({\"image_generate\"})",
+    "tests": [
+      "tests/cloud/surface/test_other_hand_handler.py::test_profile_offers_only_the_tools_the_prompt_names"
+    ]
+  }
+]


### PR DESCRIPTION
The Otherhand prompt names two tools, `illustrate` and `image_generate`. The
pydantic_ai backend offered every tenant-safe builtin the bridge could build
anyway. On a dev box that is 34 tools and about 26.5k characters of JSON schema,
roughly 6.6k tokens, sent on every single turn.

That is the worst kind of token. The module header in `agents/pydantic_ai.py`
records the measurement: the same system prompt caches upstream at 100% on warm
turns, and the moment a tool surface is attached, `cache_read_tokens` drops to
zero and stays there. Tool schemas do not cache. So this was the largest block
in an Otherhand request that is paid in full every time, and none of it was a
tool the prompt mentions.

## The change

The surface profile's deny set now also carries every bridged builtin except
the two the prompt commands. The backend's deny filter strips bare names from
the bridged list before the agent is built, the same route `/sites` uses to
remove Bash.

The deny is derived, not written out: `_TENANT_SAFE_TOOLS` minus the two names.
A newly classified tool is therefore withheld from the notebook by default
rather than offered until someone notices. A deny rather than an allow because
the backend applies its allow to MCP toolsets only, and the docstring there
explains why widening that would break `/sites`.

## What is not in here

This does not touch the other input costs on a turn. For the record, roughly:

| block | approx tokens | cached upstream |
|---|---|---|
| tool schemas (this PR) | 6,600 | never |
| page image, 1240x1754 | 2,900 | never |
| scene digest, up to 6,000 chars | up to 1,500 | never |
| Otherhand system prompt | 3,300 | yes, warm turns |
| runtime identity rule | 400 | yes |
| history, last 60 messages | grows | partly |

Capping history replay for this surface is the next lever, since the page
image already carries the state. That is a behaviour change and gets its own
PR.

## Tests

`test_profile_offers_only_the_tools_the_prompt_names` computes what is left
after the deny from the backend's own set and pins it to the two names. Two
mutations in `tests/mutations/other_hand_tool_surface.json`, both caught:
drop the deny (70 names offered), and widen it by one (the prompt then commands
a tool the agent lacks).

Both import-linter configs are green. Not yet measured on a live turn; the
backend logs `Dispatch-only: withheld N tool(s); M offered`, which is the line
to read after deploy.
