### PR TITLE
Let a workspace bring its own image key

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,16 @@
 docs/api-reference.md — Hand-maintained reference for cloud REST endpoints
 that are not covered by the per-endpoint Mintlify pages under docs/api/.
 
+Updated: 2026-09-11 (feat/byok-image-key) — added the "BYOK key management"
+section. The whole `/byok` prefix was undocumented here: five routes, of which
+two are new (`PUT` and `DELETE /byok/image-key`), plus the four `image_*`
+columns `ByokStatus` now carries. Two things a reader cannot get from the field
+names and both are entitlement changes rather than plumbing: the image key is
+stored WITHOUT a validation round trip, so the first refused generation is where
+a bad credential becomes visible, and a workspace with its own image key is
+neither refused as a guest nor counted against the platform's daily cap. Also
+stated that the ceiling it removes is a SPEND ceiling and not a rate one.
+
 Updated: 2026-09-02 (SA-7) — finished the Visitor Analytics section with the two
 things a reader could not get from the endpoint's own fields. First, what the
 `analytics` grant actually buys: which tiers carry it, that it needs an active
@@ -2574,6 +2584,40 @@ its chat turns on that key — the executor resolves credentials per turn and
 threads them into the agent pool's isolated backend. The turn's model must
 belong to the key's provider (402-style `byok.model_provider_mismatch` error
 frame on a mismatch, never a silent upstream 401).
+
+### BYOK key management
+
+Workspace-scoped, not user-scoped, matching where a credential is spent. Every
+response is a `ByokStatus`; no route on this prefix returns a key, and there is
+no echo on save. Once written, a key is write-only from the API's point of view.
+
+| Endpoint | Notes |
+|---|---|
+| `GET /byok/key` | `ByokStatus` — `configured`, `provider`, `last4`, `key_hint`, `last_verified_at`, `last_error`, plus the image columns below. Built from display-only columns; answering never decrypts. |
+| `PUT /byok/key` | `{provider?="anthropic", api_key}`. Validates against the provider, then encrypts and upserts. A key the provider rejects is never written. |
+| `DELETE /byok/key` | Idempotent. Removing an absent key succeeds. Clears the LLM columns rather than dropping the row when an image key still lives on it, so rotating one credential never takes the other with it. |
+| `PUT /byok/image-key` | `{api_key}` — the workspace's own fal.ai key, for illustrations. Shape-checked at the edge (`<key-id>:<secret>`) and stored encrypted, but **not** validated against fal: fal has no free endpoint that proves a credential without generating an image, so a save-time check would spend money on every paste. A bad key surfaces on the first illustration as `image_last_error`. |
+| `DELETE /byok/image-key` | Idempotent, and it never touches the LLM key. Safe to call: the workspace falls back to the platform illustrator under the daily cap (an account) or to the guest refusal (a guest), where a workspace with no LLM key answers 402 on every turn. |
+
+`ByokStatus` carries four image columns alongside the LLM ones. They are
+display-only and independent of the LLM key — a workspace may have either
+credential, both, or neither:
+
+| Field | Meaning |
+|---|---|
+| `image_configured` | Whether a fal key is stored. |
+| `image_last4` | Last four of the SECRET half, so two keys sharing a key id still read differently. |
+| `image_key_hint` | The key id, which is the non-secret half of a fal credential. Never the secret. |
+| `image_last_error` | Why the last generation was refused, or `null`. Stamped when fal answers 401/403 and cleared on the next successful save. There is no `image_verified_at`, because this is the whole verification story for the credential. The text comes from the provider and is run through the output redactor before it is stored, so an error body that echoes the submitted key does not land in a field the API hands back. |
+
+**A workspace image key bypasses the guest illustration refusal.** Guests are
+normally refused an illustration outright, and accounts are metered against a
+daily platform cap. A workspace with its own fal key is neither: it is not
+refused for being a guest, and it does not claim the platform budget. The guest
+refusal exists because a guest can mint a fresh workspace for a fresh ceiling,
+which is an argument about the platform's money and says nothing about someone
+spending their own. Note that this removes the spend ceiling but not the request
+rate — a BYOK illustration path is not rate-limited today.
 
 ### Sign-in endpoints (no session — that is the point)
 

--- a/ee/pocketpaw_ee/agent/mcp_servers/other_hand.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/other_hand.py
@@ -73,6 +73,20 @@ async def _guest_or_none() -> Any:
         return _NO_IDENTITY
 
 
+def _workspace_or_none() -> str | None:
+    """This turn's workspace, or None. The same public accessor every other
+    in-process MCP tool uses for tenancy — and the same failure posture: no
+    tenancy means no stored key, which resolves to the platform's (or, for a
+    guest, to a refusal)."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_workspace_id
+
+        return current_workspace_id()
+    except Exception:  # noqa: BLE001 — no tenancy is a missing key, not a crash
+        logger.debug("other-hand: no workspace in context for illustration", exc_info=True)
+        return None
+
+
 def _ok(message: str) -> dict[str, Any]:
     return {"content": [{"type": "text", "text": message}]}
 
@@ -82,41 +96,38 @@ async def _illustrate_handler(args: dict) -> dict:
     from pocketpaw_ee.cloud.chat.agent_service import push_sse_event
     from pocketpaw_ee.cloud.other_hand import illustrate as illustrator
     from pocketpaw_ee.cloud.other_hand.svg_to_ink import Box
-    from pocketpaw_ee.cloud.studio import fal_edit
 
     subject = str(args.get("subject") or "").strip()
     if len(subject) < 2:
         return _error("Say what to illustrate — a subject of at least two characters.")
 
-    api_key = fal_edit.fal_api_key()
-    if not api_key:
-        # Not an error the agent should retry or apologise at length for. Tell
-        # it plainly so it explains in words instead and moves on.
-        return _error(
-            "No illustrator is configured on this deployment. Explain in words "
-            "and with your own drawing instead; do not try again."
-        )
-
     from pocketpaw_ee.cloud.other_hand import illustration_budget as budget
+    from pocketpaw_ee.cloud.other_hand import illustration_credentials as creds
 
-    # Guests do not get to spend platform money on pictures, on this path
-    # either. The REST route refuses them too; gating only there would leave
-    # the whole feature reachable by simply ASKING the agent to draw, which is
-    # the more natural way in. Refused before the budget is claimed, and worded
-    # so the agent explains instead of retrying.
-    guest = await _guest_or_none()
-    if guest is not None:
-        return _error(
-            "Illustrations need an account. Say so plainly and offer to keep "
-            "going in words and your own drawing; do not try again this turn."
-        )
+    # Who pays, and whether this may happen at all. Both entry points ask the
+    # same module — this path and the toolbar button's REST route — because the
+    # rules are about money and two copies of a money rule drift.
+    #
+    # The guest check stays on BOTH paths rather than only on the route: gating
+    # there alone would leave the whole feature reachable by simply ASKING the
+    # agent to draw, which is the more natural way in.
+    is_guest = await _guest_or_none() is not None
+    grant = await creds.resolve(_workspace_or_none(), is_guest=is_guest)
+    if isinstance(grant, creds.IllustrationRefusal):
+        # Not an error the agent should retry or apologise at length for.
+        return _error(grant.reason)
+    api_key = grant.api_key
 
-    allowed, spent, cap = await budget.try_spend()
-    if not allowed:
-        return _error(
-            f"Today's illustration limit is used up ({spent}/{cap}). Explain in "
-            "words and with your own drawing instead; do not try again today."
-        )
+    # The platform's ceiling, claimed only when the platform is paying. A
+    # workspace on its own key is spending its own money and has no reason to
+    # be inside our quota.
+    if not grant.byok:
+        allowed, spent, cap = await budget.try_spend()
+        if not allowed:
+            return _error(
+                f"Today's illustration limit is used up ({spent}/{cap}). Explain in "
+                "words and with your own drawing instead; do not try again today."
+            )
 
     try:
         ops = await illustrator.illustrate_as_ops(

--- a/ee/pocketpaw_ee/cloud/byok/dto.py
+++ b/ee/pocketpaw_ee/cloud/byok/dto.py
@@ -19,6 +19,11 @@ from pydantic import BaseModel, Field, field_validator
 # reaches the provider — and before we spend a validation round trip on it.
 _ANTHROPIC_PREFIX = "sk-ant-"
 _MIN_KEY_LEN = 20
+# fal spells its credential ``<key-id>:<secret>``. Checked at the edge for the
+# same reason the Anthropic prefix is: a paste that is obviously not a fal key
+# should fail here, where the user can see the field, rather than one picture
+# later inside a generation they paid for.
+_MIN_IMAGE_KEY_LEN = 16
 
 
 class ByokSetRequest(BaseModel):
@@ -47,6 +52,29 @@ class ByokSetRequest(BaseModel):
         return v
 
 
+class ByokImageKeyRequest(BaseModel):
+    """Set or replace this workspace's fal.ai key (illustrations).
+
+    A SEPARATE route from ``ByokSetRequest`` on purpose: ``PUT /byok/key`` takes
+    the whole LLM credential or nothing, so folding the image key in would mean
+    re-pasting an Anthropic key to change an illustrator. The two credentials
+    are independent and their write paths are too.
+    """
+
+    api_key: str = Field(min_length=_MIN_IMAGE_KEY_LEN, max_length=512)
+
+    @field_validator("api_key")
+    @classmethod
+    def _looks_like_a_fal_key(cls, v: str) -> str:
+        v = v.strip()
+        if any(c.isspace() for c in v):
+            raise ValueError("the key contains whitespace — paste the key alone")
+        head, sep, secret = v.partition(":")
+        if not sep or not head or not secret:
+            raise ValueError("a fal.ai key looks like '<key-id>:<secret>'")
+        return v
+
+
 class ByokStatus(BaseModel):
     """What the UI is allowed to know about the stored key.
 
