### PR TITLE
The cascade cancelled a gateway subscription that no longer exists

### DIFF
--- a/ee/pocketpaw_ee/sites/delete_cascade.py
+++ b/ee/pocketpaw_ee/sites/delete_cascade.py
@@ -90,9 +90,15 @@ class CascadeStepFailed(Exception):
         return f"{self.step}:{self.cause}"
 
 
-# The rail a site's money runs on. "credits" is the only one this product charges
-# on now; anything else is a row from before 2026-09-05.
+# The rail a site's money runs on. Two are current: "credits" (charged against the
+# workspace balance) and "plan" (carried by the workspace's plan, no money on the
+# row at all — added 2026-09-06, a day after the credits cutover). A legacy row is
+# anything else, and the shape it actually takes is ""  — rows sold before Dodo was
+# removed read "addon" / "subscription" / "", and "" is the common one. Writing
+# this as `rail and rail != _CREDITS_RAIL` passes "" straight through as healthy,
+# which is the exact row the flag exists for.
 _CREDITS_RAIL = "credits"
+_PLAN_RAIL = "plan"
 
 
 async def run_cascade(
@@ -192,7 +198,7 @@ async def _stop_billing(*, site: Any, deps: Any) -> str:
     site.renewal_date = None
 
     rail = (getattr(site, "billing_rail", "") or "").strip()
-    if rail and rail != _CREDITS_RAIL:
+    if rail not in (_CREDITS_RAIL, _PLAN_RAIL):
         logger.warning(
             "sites.delete: site %s bills on the legacy %r rail; its local renewal is "
             "stopped but any charge on the old rail must be closed by an operator",

--- a/ee/pocketpaw_ee/sites/delete_cascade.py
+++ b/ee/pocketpaw_ee/sites/delete_cascade.py
@@ -7,7 +7,7 @@
 # that a failure at ANY point leaves the site LESS live than before and never still
 # charging:
 #
-#   1. billing off   — a failed teardown must never keep taking money;
+#   1. billing off   — a failed teardown must never keep charging the customer;
 #   2. auth off      — the signed key dies next, at near-zero cost and before
 #                      anything irreversible, so lead ingest and the concierge stop
 #                      even if every later step fails;
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 # Ledger keys, in execution order. Named rather than positional so a step inserted
 # later cannot silently renumber a half-finished cascade's record of itself.
-STEP_SUBSCRIPTION = "subscription"
+STEP_BILLING = "billing"
 STEP_REVOKE = "revoke"
 STEP_ROUTES = "routes"
 STEP_HOSTNAMES = "hostnames"
@@ -51,7 +51,7 @@ STEP_R2 = "r2"
 STEP_RECORDS = "records"
 
 CASCADE_STEPS: tuple[str, ...] = (
-    STEP_SUBSCRIPTION,
+    STEP_BILLING,
     STEP_REVOKE,
     STEP_ROUTES,
     STEP_HOSTNAMES,
@@ -67,11 +67,14 @@ CASCADE_STEPS: tuple[str, ...] = (
 # operator reading a stalled cascade needs to tell them apart.
 OUTCOME_DONE = "done"
 OUTCOME_SKIPPED = "nothing-to-do"
-# The subscription we cannot cancel because the row predates the activation webhook
-# and holds a checkout SESSION id the gateway rejects. Recorded rather than raised:
-# refusing to delete would trap the customer's site forever over a subscription we
-# can no longer reach either way, so the cascade continues and says so.
-OUTCOME_UNCANCELLABLE = "uncancellable"
+# A row that predates the credits rail. Its local renewal is stopped like any
+# other, but it may still hold a subscription on the payment gateway that this
+# package is structurally forbidden from touching (see
+# tests/cloud/sites/test_no_gateway_in_sites.py) — so an operator has to close that
+# out of band. Recorded rather than raised: refusing would trap the customer's site
+# over a charge this code could not stop either way, and leaving it silent would
+# bill them for a site that no longer exists.
+OUTCOME_LEGACY_RAIL = "legacy-rail-needs-operator"
 
 
 class CascadeStepFailed(Exception):
@@ -87,17 +90,9 @@ class CascadeStepFailed(Exception):
         return f"{self.step}:{self.cause}"
 
 
-def _is_session_id(subscription_id: str) -> bool:
-    """Whether this is a checkout SESSION id rather than a real subscription id.
-
-    ``service.py`` records that rows created before the ``subscription.active``
-    webhook learned to persist the authoritative id still hold a ``cks_`` checkout
-    session id, and that "a session id cannot cancel a subscription and cannot
-    change its plan — the gateway rejects it." Those subscriptions are unreachable
-    from our side, so the cascade records the fact and continues rather than
-    trapping the site.
-    """
-    return subscription_id.startswith("cks_")
+# The rail a site's money runs on. "credits" is the only one this product charges
+# on now; anything else is a row from before 2026-09-05.
+_CREDITS_RAIL = "credits"
 
 
 async def run_cascade(
@@ -151,8 +146,8 @@ def _classify(exc: Exception) -> str:
 
 
 async def _run_step(step: str, *, site: Any, deps: Any) -> str:
-    if step == STEP_SUBSCRIPTION:
-        return await _cancel_subscription(site=site, deps=deps)
+    if step == STEP_BILLING:
+        return await _stop_billing(site=site, deps=deps)
     if step == STEP_REVOKE:
         return await _revoke_key(site=site, deps=deps)
     if step == STEP_ROUTES:
@@ -170,23 +165,41 @@ async def _run_step(step: str, *, site: Any, deps: Any) -> str:
     raise CascadeStepFailed(step, "unknown_step")
 
 
-async def _cancel_subscription(*, site: Any, deps: Any) -> str:
-    """FIRST, so a teardown that fails later never keeps billing."""
-    sub_id = (getattr(site, "subscription_id", "") or "").strip()
+async def _stop_billing(*, site: Any, deps: Any) -> str:
+    """FIRST, so a teardown that fails later never keeps charging the customer.
+
+    STOPPING THE MONEY IS A LOCAL WRITE, NOT A REMOTE CALL. A paid site is charged
+    against the workspace's own credit balance, and ``renewal_sweeper`` selects the
+    rows it charges on ``subscription_status == "active"`` — so clearing that status
+    is precisely what ends the charging. There is nothing to cancel anywhere else:
+    the gateway rails were deleted on 2026-09-05, and this package may not even name
+    them (``tests/cloud/sites/test_no_gateway_in_sites.py`` asserts it against the
+    source, because a reintroduced call would build its own client and sail past any
+    injected double).
+
+    A LEGACY ROW STILL GETS ITS LOCAL RENEWAL STOPPED, and is then flagged. Its
+    money may run on the old rail, which this code cannot reach and must not try to;
+    an operator closes that. Saying so in the ledger is the difference between a
+    known follow-up and a customer billed for a site that no longer exists.
+    """
     status = getattr(site, "subscription_status", "none")
-    if not sub_id or status in ("none", "cancelled"):
+    if status in ("none", "cancelled"):
+        # Not currently paying for anything, so there is nothing to stop.
         return OUTCOME_SKIPPED
-    if _is_session_id(sub_id):
-        # Unreachable from our side. Say so in the ledger and keep going — refusing
-        # here would trap the site permanently over a subscription that cannot be
-        # cancelled through this product either way.
+
+    # The local stop, which is the whole mechanism on the credits rail.
+    site.subscription_status = "none"
+    site.renewal_date = None
+
+    rail = (getattr(site, "billing_rail", "") or "").strip()
+    if rail and rail != _CREDITS_RAIL:
         logger.warning(
-            "sites.delete: subscription %s is a checkout session id and cannot be "
-            "cancelled; continuing the cascade",
-            sub_id,
+            "sites.delete: site %s bills on the legacy %r rail; its local renewal is "
+            "stopped but any charge on the old rail must be closed by an operator",
+            getattr(site, "id", "?"),
+            rail,
         )
-        return OUTCOME_UNCANCELLABLE
-    await deps.cancel_subscription(sub_id)
+        return OUTCOME_LEGACY_RAIL
     return OUTCOME_DONE
 
 

--- a/tests/ee/sites/test_delete_cascade.py
+++ b/tests/ee/sites/test_delete_cascade.py
@@ -11,8 +11,8 @@ import pytest
 from pocketpaw_ee.sites.delete_cascade import (
     CASCADE_STEPS,
     OUTCOME_DONE,
+    OUTCOME_LEGACY_RAIL,
     OUTCOME_SKIPPED,
-    OUTCOME_UNCANCELLABLE,
     CascadeStepFailed,
     run_cascade,
 )
@@ -34,8 +34,9 @@ class _Site:
         self.d1_database_id = "db1"
         self.signed_key = "key-abc"
         self.revoked = False
-        self.subscription_id = "sub_live"
         self.subscription_status = "active"
+        self.renewal_date = "2026-10-01"
+        self.billing_rail = "credits"
         self.domains = [_Domain()]
         self.delete_ledger: dict[str, str] = {}
         self.__dict__.update(kw)
@@ -77,17 +78,10 @@ class _Assets:
 
 
 class _Deps:
-    def __init__(self, cf=None, assets=None, fail_cancel=False):
+    def __init__(self, cf=None, assets=None):
         self.cloudflare = cf or _CF()
         self.assets = assets if assets is not None else _Assets()
-        self.cancelled: list[str] = []
         self.records: list[tuple[str, str]] = []
-        self.fail_cancel = fail_cancel
-
-    async def cancel_subscription(self, sub_id):
-        if self.fail_cancel:
-            raise RuntimeError("gateway down")
-        self.cancelled.append(sub_id)
 
     async def purge_records(self, *, workspace_id, site_id):
         self.records.append((workspace_id, site_id))
@@ -121,8 +115,11 @@ async def test_billing_stops_before_anything_else_happens() -> None:
     await run_cascade(site=site, deps=deps, save=_saver(saves))
 
     # The first thing ever persisted is the subscription step, alone.
-    assert saves[0] == {"subscription": OUTCOME_DONE}
-    assert deps.cancelled == ["sub_live"]
+    assert saves[0] == {"billing": OUTCOME_DONE}
+    # The stop is LOCAL: the renewal sweeper only charges rows whose status is
+    # "active", so clearing it is the whole mechanism. Nothing remote is called.
+    assert site.subscription_status == "none"
+    assert site.renewal_date is None
 
 
 @pytest.mark.asyncio
@@ -165,7 +162,7 @@ async def test_a_failure_stops_the_cascade_and_keeps_what_finished() -> None:
 
     assert err.value.step == "script"
     assert err.value.reason.startswith("script:")
-    assert set(site.delete_ledger) == {"subscription", "revoke", "routes", "hostnames"}
+    assert set(site.delete_ledger) == {"billing", "revoke", "routes", "hostnames"}
     # The reclaim steps must not have run behind a site that is still serving.
     assert "delete_database" not in deps.cloudflare.calls
     assert deps.records == []
@@ -175,28 +172,43 @@ async def test_a_failure_stops_the_cascade_and_keeps_what_finished() -> None:
 async def test_a_resumed_cascade_skips_finished_steps_instead_of_repeating_them() -> None:
     """Several steps are idempotent in fact but not in spirit — re-cancelling a
     subscription or re-charging a purge is not free even when it is safe."""
-    site = _Site(delete_ledger={"subscription": OUTCOME_DONE, "revoke": OUTCOME_DONE})
+    site = _Site(delete_ledger={"billing": OUTCOME_DONE, "revoke": OUTCOME_DONE})
     deps = _Deps()
 
     await run_cascade(site=site, deps=deps, save=_saver([]))
 
-    assert deps.cancelled == []  # not cancelled a second time
+    # The finished billing step is not re-run, so an already-active status is not
+    # cleared a second time and the ledger is not rewritten.
+    assert site.subscription_status == "active"
     assert list(site.delete_ledger) == list(CASCADE_STEPS)
 
 
 @pytest.mark.asyncio
-async def test_an_uncancellable_subscription_is_recorded_and_does_not_block() -> None:
-    """A row predating the activation webhook holds a checkout SESSION id the
-    gateway rejects. Refusing to delete would trap the customer's site forever over
-    a subscription we cannot reach either way."""
-    site = _Site(subscription_id="cks_legacy")
+async def test_a_legacy_rail_is_flagged_but_still_has_its_local_renewal_stopped() -> None:
+    """A row from before the credits rail may still be charged somewhere this
+    package is forbidden to reach. Stopping the local renewal is what this code CAN
+    do; the flag is what stops the rest becoming a customer billed for a site that
+    no longer exists. Refusing outright would trap the site over a charge this code
+    could not stop either way."""
+    site = _Site(billing_rail="plan")
     deps = _Deps()
 
     await run_cascade(site=site, deps=deps, save=_saver([]))
 
-    assert site.delete_ledger["subscription"] == OUTCOME_UNCANCELLABLE
-    assert deps.cancelled == []
+    assert site.delete_ledger["billing"] == OUTCOME_LEGACY_RAIL
+    # Flagged, but the half that IS reachable still happened.
+    assert site.subscription_status == "none"
     assert list(site.delete_ledger) == list(CASCADE_STEPS)
+
+
+@pytest.mark.asyncio
+async def test_a_free_site_has_no_billing_to_stop() -> None:
+    site = _Site(subscription_status="none")
+    deps = _Deps()
+
+    await run_cascade(site=site, deps=deps, save=_saver([]))
+
+    assert site.delete_ledger["billing"] == "nothing-to-do"
 
 
 @pytest.mark.asyncio
@@ -247,13 +259,13 @@ async def test_a_static_site_has_no_d1_and_says_so_rather_than_claiming_it_delet
 async def test_the_failure_reason_never_carries_provider_text() -> None:
     """``delete_reason`` is surfaced, so it holds a fixed token the way
     ``build_reason`` does — not a Cloudflare or driver sentence."""
-    deps = _Deps(fail_cancel=True)
+    deps = _Deps(cf=_CF(fail_on="delete_database"))
 
     with pytest.raises(CascadeStepFailed) as err:
         await run_cascade(site=_Site(), deps=deps, save=_saver([]))
 
-    assert err.value.reason == "subscription:runtimeerror"
-    assert "gateway down" not in err.value.reason
+    assert err.value.reason == "d1:runtimeerror"
+    assert "cloudflare said no" not in err.value.reason
 
 
 @pytest.mark.asyncio
@@ -289,5 +301,5 @@ def test_nothing_to_do_and_done_stay_distinguishable() -> None:
     """
     assert OUTCOME_DONE == "done"
     assert OUTCOME_SKIPPED == "nothing-to-do"
-    assert OUTCOME_UNCANCELLABLE == "uncancellable"
-    assert len({OUTCOME_DONE, OUTCOME_SKIPPED, OUTCOME_UNCANCELLABLE}) == 3
+    assert OUTCOME_LEGACY_RAIL == "legacy-rail-needs-operator"
+    assert len({OUTCOME_DONE, OUTCOME_SKIPPED, OUTCOME_LEGACY_RAIL}) == 3

--- a/tests/ee/sites/test_delete_cascade.py
+++ b/tests/ee/sites/test_delete_cascade.py
@@ -190,7 +190,7 @@ async def test_a_legacy_rail_is_flagged_but_still_has_its_local_renewal_stopped(
     do; the flag is what stops the rest becoming a customer billed for a site that
     no longer exists. Refusing outright would trap the site over a charge this code
     could not stop either way."""
-    site = _Site(billing_rail="plan")
+    site = _Site(billing_rail="subscription")
     deps = _Deps()
 
     await run_cascade(site=site, deps=deps, save=_saver([]))
@@ -199,6 +199,45 @@ async def test_a_legacy_rail_is_flagged_but_still_has_its_local_renewal_stopped(
     # Flagged, but the half that IS reachable still happened.
     assert site.subscription_status == "none"
     assert list(site.delete_ledger) == list(CASCADE_STEPS)
+
+
+@pytest.mark.asyncio
+async def test_an_empty_rail_is_legacy_because_that_is_what_legacy_rows_look_like() -> None:
+    """THE case this flag exists for, and the one a truthiness check silently drops.
+
+    Rows sold before Dodo was removed carry "addon" / "subscription" / "", and ""
+    is the common shape — it is what every row written before `billing_rail` was
+    introduced has. Under `if rail and rail != _CREDITS_RAIL` an empty rail is
+    falsy, so it records OUTCOME_DONE with no warning and no operator follow-up:
+    a customer still billed for a site that no longer exists, reported as healthy.
+
+    MUTATION: restore `if rail and rail != _CREDITS_RAIL`.
+    """
+    site = _Site(billing_rail="")
+    deps = _Deps()
+
+    await run_cascade(site=site, deps=deps, save=_saver([]))
+
+    assert site.delete_ledger["billing"] == OUTCOME_LEGACY_RAIL
+    assert site.subscription_status == "none"
+
+
+@pytest.mark.asyncio
+async def test_the_plan_rail_is_current_and_carries_no_money_to_flag() -> None:
+    """`plan` landed 2026-09-06, the day AFTER the credits cutover, so it is not a
+    legacy rail. A plan-carried site has period_paid_usd = 0, no renewal_date and
+    is invisible to the renewal sweep — flagging it sends an operator chasing a
+    charge that does not exist, which is how a real flag stops being believed.
+
+    MUTATION: drop _PLAN_RAIL from the predicate.
+    """
+    site = _Site(billing_rail="plan")
+    deps = _Deps()
+
+    await run_cascade(site=site, deps=deps, save=_saver([]))
+
+    assert site.delete_ledger["billing"] == OUTCOME_DONE
+    assert site.subscription_status == "none"
 
 
 @pytest.mark.asyncio

--- a/tests/mutations/sites_delete_cascade.json
+++ b/tests/mutations/sites_delete_cascade.json
@@ -18,9 +18,9 @@
     ]
   },
   {
-    "label": "billing is cancelled last instead of first, so every teardown that fails partway keeps charging the customer for a site that no longer serves",
+    "label": "billing is stopped last instead of first, so every teardown that fails partway leaves the site still charging the customer for something that no longer serves",
     "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
-    "find": "CASCADE_STEPS: tuple[str, ...] = (\n    STEP_SUBSCRIPTION,\n    STEP_REVOKE,",
+    "find": "CASCADE_STEPS: tuple[str, ...] = (\n    STEP_BILLING,\n    STEP_REVOKE,",
     "replace": "CASCADE_STEPS: tuple[str, ...] = (\n    STEP_REVOKE,",
     "tests": [
       "tests/ee/sites/test_delete_cascade.py"
@@ -38,8 +38,8 @@
   {
     "label": "the signed key is revoked last, so a cascade that fails early leaves a public lead-ingest surface open on a site being torn down",
     "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
-    "find": "    STEP_SUBSCRIPTION,\n    STEP_REVOKE,\n    STEP_ROUTES,",
-    "replace": "    STEP_SUBSCRIPTION,\n    STEP_ROUTES,",
+    "find": "    STEP_BILLING,\n    STEP_REVOKE,\n    STEP_ROUTES,",
+    "replace": "    STEP_BILLING,\n    STEP_ROUTES,",
     "tests": [
       "tests/ee/sites/test_delete_cascade.py"
     ]
@@ -54,10 +54,10 @@
     ]
   },
   {
-    "label": "an uncancellable checkout-session subscription raises instead of being recorded, trapping the customer's site permanently over a subscription nothing can cancel",
+    "label": "a legacy-rail row is reported as an ordinary stop, so a site that may still be charged on a rail this package cannot reach is deleted with nothing flagging it",
     "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
-    "find": "        return OUTCOME_UNCANCELLABLE",
-    "replace": "        raise CascadeStepFailed(STEP_SUBSCRIPTION, \"uncancellable\")",
+    "find": "        return OUTCOME_LEGACY_RAIL",
+    "replace": "        return OUTCOME_DONE",
     "tests": [
       "tests/ee/sites/test_delete_cascade.py"
     ]
@@ -76,6 +76,15 @@
     "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
     "find": "    name = type(exc).__name__\n    return \"\".join(c.lower() if c.isalnum() else \"_\" for c in name).strip(\"_\") or \"error\"",
     "replace": "    return str(exc)",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py"
+    ]
+  },
+  {
+    "label": "the billing step stops flagging the row but also stops clearing the status, so the renewal sweeper keeps charging a workspace for a site that has been destroyed",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "    site.subscription_status = \"none\"\n    site.renewal_date = None",
+    "replace": "    pass",
     "tests": [
       "tests/ee/sites/test_delete_cascade.py"
     ]

--- a/tests/mutations/sites_delete_cascade.json
+++ b/tests/mutations/sites_delete_cascade.json
@@ -88,5 +88,23 @@
     "tests": [
       "tests/ee/sites/test_delete_cascade.py"
     ]
+  },
+  {
+    "label": "an empty billing_rail passes as healthy (the legacy shape that actually exists)",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "    if rail not in (_CREDITS_RAIL, _PLAN_RAIL):",
+    "replace": "    if rail and rail != _CREDITS_RAIL:",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py::test_an_empty_rail_is_legacy_because_that_is_what_legacy_rows_look_like"
+    ]
+  },
+  {
+    "label": "the current plan rail is flagged as legacy (operator chases a charge that does not exist)",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "    if rail not in (_CREDITS_RAIL, _PLAN_RAIL):",
+    "replace": "    if rail != _CREDITS_RAIL:",
+    "tests": [
+      "tests/ee/sites/test_delete_cascade.py::test_the_plan_rail_is_current_and_carries_no_money_to_flag"
+    ]
   }
 ]


### PR DESCRIPTION
My regression, merged in #2134, caught by the structural guard that exists for exactly this. `test_no_gateway_in_sites` asserts **against the source** that the sites package never names the payments provider or its verbs — because a reintroduced call would build its own client and sail past any injected double. `delete_cascade.py` named `cancel_subscription` three times.

## The premise was wrong, not the wording

Paw Sites moved **off the gateway to the workspace credit balance on 2026-09-05** (`docs/runbooks/2026-09-05-site-plans-on-credits.md`) — four days before I designed a cascade step that cancels a gateway subscription. I built it from a recalled fact about per-site Dodo billing and never re-read the tree. That's the exact failure mode my own notes warn about for versioned facts, and the guard caught what review didn't.

## Stopping the money is a local write

`renewal_sweeper` selects the rows it charges on `subscription_status == "active"`, so clearing that status **is** the mechanism. `service.py` already does the same thing in five places. There is nothing remote to call, and this package may not even name what used to be called.

## A legacy row is flagged, not refused

A row from before the credits rail still gets its local renewal stopped, then carries `OUTCOME_LEGACY_RAIL`. Its money may run on the old rail, which this code cannot reach and must not try to, so an operator closes that.

Flagging is the difference between a known follow-up and a customer billed for a site that no longer exists. Refusing outright would trap the site over a charge this code couldn't stop either way — the same reasoning the previous version had, applied to the right fact.

## This retires the `cks_` question

I'd been carrying "how many prod rows hold a checkout session id we can't cancel" as an open blocker across several updates. It was real under the Dodo rail and is **moot under credits** — there's no session id to be unable to cancel. Withdrawn.

## Verification

`test_no_gateway_in_sites` passes. 1998 pass across `tests/ee/sites` + `tests/cloud/sites`, with failures back to the **4 known pre-existing** ones — the gateway red is gone.

`tests/mutations/sites_delete_cascade.json` re-pointed, **all 10 caught**, including a new one for a billing step that flags the row but stops clearing the status — which would leave the sweeper charging a workspace for a destroyed site. `mutate.py --validate` green at 1386 anchors across 111 plans.

---

**Update — review found the new flag inverted at both ends, now fixed.**

The premise of this PR was right (the gateway cancel was dead code). The predicate that replaced it was not:

- `if rail and rail != _CREDITS_RAIL` — an empty rail is **falsy**, so it fell through to `OUTCOME_DONE` with no warning. That is not an edge case; it is the shape legacy rows actually have. Pre-cutover rows read `"addon"` / `"subscription"` / `""`, and `""` is what every row written before `billing_rail` existed carries. The one row this flag was built for was the one row it passed as healthy.
- The other end: `"plan"` was flagged. It landed 2026-09-06, a day *after* the credits cutover, so it is current — a plan-carried site has no money on the row at all. Flagging it sends an operator after a charge that does not exist, which is how a flag stops being believed.

Both fixed by using the predicate `service.py:6382` already uses: `rail not in (_CREDITS_RAIL, _PLAN_RAIL)`.

The tests were certifying the bug. The legacy case was built as `billing_rail="plan"` and **no test anywhere passed `""`**, so the mutation plan reported 10/10 caught while the buggy value had no gate at all. Now 12/12, with the two new cases each proven by a mutation that restores one half of the old behaviour.
