### PR TITLE
fix(memory): two agent tools read and deleted across every tenant

### DIFF
--- a/ee/pocketpaw_ee/cloud/memory/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/memory/mongo_store.py
@@ -21,15 +21,38 @@ Tenant scope
 Every row is stamped with a ``workspace_id`` so multi-tenant ee deployments
 can isolate reads. For SESSION rows the adapter resolves it from the linked
 Session.workspace at write time. For LONG_TERM / DAILY rows callers populate
-``entry.metadata["workspace_id"]``. Reads expose ``workspace_id`` as a
-parameter on the adapter-specific helpers (``list_facts_in_workspace``,
-``get_session_in_workspace``); the protocol-level methods stay unscoped to
-preserve the ``MemoryStoreProtocol`` contract for OSS callers.
+``entry.metadata["workspace_id"]``.
+
+**Changed 2026-09-11.** This module previously said:
+
+    Reads expose ``workspace_id`` as a parameter on the adapter-specific
+    helpers (``list_facts_in_workspace``, ``get_session_in_workspace``); the
+    protocol-level methods stay unscoped to preserve the
+    ``MemoryStoreProtocol`` contract for OSS callers.
+
+That was true, and it was the defect. The protocol-level methods are reachable
+from ``recall``, ``clear_session`` and ``delete_session`` — built-in agent tools
+on the ``_TENANT_SAFE_TOOLS`` allowlist in ``pocketpaw.agents.pydantic_ai``,
+where the grant is annotated "scoped by the caller's own session key". Nothing
+in this adapter was scoping them, so one tenant's prompt could read every
+workspace's memory facts by regex, and delete another tenant's pocket messages.
+
+Now every protocol-level read and delete resolves the active workspace through
+``_scoped`` / ``_row_in_scope`` and refuses rather than answering globally. The
+``MemoryStoreProtocol`` signatures are unchanged, so the OSS contract holds; what
+changed is that a multi-tenant deployment with no workspace in context gets an
+empty result and a loud log line instead of everyone's data. Single-tenant and
+local installs are unaffected — ``_tenant_isolation_required()`` is false there,
+and the methods behave exactly as before.
+
+``POCKETPAW_MEMORY_ALLOW_GLOBAL_READS=1`` restores the old behaviour for an
+operator who needs it, and says so in the log every time it is consulted.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import re
 from datetime import UTC, datetime
 
@@ -82,6 +105,108 @@ def _normalize_session_key(key: str) -> str:
     return key
 
 
+_ALLOW_GLOBAL_ENV = "POCKETPAW_MEMORY_ALLOW_GLOBAL_READS"
+
+
+def _active_workspace_scope() -> str | None:
+    """The workspace bound for this execution context, or None.
+
+    Reads the OSS-core ``current_workspace`` ContextVar rather than any ee
+    ContextVar, for two reasons: it is the seam OSS core owns for exactly this
+    (``pocketpaw.stores``), and ``agent_service.attach_agent_identity`` bridges
+    the per-stream workspace onto it (ISO-3), including the second bind inside
+    prewarm that exists so in-process tools can read identity at all.
+    """
+    try:
+        from pocketpaw.stores import current_workspace  # type: ignore[import-untyped]
+
+        value = current_workspace.get()
+    except Exception:  # noqa: BLE001 — an unreadable ContextVar means "no scope"
+        return None
+    if not isinstance(value, str):
+        return None
+    return value.strip() or None
+
+
+def _tenant_isolation_required() -> bool:
+    """True when this deployment holds more than one tenant.
+
+    Fails CLOSED. If the signal cannot be read we isolate, because the unsafe
+    direction here is answering a query globally — the opposite of the pocket
+    router's bypass gate, where the unsafe direction is opening the bypass.
+    Both refuse on an unreadable signal; the returned boolean differs because
+    the dangerous answer differs.
+
+    ``is_multi_tenant_cloud()`` rather than an env flag, for the reason given in
+    PR #2126: a flag defaults to whatever an operator remembers to set, and this
+    one would have to be remembered on every deployment that ever gains a second
+    tenant.
+    """
+    if os.environ.get(_ALLOW_GLOBAL_ENV, "").strip().lower() in ("1", "true", "yes", "on"):
+        logger.warning(
+            "%s is set — memory reads are NOT tenant-scoped. Every workspace's "
+            "memory facts and pocket messages are visible to every caller.",
+            _ALLOW_GLOBAL_ENV,
+        )
+        return False
+    try:
+        from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
+
+        return bool(is_multi_tenant_cloud())
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Could not determine whether this deployment is multi-tenant; "
+            "scoping memory reads to the active workspace (fail-closed)."
+        )
+        return True
+
+
+def _scoped(filters: dict, *, field: str = "workspace_id") -> dict | None:
+    """Narrow ``filters`` to the active workspace, or None meaning "refuse".
+
+    None is the caller's signal to return an empty result rather than run the
+    query: in a multi-tenant deployment a request with no workspace in context
+    cannot be attributed, and answering it globally is the defect this closes.
+
+    Rows carrying no ``workspace_id`` (legacy and OSS-path data) fall out of a
+    scoped read. That is deliberate and matches ``list_facts_in_workspace``,
+    which has always excluded them — an unattributed row cannot be shown to a
+    tenant on the assumption that it is theirs.
+    """
+    if not _tenant_isolation_required():
+        return filters
+    workspace_id = _active_workspace_scope()
+    if not workspace_id:
+        return None
+    return {**filters, field: workspace_id}
+
+
+def _refused(operation: str) -> None:
+    """Log a refused unscoped access. Loud, because silence is the failure mode."""
+    logger.warning(
+        "MongoMemoryStore.%s refused: multi-tenant deployment with no workspace "
+        "bound in this execution context. Returning an empty result rather than "
+        "reading across tenants. Bind identity via attach_agent_identity before "
+        "the agent runs, or pass an explicit workspace via the *_in_workspace "
+        "helpers.",
+        operation,
+    )
+
+
+def _row_in_scope(row_workspace: str | None) -> bool:
+    """True when a fetched row may be shown to the current context.
+
+    Used by the id-keyed methods (``get``, ``delete``), where the check has to
+    happen after the fetch because the id IS the whole query.
+    """
+    if not _tenant_isolation_required():
+        return True
+    workspace_id = _active_workspace_scope()
+    if not workspace_id:
+        return False
+    return row_workspace == workspace_id
+
+
 def _message_to_entry(msg: Message) -> MemoryEntry:
     """Translate a pocket-context Message to a protocol MemoryEntry."""
     ts = msg.createdAt or datetime.now(UTC)
