### PR TITLE
Uploads accept any file type, and a deployment can narrow it

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1232,6 +1232,51 @@ v1 is a plain GET for the client to poll. A push stream is the upgrade path
 if polling stops being enough — event-driven off the existing run-status
 transitions, not a faster poll.
 
+## Files — Accepted Types and Size
+
+`POST /uploads` accepts **any file type** by default. A Blender `.blend`, a
+Photoshop `.psd`, an FBX rig, a firmware image, a packet capture — none of them
+need to be registered anywhere first.
+
+This was not always true. Until 2026-09-11 the pipeline enforced an exact-match
+allowlist of about 35 browser-native document and code mimes, and anything
+outside it came back in the response's `failed[]` array with
+`code: "unsupported_mime"`. The list could only be widened by editing
+`src/pocketpaw/uploads/config.py`.
+
+**Narrowing it again is a deployment choice.**
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `POCKETPAW_UPLOAD_ALLOWED_MIMES` | `*/*` | Comma-separated policy. Entries may be exact (`application/pdf`), a family (`image/*`), or the `*/*` wildcard. Case and `;charset=…` parameters are ignored on both sides of the comparison. A blank or unparseable value falls back to `*/*` rather than locking uploads out. |
+| `POCKETPAW_UPLOAD_MAX_BYTES` | `26214400` (25 MiB) | Per-file ceiling. The ASGI request-body ceiling in `security/body_limit.py` is derived from this × `max_files_per_batch`, so raising this raises that guard with it. A file over the limit fails with `code: "too_large"`. |
+
+Example — an install that only wants images and PDFs:
+
+```bash
+POCKETPAW_UPLOAD_ALLOWED_MIMES="image/*,application/pdf"
+```
+
+**Accepting a type is not the same as rendering it inline.** This policy governs
+what may be *stored*; `INLINE_MIMES` governs what may be *served inline*. Every
+download rail serves anything outside that short set as
+`Content-Disposition: attachment`, so an uploaded `.html` or `.svg` downloads
+rather than executing on the storage origin. That set did not change when the
+type policy opened up.
+
+**What a file is recorded as.** The stored `mime` comes from, in order: magic
+bytes (which overrule a lying `Content-Type`), the client's `Content-Type` when
+it says something useful, and the filename otherwise. A browser sends
+`application/octet-stream` for anything it does not recognise, so
+`spaceship.blend` records as `application/x-blender` and keeps a `.blend` on its
+storage key. Formats the stdlib registry misses live in `_EXT_TO_MIME_EXTRAS`;
+extending it is always safe, since it decides what a file is *called*, never
+whether it is accepted.
+
+Source: `src/pocketpaw/uploads/config.py`,
+`src/pocketpaw/uploads/service.py::UploadService._upload_one` (the single gate
+every upload path goes through, OSS and cloud alike).
+
 ## Files — Content Search
 
 `POST /files/search` answers "which of my files says this?" — as distinct from

--- a/src/pocketpaw/uploads/config.py
+++ b/src/pocketpaw/uploads/config.py
@@ -1,12 +1,46 @@
-"""Upload configuration — size limits, mime allowlist, storage root."""
+"""Upload configuration — size limits, mime policy, storage root.
+
+2026-09-11 — ``allowed_mimes`` defaults to ``*/*`` instead of the ~35-type
+``DEFAULT_ALLOWED_MIMES``, which refused .blend/.psd/.fbx and everything else
+nobody listed. Narrow it per deploy with ``POCKETPAW_UPLOAD_ALLOWED_MIMES``.
+
+Safe because the type list never was the control that kept an uploaded .html
+off our origin — ``INLINE_MIMES`` is, and every download rail serves anything
+outside it as ``Content-Disposition: attachment``. That set is unchanged.
+"""
 
 from __future__ import annotations
 
+import logging
+import mimetypes
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
+#: Accepts every type. Also valid as a family form (``image/*``).
+ANY_MIME = "*/*"
+ALLOW_ANY_MIMES: frozenset[str] = frozenset({ANY_MIME})
+
+#: Comma-separated policy, e.g. ``image/*,application/pdf``.
+ALLOWED_MIMES_ENV = "POCKETPAW_UPLOAD_ALLOWED_MIMES"
+
+#: Per-file ceiling. ``security/body_limit.py`` derives the ASGI request
+#: ceiling from this x ``max_files_per_batch``, so raising it raises that too.
+MAX_BYTES_ENV = "POCKETPAW_UPLOAD_MAX_BYTES"
+
+_DEFAULT_MAX_FILE_BYTES = 25 * 1024 * 1024  # 25 MiB
+
+# What a client sends when it does not recognise the file. Means "ask the
+# filename instead", not "this is a binary blob".
+_GENERIC_MIMES: frozenset[str] = frozenset(
+    {"", "application/octet-stream", "binary/octet-stream", "application/binary"}
+)
+
 # Mimes safe to render inline (images, pdf, plain text). Everything else gets
