### PR TITLE
Stop offering tools that can only refuse, and let a send turn them off

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,12 @@
 docs/api-reference.md — Hand-maintained reference for cloud REST endpoints
 that are not covered by the per-endpoint Mintlify pages under docs/api/.
 
+Updated: 2026-09-11 (feat/otherhand-tools-toggle) — added the "Agent chat — the
+`tools` switch" section for the new per-send request field. Written around the
+two things a client cannot infer from a `bool | None`: the field is subtractive
+only, so `true` is a no-op and cannot re-enable anything the server withdrew,
+and it governs one send rather than being a setting that sticks.
+
 Updated: 2026-09-11 (feat/byok-image-key) — added the "BYOK key management"
 section. The whole `/byok` prefix was undocumented here: five routes, of which
 two are new (`PUT` and `DELETE /byok/image-key`), plus the four `image_*`
@@ -1190,6 +1196,36 @@ Response `200`:
 conversion, a pricing-rules engine, and disputes / clawback. This endpoint
 returns a raw sum of declared values — the queryable figure those layers
 will build on later (see `outcome-spec.md`).
+
+## Agent chat — the `tools` switch
+
+`POST /cloud/chat/{scope}/{scope_id}/agent` takes an optional `tools` field on
+the request body.
+
+| Value | Effect |
+|---|---|
+| `false` | Run this turn with no tool surface at all. No custom tools and no MCP toolsets are built, so nothing can reach the wire. |
+| `true` | Nothing. Identical to omitting the field. |
+| omitted / `null` | Today's behaviour, which is what every existing client sends. |
+
+**It can only withdraw tools, never add one.** The backend forwards the flag
+only when it is exactly `false`; `true` is dropped on the floor, so a client
+cannot use this field to switch on a tool the server did not intend to offer,
+and it cannot undo a server-side withdrawal (the surface profile's
+`deny_mcp_tool_ids` is a different mechanism that the request body never
+reaches). The only direction of travel is subtractive.
+
+**It is per-send, not a setting.** The flag applies to the one turn that
+carries it and is not remembered. It is part of the agent cache key, so a
+turn asking for no tools never gets served a cached agent that was built with
+them.
+
+Two reasons a client reaches for it, both from the Otherhand kiosk: a gateway
+profile that refuses the `tools` field outright and 400s the whole turn, and a
+weaker model that fixates on a tool instead of doing the work. It is also the
+largest token lever on that surface, because the upstream prompt cache does
+not cover tool schemas — a run carrying a tool surface reads zero cached
+tokens every turn.
 
 ## Agent Activity
 

