### PR TITLE
Honour the per-send model on the pydantic_ai backend

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1689,10 +1689,12 @@ async def _drive_agent_loop(
         if surface_skills:
             run_kwargs["skill_names"] = surface_skills
         # CS-13 — per-send model override. Same withhold-when-empty idiom as the
-        # kwargs above: only the Claude SDK backend accepts ``model_override``
-        # (the 7 other backends keep the narrower signature), so it is forwarded
-        # ONLY when the client actually chose a model for this turn. ``None`` =
-        # legacy path, byte-identical to today.
+        # kwargs above: the Claude SDK and pydantic_ai backends accept
+        # ``model_override`` (2026-09-10 — the cloud default is pydantic_ai, so
+        # before that a composer model picker was a dead control there), the
+        # rest keep the narrower signature, so it is forwarded ONLY when the
+        # client actually chose a model for this turn. ``None`` = legacy path,
+        # byte-identical to today.
         if ctx.model_override:
             run_kwargs["model_override"] = ctx.model_override
         # Per-send tool switch. Same withhold-when-empty idiom: only an explicit

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -9,6 +9,18 @@ Changes:
   credentials: reaching it with a rejected gateway address would put every
   such turn on OUR key, so a tenant's bad (or hostile) address would spend our
   money. A refused turn is the correct answer — the address is theirs to fix.
+- 2026-09-11 (feat/pydantic-ai-model-override) — a per-send ``model`` is checked
+  against the gateway's own catalog before it is forwarded. The edge validates a
+  SHAPE (a regex and a length) and the composer's picker is three hardcoded
+  presets plus a free-text field, so once the override became live on the
+  cloud's default backend the field was free-text model selection billed to the
+  platform key. ``_model_is_unknown_to_gateway`` rejects only what it positively
+  knows is unserved — an unreachable or empty catalog lets the turn through
+  rather than making the picker a dead control again, matching what
+  ``resolve_turn_credentials`` does with its own failure. It is NOT an
+  entitlement check: every model the gateway serves is in the catalog, so a
+  per-plan allowlist is still the thing that would put a ceiling on cost, and
+  this is the seam it plugs into.
 
 - 2026-09-08 (fix/attachment-only-turns) — ``_drive_agent_loop`` now runs its
   ``user_content`` through ``agent_service.resolve_user_content`` before
@@ -1418,6 +1430,63 @@ async def _prewarm_session(ctx: ScopeContext, flow_context: dict[str, Any] | Non
         logger.debug("prewarm_session skipped (swallowed): %s", exc)
 
 
+#: How long a per-send model check may hold up a turn. The catalog client's own
+#: timeout is 15s per read and it makes two, so an unreachable proxy could add
+#: half a minute to a turn that is going to run fine. A check that times out is
+#: a check that did not happen, which is the fail-open case below.
+_MODEL_CHECK_TIMEOUT_SECONDS = 5.0
+
+
+async def _model_is_unknown_to_gateway(model_id: str) -> bool:
+    """True only when we POSITIVELY know the gateway does not serve ``model_id``.
+
+    The per-send model is validated at the edge by a regex and nothing else, and
+    the composer's picker is three hardcoded presets plus a free-text field, so
+    without this a workspace names any model string it likes and the platform
+    key pays for whatever the gateway is willing to route.
+
+    The catalog is the right list to check against because it is the UNION of
+    what the proxy describes (``/model/info``) and what it routes
+    (``/v1/models``) — never narrower than the routable set. So an id missing
+    from it is an id the gateway would refuse anyway, and refusing here turns an
+    opaque upstream 400 into a typed error the composer can show.
+
+    It is deliberately NOT an entitlement check. Every model the gateway serves
+    is in the catalog, so this does not stop a workspace from picking an
+    expensive one; it stops free text. A per-plan allowlist is the thing that
+    puts a ceiling on cost, and this is the seam it plugs into.
+
+    Fail-open in two directions, both of which would otherwise make the picker a
+    dead control on a healthy deployment:
+
+    * the catalog is unreachable — ``/model/info`` is an admin route and can be
+      gated or down while chat routing is fine. Matches what
+      ``resolve_turn_credentials`` does with its own failure a few lines below.
+    * the catalog came back EMPTY — indistinguishable from "unknown id" on a
+      per-id lookup, and rejecting every send is far worse than the cost
+      exposure being checked for.
+    """
+    from pocketpaw_ee.catalog import service as catalog_service
+
+    try:
+        entries = await asyncio.wait_for(
+            catalog_service.list_models(), timeout=_MODEL_CHECK_TIMEOUT_SECONDS
+        )
+    except Exception:
+        logger.warning(
+            "model catalog unavailable — per-send model %r runs unchecked this turn",
+            model_id,
+            exc_info=True,
+        )
+        return False
+    if not entries:
+        logger.warning(
+            "model catalog is empty — per-send model %r runs unchecked this turn", model_id
+        )
+        return False
+    return not any(entry.id == model_id for entry in entries)
+
+
 async def _drive_agent_loop(
     ctx: ScopeContext,
     *,
@@ -1695,7 +1764,24 @@ async def _drive_agent_loop(
         # rest keep the narrower signature, so it is forwarded ONLY when the
         # client actually chose a model for this turn. ``None`` = legacy path,
         # byte-identical to today.
+        # The id itself is checked against the gateway's own model list before
+        # it is forwarded — the edge validates a SHAPE (a regex and a length),
+        # which says nothing about whether the model exists or whether we serve
+        # it. See ``_model_is_unknown_to_gateway`` for why this rejects only
+        # what we positively know is not served.
         if ctx.model_override:
+            if await _model_is_unknown_to_gateway(ctx.model_override):
+                yield (
+                    "error",
+                    {
+                        "code": "model.not_available",
+                        "message": (
+                            f"'{ctx.model_override}' isn't a model this workspace can "
+                            "run. Pick one from the model menu."
+                        ),
+                    },
+                )
+                return
             run_kwargs["model_override"] = ctx.model_override
         # Per-send tool switch. Same withhold-when-empty idiom: only an explicit
         # False is a request, so a client that never sends the field (every

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -390,6 +390,19 @@ are now the same object the parser consults, so the three cannot drift.
 ``deep_agents`` has the identical split and is deliberately NOT touched here.
 The claim in ``_parse_provider_model`` that the two mirror each other no longer
 holds, and fixing it there is its own change.
+
+Updated 2026-09-10 (feat/pydantic-ai-model-override) — **the per-send model was
+accepted and thrown away.** ``run`` declared ``model_override`` with a
+``noqa: ARG002`` and a comment saying only the Claude SDK backend consumed it.
+The cloud's default backend is this one, so a model picker in the composer was
+a dead control: the user chose a model, the turn ran on the configured one, and
+nothing said so. ``model_override`` is now the spec ``_build_model`` parses. A
+bare name keeps the configured provider, which is what makes it safe on a BYOK
+gateway — ``build_settings_override`` pins ``pydantic_ai_model`` to the STORED
+gateway model, and the per-send choice beats that name while the gateway's base
+URL and key stay put. It also rides the agent cache key and the per-run model
+settings: the cache is ONE slot, so a key that still read the setting would
+hand turn two the agent built for turn one, model and output cap included.
 """
 
 from __future__ import annotations
@@ -1021,7 +1034,7 @@ class PydanticAIBackend:
             provider = "litellm"
         return provider, model_str
 
-    def _resolve_max_output_tokens(self) -> int | None:
+    def _resolve_max_output_tokens(self, model_spec: str | None = None) -> int | None:
         """The ``max_tokens`` this run should send, or None to send none.
 
         Resolved from the SAME ``_parse_provider_model`` output that built the
@@ -1032,13 +1045,13 @@ class PydanticAIBackend:
         try:
             from pocketpaw.agents.model_limits import resolve_max_output_tokens
 
-            provider, model = self._parse_provider_model()
+            provider, model = self._parse_provider_model(model_spec)
             return resolve_max_output_tokens(provider, model, self.settings)
         except Exception:  # noqa: BLE001 — a token cap must never break a run
             logger.debug("Could not resolve a max output token cap", exc_info=True)
             return None
 
-    def _run_model_settings(self) -> Any:
+    def _run_model_settings(self, model_spec: str | None = None) -> Any:
         """The ``model_settings`` for THIS run, or None to send none.
 
         Two per-run values live here, both of which the cached agent must not
@@ -1058,14 +1071,14 @@ class PydanticAIBackend:
         """
         settings: dict[str, Any] = {}
 
-        max_output = self._resolve_max_output_tokens()
+        max_output = self._resolve_max_output_tokens(model_spec)
         if max_output:
             settings["max_tokens"] = max_output
 
         # The provider is re-parsed rather than threaded down because
         # ``_resolve_max_output_tokens`` already parses it the same way; the two
         # cannot disagree about which model this run resolved.
-        provider, _model = self._parse_provider_model()
+        provider, _model = self._parse_provider_model(model_spec)
         end_user = end_user_id_for(provider)
         if end_user:
             settings["openai_user"] = end_user
@@ -2032,6 +2045,7 @@ class PydanticAIBackend:
         allow_mcp_tool_ids: frozenset[str] | None = None,
         exclusive_mcp_tools: bool = False,
         system_prompt_digest: str = "",
+        model_spec: str | None = None,
         tools_enabled: bool = True,
     ) -> Any:
         """Build (and cache) the pydantic-ai ``Agent``.
@@ -2072,7 +2086,11 @@ class PydanticAIBackend:
         tools = list(self._build_custom_tools()) if tools_enabled else []
 
         agent_key = (
-            self.settings.pydantic_ai_model,
+            # The spec that BUILT ``model``, not the configured default: a
+            # per-send ``model_override`` builds a different model object, and a
+            # key that still read the setting would serve the cached agent —
+            # holding the previous model — to a turn that asked for another one.
+            model_spec or self.settings.pydantic_ai_model,
             is_pocket_session,
             len(mcp_toolsets),
             self._tools_version,
@@ -2288,13 +2306,16 @@ class PydanticAIBackend:
         #                         SDK built-ins on this backend, so there is
         #                         nothing to grant; ignoring it removes tools,
         #                         never adds them.
-        #   ``model_override``    per-send model choice, consumed only by the
-        #                         Claude SDK backend (as on the other six).
         #   ``session_handle`` /  native CLI-session resume and warm-client
         #   ``warm_client`` /     reuse — this backend has no subprocess to
         #   ``on_client_built``   resume or lease.
         allow_sdk_tools: frozenset[str] = frozenset(),  # noqa: ARG002
-        model_override: str | None = None,  # noqa: ARG002
+        # The per-send model choice. HONOURED here since 2026-09-10: it is the
+        # spec ``_build_model`` parses, so a bare name keeps the configured
+        # provider (and, on a BYOK gateway, its base URL and key) and only the
+        # model changes. It also keys the agent cache — see
+        # ``_get_or_create_agent``.
+        model_override: str | None = None,
         session_handle: Any = None,  # noqa: ARG002
         warm_client: Any = None,  # noqa: ARG002
         on_client_built: Any = None,  # noqa: ARG002
@@ -2370,7 +2391,7 @@ class PydanticAIBackend:
             return self._usage_event_from(run_usage, model_name=getattr(model, "model_name", None))
 
         try:
-            model = self._build_model()
+            model = self._build_model(model_override)
 
             # A gated surface is one where WHICH tools the agent has is part of
             # the contract. The agentapi model cannot be part of that contract —
@@ -2399,6 +2420,7 @@ class PydanticAIBackend:
                 allow_mcp_tool_ids=allow_mcp_tool_ids,
                 exclusive_mcp_tools=exclusive_mcp_tools,
                 system_prompt_digest=system_prompt_digest,
+                model_spec=model_override,
                 tools_enabled=tools_enabled,
             )
 
@@ -2420,7 +2442,7 @@ class PydanticAIBackend:
             # the model and the tenant THIS run resolved. The fast-model path
             # swaps the model but reuses these settings, which is what keeps a
             # run that downshifts mid-flight attributed to the same workspace.
-            run_settings = self._run_model_settings()
+            run_settings = self._run_model_settings(model_override)
             if run_settings:
                 kwargs["model_settings"] = run_settings
 

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -403,6 +403,12 @@ gateway model, and the per-send choice beats that name while the gateway's base
 URL and key stay put. It also rides the agent cache key and the per-run model
 settings: the cache is ONE slot, so a key that still read the setting would
 hand turn two the agent built for turn one, model and output cap included.
+
+The override names a MODEL, never a provider, and ``run`` refuses a
+provider-prefixed one. A spec like ``litellm:anything`` would otherwise resolve
+the deployment's proxy key on a turn that is supposed to run on the tenant's —
+a credential switch wearing a model id, which ``provider_allows_model`` cannot
+catch because a gateway's model ids are its own namespace.
 """
 
 from __future__ import annotations
@@ -2391,6 +2397,30 @@ class PydanticAIBackend:
             return self._usage_event_from(run_usage, model_name=getattr(model, "model_name", None))
 
         try:
+            # A per-send model picks a model WITHIN the configured provider,
+            # never a provider. ``_parse_provider_model`` splits on a colon when
+            # the prefix names a known provider, so an unguarded override is a
+            # CREDENTIAL switch wearing a model id: a BYOK gateway turn runs on
+            # an isolated backend holding the tenant's key but still carrying
+            # the deployment's ``litellm_api_key``, and ``litellm:anything``
+            # from the composer's free-text field would resolve the proxy's own
+            # credential. ``provider_allows_model`` cannot catch it — on a
+            # gateway it passes every name, because a gateway's ids are its own
+            # namespace. The PREFIX is what is checked, not the colon: a model
+            # name may legitimately carry one (``minimax/minimax-m3:free``,
+            # ``llama3.2:latest``).
+            if (model_override or "").partition(":")[0].strip() in _KNOWN_PROVIDERS:
+                yield AgentEvent(
+                    type="error",
+                    content=(
+                        f"Model {model_override!r} names a provider. A per-send "
+                        "model can only pick a model on the provider this agent "
+                        "is already configured for — drop the prefix."
+                    ),
+                )
+                yield AgentEvent(type="done", content="")
+                return
+
             model = self._build_model(model_override)
 
             # A gated surface is one where WHICH tools the agent has is part of

--- a/tests/cloud/runs/test_run_core_byok_wiring.py
+++ b/tests/cloud/runs/test_run_core_byok_wiring.py
@@ -31,6 +31,11 @@
 #   * a generic resolver crash -> still degrades to platform, unchanged. That
 #     one keeps the other two honest: a catch written too wide would start
 #     refusing turns that used to run.
+#
+# Updated 2026-09-11 (feat/pydantic-ai-model-override) — ``_drive`` now stubs
+# the model catalog permissively. A per-send model is checked against it before
+# the byok rules run, and without the stub the two ``model_override`` cases here
+# reach for a live proxy and pass only because that check fails open.
 
 from __future__ import annotations
 
@@ -39,6 +44,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry
 from pocketpaw_ee.cloud.byok.service import TurnCredentials
 from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
 from pocketpaw_ee.cloud.chat.runs import run_core
@@ -148,6 +154,27 @@ async def _drive(
 
     monkeypatch.setattr("pocketpaw_ee.cloud.byok.service.resolve_turn_credentials", _resolve)
     monkeypatch.setattr("pocketpaw_ee.cloud.auth.guest_budget.load_guest", guest_loader)
+
+    # A per-send model is now checked against the gateway's catalog before it is
+    # forwarded (2026-09-11). Stubbed PERMISSIVE here so these tests keep
+    # measuring the byok rules and nothing else — without it a
+    # ``model_override`` case reaches for a live proxy and passes only because
+    # that check fails open, which would hide a byok regression behind an
+    # unrelated outage path. ``test_run_core_model_catalog.py`` owns the check
+    # itself.
+    async def _catalog_serves_everything(**_kwargs):
+        model_id = ctx.model_override or "claude-opus-4-6"
+        return [
+            ModelCatalogEntry(
+                id=model_id,
+                display_name=model_id,
+                provider="anthropic",
+                modality=Modality.CHAT,
+                status="available",
+            )
+        ]
+
+    monkeypatch.setattr("pocketpaw_ee.catalog.service.list_models", _catalog_serves_everything)
 
     async def _never_cancelled():
         return False

--- a/tests/cloud/runs/test_run_core_model_catalog.py
+++ b/tests/cloud/runs/test_run_core_model_catalog.py
@@ -1,0 +1,216 @@
+# tests/cloud/runs/test_run_core_model_catalog.py — a per-send model must name
+# something the gateway actually serves.
+#
+# Created 2026-09-11 (feat/pydantic-ai-model-override). Until the override was
+# honoured on pydantic_ai it was a dead control on the cloud's default backend,
+# so a free-text model id never reached the platform gateway. Once it works,
+# ``model`` on the request is checked against nothing but a regex — the
+# composer's picker is three hardcoded presets plus a free-text field, and
+# ``provider_allows_model`` runs on the BYOK branch alone.
+#
+# The catalog is the union of what the proxy describes (/model/info) and what it
+# routes (/v1/models), so it is never narrower than the routable set. An id the
+# catalog does not hold is one the gateway would refuse anyway; rejecting it here
+# turns an opaque upstream 400 into a typed error the composer can show.
+#
+# The two tests that earn their space are the fail-open ones. A catalog outage
+# and an empty catalog must NOT reject the turn: either would make every
+# override fail on a deployment whose /model/info is admin-gated or misread,
+# which is the dead-control bug this branch exists to remove.
+#
+# Harness cloned from test_run_core_byok_wiring.py (capture pool + stubbed
+# collaborators; hermetic, no mongod, no proxy).
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pocketpaw_ee.catalog.models import Modality, ModelCatalogEntry
+from pocketpaw_ee.cloud.byok.service import TurnCredentials
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Ev:
+    def __init__(self, type_: str, content: str = "") -> None:
+        self.type = type_
+        self.content = content
+        self.metadata: dict[str, Any] = {}
+
+
+class _CapturePool:
+    def __init__(self) -> None:
+        self.run_kwargs: dict[str, Any] | None = None
+        self.run_called = False
+
+    async def get(self, _agent_id):
+        return SimpleNamespace(config={"backend": "pydantic_ai", "model": ""}, agent_name="A")
+
+    def run(self, agent_id, content, session_key, **kwargs):
+        self.run_called = True
+        self.run_kwargs = kwargs
+
+        async def _gen():
+            yield _Ev("message", "hi back")
+            yield _Ev("done")
+
+        return _gen()
+
+
+def _entry(model_id: str) -> ModelCatalogEntry:
+    return ModelCatalogEntry(
+        id=model_id,
+        display_name=model_id,
+        provider="anthropic",
+        modality=Modality.CHAT,
+        status="available",
+    )
+
+
+def _ctx(*, model_override: str | None = None) -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        model_override=model_override,
+    )
+
+
+async def _drive(
+    monkeypatch,
+    ctx: ScopeContext,
+    *,
+    catalog,
+) -> tuple[_CapturePool, list[tuple[str, dict]]]:
+    """Run the loop with *catalog* standing in for ``catalog_service.list_models``.
+
+    Pass a list of entries, or an exception instance to raise.
+    """
+    monkeypatch.delenv("POCKETPAW_SESSION_SUPERVISOR", raising=False)
+
+    pool = _CapturePool()
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: pool)
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda *a, **k: "")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda *a, **k: None)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda *a, **k: None)
+
+    async def _list_models(**_kwargs):
+        if isinstance(catalog, BaseException):
+            raise catalog
+        return list(catalog)
+
+    monkeypatch.setattr("pocketpaw_ee.catalog.service.list_models", _list_models)
+
+    async def _resolve(workspace_id):
+        return TurnCredentials(source="platform")
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.byok.service.resolve_turn_credentials", _resolve)
+
+    async def _not_guest(user_id):
+        return None
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.auth.guest_budget.load_guest", _not_guest)
+
+    async def _never_cancelled():
+        return False
+
+    out: list[tuple[str, dict]] = []
+    gen = run_core._drive_agent_loop(
+        ctx,
+        user_content="hi",
+        attachments_in=None,
+        mentions_in=None,
+        history=[],
+        is_cancelled=_never_cancelled,
+        emit_stream_start=False,
+    )
+    async for ev in gen:
+        out.append(ev)
+    return pool, out
+
+
+# ---------------------------------------------------------------------------
+
+
+async def test_a_model_the_gateway_never_heard_of_is_refused(monkeypatch):
+    """The finding: a per-send model was free text billed to the platform key."""
+    pool, out = await _drive(
+        monkeypatch,
+        _ctx(model_override="gpt-9-ultra-expensive"),
+        catalog=[_entry("claude-opus-4-8")],
+    )
+    assert pool.run_called is False, "an unknown model must never reach the gateway"
+    errors = [d for name, d in out if name == "error"]
+    assert errors and errors[0]["code"] == "model.not_available"
+    assert "gpt-9-ultra-expensive" in errors[0]["message"]
+
+
+async def test_a_catalogued_model_runs(monkeypatch):
+    pool, _ = await _drive(
+        monkeypatch,
+        _ctx(model_override="claude-opus-4-8"),
+        catalog=[_entry("claude-opus-4-8"), _entry("claude-haiku-4-5")],
+    )
+    assert pool.run_called is True
+    assert pool.run_kwargs.get("model_override") == "claude-opus-4-8"
+
+
+async def test_no_override_never_reads_the_catalog(monkeypatch):
+    """An auto send is the common case and must not pay a catalog read."""
+    pool, _ = await _drive(
+        monkeypatch,
+        _ctx(),
+        catalog=RuntimeError("the catalog must not be consulted for an auto send"),
+    )
+    assert pool.run_called is True
+    assert "model_override" not in (pool.run_kwargs or {})
+
+
+async def test_an_unreachable_catalog_does_not_kill_the_turn(monkeypatch, caplog):
+    """Fail OPEN, matching the byok resolver ten lines below the check.
+
+    ``/model/info`` is an admin route and can be gated or down on a deployment
+    whose chat routing is perfectly healthy. Refusing there would make the
+    picker a dead control again, which is the bug this branch removes.
+    """
+    with caplog.at_level(logging.WARNING):
+        pool, out = await _drive(
+            monkeypatch,
+            _ctx(model_override="claude-opus-4-8"),
+            catalog=RuntimeError("proxy unreachable"),
+        )
+    assert pool.run_called is True
+    assert pool.run_kwargs.get("model_override") == "claude-opus-4-8"
+    assert not [d for name, d in out if name == "error"]
+    assert any("catalog" in r.message.lower() for r in caplog.records)
+
+
+async def test_an_empty_catalog_refuses_nothing(monkeypatch):
+    """A proxy that describes no models must not reject every model.
+
+    ``get_model`` cannot tell "unknown id" from "catalog came back empty", and
+    the second one rejecting every send is a far worse failure than the cost
+    exposure being checked for.
+    """
+    pool, out = await _drive(
+        monkeypatch,
+        _ctx(model_override="claude-opus-4-8"),
+        catalog=[],
+    )
+    assert pool.run_called is True
+    assert not [d for name, d in out if name == "error"]