@@ -59,3 +87,13 @@ class ByokStatus(BaseModel):
     key_hint: str | None = None
     last_verified_at: datetime | None = None
     last_error: str | None = None
+
+    # The illustration credential (2026-09-11). Display-only, like the pair
+    # above, and independent of it: a workspace may have either, both, or
+    # neither. There is no ``image_verified_at`` because fal cannot be asked
+    # whether a key is good without generating an image — ``image_last_error``
+    # is stamped by the first refused generation instead.
+    image_configured: bool = False
+    image_last4: str | None = None
+    image_key_hint: str | None = None
+    image_last_error: str | None = None

--- a/ee/pocketpaw_ee/cloud/byok/router.py
+++ b/ee/pocketpaw_ee/cloud/byok/router.py
@@ -3,7 +3,7 @@
 #
 # Created 2026-08-28 (feat/other-hand-byok).
 #
-# Three routes, and a hard rule: NOTHING here returns a key. Every response is a
+# Five routes, and a hard rule: NOTHING here returns a key. Every response is a
 # ``ByokStatus`` built from display-only columns. There is no GET that reveals
 # the credential and no echo on save — once set, a key is write-only from the
 # API's point of view, and the only code that can read it back is the turn path.
@@ -17,7 +17,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 
 from pocketpaw_ee.cloud.byok import service as byok_service
-from pocketpaw_ee.cloud.byok.dto import ByokSetRequest, ByokStatus
+from pocketpaw_ee.cloud.byok.dto import ByokImageKeyRequest, ByokSetRequest, ByokStatus
 from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
 
 router = APIRouter(prefix="/byok", tags=["BYOK"])
@@ -57,3 +57,39 @@ async def delete_byok_key(
 ) -> ByokStatus:
     """Remove the key. Idempotent — removing an absent key succeeds."""
     return await byok_service.delete_key(workspace_id)