--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -289,6 +289,9 @@ async def post_agent_chat(
         # the request body; ``None`` for every older client leaves model selection
         # to the backend.
         model_override=body.model,
+        # Per-send tool switch. ``None`` for every older client, which is the
+        # legacy path; only an explicit ``False`` changes anything.
+        tools_enabled=body.tools,
         # Studio Flow build context — ride the spec to the executor so the agent
         # knows the ACTIVE FLOW ID and ``build_studio_flow`` persists into the
         # flow project the user is on (``None`` on every non-studio surface).

--- a/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
@@ -111,6 +111,20 @@ class CloudAgentChatRequest(BaseModel):
     # Argument string for ``intent="skill:<name>"`` (empty when the skill
     # was invoked bare). Reserved — not consumed by the backend yet.
     skill_args: str | None = None
+    # Per-send TOOL SWITCH (2026-09-11). ``False`` runs the turn with no tool
+    # surface at all; ``None`` (every existing client) is today's behaviour.
+    #
+    # Two reasons a user reaches for it, both observed on the Otherhand kiosk:
+    # a gateway profile that refuses the ``tools`` field outright and 400s the
+    # whole turn, and a weaker model that fixates on a tool instead of doing the
+    # work. On this surface the cost is small and the saving is not — the page
+    # is written with ``page-ops`` in ordinary text, so a tool-less turn still
+    # draws; what it loses is the agent's ability to generate an illustration.
+    #
+    # It is also the biggest token lever the surface has: the upstream prompt
+    # cache does not cover tool schemas, so a run carrying a tool surface reads
+    # zero cached tokens on every turn.
+    tools: bool | None = None
     # Surface-aware context hint (RFC: universal surface context).
     # ``surface`` is the SurfaceKind enum value the client computed from
     # ``$page.route.id`` ("home", "pockets", "pocket", "mission_control",

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -867,6 +867,10 @@ class ScopeContext:
     # ``claude_sdk_model``. ``None`` (older clients / no picker) leaves the backend's
     # own selection untouched — byte-identical to today.
     model_override: str | None = None
+    #: Per-send tool switch (2026-09-11). ``False`` runs with no tool surface;
+    #: ``None`` is the legacy path. Copied onto ``ctx`` by ``execute_run``
+    #: exactly like ``model_override`` beside it.
+    tools_enabled: bool | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/chat/runs/domain.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/domain.py
@@ -13,6 +13,8 @@ non-/sites and older clients are unchanged.
 
 Changes: 2026-07-08 (CS-13, feat/per-send-model-override) — ``RunSpec`` grows
 ``model_override``: the optional per-send model id from ``CloudAgentChatRequest.model``.
+``tools_enabled``: the optional per-send tool switch from ``CloudAgentChatRequest.tools``.
+  ``False`` runs the turn with no tool surface; ``None`` is every older client.
 Same boundary reason as ``surface`` — the HTTP handler has the value but submits a
 ``RunSpec`` to the executor, so without carrying it the executor's rebuilt ctx would
 never see the client's model choice. ``None`` (the default / older clients) leaves the
@@ -149,6 +151,7 @@ class RunSpec(BaseModel):
     # must ride the spec to survive the submit. ``None`` = backend picks the model
     # (the legacy path). Validated at the HTTP edge before it ever reaches here.
     model_override: str | None = None
+    tools_enabled: bool | None = None
     # Studio Flow build context, mirrored from ``CloudAgentChatRequest.flow_context``
     # so the executor (which rebuilds its own ctx from this spec) can inject the
     # ACTIVE FLOW ID into the agent's prompt and drive ``build_studio_flow`` into

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -344,6 +344,7 @@ import os
 import re
 import uuid
 from collections.abc import AsyncIterator
+from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
@@ -592,11 +593,62 @@ async def _resolve_entity_profile(ctx: ScopeContext) -> SurfaceProfile:
         return resolve_profile(SurfaceKind.GENERIC, SurfaceMeta())
 
     base = resolve_profile(ctx.surface_context.kind, ctx.surface_context.meta)
+    base = await _deny_tools_that_would_only_refuse(ctx, base)
     pocket_id = ctx.surface_context.meta.pocket_id
     if not pocket_id:
         return base
     override = await _load_entity_profile_override(ctx.workspace_id, pocket_id)
     return compose_entity_profile(base, override)
+
+
+#: The Otherhand drawing tools, as the bare names ``_expand_tool_ids`` resolves.
+_ILLUSTRATION_TOOLS: frozenset[str] = frozenset({"illustrate", "image_generate"})
+
+
+async def _deny_tools_that_would_only_refuse(
+    ctx: ScopeContext, base: SurfaceProfile
+) -> SurfaceProfile:
+    """Withdraw the drawing tools from a caller who cannot use them.
+
+    Observed 2026-09-11 on the live kiosk: a guest asked for a butterfly, the
+    agent called ``illustrate``, the tool refused ("needs an account"), and the
+    agent called it again — SIXTEEN times across 27 seconds, ending in a reply
+    that apologised sixteen times in one paragraph. The refusal text says "do
+    not try again this turn" and the bridge returns it rather than raising, so
+    nothing forces a stop; a weaker model simply keeps trying.
+
+    The wording was never the fix. A tool that will refuse every call is a tool
+    the agent should not have, so it is withdrawn before the run instead. The
+    turn then does the thing the page actually needs — ``page-ops`` are written
+    in ordinary text, not through a tool — and says nothing about a pen it was
+    never offered.
+
+    Only on this surface. Every other one carries neither tool, so asking
+    elsewhere would add a database read to every run in the product.
+
+    Costs one extra ``find_one`` on a turn that CAN illustrate, because the tool
+    asks the same module again when it fires. Cheaper than the alternative,
+    which is two copies of a money rule.
+    """
+    if ctx.surface_context is None or ctx.surface_context.kind is not SurfaceKind.OTHER_HAND:
+        return base
+    try:
+        from pocketpaw_ee.cloud.auth import guest_budget
+        from pocketpaw_ee.cloud.other_hand import illustration_credentials as creds
+
+        grant = await creds.resolve(
+            ctx.workspace_id,
+            is_guest=await guest_budget.load_guest(ctx.user_id) is not None,
+        )
+    except Exception:  # noqa: BLE001 — a tool surface must not fail a turn
+        logger.debug("other-hand: could not resolve illustration access", exc_info=True)
+        return base
+    if not isinstance(grant, creds.IllustrationRefusal):
+        return base
+    return replace(
+        base,
+        deny_mcp_tool_ids=frozenset(base.deny_mcp_tool_ids) | _ILLUSTRATION_TOOLS,
+    )
 
 
 def _pawbar_run_from_ctx(ctx: ScopeContext) -> dict[str, Any] | None:
@@ -1634,6 +1686,11 @@ async def _drive_agent_loop(
         # legacy path, byte-identical to today.
         if ctx.model_override:
             run_kwargs["model_override"] = ctx.model_override
+        # Per-send tool switch. Same withhold-when-empty idiom: only an explicit
+        # False is a request, so a client that never sends the field (every
+        # older one) produces a byte-identical run.
+        if ctx.tools_enabled is False:
+            run_kwargs["tools_enabled"] = False
         # --- BYOK per-turn credentials (feat/byok-guest-backend, 2026-09-01) ----
         # Resolve whose credential pays for THIS turn — the call the byok
         # service's own header always said the turn path makes, wired at last.
@@ -2294,6 +2351,7 @@ async def execute_run(spec: RunSpec) -> None:
     # model choice reaches ``_drive_agent_loop`` only via this copy. ``None`` (older
     # clients) leaves the backend's own model selection untouched.
     ctx.model_override = spec.model_override
+    ctx.tools_enabled = spec.tools_enabled
 
     # Mirror agent_router._ensure_scope_session so _drive_agent_loop's
     # title-gen guard (`if not history and ctx.session_id`) actually fires

--- a/src/pocketpaw/agents/backend.py
+++ b/src/pocketpaw/agents/backend.py
@@ -148,6 +148,27 @@ def _accepts_prompt_digest_kwarg(func: Any) -> bool:
         return False
 
 
+def _accepts_tools_enabled_kwarg(func: Any) -> bool:
+    """Does ``func`` name ``tools_enabled`` in its signature?
+
+    The same question ``_accepts_images_kwarg`` asks, for the per-send tool
+    switch (2026-09-11). Withhold-when-empty is NOT enough on its own, and this
+    is the second kwarg to learn that the hard way: only an explicit ``False``
+    rides, but the moment a user turns the switch OFF that False goes to
+    whatever backend the agent is configured for. A logged-in workspace runs on
+    ``claude_agent_sdk``, whose signature did not declare it, so every
+    tools-off turn died in ``TypeError: run() got an unexpected keyword
+    argument 'tools_enabled'``.
+
+    Withholding narrows WHEN the kwarg is forwarded; it never narrows WHERE.
+    Only the signature can do that.
+    """
+    try:
+        return "tools_enabled" in inspect.signature(func).parameters
+    except (TypeError, ValueError):  # pragma: no cover - exotic callables
+        return False
+
+
 def forward_prompt_digest(backend: Any, run_kwargs: dict[str, Any], digest: str) -> dict[str, Any]:
     """Return ``run_kwargs`` carrying ``digest`` iff ``backend`` declares it.
 

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -2078,6 +2078,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         session_handle: SessionHandle | None = None,
         model_override: str | None = None,
         exclusive_mcp_tools: bool = False,
+        tools_enabled: bool = True,
     ) -> _BuiltOptions:
         """Assemble the ``ClaudeAgentOptions`` a turn (or a prewarm) will run on.
 
@@ -2393,6 +2394,21 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # all passed explicitly below, so none of them depend on
         # setting sources. See
         # https://code.claude.com/docs/en/agent-sdk/modifying-system-prompts
+        # Per-send tool switch (2026-09-11). ``tools`` is the BASE SET and
+        # ``allowed_tools`` only filters it, so emptying the allowlist is NOT
+        # how you turn tools off here — measured in the SDK's own CLI
+        # transport, which extends the command with ``--allowed-tools`` only
+        # ``if effective_allowed_tools:``. An empty list is therefore not
+        # "allow nothing", it is "say nothing", and the CLI falls back to its
+        # DEFAULT tool set. A switch built that way would read Off and change
+        # nothing, which is the exact defect this switch already shipped once.
+        #
+        # ``tools=[]`` is the lever: the transport turns it into ``--tools ""``.
+        # The allowlist is emptied too, because it is what the warm-client cache
+        # key is built from — without that a tools-off turn would be served the
+        # client built WITH tools, the one-slot problem again.
+        if not tools_enabled:
+            allowed_tools = []
         options_kwargs = {
             "system_prompt": system_prompt_arg,
             "allowed_tools": allowed_tools,
@@ -2401,6 +2417,8 @@ class ClaudeSDKBackend(BaseAgentBackend):
             "cwd": str(resolved_cwd),
             "max_turns": self.settings.claude_sdk_max_turns or None,
         }
+        if not tools_enabled:
+            options_kwargs["tools"] = []
 
         # Load PocketPaw's bundled skills as a Claude Code *local plugin*.
         # ``setting_sources=[]`` above disables the SDK's ~/.claude/skills
@@ -2544,8 +2562,10 @@ class ClaudeSDKBackend(BaseAgentBackend):
             resolved_cwd,
         )
 
-        # Wire in MCP servers (policy-filtered)
-        mcp_servers = self._get_mcp_servers()
+        # Wire in MCP servers (policy-filtered). Skipped entirely on a
+        # tools-off turn: an MCP server is a tool source, and registering one
+        # whose ids are not on the allowlist still pays its startup.
+        mcp_servers = {} if not tools_enabled else self._get_mcp_servers()
         if mcp_servers:
             options_kwargs["mcp_servers"] = mcp_servers
             logger.info("MCP: passing %d servers to Claude SDK", len(mcp_servers))
@@ -2719,6 +2739,12 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 allow_mcp_tool_ids=allow_mcp_tool_ids,
                 skill_names=skill_names,
                 exclusive_mcp_tools=exclusive_mcp_tools,
+                # No ``tools_enabled`` here on purpose: prewarm runs BEFORE the
+                # send, so the per-send switch does not exist yet. It builds the
+                # default (tools on), and a tools-off turn therefore has a
+                # different ``allowed_tools`` and so a different cache key, and
+                # pays a cold start. That is the right trade: the alternative is
+                # prewarming a client the common case would then evict.
                 stderr_sink=[],
             )
             # Remember the digest we may have adopted a dir under, so a failed
@@ -2911,6 +2937,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         model_override: str | None = None,
         exclusive_mcp_tools: bool = False,
         system_prompt_digest: str = "",