@@ -130,11 +255,17 @@ class MongoMemoryStore:
     ~~~~~~~~~~~~~~~~~~~~
     Every persisted row carries a ``workspace_id`` (derived from the linked
     ``Session.workspace`` for pocket messages, supplied via
-    ``entry.metadata["workspace_id"]`` for facts). The protocol-level read
-    methods stay tenant-agnostic to keep the ``MemoryStoreProtocol`` contract
-    unchanged for OSS callers; ee callers that need strict isolation should
-    use the adapter-specific ``*_in_workspace`` helpers, which add an explicit
-    ``workspace_id`` filter.
+    ``entry.metadata["workspace_id"]`` for facts).
+
+    The protocol-level methods keep their ``MemoryStoreProtocol`` signatures but
+    are no longer tenant-agnostic: each resolves the active workspace from the
+    ``current_workspace`` ContextVar and, on a multi-tenant deployment with no
+    workspace in context, returns an empty result rather than reading across
+    tenants. See the module docstring for why that changed.
+
+    The ``*_in_workspace`` helpers remain the right call for any ee caller that
+    already holds a request scope — they take the workspace explicitly and do
+    not depend on a ContextVar being bound.
     """
 
     async def save(self, entry: MemoryEntry) -> str:
@@ -214,9 +345,15 @@ class MongoMemoryStore:
             return None
         msg = await Message.get(oid)
         if msg and msg.context_type == "pocket":
+            if not _row_in_scope(msg.workspace_id):
+                _refused("get")
+                return None
             return _message_to_entry(msg)
         fact = await MemoryFactDoc.get(oid)
         if fact:
+            if not _row_in_scope(fact.workspace_id):
+                _refused("get")
+                return None
             return _fact_to_entry(fact)
         return None
 
@@ -227,11 +364,17 @@ class MongoMemoryStore:
             return False
         msg = await Message.get(oid)
         if msg and msg.context_type == "pocket":
+            if not _row_in_scope(msg.workspace_id):
+                _refused("delete")
+                return False
             from pocketpaw_ee.cloud.chat import message_service
 
             return await message_service.delete_message_doc_by_id(entry_id)
         fact = await MemoryFactDoc.get(oid)
         if fact:
+            if not _row_in_scope(fact.workspace_id):
+                _refused("delete")
+                return False
             await fact.delete()
             return True
         return False
@@ -252,7 +395,11 @@ class MongoMemoryStore:
                 raise NotImplementedError("tag search is not supported for SESSION messages in v1")
             if query:
                 filters["content"] = {"$regex": re.escape(query), "$options": "i"}
-            messages = await Message.find(filters).sort("-createdAt").limit(limit).to_list()
+            scoped = _scoped(filters)
+            if scoped is None:
+                _refused("search")
+                return []
+            messages = await Message.find(scoped).sort("-createdAt").limit(limit).to_list()
             return [_message_to_entry(m) for m in messages]
 
         fact_filters: dict = {}
@@ -262,7 +409,11 @@ class MongoMemoryStore:
             fact_filters["tags"] = {"$in": tags}
         if query:
             fact_filters["content"] = {"$regex": re.escape(query), "$options": "i"}
-        facts = await MemoryFactDoc.find(fact_filters).sort("-createdAt").limit(limit).to_list()
+        scoped_facts = _scoped(fact_filters)
+        if scoped_facts is None:
+            _refused("search")
+            return []
+        facts = await MemoryFactDoc.find(scoped_facts).sort("-createdAt").limit(limit).to_list()
         return [_fact_to_entry(f) for f in facts]
 
     async def get_by_type(
@@ -272,25 +423,32 @@ class MongoMemoryStore:
         user_id: str | None = None,
     ) -> list[MemoryEntry]:
         if memory_type == MemoryType.SESSION:
-            messages = (
-                await Message.find({"context_type": "pocket"})
-                .sort("-createdAt")
-                .limit(limit)
-                .to_list()
-            )
+            scoped = _scoped({"context_type": "pocket"})
+            if scoped is None:
+                _refused("get_by_type")
+                return []
+            messages = await Message.find(scoped).sort("-createdAt").limit(limit).to_list()
             return [_message_to_entry(m) for m in messages]
 
         filters: dict = {"type": memory_type.value}
         if user_id is not None:
             filters["user_id"] = user_id
-        facts = await MemoryFactDoc.find(filters).sort("-createdAt").limit(limit).to_list()
+        scoped_facts = _scoped(filters)
+        if scoped_facts is None:
+            _refused("get_by_type")
+            return []
+        facts = await MemoryFactDoc.find(scoped_facts).sort("-createdAt").limit(limit).to_list()
         return [_fact_to_entry(f) for f in facts]
 
     async def get_session(
         self, session_key: str, limit: int | None = DEFAULT_SESSION_HISTORY_LIMIT
     ) -> list[MemoryEntry]:
         key = _normalize_session_key(session_key)
-        query = Message.find({"context_type": "pocket", "session_key": key})
+        scoped = _scoped({"context_type": "pocket", "session_key": key})
+        if scoped is None:
+            _refused("get_session")
+            return []
+        query = Message.find(scoped)
         if limit is None:
             messages = await query.sort("createdAt").to_list()
         else:
@@ -306,7 +464,11 @@ class MongoMemoryStore:
         from pocketpaw_ee.cloud.chat import message_service
 
         key = _normalize_session_key(session_key)
-        messages = await Message.find({"context_type": "pocket", "session_key": key}).to_list()
+        scoped = _scoped({"context_type": "pocket", "session_key": key})
+        if scoped is None:
+            _refused("clear_session")
+            return 0
+        messages = await Message.find(scoped).to_list()
         count = 0
         for m in messages:
             if await message_service.delete_message_doc_by_id(str(m.id)):
@@ -321,8 +483,15 @@ class MongoMemoryStore:
         The adapter never auto-creates `sessions` rows — that's the API layer's
         job (`SessionService`). A None return means no user-facing session
         metadata exists, even if messages do.
+
+        ``Session`` names its tenant column ``workspace``, not ``workspace_id``
+        like ``Message`` and ``MemoryFactDoc`` — hence the explicit ``field``.
         """