--- a/tests/mutations/pydantic_ai_model_override.json
+++ b/tests/mutations/pydantic_ai_model_override.json
@@ -1,0 +1,29 @@
+[
+  {
+    "label": "the override is dropped again \u2014 the composer picker silently runs the configured model",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            model = self._build_model(model_override)",
+    "replace": "            model = self._build_model()",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_model_override_reaches_the_model_factory_and_the_agent_key"
+    ]
+  },
+  {
+    "label": "the agent key ignores the spec \u2014 turn two is served turn one's agent, holding turn one's model",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            model_spec or self.settings.pydantic_ai_model,",
+    "replace": "            self.settings.pydantic_ai_model,",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_model_override_reaches_the_model_factory_and_the_agent_key"
+    ]
+  },
+  {
+    "label": "the spec stops reaching the parser \u2014 the override takes the gateway's endpoint with it or loses it",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        provider, model = self._parse_provider_model(model_spec)\n\n        if provider == \"agentapi\":",
+    "replace": "        provider, model = self._parse_provider_model()\n\n        if provider == \"agentapi\":",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_model_override_builds_the_model_it_names"
+    ]
+  }
+]

--- a/tests/mutations/pydantic_ai_model_override.json
+++ b/tests/mutations/pydantic_ai_model_override.json
@@ -1,6 +1,6 @@
 [
   {
-    "label": "the override is dropped again \u2014 the composer picker silently runs the configured model",
+    "label": "the override is dropped again — the composer picker silently runs the configured model",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "            model = self._build_model(model_override)",
     "replace": "            model = self._build_model()",
@@ -9,7 +9,7 @@
     ]
   },
   {
-    "label": "the agent key ignores the spec \u2014 turn two is served turn one's agent, holding turn one's model",
+    "label": "the agent key ignores the spec — turn two is served turn one's agent, holding turn one's model",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "            model_spec or self.settings.pydantic_ai_model,",
     "replace": "            self.settings.pydantic_ai_model,",
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "label": "the spec stops reaching the parser \u2014 the override takes the gateway's endpoint with it or loses it",
+    "label": "the spec stops reaching the parser — the override takes the gateway's endpoint with it or loses it",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "        provider, model = self._parse_provider_model(model_spec)\n\n        if provider == \"agentapi\":",
     "replace": "        provider, model = self._parse_provider_model()\n\n        if provider == \"agentapi\":",
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "label": "the provider guard is removed \u2014 a free-text 'litellm:x' runs a guest's turn on the deployment's proxy key",
+    "label": "the provider guard is removed — a free-text 'litellm:x' runs a guest's turn on the deployment's proxy key",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "            if (model_override or \"\").partition(\":\")[0].strip() in _KNOWN_PROVIDERS:",
     "replace": "            if False:",
@@ -36,12 +36,39 @@
     ]
   },
   {
-    "label": "the guard widens to any colon \u2014 OpenRouter ':free' and Ollama ':latest' model ids become unpickable",
+    "label": "the guard widens to any colon — OpenRouter ':free' and Ollama ':latest' model ids become unpickable",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "            if (model_override or \"\").partition(\":\")[0].strip() in _KNOWN_PROVIDERS:",
     "replace": "            if \":\" in (model_override or \"\"):",
     "tests": [
       "tests/test_pydantic_ai_backend.py::test_a_colon_in_a_model_name_is_still_allowed"
+    ]
+  },
+  {
+    "label": "the catalog check is dropped — a per-send model is free text billed to the platform key",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "            if await _model_is_unknown_to_gateway(ctx.model_override):",
+    "replace": "            if False:",
+    "tests": [
+      "tests/cloud/runs/test_run_core_model_catalog.py::test_a_model_the_gateway_never_heard_of_is_refused"
+    ]
+  },
+  {
+    "label": "an unreachable catalog refuses the turn — every override dies when /model/info is gated",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "            exc_info=True,\n        )\n        return False\n    if not entries:",
+    "replace": "            exc_info=True,\n        )\n        return True\n    if not entries:",
+    "tests": [
+      "tests/cloud/runs/test_run_core_model_catalog.py::test_an_unreachable_catalog_does_not_kill_the_turn"
+    ]
+  },
+  {
+    "label": "an empty catalog refuses everything — a proxy that describes no models blocks every send",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "    if not entries:\n        logger.warning(",
+    "replace": "    if False:\n        logger.warning(",
+    "tests": [
+      "tests/cloud/runs/test_run_core_model_catalog.py::test_an_empty_catalog_refuses_nothing"
     ]
   }
 ]