+        tools_enabled: bool = True,
     ) -> AsyncIterator[AgentEvent]:
         """Process a message through Claude Agent SDK with streaming.
 
@@ -3087,6 +3114,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 session_handle=session_handle,
                 model_override=model_override,
                 exclusive_mcp_tools=exclusive_mcp_tools,
+                tools_enabled=tools_enabled,
                 stderr_sink=_stderr_lines,
             )
             options = _built.options

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -678,6 +678,7 @@ class AgentPool:
         on_client_built: Callable[[Any, str, Callable], None] | None = None,
         model_override: str | None = None,
         exclusive_mcp_tools: bool = False,
+        tools_enabled: bool = True,
         surface_preamble: str = "",
         surface_cache_key: str | None = None,
         byok_api_key: str | None = None,
@@ -891,6 +892,13 @@ class AgentPool:
             # False = legacy grant-union path, unchanged for every existing run.
             if exclusive_mcp_tools:
                 run_kwargs["exclusive_mcp_tools"] = exclusive_mcp_tools
+            # Per-send tool switch (2026-09-11). Same withhold-when-empty rule,
+            # and here the default carries real meaning: True is "the tool
+            # surface this run already resolved", so forwarding it always would
+            # say nothing while narrowing which backends can be called. Only an
+            # explicit False is a request, so only False rides.
+            if tools_enabled is False:
+                run_kwargs["tools_enabled"] = tools_enabled
             # BYOK: swap the SHARED backend for a private one, built for this
             # run alone. Anything that fails here (an unregistered backend, a
             # bad settings key) falls back to the shared instance rather than

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -177,7 +177,11 @@ from typing import TYPE_CHECKING, Any
 # protocol. Re-imported (not re-implemented) so ``AgentPool``'s own call sites
 # below and the existing ``from pocketpaw.agents.pool import ...`` importers
 # resolve to the ONE definition.
-from pocketpaw.agents.backend import _accepts_prompt_digest, _accepts_prompt_digest_kwarg
+from pocketpaw.agents.backend import (
+    _accepts_prompt_digest,
+    _accepts_prompt_digest_kwarg,
+    _accepts_tools_enabled_kwarg,
+)
 from pocketpaw.agents.errors import (
     AgentBackendUnavailable,
     AgentDisabled,
@@ -892,13 +896,6 @@ class AgentPool:
             # False = legacy grant-union path, unchanged for every existing run.
             if exclusive_mcp_tools:
                 run_kwargs["exclusive_mcp_tools"] = exclusive_mcp_tools
-            # Per-send tool switch (2026-09-11). Same withhold-when-empty rule,
-            # and here the default carries real meaning: True is "the tool
-            # surface this run already resolved", so forwarding it always would
-            # say nothing while narrowing which backends can be called. Only an
-            # explicit False is a request, so only False rides.
-            if tools_enabled is False:
-                run_kwargs["tools_enabled"] = tools_enabled
             # BYOK: swap the SHARED backend for a private one, built for this
             # run alone. Anything that fails here (an unregistered backend, a
             # bad settings key) falls back to the shared instance rather than
@@ -926,6 +923,29 @@ class AgentPool:
                         exc_info=True,
                     )
                     run_backend = instance.backend
+
+            # Per-send tool switch (2026-09-11). TWO gates, and the first one
+            # alone was a bug in production.
+            #
+            # Withhold-when-empty: the default True means "the tool surface this
+            # run already resolved", which says nothing, so only an explicit
+            # False is a request and only False rides. With the signature gate
+            # below in place this half no longer prevents a crash — forwarding
+            # True would be harmless, and a mutation that does so escapes the
+            # suite on purpose. It stays because it keeps ``run_kwargs``
+            # byte-identical on an ordinary turn, which is the shape every other
+            # optional kwarg in this block has.
+            #
+            # AND ask the signature. Withholding narrows WHEN the kwarg is sent;
+            # it never narrows WHERE. The moment a user turned the switch off,
+            # that False went to whatever backend their agent runs on — a
+            # logged-in workspace is on ``claude_agent_sdk`` — and every
+            # tools-off turn died in ``TypeError: run() got an unexpected
+            # keyword argument 'tools_enabled'``. Asked of ``run_backend``
+            # rather than the cached one because a BYOK run is served by a
+            # different object.
+            if tools_enabled is False and _accepts_tools_enabled_kwarg(run_backend.run):
+                run_kwargs["tools_enabled"] = tools_enabled
 
             async for event in run_backend.run(message, **run_kwargs):
                 instance.last_active = datetime.now(UTC)

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -1502,7 +1502,12 @@ class PydanticAIBackend:
         """
         return None
 