-        return await Session.find_one(Session.sessionId == session_key)
+        scoped = _scoped({"sessionId": session_key}, field="workspace")
+        if scoped is None:
+            _refused("get_session_info")
+            return None
+        return await Session.find_one(scoped)
 
     async def _load_session_index_async(self, *, workspace_id: str, owner_id: str) -> dict:
         """Build a session-index dict from one owner's pocket-context Sessions.
@@ -380,7 +549,11 @@ class MongoMemoryStore:
         """
         session = await self.get_session_info(session_key)
         key = _normalize_session_key(session_key)
-        query = Message.find({"context_type": "pocket", "session_key": key})
+        scoped = _scoped({"context_type": "pocket", "session_key": key})
+        if scoped is None:
+            _refused("get_session_with_messages")
+            return None, []
+        query = Message.find(scoped)
         if limit is None:
             messages = await query.sort("createdAt").to_list()
         else:

--- a/tests/cloud/memory/test_protocol_reads_are_scoped.py
+++ b/tests/cloud/memory/test_protocol_reads_are_scoped.py
@@ -1,0 +1,395 @@
+"""The protocol-level reads must not answer across tenants.
+
+``recall``, ``clear_session`` and ``delete_session`` are built-in agent tools on
+the ``_TENANT_SAFE_TOOLS`` allowlist in ``pocketpaw.agents.pydantic_ai``, where
+the grant carries the annotation::
+
+    # memory + sessions — scoped by the caller's own session key
+
+``MongoMemoryStore`` did not scope them. ``search`` built its filter from type,
+tags and a content regex and nothing else, so a tenant's own prompt returned
+every workspace's memory facts; ``clear_session`` deleted by a model-supplied
+session key with no tenant predicate.
+
+WHY THE EXISTING ISOLATION TESTS DID NOT CATCH IT
+
+``test_workspace_isolation.py`` covers ``get_session_in_workspace`` and
+``list_facts_in_workspace`` — the helpers that take an explicit workspace and
+were always correct. The agent tools do not call those. The file named for
+workspace isolation tested the half that was already isolated.
+
+WHY A CONTEXTVAR AND NOT A PARAMETER
+
+The ``MemoryStoreProtocol`` signatures are OSS API; adding a workspace argument
+would change the contract for every implementation. ``current_workspace`` lives
+in OSS core (``pocketpaw.stores``) for exactly this, and
+``agent_service.attach_agent_identity`` bridges the per-stream workspace onto it
+— including the second bind inside prewarm that exists so in-process tools can
+read identity at all (``agent_service.py:510``).
+
+Mutations that must fail these tests: dropping either ``_scoped`` call in
+``search``, returning the unscoped filter when no workspace is bound, treating
+any present value of the override as truthy, and failing OPEN when the
+multi-tenant signal cannot be read.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pocketpaw_ee.cloud.memory import mongo_store as ms
+
+from pocketpaw.memory.protocol import MemoryEntry, MemoryType
+from pocketpaw.stores import current_workspace
+
+
+def _fact(content: str, workspace_id: str | None) -> MemoryEntry:
+    meta = {"workspace_id": workspace_id} if workspace_id else {}
+    return MemoryEntry(
+        id="",
+        type=MemoryType.LONG_TERM,
+        content=content,
+        metadata=meta,
+    )
+
+
+@pytest.fixture
+def multi_tenant(monkeypatch):
+    """Make ``is_multi_tenant_cloud()`` report a multi-tenant deployment."""
+    import sys
+    import types
+
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+    module.is_multi_tenant_cloud = lambda: True
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+    monkeypatch.delenv(ms._ALLOW_GLOBAL_ENV, raising=False)
+
+
+@pytest.fixture
+def single_tenant(monkeypatch):
+    import sys
+    import types
+
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+    module.is_multi_tenant_cloud = lambda: False
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+    monkeypatch.delenv(ms._ALLOW_GLOBAL_ENV, raising=False)
+
+
+@pytest.fixture
+def in_workspace():
+    """Bind ``current_workspace`` the way attach_agent_identity does.
+
+    No teardown, deliberately. The bind happens inside the async test body, so
+    it lands in the context of the task running that test — which is discarded
+    when the task ends, taking the binding with it. Resetting from the fixture's
+    own (outer) context raises "Token was created in a different Context", and
+    the assertion below is the cheaper guarantee: every test starts unbound.
+    """
+    assert current_workspace.get() is None, (
+        "current_workspace leaked from an earlier test — these tests rely on "
+        "each one starting unbound"
+    )
+    return current_workspace.set
+
+
+# ---------------------------------------------------------------------------
+# The finding
+# ---------------------------------------------------------------------------
+
+
+class TestSearchIsScoped:
+    async def test_recall_does_not_return_another_tenants_facts(
+        self, store, multi_tenant, in_workspace
+    ):
+        """The reproduction. One tenant's prompt must not read the other's."""
+        await store.save(_fact("alpha secret roadmap", "ws-alpha"))
+        await store.save(_fact("beta secret roadmap", "ws-beta"))
+
+        in_workspace("ws-alpha")
+        results = await store.search("secret")
+        contents = [e.content for e in results]
+
+        assert "alpha secret roadmap" in contents
+        assert "beta secret roadmap" not in contents, (
+            "recall returned another workspace's memory facts"
+        )
+
+    async def test_an_unbound_context_reads_nothing(self, store, multi_tenant):
+        """No workspace in context must mean empty, never everything.
+
+        This is the case that decides the shape of the fix. Returning the
+        unscoped filter here would look like a working search and leak the
+        whole deployment.
+        """
+        await store.save(_fact("alpha secret", "ws-alpha"))
+        await store.save(_fact("beta secret", "ws-beta"))
+
+        assert await store.search("secret") == []
+
+    async def test_session_search_is_scoped_too(self, store, multi_tenant, in_workspace):
+        """The SESSION branch builds its own filter and needs its own scoping."""
+        from pocketpaw_ee.cloud.models.session import Session
+
+        for ws, key, text in (
+            ("ws-alpha", f"k-a-{uuid.uuid4().hex[:6]}", "alpha message"),
+            ("ws-beta", f"k-b-{uuid.uuid4().hex[:6]}", "beta message"),
+        ):
+            await Session(sessionId=key, context_type="pocket", workspace=ws, owner="u").insert()
+            await store.save(
+                MemoryEntry(
+                    id="",
+                    type=MemoryType.SESSION,
+                    content=text,
+                    role="user",
+                    session_key=key,
+                )
+            )
+
+        in_workspace("ws-alpha")
+        results = await store.search("message", memory_type=MemoryType.SESSION)
+        contents = [e.content for e in results]
+
+        assert "alpha message" in contents
+        assert "beta message" not in contents
+
+
+class TestClearSessionIsScoped:
+    async def test_clear_session_cannot_delete_another_tenants_messages(
+        self, store, multi_tenant, in_workspace
+    ):
+        """``session_key`` is a model-supplied tool argument — a destructive one."""
+        from pocketpaw_ee.cloud.models.message import Message
+        from pocketpaw_ee.cloud.models.session import Session
+
+        victim_key = f"victim-{uuid.uuid4().hex[:6]}"
+        await Session(
+            sessionId=victim_key, context_type="pocket", workspace="ws-beta", owner="u2"
+        ).insert()
+        await store.save(
+            MemoryEntry(
+                id="",
+                type=MemoryType.SESSION,
+                content="beta's message",
+                role="user",
+                session_key=victim_key,
+            )
+        )
+
+        in_workspace("ws-alpha")
+        deleted = await store.clear_session(victim_key)
+
+        assert deleted == 0, "cleared another workspace's session"
+        survivors = await Message.find({"session_key": victim_key}).to_list()
+        assert len(survivors) == 1, "another workspace's messages were deleted"
+
+    async def test_clear_session_still_works_in_its_own_workspace(
+        self, store, multi_tenant, in_workspace
+    ):
+        """The scoping must not break the tool for its legitimate use."""
+        from pocketpaw_ee.cloud.models.session import Session
+
+        key = f"mine-{uuid.uuid4().hex[:6]}"
+        await Session(
+            sessionId=key, context_type="pocket", workspace="ws-alpha", owner="u1"
+        ).insert()
+        await store.save(
+            MemoryEntry(
+                id="",
+                type=MemoryType.SESSION,
+                content="my message",
+                role="user",
+                session_key=key,
+            )
+        )
+
+        in_workspace("ws-alpha")
+        assert await store.clear_session(key) == 1
+
+
+class TestIdKeyedMethodsAreScoped:
+    """``get`` and ``delete`` take an id, so the check is after the fetch."""
+
+    async def test_get_refuses_a_foreign_row(self, store, multi_tenant, in_workspace):
+        entry_id = await store.save(_fact("beta fact", "ws-beta"))
+
+        in_workspace("ws-alpha")
+        assert await store.get(entry_id) is None
+
+    async def test_delete_refuses_a_foreign_row(self, store, multi_tenant, in_workspace):
+        from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
+
+        entry_id = await store.save(_fact("beta fact", "ws-beta"))
+
+        in_workspace("ws-alpha")
+        assert await store.delete(entry_id) is False
+        assert await MemoryFactDoc.get(entry_id) is not None, "foreign fact was deleted"
+
+    async def test_get_returns_its_own_row(self, store, multi_tenant, in_workspace):
+        entry_id = await store.save(_fact("alpha fact", "ws-alpha"))
+
+        in_workspace("ws-alpha")
+        got = await store.get(entry_id)
+        assert got is not None and got.content == "alpha fact"
+
+
+class TestSessionInfoUsesTheRightFieldName:
+    """``Session`` names its tenant column ``workspace``, not ``workspace_id``.
+
+    Scoping it on the wrong field would match nothing and silently break every
+    caller, which a test asserting only "the foreign row is hidden" would pass.
+    """
+
+    async def test_own_session_is_found(self, store, multi_tenant, in_workspace):
+        from pocketpaw_ee.cloud.models.session import Session
+
+        key = f"k-{uuid.uuid4().hex[:6]}"
+        await Session(
+            sessionId=key, context_type="pocket", workspace="ws-alpha", owner="u1"
+        ).insert()
+
+        in_workspace("ws-alpha")
+        assert await store.get_session_info(key) is not None
+
+    async def test_foreign_session_is_not(self, store, multi_tenant, in_workspace):
+        from pocketpaw_ee.cloud.models.session import Session
+
+        key = f"k-{uuid.uuid4().hex[:6]}"
+        await Session(
+            sessionId=key, context_type="pocket", workspace="ws-beta", owner="u2"
+        ).insert()
+
+        in_workspace("ws-alpha")
+        assert await store.get_session_info(key) is None
+
+
+# ---------------------------------------------------------------------------
+# The deployments that must NOT change
+# ---------------------------------------------------------------------------
+
+
+class TestSingleTenantIsUnaffected:
+    async def test_a_local_install_still_searches_everything(self, store, single_tenant):
+        """No cloud DB means one tenant, and the protocol contract is preserved.
+
+        A local desktop install has no workspace bound and must keep working
+        exactly as before — this is why the gate is ``is_multi_tenant_cloud()``
+        and not "is a workspace bound".
+        """
+        await store.save(_fact("untagged legacy fact", None))
+        await store.save(_fact("tagged fact", "ws-1"))
+
+        contents = [e.content for e in await store.search("fact")]
+        assert "untagged legacy fact" in contents
+        assert "tagged fact" in contents
+
+    async def test_a_local_install_can_still_clear_a_session(self, store, single_tenant):
+        from pocketpaw_ee.cloud.models.session import Session
+
+        key = f"local-{uuid.uuid4().hex[:6]}"
+        await Session(sessionId=key, context_type="pocket", workspace="ws-1", owner="u1").insert()
+        await store.save(
+            MemoryEntry(
+                id="",
+                type=MemoryType.SESSION,
+                content="local message",
+                role="user",
+                session_key=key,
+            )
+        )
+
+        assert await store.clear_session(key) == 1
+
+
+# ---------------------------------------------------------------------------
+# The gate itself
+# ---------------------------------------------------------------------------
+
+
+class TestTheGate:
+    def test_an_unreadable_signal_isolates(self, monkeypatch):
+        """Fail CLOSED. Here that means isolating, not opening.
+
+        The pocket router's bypass gate returns False on an unreadable signal;
+        this one returns True. Both refuse — the boolean differs because the
+        dangerous answer differs.
+        """
+        import sys
+        import types
+
+        module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+
+        def _explode():
+            raise RuntimeError("no db")
+
+        module.is_multi_tenant_cloud = _explode
+        monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+        monkeypatch.delenv(ms._ALLOW_GLOBAL_ENV, raising=False)
+
+        assert ms._tenant_isolation_required() is True
+
+    def test_the_override_re_opens_it(self, multi_tenant, monkeypatch):
+        monkeypatch.setenv(ms._ALLOW_GLOBAL_ENV, "1")
+        assert ms._tenant_isolation_required() is False
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+    def test_only_an_explicit_override_re_opens_it(self, multi_tenant, monkeypatch, value):
+        """``...=0`` must not mean yes."""
+        monkeypatch.setenv(ms._ALLOW_GLOBAL_ENV, value)
+        assert ms._tenant_isolation_required() is True
+
+    def test_a_blank_workspace_is_not_a_scope(self, multi_tenant, in_workspace):
+        """An empty ContextVar must refuse, not filter on the empty string.
+
+        Filtering on ``workspace_id == ""`` would match nothing and read as a
+        working scope, which is the quiet version of the same bug.
+        """
+        in_workspace("   ")
+        assert ms._scoped({"a": 1}) is None
+
+
+class TestTheToolsThatReachThis:
+    """The allowlist grant that made this reachable, pinned.
+
+    If a future change adds another memory or session tool to
+    ``_TENANT_SAFE_TOOLS``, this test is where someone finds out that the tool
+    needs the same audit against the CLOUD store rather than the file store the
+    annotation was written for.
+    """
+
+    def test_the_known_memory_tools_are_the_ones_audited(self):
+        from pocketpaw.agents.pydantic_ai import _TENANT_SAFE_TOOLS
+
+        memory_tools = {
+            t
+            for t in _TENANT_SAFE_TOOLS
+            if t
+            in {
+                "remember",
+                "recall",
+                "forget",
+                "clear_session",
+                "delete_session",
+                "list_sessions",
+                "new_session",
+                "rename_session",
+                "switch_session",
+            }
+        }
+        assert memory_tools == {
+            "remember",
+            "recall",
+            "forget",
+            "clear_session",
+            "delete_session",
+            "list_sessions",
+            "new_session",
+            "rename_session",
+            "switch_session",
+        }, (
+            "The memory/session tool set on _TENANT_SAFE_TOOLS changed. Every tool "
+            "there reaches MongoMemoryStore through MemoryManager; re-check the new "
+            "one against the CLOUD store, not the file store the allowlist comment "
+            "describes."
+        )

--- a/tests/mutations/memory_protocol_scoping.json
+++ b/tests/mutations/memory_protocol_scoping.json
@@ -1,0 +1,72 @@
+[
+  {
+    "label": "drop scoping from the fact search — the shipped state",
+    "file": "ee/pocketpaw_ee/cloud/memory/mongo_store.py",
+    "find": "        scoped_facts = _scoped(fact_filters)\n        if scoped_facts is None:\n            _refused(\"search\")\n            return []\n        facts = await MemoryFactDoc.find(scoped_facts).sort(\"-createdAt\").limit(limit).to_list()",
+    "replace": "        facts = await MemoryFactDoc.find(fact_filters).sort(\"-createdAt\").limit(limit).to_list()",
+    "tests": ["tests/cloud/memory/test_protocol_reads_are_scoped.py"]
+  },
+  {
+    "label": "drop scoping from the SESSION search branch",
+    "file": "ee/pocketpaw_ee/cloud/memory/mongo_store.py",
+    "find": "            scoped = _scoped(filters)\n            if scoped is None:\n                _refused(\"search\")\n                return []\n            messages = await Message.find(scoped).sort(\"-createdAt\").limit(limit).to_list()",
+    "replace": "            messages = await Message.find(filters).sort(\"-createdAt\").limit(limit).to_list()",
+    "tests": ["tests/cloud/memory/test_protocol_reads_are_scoped.py"]
+  },
+  {
+    "label": "answer globally when no workspace is bound instead of refusing",
+    "file": "ee/pocketpaw_ee/cloud/memory/mongo_store.py",
+    "find": "    workspace_id = _active_workspace_scope()\n    if not workspace_id:\n        return None\n    return {**filters, field: workspace_id}",
+    "replace": "    workspace_id = _active_workspace_scope()\n    if not workspace_id:\n        return filters\n    return {**filters, field: workspace_id}",
+    "tests": ["tests/cloud/memory/test_protocol_reads_are_scoped.py"]
+  },
+  {
+    "label": "fail OPEN when the multi-tenant signal cannot be read",
+    "file": "ee/pocketpaw_ee/cloud/memory/mongo_store.py",
+    "find": "            \"scoping memory reads to the active workspace (fail-closed).\"\n        )\n        return True",
+    "replace": "            \"scoping memory reads to the active workspace (fail-closed).\"\n        )\n        return False",
+    "tests": ["tests/cloud/memory/test_protocol_reads_are_scoped.py"]
+  },
+  {
+    "label": "treat any present value of the override as truthy, so =0 means yes",
+    "file": "ee/pocketpaw_ee/cloud/memory/mongo_store.py",
+    "find": "    if os.environ.get(_ALLOW_GLOBAL_ENV, \"\").strip().lower() in (\"1\", \"true\", \"yes\", \"on\"):",
+    "replace": "    if _ALLOW_GLOBAL_ENV in os.environ:",
+    "tests": ["tests/cloud/memory/test_protocol_reads_are_scoped.py"]
+  },
+  {
+    "label": "accept a blank workspace as a scope",
+    "file": "ee/pocketpaw_ee/cloud/memory/mongo_store.py",
+    "find": "    if not isinstance(value, str):\n        return None\n    return value.strip() or None",
+    "replace": "    if not isinstance(value, str):\n        return None\n    return value",
+    "tests": ["tests/cloud/memory/test_protocol_reads_are_scoped.py"]
+  },
+  {
+    "label": "drop scoping from clear_session — the destructive half",
+    "file": "ee/pocketpaw_ee/cloud/memory/mongo_store.py",
+    "find": "        scoped = _scoped({\"context_type\": \"pocket\", \"session_key\": key})\n        if scoped is None:\n            _refused(\"clear_session\")\n            return 0\n        messages = await Message.find(scoped).to_list()",
+    "replace": "        messages = await Message.find({\"context_type\": \"pocket\", \"session_key\": key}).to_list()",
+    "tests": ["tests/cloud/memory/test_protocol_reads_are_scoped.py"]
+  },
+  {
+    "label": "let the id-keyed methods through without a tenant comparison",
+    "file": "ee/pocketpaw_ee/cloud/memory/mongo_store.py",
+    "find": "    workspace_id = _active_workspace_scope()\n    if not workspace_id:\n        return False\n    return row_workspace == workspace_id",
+    "replace": "    return True",
+    "tests": ["tests/cloud/memory/test_protocol_reads_are_scoped.py"]
+  },
+  {
+    "label": "scope get_session_info on workspace_id, the field Session does not have",
+    "file": "ee/pocketpaw_ee/cloud/memory/mongo_store.py",
+    "find": "        scoped = _scoped({\"sessionId\": session_key}, field=\"workspace\")",
+    "replace": "        scoped = _scoped({\"sessionId\": session_key})",
+    "tests": ["tests/cloud/memory/test_protocol_reads_are_scoped.py"]
+  },
+  {
+    "label": "isolate always, breaking single-tenant and local installs",
+    "file": "ee/pocketpaw_ee/cloud/memory/mongo_store.py",
+    "find": "    if not _tenant_isolation_required():\n        return filters\n    workspace_id = _active_workspace_scope()",
+    "replace": "    workspace_id = _active_workspace_scope()",
+    "tests": ["tests/cloud/memory/test_protocol_reads_are_scoped.py"]
+  }
+]


### PR DESCRIPTION
Found by a Mongo query-level tenancy audit — the pass `audit-auth.md` asked for and did not do. Full findings: `audits/audit-tenancy.md` (T-7).

## What

`recall`, `clear_session` and `delete_session` are built-in agent tools on the `_TENANT_SAFE_TOOLS` allowlist in `agents/pydantic_ai.py`, so every tenant's chat agent holds them. The grant carries this annotation:

```python
# memory + sessions — scoped by the caller's own session key
"remember", "recall", "forget", "clear_session", "delete_session",
```

`MongoMemoryStore` was not scoping them.

```python
fact_filters: dict = {}
if memory_type is not None: fact_filters["type"] = memory_type.value
if tags:                    fact_filters["tags"] = {"$in": tags}
if query:                   fact_filters["content"] = {"$regex": re.escape(query), ...}
facts = await MemoryFactDoc.find(fact_filters)...
```

No session key. No workspace. `MemoryFactDoc` carries `workspace_id` and it was not in the filter. A tenant's own prompt returned every workspace's memory facts, selected by a regex the tenant wrote. `clear_session` deleted by a model-supplied session key with the same absence of a tenant predicate.

No bypass, no forged header, no guessed id. This is the most reachable defect the audit found.

## Why it looked settled

The module documented the decision:

> the protocol-level methods stay unscoped to preserve the `MemoryStoreProtocol` contract for OSS callers

That was accurate, and it was the defect. The premise was written when the file store was the only implementation; nobody re-checked it when the tools reached a cloud store. The contract is preserved either way — the protocol signatures do not move.

## How

One choke point, not seven patches. `get`, `delete`, `get_session`, `get_session_info` and `get_session_with_messages` had the same hole — `delete` being a cross-tenant destructive primitive keyed on an id.

- `_scoped(filters)` narrows a filter to the active workspace, or returns `None` meaning *refuse*.
- `_row_in_scope(row_workspace)` is the post-fetch equivalent for the id-keyed methods, where the id is the whole query.
- The workspace comes from the OSS-core `current_workspace` ContextVar, which `attach_agent_identity` already bridges onto — including the second bind inside prewarm that exists precisely so in-process tools can read identity (`agent_service.py:510`).

Gated on `is_multi_tenant_cloud()` rather than an env flag, for the reason #2126 gave: a flag defaults to whatever an operator remembers to set, and this one would need remembering on every deployment that ever gains a second tenant. `POCKETPAW_MEMORY_ALLOW_GLOBAL_READS=1` restores the old behaviour and says so in the log each time it is consulted.

Fails closed in the direction that matters here — an unreadable multi-tenant signal isolates. That is the opposite boolean from the pocket router's bypass gate and the same intent: refuse.

**Local and single-tenant installs are unchanged.** `_tenant_isolation_required()` is false there and every method behaves exactly as before, including for legacy rows with no `workspace_id`.

## Why the existing isolation tests missed it

`tests/cloud/memory/test_workspace_isolation.py` already existed. It covers `get_session_in_workspace` and `list_facts_in_workspace` — the helpers that take an explicit workspace and were always correct. The agent tools do not call those. The file named for workspace isolation tested the half that was already isolated.

## Verification

- 10 mutations across the gate, all caught (`tests/mutations/memory_protocol_scoping.json`) — including "answer globally when no workspace is bound", "fail OPEN when the signal cannot be read", and "scope `get_session_info` on `workspace_id`", the field `Session` does not have.
- `tests/cloud/memory/` — 125 passed.
- `mutate.py --validate` — 1395 anchors across 112 plans each resolve exactly once.
- ruff check and format clean.

## Note for review

`TestTheToolsThatReachThis` pins the memory/session tool set on `_TENANT_SAFE_TOOLS`. If someone adds another tool there, that test is where they find out it needs the same audit against the **cloud** store rather than the file store the allowlist comment describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)