--- a/tests/mutations/pydantic_ai_model_override.json
+++ b/tests/mutations/pydantic_ai_model_override.json
@@ -25,5 +25,23 @@
     "tests": [
       "tests/test_pydantic_ai_backend.py::test_model_override_builds_the_model_it_names"
     ]
+  },
+  {
+    "label": "the provider guard is removed \u2014 a free-text 'litellm:x' runs a guest's turn on the deployment's proxy key",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            if (model_override or \"\").partition(\":\")[0].strip() in _KNOWN_PROVIDERS:",
+    "replace": "            if False:",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_model_override_cannot_switch_provider"
+    ]
+  },
+  {
+    "label": "the guard widens to any colon \u2014 OpenRouter ':free' and Ollama ':latest' model ids become unpickable",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            if (model_override or \"\").partition(\":\")[0].strip() in _KNOWN_PROVIDERS:",
+    "replace": "            if \":\" in (model_override or \"\"):",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_a_colon_in_a_model_name_is_still_allowed"
+    ]
   }
 ]

--- a/tests/test_prompt_backend_digest.py
+++ b/tests/test_prompt_backend_digest.py
@@ -556,7 +556,7 @@ async def test_capability_instructions_are_still_contributed_at_run_time():
         yield "ok"
 
     backend = PydanticAIBackend(Settings(pydantic_ai_skills_enabled=True))