-    def _build_capabilities(self, skill_names: frozenset[str] = frozenset()) -> list:
+    def _build_capabilities(
+        self,
+        skill_names: frozenset[str] = frozenset(),
+        *,
+        tools_enabled: bool = True,
+    ) -> list:
         """Build the ``pydantic-ai-harness`` capabilities for this backend.
 
         Four of the PRD's six are wired. The other two are dropped, with the
@@ -1535,12 +1540,27 @@ class PydanticAIBackend:
           ``agents`` FOLDER on disk, and we have no in-code subagents to
           register. Wiring it with an empty list would add a capability that
           can never fire. Revisit when there is a real subagent to declare.
+
+        **``tools_enabled=False`` drops every capability that puts a tool on
+        the wire** — ``ToolSearch`` (``search_tools``), the native web tools,
+        ``Planning`` (``write_plan``), ``OverflowingToolOutput``
+        (``read_tool_result``) and skills (``load_capability``). Gating
+        ``tools=``/``toolsets=`` alone is NOT enough: a capability registers its
+        own toolset, so the four above kept a ``tools`` field on the request and
+        a gateway profile that rejects the field still answered 400
+        ``unsupported_capability``. Measured with ``FunctionModel``; see
+        ``test_tools_off_puts_no_tool_on_the_wire``. The context-management
+        capabilities (``SlidingWindow``, ``ClearToolResults``,
+        ``StepPersistence``) carry no tools and stay on.
         """
         # Built first and outside the harness gate: tool search belongs to
         # pydantic-ai core, so turning the harness off must not silently drop
         # our ranking function back to the built-in one.
         capabilities: list = []
         for build in (
+            # ``ToolSearch`` is NOT gated on ``tools_enabled``: it ranks a
+            # corpus, and with tools off the corpus is empty, so it puts
+            # nothing on the wire. Measured — gating it changed no request.
             self._build_tool_search_capability,
             self._build_thinking_capability,
             self._build_select_model_capability,
@@ -1549,7 +1569,11 @@ class PydanticAIBackend:
             cap = build()
             if cap is not None:
                 capabilities.append(cap)
-        capabilities += self._build_web_capabilities()
+        if tools_enabled:
+            # These DO need the gate: the builder reads ``_build_custom_tools``
+            # itself, so without it a tools-off run still registers a native
+            # web tool on the request.
+            capabilities += self._build_web_capabilities()
 
         if not getattr(self.settings, "pydantic_ai_harness_enabled", True):
             return capabilities
@@ -1570,15 +1594,18 @@ class PydanticAIBackend:
         capabilities += [
             SlidingWindow(max_messages=self.settings.pydantic_ai_compaction_max_messages),
             ClearToolResults(max_messages=self.settings.pydantic_ai_compaction_max_messages),
-            Planning(),
             StepPersistence(store=InMemoryStepStore(), agent_name="pocketpaw"),
         ]
-        if limit:
-            capabilities.append(
-                OverflowingToolOutput(bands=[Band(over=limit, action=Truncate(max_chars=limit))])
-            )
+        if tools_enabled:
+            capabilities.append(Planning())
+            if limit:
+                capabilities.append(
+                    OverflowingToolOutput(
+                        bands=[Band(over=limit, action=Truncate(max_chars=limit))]
+                    )
+                )
 
-        skills = self._build_skills_capability(skill_names)
+        skills = self._build_skills_capability(skill_names) if tools_enabled else None
         if skills is not None:
             capabilities.append(skills)
         return capabilities
@@ -2119,7 +2146,7 @@ class PydanticAIBackend:
             # appends to the (now empty) agent-level set per run.
             tools=tools,
             toolsets=list(mcp_toolsets) or None,
-            capabilities=self._build_capabilities(skill_names) or None,
+            capabilities=self._build_capabilities(skill_names, tools_enabled=tools_enabled) or None,
             # The agent is shared across concurrent runs; conversation state
             # rides in ``message_history`` per run, never on the agent.
             retries=2,

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -1989,6 +1989,7 @@ class PydanticAIBackend:
         allow_mcp_tool_ids: frozenset[str] | None = None,
         exclusive_mcp_tools: bool = False,
         system_prompt_digest: str = "",
+        tools_enabled: bool = True,
     ) -> Any:
         """Build (and cache) the pydantic-ai ``Agent``.
 
@@ -2023,7 +2024,9 @@ class PydanticAIBackend:
         # cache NEVER hits — every run re-instantiates the whole tool set. That
         # is not a slow path, it is a per-run cost on the thing whose entire
         # purpose is a low per-run cost, and it is invisible except as latency.
-        tools = list(self._build_custom_tools())
+        # Skipped entirely when the caller turned tools off — not built and
+        # then filtered, because the point is that none reach the wire.
+        tools = list(self._build_custom_tools()) if tools_enabled else []
 
         agent_key = (
             self.settings.pydantic_ai_model,
@@ -2058,6 +2061,10 @@ class PydanticAIBackend:
             # A DIGEST, never the key: this tuple is held in memory for the
             # process's life and lands in cache-miss logs.
             self._credential_fingerprint(),
+            # WHETHER there are tools at all. ``len(tools)`` above happens to
+            # move with it today, but it is a count and two different surfaces
+            # can share one — this says the thing itself.
+            tools_enabled,
         )
         if self._cached_agent is not None and self._cached_agent_key == agent_key:
             return self._cached_agent
@@ -2219,6 +2226,19 @@ class PydanticAIBackend:
         # backend opts in. Folded into the agent cache key so an agent built
         # under one identity is never handed to another.
         system_prompt_digest: str = "",
+        # Per-send TOOL SWITCH (2026-09-11). ``False`` builds the agent with no
+        # custom tools and no MCP toolsets at all.
+        #
+        # Two reasons a caller asks for it, both observed live: a gateway
+        # profile that refuses the ``tools`` field outright and 400s the whole
+        # turn, and a weaker model that fixates on a tool instead of answering.
+        # It is also the surface's biggest token lever — the upstream prompt
+        # cache does not cover tool schemas, so a run carrying a tool surface
+        # reads zero cached tokens every turn (measured, see the header).
+        #
+        # In the agent cache key, necessarily: the cache is ONE slot, so without
+        # it a tools-off turn would be served the agent built WITH tools.
+        tools_enabled: bool = True,
         # Accepted and deliberately unused — each is Claude-SDK plumbing with no
         # analogue here, and each is safe to drop:
         #   ``allow_sdk_tools``   ADDITIVE grant of SDK built-ins. There are no
@@ -2326,7 +2346,7 @@ class PydanticAIBackend:
                 return
 
             instructions = system_prompt or _DEFAULT_IDENTITY
-            mcp_toolsets = await self._build_mcp_tools()
+            mcp_toolsets = await self._build_mcp_tools() if tools_enabled else []
             agent = self._get_or_create_agent(
                 model,
                 instructions,
@@ -2336,6 +2356,7 @@ class PydanticAIBackend:
                 allow_mcp_tool_ids=allow_mcp_tool_ids,
                 exclusive_mcp_tools=exclusive_mcp_tools,
                 system_prompt_digest=system_prompt_digest,
+                tools_enabled=tools_enabled,
             )
 
             kwargs: dict[str, Any] = {

--- a/tests/cloud/chat/test_otherhand_tool_withdrawal.py
+++ b/tests/cloud/chat/test_otherhand_tool_withdrawal.py
@@ -1,0 +1,141 @@
+# tests/cloud/chat/test_otherhand_tool_withdrawal.py — a tool that would only
+# refuse is not offered.
+#
+# Created 2026-09-11, from a live kiosk turn. A guest asked for a butterfly. The
+# agent called ``illustrate``; the tool refused ("needs an account"); the agent
+# called it again — SIXTEEN times across 27 seconds, ending in a single reply
+# that apologised sixteen times in one paragraph.
+#
+# The refusal text already said "do not try again this turn", and the tool
+# bridge RETURNS that text rather than raising, so nothing forces a stop. The
+# wording was never going to be the fix: a weaker model simply keeps trying.
+#
+# So the tool is withdrawn before the run instead. These pin the withdrawal and,
+# just as importantly, its narrowness — it costs a database read, and a version
+# that asked on every surface would put that read in front of every turn in the
+# product.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.chat.runs import run_core
+from pocketpaw_ee.cloud.surface import SurfaceKind, SurfaceMeta, resolve_profile
+
+
+class _Ctx:
+    """The two fields the resolver reads, and nothing else."""
+
+    def __init__(self, kind):
+        self.workspace_id = "ws-1"
+        self.user_id = "u-1"
+        self.surface_context = type("_SC", (), {"kind": kind, "meta": SurfaceMeta()})()
+
+
+@pytest.fixture
+def illustration_access(monkeypatch):
+    """Control what the shared credential module answers."""
+    from pocketpaw_ee.cloud.other_hand import illustration_credentials as creds
+
+    def _set(result):
+        async def _resolve(_workspace_id, *, is_guest):
+            return result
+
+        monkeypatch.setattr(creds, "resolve", _resolve)
+
+    return _set
+
+
+@pytest.fixture(autouse=True)
+def _not_a_guest(monkeypatch):
+    from pocketpaw_ee.cloud.auth import guest_budget
+
+    async def _load(_user_id):
+        return None
+
+    monkeypatch.setattr(guest_budget, "load_guest", _load)
+
+
+BASE = resolve_profile(SurfaceKind.OTHER_HAND, SurfaceMeta())
+
+
+@pytest.mark.asyncio
+async def test_a_caller_who_cannot_illustrate_is_not_offered_the_tools(illustration_access):
+    from pocketpaw_ee.cloud.other_hand import illustration_credentials as creds
+
+    illustration_access(creds.IllustrationRefusal(reason="nope", guest_gate=True))
+
+    profile = await run_core._deny_tools_that_would_only_refuse(_Ctx(SurfaceKind.OTHER_HAND), BASE)
+
+    assert "illustrate" in profile.deny_mcp_tool_ids
+    # ``image_generate`` rides the same withdrawal: it is the other drawing tool
+    # this surface allows, and a model blocked from one reaches for the other.
+    assert "image_generate" in profile.deny_mcp_tool_ids
+
+
+@pytest.mark.asyncio
+async def test_the_surface_s_own_denies_survive(illustration_access):
+    """Folded INTO the profile, not substituted for it. The pocket-creation
+    denies are the non-negotiable ones on this surface and dropping them would
+    let 'draw me a diagram' build a POCKET."""
+    from pocketpaw_ee.cloud.other_hand import illustration_credentials as creds
+
+    illustration_access(creds.IllustrationRefusal(reason="nope"))
+
+    profile = await run_core._deny_tools_that_would_only_refuse(_Ctx(SurfaceKind.OTHER_HAND), BASE)
+
+    for tool_id in BASE.deny_mcp_tool_ids:
+        assert tool_id in profile.deny_mcp_tool_ids
+
+
+@pytest.mark.asyncio
+async def test_a_caller_who_can_illustrate_keeps_the_tools(illustration_access):
+    from pocketpaw_ee.cloud.other_hand import illustration_credentials as creds
+
+    illustration_access(creds.IllustrationGrant(api_key="k", byok=False))
+
+    profile = await run_core._deny_tools_that_would_only_refuse(_Ctx(SurfaceKind.OTHER_HAND), BASE)
+
+    assert "illustrate" not in profile.deny_mcp_tool_ids
+    assert profile is BASE, "an allowed caller should not pay for a rebuilt profile"
+
+
+@pytest.mark.asyncio
+async def test_other_surfaces_are_never_asked(monkeypatch):
+    """The narrowness assertion. Every other surface carries neither tool, so
+    asking there would add a database read to every run in the product."""
+    from pocketpaw_ee.cloud.other_hand import illustration_credentials as creds
+
+    asked: list[str | None] = []
+
+    async def _record(workspace_id, *, is_guest):
+        # Recorded rather than raised: the resolver swallows exceptions by
+        # design (it fails open), so an AssertionError in here would be caught
+        # and the test would pass whatever the code did.
+        asked.append(workspace_id)
+        return creds.IllustrationGrant(api_key="k", byok=False)
+
+    monkeypatch.setattr(creds, "resolve", _record)
+
+    base = resolve_profile(SurfaceKind.GENERIC, SurfaceMeta())
+    result = await run_core._deny_tools_that_would_only_refuse(_Ctx(SurfaceKind.GENERIC), base)
+
+    assert asked == [], "a non-drawing surface asked about illustration access"
+    assert result is base
+
+
+@pytest.mark.asyncio
+async def test_a_failure_to_decide_leaves_the_surface_alone(monkeypatch):
+    """Fails OPEN, unlike the spend gates. This is a token-and-latency
+    optimisation standing in front of a tool that refuses correctly on its own,
+    so a database blip must not cost the feature."""
+    from pocketpaw_ee.cloud.other_hand import illustration_credentials as creds
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("mongo is having a day")
+
+    monkeypatch.setattr(creds, "resolve", _boom)
+
+    assert (
+        await run_core._deny_tools_that_would_only_refuse(_Ctx(SurfaceKind.OTHER_HAND), BASE)
+        is BASE
+    )

--- a/tests/mutations/otherhand_tools_toggle.json
+++ b/tests/mutations/otherhand_tools_toggle.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "the tool surface is built anyway — a tools-off turn still sends schemas the gateway 400s on",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        tools = list(self._build_custom_tools()) if tools_enabled else []",
+    "replace": "        tools = list(self._build_custom_tools())",
+    "tests": ["tests/test_pydantic_ai_backend.py::test_tools_off_builds_an_agent_with_no_tools"]
+  },
+  {
+    "label": "the switch leaves the agent cache key — a tools-off turn is served the agent built WITH tools",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            tools_enabled,\n        )\n        if self._cached_agent is not None",
+    "replace": "        )\n        if self._cached_agent is not None",
+    "tests": ["tests/test_pydantic_ai_backend.py::test_tools_off_and_tools_on_do_not_share_a_cached_agent"]
+  },
+  {
+    "label": "tools default to OFF — every existing turn in the product silently loses its tools",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        tools_enabled: bool = True,\n        # Accepted and deliberately unused",
+    "replace": "        tools_enabled: bool = False,\n        # Accepted and deliberately unused",
+    "tests": ["tests/test_pydantic_ai_backend.py::test_tools_default_to_on"]
+  },
+  {
+    "label": "the drawing tools are offered to a caller who cannot use them — the sixteen-refusal loop returns",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "    if not isinstance(grant, creds.IllustrationRefusal):\n        return base",
+    "replace": "    if True:\n        return base",
+    "tests": ["tests/cloud/chat/test_otherhand_tool_withdrawal.py::test_a_caller_who_cannot_illustrate_is_not_offered_the_tools"]
+  },
+  {
+    "label": "the withdrawal REPLACES the surface denies — 'draw me a diagram' can build a POCKET again",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "        deny_mcp_tool_ids=frozenset(base.deny_mcp_tool_ids) | _ILLUSTRATION_TOOLS,",
+    "replace": "        deny_mcp_tool_ids=_ILLUSTRATION_TOOLS,",
+    "tests": ["tests/cloud/chat/test_otherhand_tool_withdrawal.py::test_the_surface_s_own_denies_survive"]
+  },
+  {
+    "label": "every surface pays for the lookup — a database read lands in front of every turn in the product",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "    if ctx.surface_context is None or ctx.surface_context.kind is not SurfaceKind.OTHER_HAND:\n        return base",
+    "replace": "    if ctx.surface_context is None:\n        return base",
+    "tests": ["tests/cloud/chat/test_otherhand_tool_withdrawal.py::test_other_surfaces_are_never_asked"]
+  }
+]

--- a/tests/mutations/otherhand_tools_toggle.json
+++ b/tests/mutations/otherhand_tools_toggle.json
@@ -1,44 +1,101 @@
 [
   {
-    "label": "the tool surface is built anyway — a tools-off turn still sends schemas the gateway 400s on",
+    "label": "the tool surface is built anyway \u2014 a tools-off turn still sends schemas the gateway 400s on",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "        tools = list(self._build_custom_tools()) if tools_enabled else []",
     "replace": "        tools = list(self._build_custom_tools())",
-    "tests": ["tests/test_pydantic_ai_backend.py::test_tools_off_builds_an_agent_with_no_tools"]
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_tools_off_puts_no_tool_on_the_wire"
+    ]
   },
   {
-    "label": "the switch leaves the agent cache key — a tools-off turn is served the agent built WITH tools",
+    "label": "the switch leaves the agent cache key \u2014 a tools-off turn is served the agent built WITH tools",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "            tools_enabled,\n        )\n        if self._cached_agent is not None",
     "replace": "        )\n        if self._cached_agent is not None",
-    "tests": ["tests/test_pydantic_ai_backend.py::test_tools_off_and_tools_on_do_not_share_a_cached_agent"]
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_tools_off_and_tools_on_do_not_share_a_cached_agent"
+    ]
   },
   {
-    "label": "tools default to OFF — every existing turn in the product silently loses its tools",
+    "label": "tools default to OFF \u2014 every existing turn in the product silently loses its tools",
     "file": "src/pocketpaw/agents/pydantic_ai.py",
     "find": "        tools_enabled: bool = True,\n        # Accepted and deliberately unused",
     "replace": "        tools_enabled: bool = False,\n        # Accepted and deliberately unused",
-    "tests": ["tests/test_pydantic_ai_backend.py::test_tools_default_to_on"]
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_tools_default_to_on"
+    ]
   },
   {
-    "label": "the drawing tools are offered to a caller who cannot use them — the sixteen-refusal loop returns",
+    "label": "the drawing tools are offered to a caller who cannot use them \u2014 the sixteen-refusal loop returns",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
     "find": "    if not isinstance(grant, creds.IllustrationRefusal):\n        return base",
     "replace": "    if True:\n        return base",
-    "tests": ["tests/cloud/chat/test_otherhand_tool_withdrawal.py::test_a_caller_who_cannot_illustrate_is_not_offered_the_tools"]
+    "tests": [
+      "tests/cloud/chat/test_otherhand_tool_withdrawal.py::test_a_caller_who_cannot_illustrate_is_not_offered_the_tools"
+    ]
   },
   {
-    "label": "the withdrawal REPLACES the surface denies — 'draw me a diagram' can build a POCKET again",
+    "label": "the withdrawal REPLACES the surface denies \u2014 'draw me a diagram' can build a POCKET again",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
     "find": "        deny_mcp_tool_ids=frozenset(base.deny_mcp_tool_ids) | _ILLUSTRATION_TOOLS,",
     "replace": "        deny_mcp_tool_ids=_ILLUSTRATION_TOOLS,",
-    "tests": ["tests/cloud/chat/test_otherhand_tool_withdrawal.py::test_the_surface_s_own_denies_survive"]
+    "tests": [
+      "tests/cloud/chat/test_otherhand_tool_withdrawal.py::test_the_surface_s_own_denies_survive"
+    ]
   },
   {
-    "label": "every surface pays for the lookup — a database read lands in front of every turn in the product",
+    "label": "every surface pays for the lookup \u2014 a database read lands in front of every turn in the product",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
     "find": "    if ctx.surface_context is None or ctx.surface_context.kind is not SurfaceKind.OTHER_HAND:\n        return base",
     "replace": "    if ctx.surface_context is None:\n        return base",
-    "tests": ["tests/cloud/chat/test_otherhand_tool_withdrawal.py::test_other_surfaces_are_never_asked"]
+    "tests": [
+      "tests/cloud/chat/test_otherhand_tool_withdrawal.py::test_other_surfaces_are_never_asked"
+    ]
+  },
+  {
+    "label": "capabilities ignore the switch \u2014 Planning puts write_plan back on a tools-off request",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        if tools_enabled:\n            capabilities.append(Planning())",
+    "replace": "        capabilities.append(Planning())\n        if tools_enabled:",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_tools_off_puts_no_tool_on_the_wire"
+    ]
+  },
+  {
+    "label": "the gate is total \u2014 Planning is dropped from ordinary runs too, so the todo toolset silently vanishes",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        if tools_enabled:\n            capabilities.append(Planning())",
+    "replace": "        if False:\n            capabilities.append(Planning())",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_tools_on_still_puts_the_capability_tools_on_the_wire"
+    ]
+  },
+  {
+    "label": "skills ignore the switch \u2014 load_capability rides a tools-off request",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        skills = self._build_skills_capability(skill_names) if tools_enabled else None",
+    "replace": "        skills = self._build_skills_capability(skill_names)",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_tools_off_puts_no_tool_on_the_wire"
+    ]
+  },
+  {
+    "label": "the capability call site drops the switch \u2014 every gated capability comes back",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            capabilities=self._build_capabilities(skill_names, tools_enabled=tools_enabled) or None,",
+    "replace": "            capabilities=self._build_capabilities(skill_names) or None,",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_tools_off_puts_no_tool_on_the_wire"
+    ]
+  },
+  {
+    "label": "native web tools ignore the switch \u2014 a tools-off request still registers web_search",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        if tools_enabled:\n            # These DO need the gate",
+    "replace": "        if True:\n            # These DO need the gate",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_tools_off_puts_no_tool_on_the_wire"
+    ]
   }
 ]

--- a/tests/mutations/otherhand_tools_toggle.json
+++ b/tests/mutations/otherhand_tools_toggle.json
@@ -97,5 +97,68 @@
     "tests": [
       "tests/test_pydantic_ai_backend.py::test_tools_off_puts_no_tool_on_the_wire"
     ]
+  },
+  {
+    "label": "the pool forwards the switch without asking the signature \u2014 every tools-off turn on a narrow backend dies in TypeError",
+    "file": "src/pocketpaw/agents/pool.py",
+    "find": "            if tools_enabled is False and _accepts_tools_enabled_kwarg(run_backend.run):",
+    "replace": "            if tools_enabled is False:",
+    "tests": [
+      "tests/test_tools_switch_reaches_every_backend.py::test_a_tools_off_turn_on_a_narrow_backend_does_not_crash"
+    ]
+  },
+  {
+    "label": "the signature check always says no \u2014 the switch is silently dead on every backend",
+    "file": "src/pocketpaw/agents/backend.py",
+    "find": "        return \"tools_enabled\" in inspect.signature(func).parameters",
+    "replace": "        return False",
+    "tests": [
+      "tests/test_tools_switch_reaches_every_backend.py::test_a_backend_that_declares_it_is_offered_the_kwarg"
+    ]
+  },
+  {
+    "label": "the SDK backend relies on an empty allowlist \u2014 the CLI omits the flag and falls back to its DEFAULT tools",
+    "file": "src/pocketpaw/agents/claude_sdk.py",
+    "find": "        if not tools_enabled:\n            options_kwargs[\"tools\"] = []",
+    "replace": "        if False:\n            options_kwargs[\"tools\"] = []",
+    "tests": [
+      "tests/test_tools_switch_reaches_every_backend.py::test_tools_off_sets_the_base_tool_set_empty"
+    ]
+  },
+  {
+    "label": "the base tool set is emptied on EVERY turn \u2014 the SDK backend loses all its tools",
+    "file": "src/pocketpaw/agents/claude_sdk.py",
+    "find": "        if not tools_enabled:\n            options_kwargs[\"tools\"] = []",
+    "replace": "        if True:\n            options_kwargs[\"tools\"] = []",
+    "tests": [
+      "tests/test_tools_switch_reaches_every_backend.py::test_tools_on_is_unchanged"
+    ]
+  },
+  {
+    "label": "a tools-off turn still registers every MCP server",
+    "file": "src/pocketpaw/agents/claude_sdk.py",
+    "find": "        mcp_servers = {} if not tools_enabled else self._get_mcp_servers()",
+    "replace": "        mcp_servers = self._get_mcp_servers()",
+    "tests": [
+      "tests/test_tools_switch_reaches_every_backend.py::test_tools_off_registers_no_mcp_servers"
+    ]
+  },
+  {
+    "label": "the allowlist survives a tools-off turn \u2014 the warm client built WITH tools is reused",
+    "file": "src/pocketpaw/agents/claude_sdk.py",
+    "find": "        if not tools_enabled:\n            allowed_tools = []",
+    "replace": "        if False:\n            allowed_tools = []",
+    "tests": [
+      "tests/test_tools_switch_reaches_every_backend.py::test_tools_off_empties_the_allowlist_so_the_cache_key_differs"
+    ]
+  },
+  {
+    "label": "the pool never forwards the switch \u2014 it reads Off and does nothing on every backend",
+    "file": "src/pocketpaw/agents/pool.py",
+    "find": "            if tools_enabled is False and _accepts_tools_enabled_kwarg(run_backend.run):\n                run_kwargs[\"tools_enabled\"] = tools_enabled",
+    "replace": "            if False:\n                run_kwargs[\"tools_enabled\"] = tools_enabled",
+    "tests": [
+      "tests/test_tools_switch_reaches_every_backend.py::test_a_tools_off_turn_still_reaches_a_backend_that_declares_it"
+    ]
   }
 ]

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -3204,16 +3204,70 @@ def test_a_broken_logfire_does_not_break_the_run():
 # turn still draws.
 
 
-def test_tools_off_builds_an_agent_with_no_tools():
-    built: list[object] = []
+def test_tools_off_puts_no_tool_on_the_wire():
+    """Measure what the MODEL is handed, not what the backend chose to build.
 