+
+
+# ── The illustration credential ─────────────────────────────────────────────
+#
+# Its own pair of routes rather than fields on ``/key`` (2026-09-11). ``PUT
+# /byok/key`` takes the whole LLM credential or nothing, so carrying the image
+# key there would mean re-pasting an Anthropic key to change an illustrator.
+#
+# And unlike the LLM key, this one HAS a remove route, because removing it is
+# safe: the workspace falls back to today's behaviour (the platform's key under
+# the daily cap for an account, a refusal for a guest), where a workspace with
+# no LLM key answers 402 on every turn.
+
+
+@router.put("/image-key", response_model=ByokStatus)
+async def set_byok_image_key(
+    body: ByokImageKeyRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> ByokStatus:
+    """Store the workspace's own fal.ai key, encrypted.
+
+    Stored WITHOUT a validation round trip, unlike the LLM key: fal has no free
+    endpoint that proves a credential without generating an image, so checking
+    on save would spend money on every paste. A bad key surfaces on the first
+    illustration, as ``image_last_error`` on this same status.
+    """
+    return await byok_service.set_image_key(workspace_id, body.api_key, user_id=user_id)
+
+
+@router.delete("/image-key", response_model=ByokStatus)
+async def delete_byok_image_key(
+    workspace_id: str = Depends(current_workspace_id),
+) -> ByokStatus:
+    """Remove the fal key. Idempotent, and it never touches the LLM key."""
+    return await byok_service.delete_image_key(workspace_id)

--- a/ee/pocketpaw_ee/cloud/byok/service.py
+++ b/ee/pocketpaw_ee/cloud/byok/service.py
@@ -1,5 +1,17 @@
 # ee/pocketpaw_ee/cloud/byok/service.py — the only reader of ByokProviderKey.
 #
+# Updated 2026-09-11 (feat/byok-image-key), on review:
+#
+#   * ``delete_key`` clears the gateway columns only when the document
+#     declares them. They arrive with the sibling feat/byok-custom-gateway
+#     branch, and assigning a field pydantic does not know about raises — so
+#     the unguarded version failed every delete on a row that also held an
+#     image key, which is the exact case this function exists to handle.
+#   * Provider error text goes through ``_safe_provider_error`` before it is
+#     stored. ``last_error`` / ``image_last_error`` are returned by the status
+#     API and rendered verbatim, and the text is written by whoever refused
+#     the call.
+#
 # Updated 2026-09-01 (feat/byok-guest-backend): ``set_key`` gained
 # ``validate: bool = True`` so the guest-mint route (which validates BEFORE
 # minting anything) can store without a second provider round trip. Also added
@@ -32,6 +44,7 @@ from typing import Literal
 
 import httpx
 
+from pocketpaw.security.redact import redact_output
 from pocketpaw_ee.cloud._core import crypto
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.byok.dto import ByokStatus
@@ -199,15 +212,44 @@ async def delete_key(workspace_id: str) -> ByokStatus:
         doc.encrypted_key = ""
         doc.last4 = ""
         doc.key_hint = None
-        doc.base_url = None
-        doc.model = None
         doc.last_verified_at = None
         doc.last_error = None
+        # ``base_url`` / ``model`` belong to the gateway credential that
+        # feat/byok-custom-gateway adds to this row. That branch is a SIBLING
+        # of this one, so the columns are absent until it merges — and
+        # assigning a field the document does not declare RAISES in pydantic,
+        # which would fail this delete for every workspace that also has an
+        # image key. Ask the document instead of assuming, so the clear is
+        # correct on either side of that merge.
+        for gateway_field in ("base_url", "model"):
+            if gateway_field in type(doc).model_fields:
+                setattr(doc, gateway_field, None)
         await doc.save()
     else:
         await doc.delete()
     logger.info("byok: key removed for workspace=%s", workspace_id)
     return await get_status(workspace_id)
+
+
+#: How much provider error text is worth keeping. Long enough to say what went
+#: wrong, short enough that a stack trace or an echoed request body does not
+#: end up in a settings panel.
+_PROVIDER_ERROR_MAX_LEN = 300
+
+
+def _safe_provider_error(message: str) -> str:
+    """Provider error text, fit to be stored and handed back to the client.
+
+    ``last_error`` / ``image_last_error`` are returned by ``ByokStatus`` and
+    rendered verbatim in the settings panel, and the text comes from whoever
+    refused the call — fal, Anthropic, or a gateway the workspace named. Some
+    providers echo the submitted credential back in their error body, so this
+    goes through the same redactor the agent's output does before it is stored.
+
+    Redact THEN truncate: truncating first can cut a key in half and leave a
+    remnant no pattern matches.
+    """
+    return redact_output(message)[:_PROVIDER_ERROR_MAX_LEN]
 
 
 async def record_auth_failure(workspace_id: str, message: str) -> None:
@@ -219,7 +261,7 @@ async def record_auth_failure(workspace_id: str, message: str) -> None:
     try:
         doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
         if doc is not None:
-            doc.last_error = message[:300]
+            doc.last_error = _safe_provider_error(message)
             await doc.save()
     except Exception:  # noqa: BLE001 — diagnostics must not mask the real error
         logger.warning("byok: could not record auth failure", exc_info=True)
@@ -383,7 +425,7 @@ async def record_image_auth_failure(workspace_id: str | None, message: str) -> N
     try:
         doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
         if doc is not None and doc.image_encrypted_key:
-            doc.image_last_error = message[:300]
+            doc.image_last_error = _safe_provider_error(message)
             await doc.save()
     except Exception:  # noqa: BLE001
         logger.debug("byok: could not record image auth failure", exc_info=True)

--- a/ee/pocketpaw_ee/cloud/byok/service.py
+++ b/ee/pocketpaw_ee/cloud/byok/service.py
@@ -82,12 +82,16 @@ async def get_status(workspace_id: str) -> ByokStatus:
     if doc is None:
         return ByokStatus(configured=False)
     return ByokStatus(
-        configured=True,
+        configured=bool(doc.encrypted_key),
         provider=doc.provider,
         last4=doc.last4,
         key_hint=doc.key_hint,
         last_verified_at=doc.last_verified_at,
         last_error=doc.last_error,
+        image_configured=bool(doc.image_encrypted_key),
+        image_last4=doc.image_last4,
+        image_key_hint=doc.image_key_hint,
+        image_last_error=doc.image_last_error,
     )
 
 
@@ -181,12 +185,29 @@ async def set_key(
 
 
 async def delete_key(workspace_id: str) -> ByokStatus:
-    """Remove the workspace's key. Idempotent — deleting nothing is success."""
+    """Remove the workspace's LLM key. Idempotent — deleting nothing is success.
+
+    Clears the columns rather than dropping the row whenever an IMAGE key still
+    lives on it. One row holds two independent credentials (2026-09-11), and
+    removing one must never take the other with it — a user who rotates their
+    Anthropic key would otherwise silently lose their illustrator.
+    """
     doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
-    if doc is not None:
+    if doc is None:
+        return ByokStatus(configured=False)
+    if doc.image_encrypted_key:
+        doc.encrypted_key = ""
+        doc.last4 = ""
+        doc.key_hint = None
+        doc.base_url = None
+        doc.model = None
+        doc.last_verified_at = None
+        doc.last_error = None
+        await doc.save()
+    else:
         await doc.delete()
-        logger.info("byok: key removed for workspace=%s", workspace_id)
-    return ByokStatus(configured=False)
+    logger.info("byok: key removed for workspace=%s", workspace_id)
+    return await get_status(workspace_id)
 
 
 async def record_auth_failure(workspace_id: str, message: str) -> None:
@@ -233,6 +254,139 @@ async def resolve_turn_credentials(workspace_id: str | None) -> TurnCredentials:
     if not plaintext:
         return TurnCredentials(source="platform")
     return TurnCredentials(source="byok", api_key=plaintext, provider=doc.provider)
+
+
+# ── The illustration credential (fal.ai) ────────────────────────────────────
+#
+# Added 2026-09-11 (feat/byok-image-key). Illustrations are generated through
+# fal and billed per image on the PLATFORM's account, which is why guests are
+# refused them outright: a guest can mint a fresh workspace for a fresh daily
+# ceiling, so the cap alone left a bill attached to a signup form. A workspace
+# that brings its own fal key pays for its own pictures, and that objection
+# disappears.
+#
+# NOT validated on save. fal has no free endpoint that proves a key without
+# generating an image, so a validate-on-save would spend money every time
+# someone pasted one. ``record_image_auth_failure`` stamps the row the first
+# time a generation is refused, which is the same signal one picture later.
+
+
+def _fal_hint(api_key: str) -> str:
+    """The non-secret half of a fal key.
+
+    fal spells its credential ``<key-id>:<secret>``. The id is not secret and
+    is what tells two keys apart; the secret is the part that must never be
+    displayed. ``_hint`` above splits on ``-`` and would print three UUID
+    segments of a fal key, so this one exists rather than reusing it.
+    """
+    return api_key.partition(":")[0] if ":" in api_key else ""
+
+
+def _fal_last4(api_key: str) -> str:
+    """Last four of the SECRET half, so two keys sharing an id still differ."""
+    secret = api_key.partition(":")[2] if ":" in api_key else api_key
+    return secret[-4:]
+
+
+async def set_image_key(
+    workspace_id: str,
+    api_key: str,
+    *,
+    user_id: str | None = None,
+) -> ByokStatus:
+    """Encrypt-and-upsert the workspace's fal key. Never touches the LLM key."""
+    if not crypto.is_configured():
+        raise ValidationError(
+            "byok.encryption_unavailable",
+            "This deployment cannot store provider keys — CLOUD_ENCRYPTION_KEY "
+            "is not set. Contact the operator.",
+        )
+
+    doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
+    if doc is None:
+        # A workspace may bring an image key and no LLM key at all — on a
+        # platform-credential deployment that is the ordinary case. The row is
+        # created with an EMPTY ``encrypted_key``, which ``get_status`` reads as
+        # "no LLM key configured" and ``resolve_turn_credentials`` reads as
+        # platform. Both already handle the empty string.
+        doc = ByokProviderKey(workspace=workspace_id, encrypted_key="", last4="")
+
+    doc.image_encrypted_key = crypto.encrypt(api_key)
+    doc.image_last4 = _fal_last4(api_key)
+    doc.image_key_hint = _fal_hint(api_key)
+    doc.image_last_error = None
+    doc.set_by_user = user_id or doc.set_by_user
+    await doc.save()
+
+    logger.info("byok: image key set for workspace=%s", workspace_id)
+    return await get_status(workspace_id)
+
+
+async def delete_image_key(workspace_id: str) -> ByokStatus:
+    """Remove the fal key. Idempotent, and it never touches the LLM key.
+
+    Unlike the LLM key, removing this one is SAFE and the UI offers it: a
+    workspace with no image key falls back to today's behaviour (the platform
+    key under the daily cap for accounts, a refusal for guests), where a
+    workspace with no LLM key answers 402 on every turn.
+    """
+    doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
+    if doc is None:
+        return ByokStatus(configured=False)
+    if doc.encrypted_key:
+        doc.image_encrypted_key = None
+        doc.image_last4 = None
+        doc.image_key_hint = None
+        doc.image_last_error = None
+        await doc.save()
+    else:
+        # Nothing left on the row once the image key goes.
+        await doc.delete()
+        return ByokStatus(configured=False)
+    logger.info("byok: image key removed for workspace=%s", workspace_id)
+    return await get_status(workspace_id)
+
+
+async def resolve_image_key(workspace_id: str | None) -> str | None:
+    """The workspace's own fal key, or None. A DECRYPT SITE.
+
+    Same degrade-to-None shape as ``resolve_turn_credentials``: an undecryptable
+    row (the deployment's Fernet key rotated) reads as "no key", so the caller
+    falls back to the platform's rather than failing. Never raises — an
+    illustration is not worth breaking a turn over.
+    """
+    if not workspace_id:
+        return None
+    try:
+        doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
+        if doc is None or not doc.image_encrypted_key:
+            return None
+        return crypto.decrypt(doc.image_encrypted_key) or None
+    except Exception:  # noqa: BLE001 — an unreadable key is a missing key
+        logger.warning(
+            "byok: stored image key for workspace=%s is unreadable; using the "
+            "platform illustrator this time",
+            workspace_id,
+        )
+        return None
+
+
+async def record_image_auth_failure(workspace_id: str | None, message: str) -> None:
+    """Mark the stored fal key as having failed, so the UI stops showing it good.
+
+    This IS the verification story for this credential (see the header): there
+    is no save-time check, so the first refused generation is where a bad key
+    becomes visible. Best-effort — bookkeeping never fails the caller.
+    """
+    if not workspace_id:
+        return
+    try:
+        doc = await ByokProviderKey.find_one(ByokProviderKey.workspace == workspace_id)
+        if doc is not None and doc.image_encrypted_key:
+            doc.image_last_error = message[:300]
+            await doc.save()
+    except Exception:  # noqa: BLE001
+        logger.debug("byok: could not record image auth failure", exc_info=True)
 
 
 #: Model names that mean "let the backend pick" — never a cross-provider pin.

--- a/ee/pocketpaw_ee/cloud/models/byok_key.py
+++ b/ee/pocketpaw_ee/cloud/models/byok_key.py
@@ -21,9 +21,9 @@
 #
 # WHY a separate doc (not a field on Workspace / WorkspaceSettings): RFC 03 keeps
 # domain-specific config in domain-owned docs, and this one has the strictest
-# read rule in the codebase — exactly one service decrypts it, on the turn path.
-# Folding it into a broadly-read doc would put a live provider credential inside
-# every workspace fetch.
+# read rule in the codebase — exactly one service decrypts it, and only on a
+# path that is about to spend the credential. Folding it into a broadly-read doc
+# would put a live provider credential inside every workspace fetch.
 #
 # Created 2026-08-28 (feat/other-hand-byok): new entity. Registered in
 # ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
@@ -71,6 +71,20 @@ class ByokProviderKey(TimestampedDocument):
     # Set when a turn fails with an auth error, so the UI can say "your key
     # stopped working" instead of showing a green state over a dead credential.
     last_error: str | None = None
+
+    # -- the illustration credential (fal.ai) --------------------------------
+    # Independent of the LLM key above: a workspace may have either, both, or
+    # neither, and setting one never touches the other. Absent on every existing
+    # row, which reads as "no image key" — today's behaviour exactly.
+    image_encrypted_key: str | None = None
+    # Display-only, same contract as ``last4`` / ``key_hint``: a status call
+    # answers from these and never decrypts. A fal key is ``<key-id>:<secret>``,
+    # so the hint is the key id (not secret) and last4 comes from the secret.
+    image_last4: str | None = None
+    image_key_hint: str | None = None
+    # Stamped when a generation comes back 401/403, cleared on the next success.
+    # This is the whole verification story for this key — see the header.
+    image_last_error: str | None = None
 
     class Settings:
         name = "byok_provider_keys"

--- a/ee/pocketpaw_ee/cloud/other_hand/illustration_credentials.py
+++ b/ee/pocketpaw_ee/cloud/other_hand/illustration_credentials.py
@@ -1,0 +1,87 @@
+# ee/pocketpaw_ee/cloud/other_hand/illustration_credentials.py — whose fal key
+# pays for this illustration, and whether it may happen at all.
+#
+# Created 2026-09-11 (feat/byok-image-key).
+#
+# There are two ways to reach the illustrator — the agent's ``illustrate`` tool
+# and the toolbar button's ``POST /other-hand/illustrate`` — and before this
+# module each decided independently. They agreed, but only because the same
+# three checks had been written twice; the first time one of them grew a fourth,
+# they would not have. The rules live here once.
+#
+# THE RULES, in order:
+#
+#   1. The workspace's OWN fal key wins. It pays for its own pictures, so the
+#      platform's daily ceiling does not apply and a guest is not refused —
+#      the guest refusal exists because a guest can mint a fresh workspace for
+#      a fresh ceiling, which is an argument about the PLATFORM's money and
+#      says nothing about someone spending their own.
+#   2. No image key, and the caller is an account: the platform's key, under
+#      the daily cap, exactly as before this module existed.
+#   3. No image key, and the caller is a guest: refused, exactly as before.
+#
+# The budget is claimed ONLY on branch 2. A workspace on its own key that also
+# consumed the platform ceiling would be paying twice — once in money and once
+# in a quota it has no reason to be inside.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+#: What the agent is told when it cannot illustrate. Worded so it explains in
+#: words and moves on rather than retrying a refusal.
+GUEST_REFUSAL = (
+    "Illustrations need an account, or your own image key in Settings. Say so "
+    "plainly and offer to keep going in words and your own drawing; do not try "
+    "again this turn."
+)
+NO_KEY_REFUSAL = (
+    "No illustrator is configured on this deployment. Explain in words and with "
+    "your own drawing instead; do not try again."
+)
+
+
+@dataclass(frozen=True)
+class IllustrationGrant:
+    """Permission to generate one illustration, and whose key pays for it."""
+
+    api_key: str
+    #: True when the key is the workspace's own. The caller stamps an auth
+    #: failure against the row only in that case — a refused PLATFORM key is an
+    #: operator problem, not something to show this workspace as its own error.
+    byok: bool
+
+
+@dataclass(frozen=True)
+class IllustrationRefusal:
+    """No illustration this time, and the words to say so."""
+
+    reason: str
+    #: True when an account would have been allowed. The REST route turns this
+    #: into the guest gate the page already renders; the agent tool just speaks.
+    guest_gate: bool = False
+
+
+async def resolve(
+    workspace_id: str | None,
+    *,
+    is_guest: bool,
+) -> IllustrationGrant | IllustrationRefusal:
+    """Apply the three rules above. Never raises."""
+    from pocketpaw_ee.cloud.byok import service as byok_service
+    from pocketpaw_ee.cloud.studio import fal_edit
+
+    own = await byok_service.resolve_image_key(workspace_id)
+    if own:
+        return IllustrationGrant(api_key=own, byok=True)
+
+    if is_guest:
+        return IllustrationRefusal(reason=GUEST_REFUSAL, guest_gate=True)
+
+    platform = fal_edit.fal_api_key()
+    if not platform:
+        return IllustrationRefusal(reason=NO_KEY_REFUSAL)
+    return IllustrationGrant(api_key=platform, byok=False)

--- a/ee/pocketpaw_ee/cloud/other_hand/router.py
+++ b/ee/pocketpaw_ee/cloud/other_hand/router.py
@@ -153,39 +153,70 @@ async def illustrate(
     from pocketpaw_ee.cloud.auth import guest_budget
     from pocketpaw_ee.cloud.other_hand import illustrate as illustrator
     from pocketpaw_ee.cloud.other_hand import illustration_budget
+    from pocketpaw_ee.cloud.other_hand import illustration_credentials as creds
     from pocketpaw_ee.cloud.other_hand.svg_to_ink import Box
-    from pocketpaw_ee.cloud.studio import fal_edit
 
-    # Guests do not get to spend platform money on pictures. The budget below
-    # is a cost CEILING, not an entitlement, and a guest can mint a fresh
-    # workspace to get a fresh ceiling, so the ceiling alone left an unbounded
-    # bill attached to a signup form that asks for nothing. Refused BEFORE the
-    # budget is claimed, so a refusal costs the workspace nothing.
-    if await guest_budget.load_guest(user_id) is not None:
-        from pocketpaw_ee.cloud._core.errors import GuestIllustrateForbidden
+    # Who pays, and whether this may happen at all. The same module the agent's
+    # ``illustrate`` tool asks, because these are money rules and two copies of
+    # a money rule drift. In short: the workspace's own fal key wins and is
+    # never capped by us; without one, an account gets the platform's key under
+    # the daily ceiling and a guest is refused — a guest can mint a fresh
+    # workspace for a fresh ceiling, so the ceiling alone left an unbounded bill
+    # attached to a signup form that asks for nothing.
+    grant = await creds.resolve(
+        workspace_id,
+        is_guest=await guest_budget.load_guest(user_id) is not None,
+    )
+    if isinstance(grant, creds.IllustrationRefusal):
+        if grant.guest_gate:
+            from pocketpaw_ee.cloud._core.errors import GuestIllustrateForbidden
 
-        raise GuestIllustrateForbidden()
+            raise GuestIllustrateForbidden()
+        # No generator anywhere. An empty op list, not an error: the page
+        # carries on and there is nothing useful to tell the user about a
+        # credential the operator has not set.
+        return {"ops": []}
 
     # A pressed button authorises ONE generation; it does not cap how many.
     # Scripted, the same button is a loop, so the ceiling has to live here and
-    # not in the UI. Claimed BEFORE the paid call and fail-closed, exactly like
-    # the MCP tool path -- this route was the one caller that skipped it.
-    allowed, spent, cap = await illustration_budget.try_spend(workspace_id)
-    if not allowed:
-        raise CloudError(
-            429,
-            "other_hand.illustration_limit",
-            f"Today's illustration limit is used up ({spent}/{cap}).",
-        )
+    # not in the UI. Claimed BEFORE the paid call and fail-closed — and only on
+    # the platform's key, because a workspace spending its own money has no
+    # reason to be inside our quota.
+    if not grant.byok:
+        allowed, spent, cap = await illustration_budget.try_spend(workspace_id)
+        if not allowed:
+            raise CloudError(
+                429,
+                "other_hand.illustration_limit",
+                f"Today's illustration limit is used up ({spent}/{cap}).",
+            )
 
     try:
         ops = await illustrator.illustrate_as_ops(
             body.prompt,
             Box(x=body.x, y=body.y, w=body.w, h=body.h),
-            api_key=fal_edit.fal_api_key(),
+            api_key=grant.api_key,
             # Budget claimed above; this flag is the generator's own gate.
             allowed=True,
         )
     except illustrator.IllustrateError as exc:
+        # The first refused generation is where a bad stored key becomes
+        # visible — there is no save-time check for a fal credential — so stamp
+        # the row rather than letting the panel show green over a dead key.
+        if grant.byok and _looks_like_auth(exc):
+            from pocketpaw_ee.cloud.byok import service as byok_service
+
+            await byok_service.record_image_auth_failure(workspace_id, str(exc))
         raise CloudError(502, "other_hand.illustrate_failed", str(exc)) from exc
     return {"ops": ops}
+
+
+def _looks_like_auth(exc: Exception) -> bool:
+    """Whether a failed generation blames the CREDENTIAL rather than the prompt.
+
+    fal's errors arrive as text through ``IllustrateError``, so this reads the
+    message. Deliberately narrow: a false positive marks a good key as broken,
+    which sends the user to re-paste a credential that was fine.
+    """
+    text = str(exc).lower()
+    return "401" in text or "403" in text or "unauthorized" in text or "forbidden" in text

--- a/src/pocketpaw/security/redact.py
+++ b/src/pocketpaw/security/redact.py
@@ -3,6 +3,14 @@ Output-level redaction for API keys, tokens, and secrets.
 
 This module prevents accidental leakage of sensitive data in agent responses.
 It operates at the message bus level, making it backend-agnostic.
+
+Updated 2026-09-11 (feat/byok-image-key): added the fal.ai credential pattern.
+``cloud/byok/service.py`` now runs provider error text through
+``redact_output`` before storing it in ``last_error`` / ``image_last_error``,
+and those columns are returned by the status API and rendered in the settings
+panel. A fal key is ``<key-id>:<secret>`` and matched no pattern here, so a
+provider that echoes the submitted credential in its error body would have
+written it into a field the API hands straight back.
 """
 
 import re
@@ -105,6 +113,17 @@ REDACT_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     (
         "Stripe API Key",
         re.compile(r"\b[rs]k_live_[0-9a-zA-Z]{24,}\b"),
+    ),
+    # fal.ai keys (<uuid key-id>:<hex secret>). Matched WHOLE rather than on
+    # the secret half alone: the key id is displayed on purpose (it is the
+    # ``image_key_hint`` column), and a bare uuid in a log line is usually an
+    # id we want to keep readable. The colon is what makes it a credential.
+    (
+        "fal.ai Key",
+        re.compile(
+            r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:[0-9a-f]{16,}\b",
+            re.IGNORECASE,
+        ),
     ),
     # PocketPaw API keys (pp_...)
     (

--- a/tests/cloud/byok/test_byok_service.py
+++ b/tests/cloud/byok/test_byok_service.py
@@ -1,5 +1,12 @@
 # tests/cloud/byok/test_byok_service.py — the BYOK credential path.
 #
+# Updated 2026-09-11 (feat/byok-image-key): the delete-path tests now drive a
+# REAL ``ByokProviderKey`` instead of a hand-rolled stand-in, and a new test
+# pins that provider error text is scrubbed before it is stored. The stub they
+# used to share declared two columns the document does not have on this branch,
+# so it accepted an assignment pydantic rejects and ``delete_key`` crashed
+# green. See ``TestTheTwoCredentialsAreIndependent``.
+#
 # Created 2026-08-28 (feat/other-hand-byok).
 #
 # Three things are worth testing here and they are all about CONTAINMENT, not
@@ -17,6 +24,7 @@ import pytest
 from pocketpaw_ee.cloud._core import crypto
 from pocketpaw_ee.cloud.byok import service as byok
 from pocketpaw_ee.cloud.byok.dto import ByokSetRequest, ByokStatus
+from pocketpaw_ee.cloud.models.byok_key import ByokProviderKey
 
 _REAL_KEY = "sk-ant-api03-" + "z" * 40
 
@@ -255,47 +263,72 @@ class TestImageKeyDisplayColumns:
         assert byok._fal_hint("nocolonhere") == ""
 
 
+def _intercepted_row(monkeypatch) -> tuple[ByokProviderKey, dict, list]:
+    """A REAL ``ByokProviderKey`` with its two Mongo writes intercepted.
+
+    ``model_construct`` rather than the constructor because Beanie's
+    ``__init__`` wants an initialised collection. The two parts under test —
+    the document's field set, and pydantic refusing an assignment to a field
+    it does not declare — both survive that, which a hand-rolled stand-in
+    class does not: an earlier version of these tests declared ``base_url``
+    and ``model`` (columns the sibling gateway branch adds and this one does
+    not have), so ``delete_key`` assigned them happily in the test and raised
+    ``ValueError: object has no field`` against the real document in
+    production. A stub laxer than the model hides the bug it exists to catch.
+
+    Only the query and the two writes are replaced. Returns the row plus what
+    ``save`` saw and whether ``delete`` was called.
+    """
+    saved: dict[str, object] = {}
+    deleted: list[bool] = []
+
+    row = ByokProviderKey.model_construct(
+        workspace="ws-1",
+        encrypted_key="llm-token",
+        last4="zzzz",
+        key_hint="sk-ant-api03",
+        provider="anthropic",
+        last_verified_at=None,
+        last_error=None,
+        image_encrypted_key="image-token",
+        image_last4="ffff",
+        image_key_hint="key-id",
+        image_last_error=None,
+    )
+
+    async def _save(self):
+        saved["encrypted_key"] = self.encrypted_key
+        saved["image_encrypted_key"] = self.image_encrypted_key
+        saved["last_error"] = self.last_error
+        saved["image_last_error"] = self.image_last_error
+
+    async def _delete(self):
+        deleted.append(True)
+
+    monkeypatch.setattr(ByokProviderKey, "save", _save)
+    monkeypatch.setattr(ByokProviderKey, "delete", _delete)
+
+    class _Query:
+        # Stands in for the QUERY, not for the row: the real class only grows
+        # its comparable ``workspace`` attribute once ``init_beanie`` has run.
+        workspace = "workspace"
+
+        @staticmethod
+        async def find_one(*_a, **_k):
+            return row
+
+    monkeypatch.setattr(byok, "ByokProviderKey", _Query)
+    return row, saved, deleted
+
+
 class TestTheTwoCredentialsAreIndependent:
     """The data-loss case. Both directions, because both are one line of code
     apart from being wrong."""
 
     @pytest.mark.asyncio
     async def test_removing_the_llm_key_keeps_the_image_key(self, monkeypatch):
-        saved: dict[str, object] = {}
-        deleted: list[bool] = []
+        _row, saved, deleted = _intercepted_row(monkeypatch)
 
-        class _Row:
-            workspace = "ws-1"
-            encrypted_key = "llm-token"
-            last4 = "zzzz"
-            key_hint = "sk-ant-api03"
-            base_url = None
-            model = None
-            provider = "anthropic"
-            last_verified_at = None
-            last_error = None
-            image_encrypted_key = "image-token"
-            image_last4 = "ffff"
-            image_key_hint = "key-id"
-            image_last_error = None
-
-            async def save(self):
-                saved["encrypted_key"] = self.encrypted_key
-                saved["image_encrypted_key"] = self.image_encrypted_key
-
-            async def delete(self):
-                deleted.append(True)
-
-        row = _Row()
-
-        class _StubDoc:
-            workspace = "workspace"
-
-            @staticmethod
-            async def find_one(*_a, **_k):
-                return row
-
-        monkeypatch.setattr(byok, "ByokProviderKey", _StubDoc)
         await byok.delete_key("ws-1")
 
         assert deleted == [], "the row was dropped, taking the image key with it"
@@ -304,46 +337,77 @@ class TestTheTwoCredentialsAreIndependent:
 
     @pytest.mark.asyncio
     async def test_removing_the_image_key_keeps_the_llm_key(self, monkeypatch):
-        saved: dict[str, object] = {}
-        deleted: list[bool] = []
+        _row, saved, deleted = _intercepted_row(monkeypatch)
 
-        class _Row:
-            workspace = "ws-1"
-            encrypted_key = "llm-token"
-            last4 = "zzzz"
-            key_hint = "sk-ant-api03"
-            base_url = None
-            model = None
-            provider = "anthropic"
-            last_verified_at = None
-            last_error = None
-            image_encrypted_key = "image-token"
-            image_last4 = "ffff"
-            image_key_hint = "key-id"
-            image_last_error = None
-
-            async def save(self):
-                saved["encrypted_key"] = self.encrypted_key
-                saved["image_encrypted_key"] = self.image_encrypted_key
-
-            async def delete(self):
-                deleted.append(True)
-
-        row = _Row()
-
-        class _StubDoc:
-            workspace = "workspace"
-
-            @staticmethod
-            async def find_one(*_a, **_k):
-                return row
-
-        monkeypatch.setattr(byok, "ByokProviderKey", _StubDoc)
         await byok.delete_image_key("ws-1")
 
         assert deleted == [], "the row was dropped, taking the LLM key with it"
         assert saved["image_encrypted_key"] is None
         assert saved["encrypted_key"] == "llm-token"
+
+    def test_the_clear_list_only_names_columns_the_document_declares(self):
+        """The shape of the bug above, stated directly.
+
+        ``delete_key`` clears the LLM half of a shared row by assigning each
+        of its columns. Naming one the document does not declare is not a
+        no-op — pydantic raises, and the delete fails for every workspace that
+        also has an image key. The sibling gateway branch adds ``base_url``
+        and ``model``; until it merges they are absent here, so the clear has
+        to ask the document rather than assume.
+        """
+        declared = set(ByokProviderKey.model_fields)
+        assert {"encrypted_key", "last4", "key_hint", "last_verified_at", "last_error"} <= declared
+        with pytest.raises(ValueError, match="no field"):
+            ByokProviderKey.model_construct(workspace="ws-1").base_url = None
+
+
+class TestStoredErrorTextCarriesNoCredential:
+    """``image_last_error`` / ``last_error`` are written by the PROVIDER and
+    read back by the settings panel.
+
+    fal, Anthropic and any gateway a workspace names all write this text, and
+    several providers echo the submitted credential in an error body. The
+    round trip is short: provider error -> stored column -> ``ByokStatus`` ->
+    "This key stopped working: {error}" in the UI.
+    """
+
+    _LEAKY = (
+        "401 Unauthorized for key "
+        "11111111-2222-3333-4444-555555555555:" + "f" * 32 + " via "
+        "https://user:hunter2@gateway.example.com/v1 "
+        "(Authorization: Bearer " + "t" * 40 + ", "
+        "api_key=" + "k" * 32 + ")"
+    )
+
+    @pytest.mark.asyncio
+    async def test_a_fal_key_echoed_in_an_error_never_reaches_the_column(self, monkeypatch):
+        _row, saved, _deleted = _intercepted_row(monkeypatch)
+
+        await byok.record_image_auth_failure("ws-1", self._LEAKY)
+
+        stored = saved["image_last_error"]
+        assert "f" * 32 not in stored, "the fal secret was stored"
+        assert "hunter2" not in stored, "the gateway password was stored"
+        assert "t" * 40 not in stored, "the bearer token was stored"
+        assert "k" * 32 not in stored, "the api_key parameter was stored"
+        assert "401" in stored, "scrubbing ate the part the user needs to read"
+
+    @pytest.mark.asyncio
+    async def test_the_llm_column_is_scrubbed_on_the_same_terms(self, monkeypatch):
+        _row, saved, _deleted = _intercepted_row(monkeypatch)
+
+        await byok.record_auth_failure("ws-1", self._LEAKY)
+
+        assert "f" * 32 not in saved["last_error"]
+        assert "hunter2" not in saved["last_error"]
+
+    def test_redaction_happens_before_truncation(self):
+        """Truncating first can cut a credential in half and leave a remnant
+        no pattern matches — the 300-char cap would then be what leaks it."""
+        secret = "f" * 32
+        padded = "x" * 290 + " key=" + "11111111-2222-3333-4444-555555555555:" + secret
+        assert secret not in byok._safe_provider_error(padded)
+        assert len(byok._safe_provider_error(padded)) <= 300
 
 
 class TestImageKeyResolution:

--- a/tests/cloud/byok/test_byok_service.py
+++ b/tests/cloud/byok/test_byok_service.py
@@ -66,6 +66,15 @@ class TestStatusNeverCarriesTheKey:
             "key_hint",
             "last_verified_at",
             "last_error",
+            # The illustration credential (2026-09-11). Same display-only rule:
+            # ``image_configured`` is a bool and the other two are a hint and a
+            # last-four, none of which needs a decrypt to compute. There is no
+            # ``image_verified_at`` because fal cannot be asked whether a key is
+            # good without generating an image.
+            "image_configured",
+            "image_last4",
+            "image_key_hint",
+            "image_last_error",
         }
         assert set(ByokStatus.model_fields) == allowed
 
@@ -195,3 +204,181 @@ class TestTheHeaderThatCarriesTheKey:
         client = self._client_for("   ")
         assert client is not None
         assert "x-api-key" not in client.headers
+
+
+# ---------------------------------------------------------------------------
+# The illustration credential (2026-09-11, feat/byok-image-key).
+#
+# One row now holds TWO independent credentials, which creates exactly one new
+# way to lose data: removing one taking the other with it. ``delete_key`` used
+# to drop the whole document, and a user rotating their Anthropic key would
+# have silently lost their illustrator.
+# ---------------------------------------------------------------------------
+
+from pocketpaw_ee.cloud.byok.dto import ByokImageKeyRequest  # noqa: E402
+
+_FAL_KEY = "11111111-2222-3333-4444-555555555555:" + "f" * 32
+
+
+class TestImageKeyValidation:
+    def test_accepts_the_shape_fal_actually_issues(self):
+        assert ByokImageKeyRequest(api_key=_FAL_KEY).api_key == _FAL_KEY
+
+    def test_rejects_a_key_with_no_secret_half(self):
+        with pytest.raises(ValueError, match="key-id"):
+            ByokImageKeyRequest(api_key="11111111-2222-3333-4444-555555555555")
+
+    def test_rejects_a_whole_shell_command(self):
+        with pytest.raises(ValueError, match="whitespace"):
+            ByokImageKeyRequest(api_key='export FAL_KEY="abc:def"')
+
+
+class TestImageKeyDisplayColumns:
+    """The hint must name the key WITHOUT naming the secret.
+
+    ``_hint`` splits on ``-``, so reusing it on a fal key would print three
+    segments of the UUID and tell the user nothing. Worse, a naive "first N
+    characters" would be right up until fal changed its format.
+    """
+
+    def test_the_hint_is_the_key_id_and_never_the_secret(self):
+        hint = byok._fal_hint(_FAL_KEY)
+        assert hint == "11111111-2222-3333-4444-555555555555"
+        assert "f" * 32 not in hint
+
+    def test_last4_comes_from_the_secret_so_two_keys_sharing_an_id_differ(self):
+        a = "same-id:" + "a" * 20 + "abcd"
+        b = "same-id:" + "a" * 20 + "wxyz"
+        assert byok._fal_last4(a) != byok._fal_last4(b)
+
+    def test_a_key_of_an_unexpected_shape_yields_no_hint_rather_than_a_guess(self):
+        assert byok._fal_hint("nocolonhere") == ""
+
+
+class TestTheTwoCredentialsAreIndependent:
+    """The data-loss case. Both directions, because both are one line of code
+    apart from being wrong."""
+
+    @pytest.mark.asyncio
+    async def test_removing_the_llm_key_keeps_the_image_key(self, monkeypatch):
+        saved: dict[str, object] = {}
+        deleted: list[bool] = []
+
+        class _Row:
+            workspace = "ws-1"
+            encrypted_key = "llm-token"
+            last4 = "zzzz"
+            key_hint = "sk-ant-api03"
+            base_url = None
+            model = None
+            provider = "anthropic"
+            last_verified_at = None
+            last_error = None
+            image_encrypted_key = "image-token"
+            image_last4 = "ffff"
+            image_key_hint = "key-id"
+            image_last_error = None
+
+            async def save(self):
+                saved["encrypted_key"] = self.encrypted_key
+                saved["image_encrypted_key"] = self.image_encrypted_key
+
+            async def delete(self):
+                deleted.append(True)
+
+        row = _Row()
+
+        class _StubDoc:
+            workspace = "workspace"
+
+            @staticmethod
+            async def find_one(*_a, **_k):
+                return row
+
+        monkeypatch.setattr(byok, "ByokProviderKey", _StubDoc)
+        await byok.delete_key("ws-1")
+
+        assert deleted == [], "the row was dropped, taking the image key with it"
+        assert saved["encrypted_key"] == "", "the LLM key was not actually removed"
+        assert saved["image_encrypted_key"] == "image-token"
+
+    @pytest.mark.asyncio
+    async def test_removing_the_image_key_keeps_the_llm_key(self, monkeypatch):
+        saved: dict[str, object] = {}
+        deleted: list[bool] = []
+
+        class _Row:
+            workspace = "ws-1"
+            encrypted_key = "llm-token"
+            last4 = "zzzz"
+            key_hint = "sk-ant-api03"
+            base_url = None
+            model = None
+            provider = "anthropic"
+            last_verified_at = None
+            last_error = None
+            image_encrypted_key = "image-token"
+            image_last4 = "ffff"
+            image_key_hint = "key-id"
+            image_last_error = None
+
+            async def save(self):
+                saved["encrypted_key"] = self.encrypted_key
+                saved["image_encrypted_key"] = self.image_encrypted_key
+
+            async def delete(self):
+                deleted.append(True)
+
+        row = _Row()
+
+        class _StubDoc:
+            workspace = "workspace"
+
+            @staticmethod
+            async def find_one(*_a, **_k):
+                return row
+
+        monkeypatch.setattr(byok, "ByokProviderKey", _StubDoc)
+        await byok.delete_image_key("ws-1")
+
+        assert deleted == [], "the row was dropped, taking the LLM key with it"
+        assert saved["image_encrypted_key"] is None
+        assert saved["encrypted_key"] == "llm-token"
+
+
+class TestImageKeyResolution:
+    @pytest.mark.asyncio
+    async def test_an_unreadable_row_reads_as_no_key_rather_than_raising(self, monkeypatch):
+        """Same posture as the LLM key's rotated-Fernet case, for a smaller
+        reason: a picture is not worth failing a turn over, so an unreadable
+        image key falls back to the platform's instead of raising inside a tool
+        call the agent is in the middle of."""
+        from cryptography.fernet import Fernet
+
+        token = crypto.encrypt(_FAL_KEY)
+        monkeypatch.setenv("CLOUD_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+        class _Row:
+            image_encrypted_key = token
+
+        class _StubDoc:
+            workspace = "workspace"
+
+            @staticmethod
+            async def find_one(*_a, **_k):
+                return _Row()
+
+        monkeypatch.setattr(byok, "ByokProviderKey", _StubDoc)
+        assert await byok.resolve_image_key("ws-1") is None
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_never_touches_the_database(self, monkeypatch):
+        class _Exploding:
+            workspace = "workspace"
+
+            @staticmethod
+            async def find_one(*_a, **_k):
+                raise AssertionError("a keyless turn queried for a credential")
+
+        monkeypatch.setattr(byok, "ByokProviderKey", _Exploding)
+        assert await byok.resolve_image_key(None) is None

--- a/tests/cloud/other_hand/test_illustrate_endpoint.py
+++ b/tests/cloud/other_hand/test_illustrate_endpoint.py
@@ -286,3 +286,120 @@ class TestGuestsCannotSpendPlatformMoneyOnPictures:
 
         res = await tool_mod._illustrate_handler({"subject": "a honeybee"})
         assert "account" in res["content"][0]["text"].lower(), res
+
+
+# ---------------------------------------------------------------------------
+# Added 2026-09-11 (feat/byok-image-key). A workspace may bring its OWN fal key,
+# and then it is spending its own money. Two things follow, and both are silent
+# when wrong:
+#
+#   * it must NOT claim the platform's daily ceiling. Charging it a quota as
+#     well as a bill is charging it twice, and nothing looks broken until the
+#     twentieth picture of the day stops for no visible reason;
+#   * a GUEST on their own key must be allowed. The guest refusal exists
+#     because a guest can mint a fresh workspace for a fresh ceiling — an
+#     argument about the platform's money that says nothing about someone
+#     spending their own.
+# ---------------------------------------------------------------------------
+
+
+class TestAWorkspaceOnItsOwnKey:
+    @pytest.fixture
+    def own_key(self, monkeypatch):
+        """The workspace has stored a fal key of its own."""
+        import pocketpaw_ee.cloud.byok.service as byok_service
+
+        async def _resolve(_workspace_id):
+            return "tenant-id:tenant-secret"
+
+        monkeypatch.setattr(byok_service, "resolve_image_key", _resolve)
+
+    @pytest.fixture
+    def budget_spy(self, monkeypatch):
+        from pocketpaw_ee.cloud.other_hand import illustration_budget
+
+        claimed: list[str | None] = []
+
+        async def _spend(workspace_id=None):
+            claimed.append(workspace_id)
+            return True, 1, 20
+
+        monkeypatch.setattr(illustration_budget, "try_spend", _spend)
+        return claimed
+
+    @pytest.mark.asyncio
+    async def test_the_route_does_not_claim_our_budget(self, monkeypatch, own_key, budget_spy):
+        from pocketpaw_ee.cloud.other_hand import router as oh_router
+
+        used: list[str] = []
+
+        async def _draw(*_a, **kw):
+            used.append(kw["api_key"])
+            return [{"t": "path", "d": "M0 0 L1 1"}]
+
+        monkeypatch.setattr(ill, "illustrate_as_ops", _draw)
+
+        body = oh_router.IllustrateRequest(prompt="a honeybee", x=0, y=0, w=600, h=600)
+        out = await oh_router.illustrate(body=body, workspace_id="ws-1")
+
+        assert out["ops"], "a workspace paying its own way should still draw"
+        assert used == ["tenant-id:tenant-secret"], "it drew on the wrong account"
+        assert budget_spy == [], "a self-funded workspace was charged our quota too"
+
+    @pytest.mark.asyncio
+    async def test_a_guest_on_their_own_key_may_draw(self, monkeypatch, own_key, budget_spy):
+        from pocketpaw_ee.cloud.auth import guest_budget
+        from pocketpaw_ee.cloud.other_hand import router as oh_router
+
+        async def _is_guest(_user_id):
+            return object()
+
+        monkeypatch.setattr(guest_budget, "load_guest", _is_guest)
+
+        async def _draw(*_a, **_k):
+            return [{"t": "path", "d": "M0 0 L1 1"}]
+
+        monkeypatch.setattr(ill, "illustrate_as_ops", _draw)
+
+        body = oh_router.IllustrateRequest(prompt="a honeybee", x=0, y=0, w=600, h=600)
+        out = await oh_router.illustrate(body=body, workspace_id="ws-g", user_id="u-guest")
+
+        assert out["ops"], "a guest on their own key was refused anyway"
+        assert budget_spy == []
+
+    @pytest.mark.asyncio
+    async def test_the_mcp_tool_does_not_claim_our_budget_either(
+        self, monkeypatch, own_key, budget_spy
+    ):
+        """The tool is the more natural way in — the agent draws when it judges
+        a picture helps — so a rule enforced only on the route is not enforced."""
+        from pocketpaw_ee.agent.mcp_servers import other_hand as tool
+
+        monkeypatch.setattr(tool, "_workspace_or_none", lambda: "ws-1")
+
+        async def _not_a_guest():
+            return None
+
+        monkeypatch.setattr(tool, "_guest_or_none", _not_a_guest)
+
+        used: list[str] = []
+
+        async def _draw(*_a, **kw):
+            used.append(kw["api_key"])
+            # The tool measures the drawing's bottom edge off ``pts``, so this
+            # stand-in carries the real op shape rather than the route's.
+            return [{"t": "path", "pts": [[0.0, 0.0], [1.0, 1.0]]}]
+
+        monkeypatch.setattr(ill, "illustrate_as_ops", _draw)
+
+        async def _push(*_a, **_k):
+            return None
+
+        import pocketpaw_ee.cloud.chat.agent_service as agent_service
+
+        monkeypatch.setattr(agent_service, "push_sse_event", _push, raising=False)
+
+        await tool._illustrate_handler({"subject": "a honeybee"})
+
+        assert used == ["tenant-id:tenant-secret"], "the tool drew on the wrong account"
+        assert budget_spy == [], "a self-funded workspace was charged our quota too"

--- a/tests/cloud/other_hand/test_illustration_credentials.py
+++ b/tests/cloud/other_hand/test_illustration_credentials.py
@@ -1,0 +1,134 @@
+# tests/cloud/other_hand/test_illustration_credentials.py — whose fal key pays.
+#
+# Created 2026-09-11 (feat/byok-image-key). Every assertion here is about money
+# moving to the right account, which is why they are worth more than the
+# generation they gate.
+#
+# The rule that is easiest to get wrong, and the one this file exists for: a
+# workspace on its OWN key must not claim the platform's daily ceiling. It is
+# paying in real money; charging it a quota as well is charging it twice, and
+# the failure is silent — the pictures keep appearing until the twentieth one
+# of the day stops for no reason the user can see.
+#
+# No ``mongo_db`` fixture: the resolver's only database call is stubbed, because
+# what is under test is the DECISION, not the read.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.other_hand import illustration_credentials as creds
+
+
+@pytest.fixture
+def stored_key(monkeypatch):
+    """Control what the workspace has stored, without a database."""
+
+    def _set(value):
+        async def _resolve(workspace_id):
+            return value
+
+        import pocketpaw_ee.cloud.byok.service as byok_service
+
+        monkeypatch.setattr(byok_service, "resolve_image_key", _resolve)
+
+    return _set
+
+
+@pytest.fixture
+def platform_key(monkeypatch):
+    """Control whether the deployment itself has a fal key."""
+
+    def _set(value):
+        from pocketpaw_ee.cloud.studio import fal_edit
+
+        monkeypatch.setattr(fal_edit, "fal_api_key", lambda: value)
+
+    return _set
+
+
+@pytest.mark.asyncio
+async def test_own_key_wins_and_is_not_the_platform_s(stored_key, platform_key):
+    stored_key("tenant-id:tenant-secret")
+    platform_key("platform-key")
+
+    grant = await creds.resolve("ws-1", is_guest=False)
+
+    assert isinstance(grant, creds.IllustrationGrant)
+    assert grant.api_key == "tenant-id:tenant-secret"
+    # ``byok`` is what tells the caller to SKIP the platform ceiling. Without
+    # it the workspace pays twice — in money and in a quota it has no reason
+    # to be inside — and nothing visibly breaks until the cap bites.
+    assert grant.byok is True
+
+
+@pytest.mark.asyncio
+async def test_a_guest_with_their_own_key_may_illustrate(stored_key, platform_key):
+    """The point of the whole feature.
+
+    Guests are refused illustrations because a guest can mint a fresh workspace
+    for a fresh ceiling — an argument about the PLATFORM's money, which says
+    nothing about someone spending their own.
+    """
+    stored_key("guest-id:guest-secret")
+    platform_key("platform-key")
+
+    grant = await creds.resolve("ws-guest", is_guest=True)
+
+    assert isinstance(grant, creds.IllustrationGrant)
+    assert grant.byok is True
+
+
+@pytest.mark.asyncio
+async def test_a_guest_without_a_key_is_still_refused(stored_key, platform_key):
+    """Unchanged, and it must stay unchanged: this is the branch that protects
+    the platform's card from a signup form that asks for nothing."""
+    stored_key(None)
+    platform_key("platform-key")
+
+    refusal = await creds.resolve("ws-guest", is_guest=True)
+
+    assert isinstance(refusal, creds.IllustrationRefusal)
+    assert refusal.guest_gate is True
+    # The caller turns this into the signup prompt the page already renders,
+    # so a guest sees the way forward rather than an error.
+
+
+@pytest.mark.asyncio
+async def test_an_account_without_a_key_falls_back_to_the_platform(stored_key, platform_key):
+    stored_key(None)
+    platform_key("platform-key")
+
+    grant = await creds.resolve("ws-1", is_guest=False)
+
+    assert isinstance(grant, creds.IllustrationGrant)
+    assert grant.api_key == "platform-key"
+    # False is what makes the caller claim the daily budget. This is today's
+    # behaviour and the branch that must not change.
+    assert grant.byok is False
+
+
+@pytest.mark.asyncio
+async def test_no_key_anywhere_refuses_without_a_guest_gate(stored_key, platform_key):
+    """An operator who never set FAL_AI_API_KEY is not a signup opportunity —
+    showing this user a "create an account" wall would send them to do
+    something that would not help."""
+    stored_key(None)
+    platform_key(None)
+
+    refusal = await creds.resolve("ws-1", is_guest=False)
+
+    assert isinstance(refusal, creds.IllustrationRefusal)
+    assert refusal.guest_gate is False
+
+
+@pytest.mark.asyncio
+async def test_no_workspace_resolves_like_no_key(stored_key, platform_key):
+    """A turn with no tenancy has no stored key to find. It must degrade to the
+    ordinary rules rather than raising inside a tool call."""
+    stored_key(None)
+    platform_key("platform-key")
+
+    grant = await creds.resolve(None, is_guest=False)
+
+    assert isinstance(grant, creds.IllustrationGrant)
+    assert grant.byok is False

--- a/tests/mutations/byok_image_key.json
+++ b/tests/mutations/byok_image_key.json
@@ -1,0 +1,56 @@
+[
+  {
+    "label": "a self-funded workspace is charged our quota too — pictures stop at 20 a day for someone paying their own bill",
+    "file": "ee/pocketpaw_ee/cloud/other_hand/router.py",
+    "find": "    if not grant.byok:\n        allowed, spent, cap = await illustration_budget.try_spend(workspace_id)",
+    "replace": "    if True:\n        allowed, spent, cap = await illustration_budget.try_spend(workspace_id)",
+    "tests": [
+      "tests/cloud/other_hand/test_illustrate_endpoint.py::TestAWorkspaceOnItsOwnKey::test_the_route_does_not_claim_our_budget"
+    ]
+  },
+  {
+    "label": "the agent's tool ignores the stored key — the more natural way in draws on the platform's account",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/other_hand.py",
+    "find": "    api_key = grant.api_key",
+    "replace": "    from pocketpaw_ee.cloud.studio import fal_edit\n\n    api_key = fal_edit.fal_api_key() or grant.api_key",
+    "tests": [
+      "tests/cloud/other_hand/test_illustrate_endpoint.py::TestAWorkspaceOnItsOwnKey::test_the_mcp_tool_does_not_claim_our_budget_either"
+    ]
+  },
+  {
+    "label": "the guest refusal moves ahead of the stored key — a guest paying their own way is refused anyway",
+    "file": "ee/pocketpaw_ee/cloud/other_hand/illustration_credentials.py",
+    "find": "    own = await byok_service.resolve_image_key(workspace_id)\n    if own:\n        return IllustrationGrant(api_key=own, byok=True)\n\n    if is_guest:",
+    "replace": "    if is_guest:\n        return IllustrationRefusal(reason=GUEST_REFUSAL, guest_gate=True)\n\n    own = await byok_service.resolve_image_key(workspace_id)\n    if own:\n        return IllustrationGrant(api_key=own, byok=True)\n\n    if False:",
+    "tests": [
+      "tests/cloud/other_hand/test_illustration_credentials.py::test_a_guest_with_their_own_key_may_illustrate"
+    ]
+  },
+  {
+    "label": "the guest refusal is dropped — a keyless guest spends platform money from a signup form that asks for nothing",
+    "file": "ee/pocketpaw_ee/cloud/other_hand/illustration_credentials.py",
+    "find": "    if is_guest:\n        return IllustrationRefusal(reason=GUEST_REFUSAL, guest_gate=True)",
+    "replace": "    if False:\n        return IllustrationRefusal(reason=GUEST_REFUSAL, guest_gate=True)",
+    "tests": [
+      "tests/cloud/other_hand/test_illustration_credentials.py::test_a_guest_without_a_key_is_still_refused"
+    ]
+  },
+  {
+    "label": "removing the LLM key drops the whole row — the user rotates one credential and silently loses the other",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "    if doc.image_encrypted_key:\n        doc.encrypted_key = \"\"",
+    "replace": "    if False:\n        doc.encrypted_key = \"\"",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestTheTwoCredentialsAreIndependent::test_removing_the_llm_key_keeps_the_image_key"
+    ]
+  },
+  {
+    "label": "the fal hint prints the secret half — a credential is displayed in a settings panel",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "    return api_key.partition(\":\")[0] if \":\" in api_key else \"\"",
+    "replace": "    return api_key",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestImageKeyDisplayColumns::test_the_hint_is_the_key_id_and_never_the_secret"
+    ]
+  }
+]

--- a/tests/mutations/byok_image_key.json
+++ b/tests/mutations/byok_image_key.json
@@ -45,6 +45,24 @@
     ]
   },
   {
+    "label": "the LLM clear names a column the document does not declare — every delete on a row that also holds an image key raises",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "        for gateway_field in (\"base_url\", \"model\"):\n            if gateway_field in type(doc).model_fields:\n                setattr(doc, gateway_field, None)",
+    "replace": "        doc.base_url = None\n        doc.model = None",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestTheTwoCredentialsAreIndependent::test_removing_the_llm_key_keeps_the_image_key"
+    ]
+  },
+  {
+    "label": "provider error text is stored raw — a gateway that echoes the submitted key writes it into a field the status API hands back",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "    return redact_output(message)[:_PROVIDER_ERROR_MAX_LEN]",
+    "replace": "    return message[:_PROVIDER_ERROR_MAX_LEN]",
+    "tests": [
+      "tests/cloud/byok/test_byok_service.py::TestStoredErrorTextCarriesNoCredential"
+    ]
+  },
+  {
     "label": "the fal hint prints the secret half — a credential is displayed in a settings panel",
     "file": "ee/pocketpaw_ee/cloud/byok/service.py",
     "find": "    return api_key.partition(\":\")[0] if \":\" in api_key else \"\"",


### PR DESCRIPTION
Illustrations are generated through fal and billed per image, on the platform's account. That is why guests are refused them outright today: a guest can mint a fresh workspace for a fresh daily ceiling, so the cap alone left a bill attached to a signup form that asks for nothing.

A workspace that brings its own fal key pays for its own pictures, and that objection disappears.

## What changes for whom

| | Today | After |
|---|---|---|
| Account, no image key | platform key, 20/day cap | unchanged |
| Account, own image key | platform key, 20/day cap | own key, no cap from us |
| Guest, no image key | refused | refused |
| Guest, own image key | refused | allowed, own key |

Two of those are silent when wrong, so both are pinned. A self-funded workspace must not also claim our daily ceiling, or it pays twice, in money and in a quota it has no reason to be inside, and nothing looks broken until the twentieth picture of the day stops for no visible reason. And a guest on their own key must be allowed, because the refusal was always an argument about our money.

## The rules live in one module now

`illustration_credentials.resolve` is asked by both entry points: the agent's `illustrate` tool and the toolbar button's route. Before this they each decided independently and agreed only because the same three checks had been written twice. The budget is claimed on exactly one branch, the platform one.

Gating only the route would never have been enough. The agent drawing when it judges a picture helps is the more natural way in.

## Storage

A second credential on the same row, not a second collection. The `workspace` index is unique, so that row already is "the workspace's own keys", and a second document would cost its own index, its own registration, and a second read on the illustrate path.

`delete_key` now clears its columns instead of dropping the row whenever an image key is still on it. It used to drop the whole document, so rotating an Anthropic key would have silently taken the illustrator with it. Both directions are tested.

## Not validated on save

fal has no free endpoint that proves a key without generating an image, so a check on save would spend money every time someone pasted one. The key is stored unvalidated and `image_last_error` is stamped the first time a generation comes back 401 or 403, which is the same signal one picture later and costs nothing. The panel copy says so rather than claiming a validation that does not happen.

The key hint needed its own helper. fal spells a credential `<key-id>:<secret>`, and the existing `_hint` splits on `-`, so it would have printed three segments of the UUID. The hint is the key id and `last4` comes from the secret.

## Routes

`PUT /byok/image-key` and `DELETE /byok/image-key`. Separate from `/key` because that route takes the whole LLM credential or nothing, so folding the image key in would mean re-pasting an Anthropic key to change an illustrator.

Remove is offered here, unlike the LLM key. Removing this one degrades to today's behaviour; removing the LLM key answers 402 on every turn.

## Tests

127 in the two touched suites. The structural guard in `test_byok_service.py` that asserts no status field can hold a credential failed on the new fields until they were justified, which is what it is for.

Mutation plan `tests/mutations/byok_image_key.json`, 6 of 6 caught.

## Scope

`image_generate` is also allow-listed on this surface and is deliberately untouched. It routes through the LiteLLM proxy on a per-tenant virtual key, so the proxy already enforces that tenant's budget and attributes the spend. Different credential, already contained.

The illustration model stays deployment-wide via `POCKETPAW_OTHER_HAND_ILLUSTRATION_MODEL`, which already points at Recraft v4 text-to-vector. A per-tenant model is not in this slice.