-# Content-Disposition: attachment to avoid in-origin HTML/SVG tricks.
+# Content-Disposition: attachment to avoid in-origin HTML/SVG tricks. This is
+# the security boundary the wildcard type policy leans on — it stays short.
 INLINE_MIMES: frozenset[str] = frozenset(
     {
         "image/png",
@@ -20,6 +54,10 @@ INLINE_MIMES: frozenset[str] = frozenset(
     }
 )
 
+# The curated browser-native set. No longer the default policy (see the module
+# docstring) — kept because it still describes "types a browser names correctly
+# and we render first-class", and because callers outside the upload gate read
+# it. Set ``POCKETPAW_UPLOAD_ALLOWED_MIMES`` to restore it as a gate.
 DEFAULT_ALLOWED_MIMES: frozenset[str] = frozenset(
     {
         # Images
@@ -75,13 +113,80 @@ DEFAULT_ALLOWED_MIMES: frozenset[str] = frozenset(
 )
 
 
+def normalize_mime(raw: str | None) -> str:
+    """Strip transport noise off a content type: parameters, case, whitespace.
+
+    ``"TEXT/Plain; charset=utf-8"`` and ``"text/plain"`` are the same type, and
+    an allowlist that treats them differently rejects real uploads for a reason
+    no user can see.
+    """
+    if not raw:
+        return ""
+    return raw.split(";", 1)[0].strip().lower()
+
+
+def is_generic_mime(mime: str | None) -> bool:
+    """True when the type says nothing — callers should ask the filename."""
+    return normalize_mime(mime) in _GENERIC_MIMES
+
+
+def mime_allowed(mime: str | None, allowed: frozenset[str]) -> bool:
+    """Whether ``mime`` passes ``allowed``: ``*/*``, exact, or ``type/*``.
+
+    An unnamed type passes only under ``*/*`` — under a narrowed policy,
+    "I don't know what this is" is not a reason to let it through.
+    """
+    if ANY_MIME in allowed:
+        return True
+    norm = normalize_mime(mime)
+    if not norm:
+        return False
+    if norm in allowed:
+        return True
+    family = norm.split("/", 1)[0]
+    return f"{family}/*" in allowed
+
+
+def allowed_mimes_from_env() -> frozenset[str]:
+    """The type policy from the environment.
+
+    Unset or unparseable yields ``*/*``: a typo must not lock every upload out
+    of the product. Same fail-to-the-default rule as ``body_limit``.
+    """
+    raw = os.environ.get(ALLOWED_MIMES_ENV, "").strip()
+    if not raw:
+        return ALLOW_ANY_MIMES
+    entries = {normalize_mime(part) for part in raw.split(",")}
+    entries.discard("")
+    if not entries:
+        logger.warning("%s=%r parsed to nothing; accepting any type", ALLOWED_MIMES_ENV, raw)
+        return ALLOW_ANY_MIMES
+    return frozenset(entries)
+
+
+def _max_file_bytes_from_env() -> int:
+    """Per-file ceiling in bytes. Malformed or non-positive falls back."""
+    raw = os.environ.get(MAX_BYTES_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_MAX_FILE_BYTES
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an int; using the default", MAX_BYTES_ENV, raw)
+        return _DEFAULT_MAX_FILE_BYTES
+    if val <= 0:
+        logger.warning("%s=%d is not positive; using the default", MAX_BYTES_ENV, val)
+        return _DEFAULT_MAX_FILE_BYTES
+    return val
+
+
 @dataclass
 class UploadSettings:
     """Static configuration for the upload pipeline."""
 
-    max_file_bytes: int = 25 * 1024 * 1024  # 25 MiB
+    max_file_bytes: int = field(default_factory=_max_file_bytes_from_env)
     max_files_per_batch: int = 50
-    allowed_mimes: frozenset[str] = field(default_factory=lambda: DEFAULT_ALLOWED_MIMES)
+    allowed_mimes: frozenset[str] = field(default_factory=allowed_mimes_from_env)
     local_root: Path = field(default_factory=lambda: Path.home() / ".pocketpaw" / "uploads")
 
 
@@ -135,6 +240,99 @@ _MIME_TO_EXT: dict[str, str] = {
 }
 
 
-def extension_for(mime: str) -> str:
-    """Map a canonical mime type to a file extension. Returns ``""`` if unknown."""
-    return _MIME_TO_EXT.get(mime, "")
+# Extensions the stdlib ``mimetypes`` registry does not know. Not a gate — the
+# policy accepts unknown types regardless; this only decides what a file is
+# RECORDED as, so extending it is always safe.
+_EXT_TO_MIME_EXTRAS: dict[str, str] = {
+    # Creative suites
+    ".blend": "application/x-blender",
+    ".blend1": "application/x-blender",
+    ".blend2": "application/x-blender",
+    ".psd": "image/vnd.adobe.photoshop",
+    ".psb": "image/vnd.adobe.photoshop",
+    ".ai": "application/vnd.adobe.illustrator",
+    ".xd": "application/vnd.adobe.xd",
+    ".sketch": "application/x-sketch",
+    ".fig": "application/x-figma",
+    ".afdesign": "application/x-affinity-designer",
+    ".afphoto": "application/x-affinity-photo",
+    ".procreate": "application/x-procreate",
+    ".kra": "application/x-krita",
+    ".xcf": "image/x-xcf",
+    ".aep": "application/x-after-effects",
+    ".prproj": "application/x-premiere-project",
+    # 3D / CAD interchange
+    ".fbx": "model/fbx",
+    ".obj": "model/obj",
+    ".stl": "model/stl",
+    ".dae": "model/vnd.collada+xml",
+    ".3ds": "application/x-3ds",
+    ".glb": "model/gltf-binary",
+    ".gltf": "model/gltf+json",
+    ".usd": "model/vnd.usd",
+    ".usda": "model/vnd.usda",
+    ".usdc": "model/vnd.usdc",
+    ".usdz": "model/vnd.usdz+zip",
+    ".step": "model/step",
+    ".stp": "model/step",
+    ".iges": "model/iges",
+    ".igs": "model/iges",
+    ".ifc": "application/x-step",
+    ".dwg": "image/vnd.dwg",
+    ".dxf": "image/vnd.dxf",
+    ".skp": "application/vnd.sketchup.skp",
+    # Archives and data
+    ".7z": "application/x-7z-compressed",
+    ".rar": "application/vnd.rar",
+    ".zst": "application/zstd",
+    ".parquet": "application/vnd.apache.parquet",
+    ".sqlite": "application/vnd.sqlite3",
+    ".db": "application/vnd.sqlite3",
+    ".ipynb": "application/x-ipynb+json",
+    ".epub": "application/epub+zip",
+    # Media containers the registry misses on some platforms
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+    ".avif": "image/avif",
+    ".mkv": "video/x-matroska",
+    ".webm": "video/webm",
+    ".opus": "audio/opus",
+    ".flac": "audio/flac",
+    ".m4a": "audio/mp4",
+}
+
+
+def mime_for_filename(filename: str | None) -> str:
+    """Content type from a filename. ``""`` when there is no clue."""
+    if not filename:
+        return ""
+    suffix = Path(filename).suffix.lower()
+    if not suffix:
+        return ""
+    extra = _EXT_TO_MIME_EXTRAS.get(suffix)
+    if extra:
+        return extra
+    guessed, _ = mimetypes.guess_type(filename)
+    norm = normalize_mime(guessed)
+    return "" if norm in _GENERIC_MIMES else norm
+
+
+def extension_for(mime: str, filename: str | None = None) -> str:
+    """A storage-key extension for this upload. ``""`` when nothing is known.
+
+    Our map first (the mime may come from magic bytes that disagree with the
+    filename), then the filename's suffix — the only source for a format nobody
+    registered — then the stdlib registry, skipped for generic types because it
+    answers ``application/octet-stream`` with ``.bin`` and would mask the name.
+    """
+    norm = normalize_mime(mime)
+    mapped = _MIME_TO_EXT.get(norm, "")
+    if mapped:
+        return mapped
+    if filename:
+        suffix = Path(filename).suffix
+        if suffix:
+            return suffix.lower()
+    if norm and norm not in _GENERIC_MIMES:
+        return mimetypes.guess_extension(norm) or ""
+    return ""

--- a/src/pocketpaw/uploads/service.py
+++ b/src/pocketpaw/uploads/service.py
@@ -1,4 +1,9 @@
-"""UploadService — validates, stores, persists metadata, and generates thumbnails."""
+"""UploadService — validates, stores, persists metadata, and generates thumbnails.
+
+2026-09-11 — the type gate goes through ``config.mime_allowed`` (``*/*`` and
+``type/*`` aware) rather than set membership, and ``_sniff_mime`` takes the
+filename so a format the client cannot name keeps a real mime and extension.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +20,14 @@ from typing import Literal
 from fastapi import UploadFile
 
 from pocketpaw.uploads.adapter import StorageAdapter
-from pocketpaw.uploads.config import UploadSettings, extension_for
+from pocketpaw.uploads.config import (
+    UploadSettings,
+    extension_for,
+    is_generic_mime,
+    mime_allowed,
+    mime_for_filename,
+    normalize_mime,
+)
 from pocketpaw.uploads.errors import (
     EmptyFile,
     NotFound,
@@ -44,7 +56,12 @@ _THUMB_FORMATS: dict[str, tuple[str, str, str]] = {
 _SNIFF_BYTES = 512
 
 
-def _sniff_mime(head: bytes, fallback: str) -> str:
+def _sniff_mime(head: bytes, fallback: str, filename: str = "") -> str:
+    """Magic bytes, then the client's ``Content-Type``, then the filename.
+
+    The client is skipped when it says nothing useful (empty, octet-stream) —
+    what a browser sends for any format it does not recognise.
+    """
     if head.startswith(b"\x89PNG\r\n\x1a\n"):
         return "image/png"
     if head.startswith(b"\xff\xd8\xff"):
@@ -55,14 +72,19 @@ def _sniff_mime(head: bytes, fallback: str) -> str:
         return "image/webp"
     if head.startswith(b"%PDF-"):
         return "application/pdf"
+    claimed = normalize_mime(fallback)
     if head.startswith(b"PK\x03\x04"):
-        # ZIP container — docx/xlsx both use this. Keep fallback if it matches.
-        if fallback in (
+        # ZIP container — docx/xlsx both use this. Keep the claim if it matches;
+        # plenty of other formats are zips too (.usdz, .kra, .epub), so an
+        # unmatched claim falls through to the filename rather than "zip".
+        if claimed in (
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         ):
-            return fallback
-    return fallback
+            return claimed
+    if claimed and not is_generic_mime(claimed):
+        return claimed
+    return mime_for_filename(filename) or claimed or "application/octet-stream"
 
 
 FailCode = Literal["too_large", "unsupported_mime", "empty", "storage_error"]
@@ -155,11 +177,12 @@ class UploadService:
         if len(head) > cap:
             raise TooLarge(f"file exceeds {cap} bytes")
 
-        mime = _sniff_mime(head, file.content_type or "application/octet-stream")
-        if mime not in self._cfg.allowed_mimes:
+        filename = _basename(file.filename) or "upload"
+        mime = _sniff_mime(head, file.content_type or "", filename)
+        if not mime_allowed(mime, self._cfg.allowed_mimes):
             raise UnsupportedMime(f"mime not allowed: {mime}")
 
-        ext = extension_for(mime)
+        ext = extension_for(mime, filename)
         key = new_storage_key("chat", ext)
 
         first = head
@@ -187,7 +210,6 @@ class UploadService:
             raise
 
         file_id = uuid.uuid4().hex
-        filename = _basename(file.filename) or "upload"
         record = FileRecord(
             id=file_id,
             storage_key=obj.key,

--- a/tests/cloud/uploads/conftest.py
+++ b/tests/cloud/uploads/conftest.py
@@ -141,3 +141,34 @@ async def store(beanie_upload_db):
     from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
 
     return MongoFileStore()
+
+
+def install_workspace_caller(app) -> None:
+    """Give a bare router-test app a caller the RBAC guards can resolve.
+
+    The write routes carry ``require_action_any_workspace("uploads.write")``,
+    whose first dep is fastapi-users' ``current_active_user``. A test app has no
+    auth stack, so that resolved nothing and every write answered 401 before its
+    role check ran — why 23 tests in this package were red on dev. Identity comes
+    from the same x-user / x-workspace headers the other deps use; the guard and
+    each route's own ACL still run for real.
+    """
+    from types import SimpleNamespace
+
+    from fastapi import Header
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+
+    add_error_handler(app)
+
+    async def _active_user_dep(
+        x_user: str = Header(default="u1"),
+        x_workspace: str = Header(default="w1"),
+    ):
+        return SimpleNamespace(
+            id=x_user,
+            active_workspace=x_workspace,
+            workspaces=[SimpleNamespace(workspace=x_workspace, role="owner")],
+        )
+
+    app.dependency_overrides[current_active_user] = _active_user_dep

--- a/tests/cloud/uploads/test_download_url.py
+++ b/tests/cloud/uploads/test_download_url.py
@@ -13,6 +13,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tests.cloud.uploads.conftest import install_workspace_caller
+
 PNG = b"\x89PNG\r\n\x1a\n" + b"body"
 
 
@@ -51,6 +53,8 @@ def ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
 
     app.dependency_overrides[current_user_id] = _user_dep
     app.dependency_overrides[current_workspace_id] = _workspace_dep
+    # These upload a file first, and that route 401s without a caller.
+    install_workspace_caller(app)
 
     app.include_router(uploads_module.router, prefix="/api/v1")
     return TestClient(app)

--- a/tests/cloud/uploads/test_folders.py
+++ b/tests/cloud/uploads/test_folders.py
@@ -8,6 +8,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tests.cloud.uploads.conftest import install_workspace_caller
+
 PNG = b"\x89PNG\r\n\x1a\n" + b"body"
 
 
@@ -56,6 +58,8 @@ def folder_client(tmp_path: Path, beanie_upload_db, monkeypatch):
 
     app.dependency_overrides[current_user_id] = _user_dep
     app.dependency_overrides[current_workspace_id] = _workspace_dep
+    # Without this the write routes 401 before their own ACL runs.
+    install_workspace_caller(app)
 
     app.include_router(uploads_module.router, prefix="/api/v1")
     client = TestClient(app)

--- a/tests/cloud/uploads/test_router.py
+++ b/tests/cloud/uploads/test_router.py
@@ -13,12 +13,26 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tests.cloud.uploads.conftest import install_workspace_caller
+
 PNG = b"\x89PNG\r\n\x1a\n" + b"body"
 
 
 @pytest.fixture()
 def ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
     """Build an app with the EE uploads router pointed at a tmp dir and fake deps."""
+    return _build_ee_client(tmp_path, monkeypatch)
+
+
+@pytest.fixture()
+def gated_ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
+    """The same app on a deployment that narrowed the accepted-types policy."""
+    from pocketpaw.uploads.config import DEFAULT_ALLOWED_MIMES
+
+    return _build_ee_client(tmp_path, monkeypatch, allowed_mimes=DEFAULT_ALLOWED_MIMES)
+
+
+def _build_ee_client(tmp_path: Path, monkeypatch, allowed_mimes=None) -> TestClient:
     import pocketpaw_ee.cloud.uploads.router as uploads_module
     from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
     from pocketpaw_ee.cloud.uploads.service import EEUploadService
@@ -27,9 +41,12 @@ def ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
     from pocketpaw.uploads.local import LocalStorageAdapter
 
     root = tmp_path / "u"
-    root.mkdir()
+    root.mkdir(exist_ok=True)
 
-    test_cfg = UploadSettings(local_root=root)
+    cfg_kwargs = {"local_root": root}
+    if allowed_mimes is not None:
+        cfg_kwargs["allowed_mimes"] = allowed_mimes
+    test_cfg = UploadSettings(**cfg_kwargs)
     test_adapter = LocalStorageAdapter(root=root)
     test_meta = MongoFileStore()
     test_svc = EEUploadService(adapter=test_adapter, meta=test_meta, cfg=test_cfg)
@@ -54,6 +71,9 @@ def ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
 
     app.dependency_overrides[current_user_id] = _user_dep
     app.dependency_overrides[current_workspace_id] = _workspace_dep
+
+    # The write routes 401 on a bare test app until the caller is supplied.
+    install_workspace_caller(app)
 
     app.include_router(uploads_module.router, prefix="/api/v1")
     return TestClient(app)
@@ -125,11 +145,9 @@ def test_delete_then_get_is_404(ee_client: TestClient):
 async def _seed_upload(fid: str = "seed1", user: str = "u1", ws: str = "w1") -> str:
     """Insert a live upload row directly via the store.
 
-    The guarded ``POST /uploads`` route depends on
-    ``require_action_any_workspace`` which the ee_client fixture does not
-    override (a pre-existing harness gap unrelated to FL-1 — it 401s in this
-    test env). Seeding through the store keeps these FL-1 tests hermetic while
-    still exercising the real PATCH route and the real /files read path.
+    Written when ``POST /uploads`` 401'd in this harness; that gap is fixed
+    (see ``install_workspace_caller``), but seeding keeps these FL-1 tests
+    hermetic while still exercising the real PATCH and /files read paths.
     """
     from datetime import UTC, datetime
 
@@ -239,8 +257,10 @@ async def test_patch_rejects_bad_hide_type(ee_client: TestClient):
     assert r2.status_code == 400
 
 
-def test_bulk_partial_success(ee_client: TestClient):
-    r = ee_client.post(
+def test_bulk_partial_success(gated_ee_client: TestClient):
+    """Per-file failures inside a 200. Needs a narrowed policy: the shipped
+    default accepts every type."""
+    r = gated_ee_client.post(
         "/api/v1/uploads",
         files=[
             ("files", ("good.png", PNG, "image/png")),
@@ -253,3 +273,18 @@ def test_bulk_partial_success(ee_client: TestClient):
     assert len(data["uploaded"]) == 1
     assert len(data["failed"]) == 1
     assert data["failed"][0]["code"] == "unsupported_mime"
+
+
+def test_workspace_upload_accepts_any_type(ee_client: TestClient):
+    """The reported bug at the route the client posts to: a .blend arrives with
+    no usable Content-Type and used to come back unsupported_mime."""
+    r = ee_client.post(
+        "/api/v1/uploads",
+        files=[("files", ("spaceship.blend", b"BLENDER-v303\x00\x00", "application/octet-stream"))],
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["failed"] == []
+    assert data["uploaded"][0]["filename"] == "spaceship.blend"
+    assert data["uploaded"][0]["mime"] == "application/x-blender"

--- a/tests/cloud/uploads/test_router_pocket_acl.py
+++ b/tests/cloud/uploads/test_router_pocket_acl.py
@@ -12,6 +12,8 @@ import pytest
 from fastapi import FastAPI, Header
 from fastapi.testclient import TestClient
 
+from tests.cloud.uploads.conftest import install_workspace_caller
+
 PNG = b"\x89PNG\r\n\x1a\n" + b"body"
 
 
@@ -49,6 +51,8 @@ def ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
 
     app.dependency_overrides[current_user_id] = _user_dep
     app.dependency_overrides[current_workspace_id] = _workspace_dep
+    # Without this the upload route 401s before the pocket ACL ever runs.
+    install_workspace_caller(app)
 
     app.include_router(uploads_module.router, prefix="/api/v1")
     return TestClient(app)

--- a/tests/uploads/test_router.py
+++ b/tests/uploads/test_router.py
@@ -9,14 +9,13 @@ from fastapi.testclient import TestClient
 PNG = b"\x89PNG\r\n\x1a\n" + b"body"
 
 
-@pytest.fixture()
-def client(tmp_path: Path, monkeypatch):
+def _build_client(tmp_path: Path, monkeypatch, allowed_mimes=None) -> TestClient:
     """Build an app with the uploads router pointed at a tmp dir."""
     # Patch module-level globals BEFORE importing the router
     import pocketpaw.api.v1.uploads as uploads_module
 
     root = tmp_path / "u"
-    root.mkdir()
+    root.mkdir(exist_ok=True)
 
     # Rebuild module-level service against tmp dirs
     from pocketpaw.uploads.config import UploadSettings
@@ -24,7 +23,10 @@ def client(tmp_path: Path, monkeypatch):
     from pocketpaw.uploads.local import LocalStorageAdapter
     from pocketpaw.uploads.service import UploadService
 
-    test_cfg = UploadSettings(local_root=root)
+    kwargs = {"local_root": root}
+    if allowed_mimes is not None:
+        kwargs["allowed_mimes"] = allowed_mimes
+    test_cfg = UploadSettings(**kwargs)
     test_adapter = LocalStorageAdapter(root=root)
     test_meta = JSONLFileStore(path=root / "_idx.jsonl")
     test_svc = UploadService(adapter=test_adapter, meta=test_meta, cfg=test_cfg)
@@ -34,6 +36,20 @@ def client(tmp_path: Path, monkeypatch):
     app = FastAPI()
     app.include_router(uploads_module.router, prefix="/api/v1")
     return TestClient(app)
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch):
+    """The shipped configuration: every type accepted."""
+    return _build_client(tmp_path, monkeypatch)
+
+
+@pytest.fixture()
+def gated_client(tmp_path: Path, monkeypatch):
+    """A deployment that narrowed the policy via POCKETPAW_UPLOAD_ALLOWED_MIMES."""
+    from pocketpaw.uploads.config import DEFAULT_ALLOWED_MIMES
+
+    return _build_client(tmp_path, monkeypatch, allowed_mimes=DEFAULT_ALLOWED_MIMES)
 
 
 def test_upload_single_roundtrip(client: TestClient):
@@ -55,8 +71,10 @@ def test_upload_single_roundtrip(client: TestClient):
     assert "inline" in r2.headers["content-disposition"]
 
 
-def test_bulk_upload_partial_success(client: TestClient):
-    r = client.post(
+def test_bulk_upload_partial_success(gated_client: TestClient):
+    """A 200 carrying per-file failures, not a 4xx for the whole batch. Needs
+    the narrowed policy — the default accepts the svg."""
+    r = gated_client.post(
         "/api/v1/uploads",
         files=[
             ("files", ("good.png", PNG, "image/png")),
@@ -68,6 +86,21 @@ def test_bulk_upload_partial_success(client: TestClient):
     assert len(data["uploaded"]) == 1
     assert len(data["failed"]) == 1
     assert data["failed"][0]["code"] == "unsupported_mime"
+
+
+def test_bulk_upload_accepts_unknown_types_by_default(client: TestClient):
+    """The default policy: a format nobody registered still uploads."""
+    r = client.post(
+        "/api/v1/uploads",
+        files=[
+            ("files", ("good.png", PNG, "image/png")),
+            ("files", ("scene.blend", b"BLENDER-v303\x00\x00", "application/octet-stream")),
+        ],
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert [u["filename"] for u in data["uploaded"]] == ["good.png", "scene.blend"]
+    assert data["failed"] == []
 
 
 def test_delete_then_get_not_found(client: TestClient):

--- a/tests/uploads/test_service.py
+++ b/tests/uploads/test_service.py
@@ -7,7 +7,12 @@ import pytest
 from fastapi import UploadFile
 
 from pocketpaw.uploads.adapter import StorageAdapter, StoredObject
-from pocketpaw.uploads.config import UploadSettings
+from pocketpaw.uploads.config import (
+    DEFAULT_ALLOWED_MIMES,
+    INLINE_MIMES,
+    UploadSettings,
+    mime_allowed,
+)
 from pocketpaw.uploads.errors import (
     EmptyFile,
     NotFound,
@@ -87,11 +92,41 @@ class TestUploadServiceSingle:
         with pytest.raises(TooLarge):
             await svc.upload(file, owner_id="u1", chat_id=None)
 
-    async def test_rejects_disallowed_mime(self, service):
+    async def test_accepts_any_type_by_default(self, service):
+        """The default policy is ``*/*``: a .blend used to be unsupported_mime.
+
+        It also keeps a real mime and extension — the client sends
+        octet-stream for a format it cannot name, so the filename supplies it.
+        """
+        svc, adapter, _ = service
+        file = _upload(b"BLENDER-v303\x00", "spaceship.blend", "application/octet-stream")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        assert rec.filename == "spaceship.blend"
+        assert rec.mime == "application/x-blender"
+        assert rec.storage_key.endswith(".blend")
+        assert adapter.blobs[rec.storage_key] == b"BLENDER-v303\x00"
+
+    async def test_rejects_disallowed_mime_when_narrowed(self, service):
+        """The gate still fires against a policy a deployment narrowed with
+        POCKETPAW_UPLOAD_ALLOWED_MIMES. Exact, family (``image/*``) and ``*/*``
+        all parse; an unnamed type passes only under ``*/*``."""
         svc, _, _ = service
-        file = _upload(b"<svg/>", "x.svg", "image/svg+xml")
+        svc._cfg = UploadSettings(
+            allowed_mimes=frozenset({"image/*"}),
+            local_root=svc._cfg.local_root,
+        )
+        ok = await svc.upload(_upload(PNG_MAGIC, "a.png", "image/png"), "u1", None)
+        assert ok.mime == "image/png"
         with pytest.raises(UnsupportedMime):
-            await svc.upload(file, owner_id="u1", chat_id=None)
+            await svc.upload(_upload(b"%PDF-1.7", "a.pdf", "application/pdf"), "u1", None)
+
+    async def test_accepting_a_type_does_not_make_it_inline(self):
+        """An uploaded .html/.svg is storable but still downloads: INLINE_MIMES,
+        not the type policy, is what keeps active content off our origin, and
+        it did not grow when the policy opened up."""
+        assert mime_allowed("text/html", UploadSettings().allowed_mimes)
+        assert "text/html" not in INLINE_MIMES
+        assert "image/svg+xml" not in INLINE_MIMES
 
     async def test_rejects_empty_file(self, service):
         svc, _, _ = service
@@ -126,8 +161,14 @@ class TestUploadServiceBulk:
         assert len(result.failed) == 0
 
     async def test_partial_failure(self, service):
+        # Needs a narrowed policy for the mime failure to exist — the default
+        # accepts the svg.
         svc, _, _ = service
-        svc._cfg = UploadSettings(max_file_bytes=100, local_root=svc._cfg.local_root)
+        svc._cfg = UploadSettings(
+            max_file_bytes=100,
+            allowed_mimes=DEFAULT_ALLOWED_MIMES,
+            local_root=svc._cfg.local_root,
+        )
         files = [
             _upload(PNG_MAGIC, "good.png", "image/png"),
             _upload(b"x" * 500, "big.bin", "application/octet-stream"),


### PR DESCRIPTION
Uploading a Blender `.blend` failed with `unsupported_mime`. So did `.psd`, `.fbx`, a firmware image, a packet capture — anything outside the ~35 browser-native mimes hardcoded in `DEFAULT_ALLOWED_MIMES`. Widening that list meant editing the source, which is not something an install can do.

## What changed

The default policy is `*/*`. The gate moved to the environment:

| Variable | Default | Notes |
| --- | --- | --- |
| `POCKETPAW_UPLOAD_ALLOWED_MIMES` | `*/*` | Comma-separated. Exact (`application/pdf`), family (`image/*`), or `*/*`. Case and `;charset=` are ignored on both sides. Blank or unparseable falls back to `*/*` — a typo must not refuse every upload in the product. |
| `POCKETPAW_UPLOAD_MAX_BYTES` | 25 MiB | Unchanged default. Worth knowing: this is the next wall a real `.blend` hits, and `body_limit` derives the ASGI request ceiling from it. |

One gate, one place: `UploadService._upload_one`, which the OSS route, the cloud route and every deliver path already funnel through.

## Why widening the type list is safe

The allowlist was never what kept an uploaded `.html` or `.svg` from executing on our origin — `INLINE_MIMES` is. Every download rail (the streaming route, the EE router, `EEUploadService.presigned_get`) serves anything outside that short set as `Content-Disposition: attachment`. Storing a type and rendering it inline are separate decisions and only the first one moved. `INLINE_MIMES` is unchanged, with a test saying so.

The precedent is in the tree: `artifact_delivery.py` and the cloud deliver path have relaxed this same gate for agent-produced files since ART-4. This generalises it rather than inventing it.

Unchanged: size cap, batch cap, the magic-byte sniff that overrules a lying `Content-Type`, filename sanitisation.

## Unknown formats get a name

A browser sends `application/octet-stream` for anything it cannot identify, which for these formats is most of the time. The sniffer now falls through to the filename, so `spaceship.blend` records as `application/x-blender` and keeps `.blend` on its storage key instead of landing as an extensionless blob. `_EXT_TO_MIME_EXTRAS` covers the creative-suite, 3D/CAD, archive and media formats the stdlib registry misses. It decides what a file is *called*, never whether it is accepted, so extending it is always safe.

## The test-harness repair in this diff

Not part of the fix, but it is why the fix is testable. `require_action_any_workspace("uploads.write")` resolves `current_active_user` first, and a bare router-test app has no auth stack — so every write answered 401 before its role check ran. 23 tests across `test_router`, `test_folders`, `test_router_pocket_acl` and `test_download_url` had been red on `dev` since that guard landed, which meant no coverage at all on the route this PR changes.

One shared helper in `tests/cloud/uploads/conftest.py` supplies the caller from the same `x-user` / `x-workspace` headers those fixtures already use. Nothing past the identity is faked: the guard still runs against the ACTIONS matrix and each route's own owner/admin ACL still runs after it.

`tests/uploads` + `tests/cloud/uploads`: 342 passing / 23 failing before, 468 passing after.

## Verified by hand

`.blend`, `.psd`, `.fbx`, `.sketch`, `.7z`, `.heic`, `.sqlite`, `.parquet`, `.pcap` all upload. Narrowing to `image/*,application/pdf` puts `.blend` back to `unsupported_mime` and still admits a PNG.

## Follow-ups, deliberately not here

- **Size default.** 25 MiB stands. Real `.blend` and `.sqlite` files run past it, so a deploy will want `POCKETPAW_UPLOAD_MAX_BYTES`. Raising the shipped default is a separate call — say 100 MiB to match the frontend's existing `FLYFISH_CAP_BYTES`.
- **Viewers for `.sqlite` / `.parquet` / `.pcap`.** These upload fine and then show the download card, because no reader exists for them in paw-enterprise (`categorize()` → `other` → `fetchMode: none`). Not a regression — they could not be uploaded at all before. Worth its own PR.
- **paw-enterprise needs no change.** The picker, drop handler, folder walk, `uploads/api.ts` and `files/api.ts` carry no `accept=` and no client-side type check. The rejection was entirely server-side.