-    backend = _backend_with_model(TestModel(custom_output_text="ok"))
+    The first version of this test asserted only that ``_build_custom_tools``
+    was not called. It passed while ``write_plan``, ``read_tool_result``,
+    ``load_capability`` and ``search_tools`` still rode the request, because a
+    CAPABILITY registers its own toolset and capabilities were not gated. A
+    gateway profile that rejects the ``tools`` field kept answering 400
+    ``unsupported_capability`` with the switch off.
+
+    ``info.function_tools`` is everything pydantic-ai will map into the request,
+    whatever put it there. Empty here means the OpenAI mapper's ``tools or
+    OMIT`` drops the field entirely rather than sending ``tools: []`` — which is
+    what the gateway asked for ("Remove the field and resend").
+
+    Mutation that must break this: restore ``Planning()`` unconditionally in
+    ``_build_capabilities``.
+    """
+    seen: list[list[str]] = []
+
+    async def _spy(messages, info: AgentInfo):
+        params = info.model_request_parameters
+        # function tools AND native ones: a native web tool is not a function
+        # tool, and it is still a ``tools`` entry on the request.
+        seen.append(
+            sorted(t.name for t in info.function_tools)
+            + sorted(type(t).__name__ for t in getattr(params, "native_tools", ()))
+        )
+        yield "ok"
+
+    # Skills and native web tools are turned ON here on purpose: each
+    # contributes a tool through a CAPABILITY rather than the tool list, and
+    # at the helper's defaults the gate on each would be untested. A stream
+    # spy never calls a tool, so the retry loop the helper's default exists
+    # to avoid cannot happen.
+    backend = _backend_with_model(
+        FunctionModel(stream_function=_spy),
+        pydantic_ai_skills_enabled=True,
+        pydantic_ai_native_web_tools=True,
+    )
     backend._custom_tools = None  # force the real builder to run if it is called
-    backend._build_custom_tools = lambda: built.append("built") or []  # type: ignore[method-assign]
 
     asyncio.run(_collect(backend, "hi", session_key="s1", tools_enabled=False))
 
-    assert built == [], "the tool surface was built on a run that asked for none"
+    assert seen == [[]], f"tools off still put {seen} on the wire"
+
+
+def test_tools_on_still_puts_the_capability_tools_on_the_wire():
+    """The other half of the gate: the default path is unchanged.
+
+    Without this, deleting ``Planning()`` outright would pass the tools-off
+    test and silently remove the todo toolset from every ordinary run.
+    """
+    seen: list[list[str]] = []
+
+    async def _spy(messages, info: AgentInfo):
+        seen.append(sorted(t.name for t in info.function_tools))
+        yield "ok"
+
+    backend = _backend_with_model(FunctionModel(stream_function=_spy))
+
+    asyncio.run(_collect(backend, "hi", session_key="s1"))
+
+    assert seen and "write_plan" in seen[0], f"the planning toolset vanished: {seen}"
 
 
 def test_tools_off_and_tools_on_do_not_share_a_cached_agent():

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -3193,3 +3193,62 @@ def test_a_broken_logfire_does_not_break_the_run():
         mod._CONFIGURED = original_flag
 
     assert "Instrumentation" in caps, "a dead exporter must not drop instrumentation"
+
+
+# --- the per-send tool switch (2026-09-11) ----------------------------------
+#
+# Two reasons a caller turns tools off, both observed live: a gateway profile
+# that refuses the ``tools`` field outright and 400s the whole turn, and a
+# weaker model that fixates on a tool instead of answering. On the Otherhand
+# surface the page is written with ``page-ops`` in ordinary text, so a tool-less
+# turn still draws.
+
+
+def test_tools_off_builds_an_agent_with_no_tools():
+    built: list[object] = []
+
+    backend = _backend_with_model(TestModel(custom_output_text="ok"))
+    backend._custom_tools = None  # force the real builder to run if it is called
+    backend._build_custom_tools = lambda: built.append("built") or []  # type: ignore[method-assign]
+
+    asyncio.run(_collect(backend, "hi", session_key="s1", tools_enabled=False))
+
+    assert built == [], "the tool surface was built on a run that asked for none"
+
+
+def test_tools_off_and_tools_on_do_not_share_a_cached_agent():
+    """The cache is ONE slot. Without the flag in the key, a tools-off turn is
+    served the agent built WITH tools and the switch does nothing."""
+    keys: list[tuple] = []
+
+    backend = _backend_with_model(TestModel(custom_output_text="ok"))
+    real = backend._get_or_create_agent
+
+    def _watch(*args, **kwargs):
+        agent = real(*args, **kwargs)
+        keys.append(backend._cached_agent_key)
+        return agent
+
+    backend._get_or_create_agent = _watch  # type: ignore[method-assign]
+
+    async def _go():
+        await _collect(backend, "hi", session_key="s1")
+        await _collect(backend, "hi", session_key="s1", tools_enabled=False)
+
+    asyncio.run(_go())
+
+    assert keys[0] != keys[1], "a tools-off turn was served the agent built with tools"
+
+
+def test_tools_default_to_on():
+    """The legacy path. Every existing caller omits the flag and must be
+    byte-identical — this is the assertion that says the default is not a
+    silent feature flag."""
+    built: list[object] = []
+
+    backend = _backend_with_model(TestModel(custom_output_text="ok"))
+    backend._build_custom_tools = lambda: built.append("built") or []  # type: ignore[method-assign]
+
+    asyncio.run(_collect(backend, "hi", session_key="s1"))
+
+    assert built == ["built"]

--- a/tests/test_tools_switch_reaches_every_backend.py
+++ b/tests/test_tools_switch_reaches_every_backend.py
@@ -1,0 +1,240 @@
+# tests/test_tools_switch_reaches_every_backend.py — the per-send tool switch,
+# at the pool seam and on the Claude SDK backend.
+#
+# Created 2026-09-12 (fix/tools-switch-sdk-backend), after the switch crashed
+# in production with ``TypeError: run() got an unexpected keyword argument
+# 'tools_enabled'``.
+#
+# The bug worth remembering: the forward was guarded by withhold-when-empty
+# alone, on the reasoning that a default True says nothing so only an explicit
+# False should ride. That is true and it is not enough. Withholding narrows
+# WHEN the kwarg is sent, never WHERE it goes — and the moment a user actually
+# turned the switch off, that False went to whatever backend their agent runs
+# on. A logged-in workspace runs on ``claude_agent_sdk``, which did not declare
+# the parameter. The comment three lines below the forward already said this,
+# about a different kwarg.
+#
+# Mutations: tests/mutations/otherhand_tools_toggle.json.
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from pocketpaw.agents.backend import _accepts_tools_enabled_kwarg
+from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+from pocketpaw.agents.pool import AgentPool
+from pocketpaw.config import Settings
+
+
+class _NarrowBackend:
+    """A backend with the narrow signature six of the eight really have.
+
+    NO ``**kwargs``. That is the whole point: a capturing double that swallows
+    anything cannot reproduce the crash, which is why the first version of
+    this test passed while production raised ``TypeError``.
+    """
+
+    def __init__(self) -> None:
+        self.called = False
+
+    async def run(
+        self,
+        message: str,
+        *,
+        system_prompt: str | None = None,
+        history: list | None = None,
+        session_key: str | None = None,
+    ) -> AsyncIterator[object]:
+        self.called = True
+        return
+        yield  # pragma: no cover — makes this an async generator
+
+
+class _WideBackend:
+    """A backend that declares the switch, like the Claude SDK one now does."""
+
+    def __init__(self) -> None:
+        self.seen: dict | None = None
+
+    async def run(
+        self,
+        message: str,
+        *,
+        system_prompt: str | None = None,
+        history: list | None = None,
+        session_key: str | None = None,
+        tools_enabled: bool = True,
+    ) -> AsyncIterator[object]:
+        self.seen = {"tools_enabled": tools_enabled}
+        return
+        yield  # pragma: no cover — makes this an async generator
+
+
+async def _drive(monkeypatch, backend, **run_kwargs) -> None:
+    pool = AgentPool()
+    inst = SimpleNamespace(
+        backend=backend,
+        soul_manager=None,
+        config={"soul_persona": "P", "system_prompt": ""},
+        last_active=datetime.now(UTC),
+        active_runs=0,
+    )
+
+    async def _fake_get(agent_id):
+        return inst
+
+    monkeypatch.setattr(pool, "get", _fake_get)
+    async for _ in pool.run("a1", "hello", "session:s1", **run_kwargs):
+        pass
+
+
+# ── the pool seam ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_tools_off_turn_on_a_narrow_backend_does_not_crash(monkeypatch) -> None:
+    """The production crash, reproduced at the seam that produced it.
+
+    The double has NO ``**kwargs`` on purpose. The pool's existing capturing
+    double does, which is exactly why nothing caught this: a double that
+    swallows every keyword cannot fail the way a real backend fails.
+
+    Mutation that must break this: drop ``_accepts_tools_enabled_kwarg`` from
+    the pool's forward.
+    """
+    backend = _NarrowBackend()
+
+    await _drive(monkeypatch, backend, tools_enabled=False)
+
+    assert backend.called, "the turn never reached the backend"
+
+
+@pytest.mark.asyncio
+async def test_a_tools_off_turn_still_reaches_a_backend_that_declares_it(
+    monkeypatch,
+) -> None:
+    """The other half. Skipping the forward entirely would pass the test above
+    and leave the switch dead everywhere.
+    """
+    backend = _WideBackend()
+
+    await _drive(monkeypatch, backend, tools_enabled=False)
+
+    assert backend.seen == {"tools_enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_a_tools_on_turn_sends_nothing(monkeypatch) -> None:
+    """Withhold-when-empty, still. A default True says nothing, so sending it
+    would only narrow which backends can be called.
+    """
+    backend = _WideBackend()
+
+    await _drive(monkeypatch, backend)
+
+    assert backend.seen == {"tools_enabled": True}, "the default was overwritten"
+
+
+def test_a_narrow_backend_is_not_offered_the_kwarg() -> None:
+    """The helper itself, in isolation."""
+
+    async def narrow_run(message, *, system_prompt=None, session_key=None):
+        yield None
+
+    assert _accepts_tools_enabled_kwarg(narrow_run) is False
+
+
+def test_a_backend_that_declares_it_is_offered_the_kwarg() -> None:
+    """The other half. Without this, a helper that always answered False would
+    pass the test above and silently disable the switch everywhere.
+    """
+
+    async def wide_run(message, *, tools_enabled: bool = True):
+        yield None
+
+    assert _accepts_tools_enabled_kwarg(wide_run) is True
+
+
+def test_the_claude_sdk_backend_declares_it() -> None:
+    """The backend the crash happened on. A signature test rather than a run
+    test because the signature IS the contract the pool asks about.
+    """
+    params = inspect.signature(ClaudeSDKBackend.run).parameters
+
+    assert "tools_enabled" in params
+    assert params["tools_enabled"].default is True, "the switch must default to on"
+
+
+# ── what "off" means on the Claude SDK backend ───────────────────────────
+
+
+def _built(tools_enabled: bool):
+    backend = ClaudeSDKBackend(Settings(agent_backend="claude_agent_sdk"))
+    return asyncio.run(
+        backend._build_options(
+            "hi",
+            system_prompt="test",
+            history=None,
+            session_key="s1",
+            deny_mcp_tool_ids=frozenset(),
+            allow_sdk_tools=frozenset(),
+            allow_mcp_tool_ids=None,
+            skill_names=frozenset(),
+            stderr_sink=[],
+            tools_enabled=tools_enabled,
+        )
+    )
+
+
+def test_tools_off_sets_the_base_tool_set_empty() -> None:
+    """``tools=[]`` is the lever, and emptying ``allowed_tools`` is NOT.
+
+    Measured in the SDK's own CLI transport: it extends the command with
+    ``--allowed-tools`` only ``if effective_allowed_tools:``. An empty allowlist
+    is therefore not "allow nothing", it is "say nothing", and the CLI falls
+    back to its DEFAULT tool set. A switch built on the allowlist alone would
+    read Off and change nothing, which is how this switch already shipped
+    broken once.
+
+    ``tools=[]`` becomes ``--tools ""``.
+
+    Mutation that must break this: drop the ``options_kwargs["tools"] = []``.
+    """
+    off = _built(False)
+
+    assert getattr(off.options, "tools", None) == []
+
+
+def test_tools_off_registers_no_mcp_servers() -> None:
+    """An MCP server is a tool source, and one whose ids are off the allowlist
+    still pays its startup.
+    """
+    off = _built(False)
+
+    assert not (getattr(off.options, "mcp_servers", None) or {})
+
+
+def test_tools_off_empties_the_allowlist_so_the_cache_key_differs() -> None:
+    """The warm-client cache key is built from ``allowed_tools``. Without this
+    a tools-off turn is served the client built WITH tools — the one-slot
+    problem this switch has already hit once on the other backend.
+    """
+    off = _built(False)
+
+    assert list(getattr(off.options, "allowed_tools", []) or []) == []
+
+
+def test_tools_on_is_unchanged() -> None:
+    """The default path. Without this, hard-coding the switch off would pass
+    every test above.
+    """
+    on = _built(True)
+
+    assert getattr(on.options, "tools", None) is None, "the base set must stay unset"
+    assert list(getattr(on.options, "allowed_tools", []) or []), "the allowlist vanished"


### PR DESCRIPTION
Stacked on #2144.

## The bug in the screenshot

A guest asked for a butterfly on the live kiosk. The agent called `illustrate`, the tool refused ("needs an account"), and the agent called it again. Sixteen times, across 27 seconds, ending in one reply that apologised sixteen times in a single paragraph.

The refusal text already said "do not try again this turn". The tool bridge **returns** that text rather than raising, so nothing forces a stop, and a weaker model simply keeps trying. The wording was never going to be the fix.

So a tool that will refuse every call is now withdrawn before the run. `_deny_tools_that_would_only_refuse` asks the same `illustration_credentials.resolve` the tool itself asks, so the rules stay in one place, and folds `illustrate` and `image_generate` into the surface deny when the answer is a refusal.

Two things about its shape:

- **This surface only.** Every other one carries neither tool, so asking elsewhere would put a database read in front of every turn in the product.
- **It fails open.** Unlike the spend gates, this is a token-and-latency optimisation standing in front of a tool that already refuses correctly on its own. A database blip must not cost the feature.

It costs one extra `find_one` on a turn that *can* illustrate, because the tool asks again when it fires. Cheaper than two copies of a money rule.

## The switch

`CloudAgentChatRequest.tools = false` runs the turn with no tool surface at all. Two reasons a user reaches for it, both from the kiosk:

- a gateway profile that refuses the `tools` field outright and 400s the whole turn (`unsupported_capability`, seen on `gpt-6-astra`);
- a weaker model that fixates on a tool instead of doing the work.

The cost on this surface is small and the saving is not. The page is written with `page-ops` in ordinary text, so a tool-less turn still draws; what it loses is the agent generating an illustration by itself.

It is also the biggest token lever the surface has. The upstream prompt cache does not cover tool schemas, so a run carrying a tool surface reads zero cached tokens on every turn. That measurement is already in the `pydantic_ai` module header.

Withhold-when-empty from the wire down: only an explicit `false` rides, so every existing client produces a byte-identical run. The flag is in the agent cache key, because that cache is one slot and without it a tools-off turn would be served the agent built with tools.

## The switch was incomplete, and the second commit finishes it

The first version gated the tool list and the MCP toolsets and stopped there. A capability registers its own toolset, so four tools still rode a tools-off request: `write_plan` from `Planning`, `read_tool_result` from `OverflowingToolOutput`, `load_capability` from skills, and a native web tool. The gateway kept answering 400 `unsupported_capability` while the switch read Off.

The tool-bearing capabilities are now gated on the same flag. The context-management ones stay on, so a tools-off turn keeps its compaction and its step record. `ToolSearch` is left alone on purpose: it ranks a corpus, and with tools off the corpus is empty, so gating it changed no request.

The reason this shipped broken is worth naming, because the test looked like a gate. It asserted that `_build_custom_tools` went uncalled, which is a true fact about a code path and not a fact about the request. Measuring the request body instead:

```
tools_enabled=True   -> "tools" key present, 39 entries
tools_enabled=False  -> no "tools" key at all
```

No key rather than an empty array matters here. The gateway asked for the field to be removed, and pydantic-ai's OpenAI mapper drops it when the list is empty.

## Tests

Passing across the four touched suites. Mutation plan `tests/mutations/otherhand_tools_toggle.json`, 11 of 11 caught, including "tools default to off", which would silently strip tools from every turn in the product.

Two mutations escaped along the way and both improved a test.

The narrowness check monkeypatched `resolve` to raise, but the resolver swallows exceptions by design, so the `AssertionError` was caught and the test passed either way. It now records whether `resolve` was called at all.

The skills gate escaped because the test helper turns skills off by default, so the capability under test was never built. `test_tools_off_puts_no_tool_on_the_wire` now turns skills and native web tools on explicitly, since each reaches the request through a capability rather than the tool list, and at the helper's defaults neither gate was covered.

## Not here

The automatic retry when a gateway answers `unsupported_capability`. The switch gives a manual fix for that profile today; the retry is its own change, and it needs a check that pydantic-ai does not wrap the error in a way that loses the `code` field.