-    backend._build_model = lambda: FunctionModel(stream_function=stream_fn)  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: FunctionModel(stream_function=stream_fn)  # type: ignore[method-assign]
     backend._mcp_tools = []
 
     async for _ in backend.run("hi", system_prompt="You are Paw.", session_key="s1"):

--- a/tests/test_proxy_spend_attribution.py
+++ b/tests/test_proxy_spend_attribution.py
@@ -172,7 +172,7 @@ def test_pydantic_ai_keeps_the_output_cap_alongside_the_tenant_id(bound_workspac
     have dropped it on every model without a cap."""
     bound_workspace("ws_alpha")
     backend = PydanticAIBackend(_settings(pydantic_ai_model="litellm:gpt-5.2"))
-    backend._resolve_max_output_tokens = lambda: 4096  # type: ignore[method-assign]
+    backend._resolve_max_output_tokens = lambda *_a, **_k: 4096  # type: ignore[method-assign]
 
     out = dict(backend._run_model_settings() or {})
 
@@ -185,7 +185,7 @@ def test_pydantic_ai_sends_no_settings_at_all_when_neither_applies(bound_workspa
     # ``model_settings`` key on the run rather than an empty dict.
     bound_workspace(None)
     backend = PydanticAIBackend(_settings(pydantic_ai_model="litellm:gpt-5.2"))
-    backend._resolve_max_output_tokens = lambda: None  # type: ignore[method-assign]
+    backend._resolve_max_output_tokens = lambda *_a, **_k: None  # type: ignore[method-assign]
 
     assert backend._run_model_settings() is None
 

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -3380,3 +3380,46 @@ def test_no_model_override_still_builds_the_configured_model():
     asyncio.run(_collect(backend, "hi", session_key="s1"))
 
     assert specs == [None]
+
+
+def test_model_override_cannot_switch_provider():
+    """A per-send model picks a model WITHIN the configured provider, never a
+    provider.
+
+    ``_parse_provider_model`` splits on a colon when the prefix names a known
+    provider, so an unguarded override is a credential switch dressed as a
+    model id. The live case: a BYOK gateway turn runs on an isolated backend
+    holding the tenant's key, but it still carries the deployment's
+    ``litellm_api_key`` — a guest typing ``litellm:anything`` into the composer's
+    free-text field would resolve the proxy's own credential and bill the
+    platform for a turn the "no keyless turns" rule says cannot happen.
+    ``provider_allows_model`` does not catch it: on a gateway it passes
+    everything, because a gateway's model ids are its own namespace.
+    """
+    backend = _backend_with_model(TestModel(custom_output_text="ok"))
+    events = asyncio.run(_collect(backend, "hi", session_key="s1", model_override="litellm:sneaky"))
+
+    errors = [e for e in events if e.type == "error"]
+    assert errors, "a provider-prefixed override ran instead of being refused"
+    assert "provider" in errors[0].content.lower()
+
+
+def test_a_colon_in_a_model_name_is_still_allowed():
+    """The guard checks the PREFIX against known providers, not the colon.
+    OpenRouter spells variants ``:free``/``:nitro`` and Ollama spells tags
+    ``llama3.2:latest`` — banning the character would ban those."""
+    specs: list[str | None] = []
+
+    def _spy(spec=None):
+        specs.append(spec)
+        return TestModel(custom_output_text="ok")
+
+    backend = _backend_with_model(TestModel(custom_output_text="ok"))
+    backend._build_model = _spy  # type: ignore[method-assign]
+
+    events = asyncio.run(
+        _collect(backend, "hi", session_key="s1", model_override="minimax/minimax-m3:free")
+    )
+
+    assert [e for e in events if e.type == "error"] == []
+    assert specs == ["minimax/minimax-m3:free"]

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -89,7 +89,7 @@ def _backend_with_model(model, **overrides) -> PydanticAIBackend:
     """
     overrides.setdefault("pydantic_ai_skills_enabled", False)
     backend = PydanticAIBackend(_settings(**overrides))
-    backend._build_model = lambda: model  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: model  # type: ignore[method-assign]
     backend._mcp_tools = []
     backend._custom_tools = []
     return backend
@@ -477,7 +477,7 @@ async def test_missing_sdk_yields_error_not_crash():
 
 
 async def test_model_failure_yields_error_then_done():
-    def boom():
+    def boom(*_a, **_k):
         raise RuntimeError("proxy unreachable")
 
     backend = PydanticAIBackend(_settings())
@@ -610,7 +610,7 @@ async def test_run_handle_is_released_on_completion():
 
 
 async def test_run_handle_is_released_on_error():
-    def boom():
+    def boom(*_a, **_k):
         raise RuntimeError("nope")
 
     backend = PydanticAIBackend(_settings())
@@ -727,7 +727,7 @@ async def test_mcp_servers_spawn_once_across_many_runs(monkeypatch):
     backend = PydanticAIBackend(
         _settings(pydantic_ai_mcp_enabled=True, pydantic_ai_skills_enabled=False)
     )
-    backend._build_model = lambda: TestModel(custom_output_text="ok")  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: TestModel(custom_output_text="ok")  # type: ignore[method-assign]
     backend._custom_tools = []
     _drive_real_mcp(monkeypatch, [server])
 
@@ -759,7 +759,7 @@ async def test_concurrent_first_runs_do_not_double_spawn(monkeypatch):
     backend = PydanticAIBackend(
         _settings(pydantic_ai_mcp_enabled=True, pydantic_ai_skills_enabled=False)
     )
-    backend._build_model = lambda: TestModel(custom_output_text="ok")  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: TestModel(custom_output_text="ok")  # type: ignore[method-assign]
     backend._custom_tools = []
     _drive_real_mcp(monkeypatch, servers)
 
@@ -784,7 +784,7 @@ async def test_mcp_server_that_fails_to_start_is_dropped_not_fatal(monkeypatch):
     backend = PydanticAIBackend(
         _settings(pydantic_ai_mcp_enabled=True, pydantic_ai_skills_enabled=False)
     )
-    backend._build_model = lambda: TestModel(custom_output_text="ok")  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: TestModel(custom_output_text="ok")  # type: ignore[method-assign]
     backend._custom_tools = []
     broken = _Broken()
     _drive_real_mcp(monkeypatch, [broken])
@@ -815,7 +815,7 @@ async def test_one_broken_server_does_not_take_down_a_healthy_one(monkeypatch):
     backend = PydanticAIBackend(
         _settings(pydantic_ai_mcp_enabled=True, pydantic_ai_skills_enabled=False)
     )
-    backend._build_model = lambda: TestModel(custom_output_text="ok")  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: TestModel(custom_output_text="ok")  # type: ignore[method-assign]
     backend._custom_tools = []
     broken = _Broken()
     _drive_real_mcp(monkeypatch, [broken, healthy], n_configs=2)
@@ -875,7 +875,7 @@ async def test_mcp_loading_is_cached_per_instance_not_per_run(monkeypatch):
     backend = PydanticAIBackend(
         _settings(pydantic_ai_mcp_enabled=True, pydantic_ai_skills_enabled=False)
     )
-    backend._build_model = lambda: TestModel(custom_output_text="ok")  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: TestModel(custom_output_text="ok")  # type: ignore[method-assign]
     # Not _backend_with_model: this test needs MCP loading live, so it pins the
     # builtin tool surface itself (TestModel would otherwise execute all 49).
     backend._custom_tools = []
@@ -1975,7 +1975,7 @@ async def _tool_surface(backend: PydanticAIBackend, **run_kwargs) -> set[str]:
         yield "ok"
 
     model = FunctionModel(stream_function=capture)
-    backend._build_model = lambda: model  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: model  # type: ignore[method-assign]
     await _collect(backend, "hi", **run_kwargs)
     return seen
 
@@ -2263,7 +2263,7 @@ async def _draft_turn(backend: PydanticAIBackend, session_key: str | None) -> st
         else:
             yield "Draft ready. Preview it at /sites."
 
-    backend._build_model = lambda: FunctionModel(stream_function=stream_fn)  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: FunctionModel(stream_function=stream_fn)  # type: ignore[method-assign]
     backend._cached_agent = None
     events = await _collect(backend, "Build an HTML bakery site", session_key=session_key)
     return "".join(e.content for e in events if e.type == "message")
@@ -2279,7 +2279,7 @@ async def _what_turn_two_sees(
         seen["messages"] = str(messages)
         yield "ok"
 
-    backend._build_model = lambda: FunctionModel(stream_function=stream_fn)  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: FunctionModel(stream_function=stream_fn)  # type: ignore[method-assign]
     backend._cached_agent = None
     history = [
         {"role": "user", "content": "Build an HTML bakery site"},
@@ -2410,7 +2410,7 @@ async def _deferred_surface(backend: PydanticAIBackend, **run_kwargs) -> set[str
         yield "ok"
 
     model = _local_only(FunctionModel(stream_function=capture))
-    backend._build_model = lambda: model  # type: ignore[method-assign]
+    backend._build_model = lambda *_a, **_k: model  # type: ignore[method-assign]
     await _collect(backend, "hi", **run_kwargs)
     return seen
 
@@ -2499,7 +2499,7 @@ async def test_a_denied_tool_cannot_be_discovered_by_searching_for_it():
             revealed.extend(t.name for t in info.function_tools)
             yield "done"
 
-    backend._build_model = lambda: _local_only(FunctionModel(stream_function=script))
+    backend._build_model = lambda *_a, **_k: _local_only(FunctionModel(stream_function=script))
     await _collect(
         backend,
         "make a landing page",
@@ -2539,7 +2539,7 @@ async def test_searching_makes_the_tool_callable_by_its_real_name():
         else:
             yield "done"
 
-    backend._build_model = lambda: _local_only(FunctionModel(stream_function=script))
+    backend._build_model = lambda *_a, **_k: _local_only(FunctionModel(stream_function=script))
     events = await _collect(backend, "build me a website")
     called = [
         (ev.metadata or {}).get("name") for ev in events if ev.type in ("tool_use", "tool_result")
@@ -2639,7 +2639,7 @@ async def test_the_backend_really_runs_our_ranking_not_the_built_in_one():
             revealed.extend(t.name for t in info.function_tools)
             yield "done"
 
-    backend._build_model = lambda: _local_only(FunctionModel(stream_function=script))
+    backend._build_model = lambda *_a, **_k: _local_only(FunctionModel(stream_function=script))
     await _collect(backend, "build me a webpage")
 
     assert "srv_create_html_site" in revealed, (
@@ -3306,3 +3306,77 @@ def test_tools_default_to_on():
     asyncio.run(_collect(backend, "hi", session_key="s1"))
 
     assert built == ["built"]
+
+
+def test_model_override_builds_the_model_it_names():
+    """The override is a model SPEC, so a bare name keeps the configured
+    provider — and on a BYOK gateway that means its base URL and its key are
+    kept while only the model changes. This is the trap the whole feature turns
+    on: ``build_settings_override`` pins ``pydantic_ai_model`` to the STORED
+    gateway model, and the per-send choice has to beat it without taking the
+    endpoint with it."""
+    backend = PydanticAIBackend(
+        _settings(
+            pydantic_ai_provider="openai_compatible",
+            pydantic_ai_model="stored/gpt-5.5",
+            openai_compatible_base_url="https://gateway.example/v1",
+            openai_compatible_api_key="sk-tenant",
+            openai_compatible_model="stored/gpt-5.5",
+        )
+    )
+    picked = backend._build_model("vendor/claude-opus-5")
+
+    assert picked.model_name == "vendor/claude-opus-5"
+    assert "gateway.example" in str(picked.base_url)
+
+
+def test_model_override_reaches_the_model_factory_and_the_agent_key():
+    """Two halves of one bug. Building the right model is not enough: the agent
+    cache holds ONE slot keyed on the configured model name, so a second turn
+    asking for a different model would have been served the first turn's agent
+    — with the first turn's model baked in."""
+    specs: list[str | None] = []
+
+    def _spy(spec=None):
+        specs.append(spec)
+        return TestModel(custom_output_text="ok")
+
+    backend = _backend_with_model(TestModel(custom_output_text="ok"))
+    backend._build_model = _spy  # type: ignore[method-assign]
+
+    keys: list[tuple] = []
+    real = backend._get_or_create_agent
+
+    def _watch(*args, **kwargs):
+        agent = real(*args, **kwargs)
+        keys.append(backend._cached_agent_key)
+        return agent
+
+    backend._get_or_create_agent = _watch  # type: ignore[method-assign]
+
+    async def _go():
+        await _collect(backend, "hi", session_key="s1", model_override="alpha-1")
+        await _collect(backend, "hi", session_key="s1", model_override="beta-2")
+
+    asyncio.run(_go())
+
+    assert specs == ["alpha-1", "beta-2"]
+    assert keys[0] != keys[1], "the agent cache served one model's agent to the other"
+    assert keys[0][0] == "alpha-1"
+
+
+def test_no_model_override_still_builds_the_configured_model():
+    """The legacy path, byte-identical: no override means no spec, so the
+    factory falls back to ``pydantic_ai_model`` exactly as before."""
+    specs: list[str | None] = []
+
+    def _spy(spec=None):
+        specs.append(spec)
+        return TestModel(custom_output_text="ok")
+
+    backend = _backend_with_model(TestModel(custom_output_text="ok"))
+    backend._build_model = _spy  # type: ignore[method-assign]
+
+    asyncio.run(_collect(backend, "hi", session_key="s1"))
+
+    assert specs == [None]


### PR DESCRIPTION
`run()` on the pydantic_ai backend accepted `model_override` and threw it away. It sat there with a `noqa: ARG002` and a comment saying only the Claude SDK backend consumed it.

The cloud's default backend is this one. So a model picker in the composer would have been a dead control: pick a model, watch the turn run on the configured one, get no error. This is the backend half of that feature.

## What changed

`model_override` is now the spec `_build_model` parses. A bare model name keeps the configured provider, and that is the part that matters for BYOK: `build_settings_override` pins `pydantic_ai_model` to the gateway model the tenant stored, and the per-send choice has to beat that name without taking the endpoint with it. It does. Base URL and key stay put, only the model moves.

Two follow-on seams had to move with it:

- **The agent cache key.** It is one slot, keyed on `settings.pydantic_ai_model`. Left alone, turn two asking for a different model gets handed turn one's cached agent, with turn one's model baked in.
- **The per-run model settings.** `_resolve_max_output_tokens` re-parses the model to pick an output cap, so without the spec it caps for a model that is not running.

## Tests

Three new ones in `tests/test_pydantic_ai_backend.py`: the gateway case (stored `stored/gpt-5.5`, override `vendor/claude-opus-5`, assert the built model names the override and still points at the gateway), the cache-key case (two turns, two overrides, assert the keys differ), and the legacy no-override path.

Mutation plan `tests/mutations/pydantic_ai_model_override.json`, 3 of 3 caught.

The test-side churn is mechanical: `_build_model` stubs were zero-arg lambdas and now take the spec.

## A hole found while wiring the frontend

`_parse_provider_model` splits on a colon when the prefix names a known provider. So an unguarded `model_override` is not a model choice, it is a credential switch wearing a model id.

The live case: a BYOK gateway turn runs on an isolated backend holding the tenant's key, but it still carries the deployment's `litellm_api_key`. A guest typing `litellm:anything` into the composer's free-text field resolves the proxy's own credential and bills the platform for a turn the "no keyless turns" rule says cannot happen. `provider_allows_model` does not catch it, because on a gateway it passes every name.

`run` now refuses a provider-prefixed override with a clear error. The PREFIX is what is checked, never the colon itself: OpenRouter spells variants `:free` and Ollama spells tags `:latest`, and both stay pickable. Two tests, both in the mutation plan, which is now 5 of 5 caught.

## The model id is now checked against the gateway

Review found the one real gap: nothing validated the model id itself. `agent_schemas.py` enforces a regex and a length, which says nothing about whether the model exists or whether we serve it, and `provider_allows_model` runs on the BYOK branch alone. While the override was dead on `pydantic_ai` that cost nothing, because the cloud's default backend ignored it. Honouring it makes the composer's free-text field a live model selector billed to the platform key.

`run_core._model_is_unknown_to_gateway` now checks the id against the model catalog before the override is forwarded. The catalog is the union of what the proxy describes through `/model/info` and what it routes through `/v1/models`, so it is never narrower than the routable set. An id missing from it is an id the gateway would refuse anyway, which is what makes this safe to reject on: it converts an opaque upstream 400 into a typed `model.not_available` error the composer can show.

It refuses only what it positively knows is unserved. An unreachable catalog and an empty one both let the turn through with a logged warning, because `/model/info` is an admin route and can be gated on a deployment whose chat routing is perfectly healthy, and refusing there would make the picker a dead control again. That is the same call `resolve_turn_credentials` makes with its own failure a few lines below. The check is bounded at 5 seconds, since the catalog client allows 15 per read and makes two of them.

### What this does not do

It is not an entitlement check and does not put a ceiling on cost. Every model the gateway serves is in the catalog by construction, so a paying workspace can still pick an expensive one and bill the platform key for it. A per-plan allowlist is the thing that would stop that. This check is the seam it plugs into, and the gap is left open deliberately rather than answered with a guessed policy.

### One thing worth knowing before merge

The review suggested validating against "the catalog the composer's model picker is populated from". The picker is not populated from a catalog. `paw-enterprise`'s `model-picker.ts` holds three hardcoded presets (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`) plus a free-text field, and those strings are not derived from the gateway. If the deployment's LiteLLM aliases are spelled differently, those presets are already broken today and this check will now say so clearly instead of failing upstream. Worth a look at the proxy's model list before this goes out.

### Tests

`tests/cloud/runs/test_run_core_model_catalog.py`, five cases. The two that earn their space are the fail-open ones: an unreachable catalog and an empty catalog must not reject the turn. `test_run_core_byok_wiring.py` gained a permissive catalog stub in its harness, because without it the two `model_override` cases there reach for a live proxy and pass only because the new check fails open, which would hide a byok regression behind an unrelated outage path.

Mutation plan now 8 of 8 caught.

## Not in this PR

- A per-plan model allowlist, which is the actual cost ceiling. Captain's call.
- The frontend model picker for the Otherhand composer.
- A stale sentence in `byok/service.py`'s `provider_allows_model` docstring says the model asked for is not the one that runs. That file's gateway support lives in #2129, so the correction goes on that branch.


