### PR TITLE
fix(chat): any user could join any workspace's public group

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/group_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/group_service.py
@@ -764,12 +764,35 @@ async def archive_group(group_id: str, user_id: str) -> None:
     await emit(GroupUpdated(data={"group_id": group_id, "archived": True}))
 
 
-async def join_group(group_id: str, user_id: str) -> None:
+async def join_group(group_id: str, user_id: str, workspace_id: str) -> None:
     """Join a public group or public channel. Adds user to members list.
-    Private channels must be joined via an invite flow."""
+    Private channels must be joined via an invite flow.
+
+    ``workspace_id`` is the CALLER's workspace, and the first check below is why
+    it is a required parameter rather than an optional one. Until 2026-09-11 this
+    function verified group type, channel visibility and archived state — three
+    checks, none of them tenancy — and then appended the caller to
+    ``Group.members``. ``_get_group_domain_or_404`` loads by ``_id`` alone, and
+    every workspace is seeded a ``type="public"`` group named General
+    (``seed_default_group``, called from ``auth/core.py``), so one POST against a
+    foreign group id made an outsider a real member of another tenant's
+    workspace. Membership is what the rest of the chat surface gates on, so that
+    single write opened ``send_message`` and ``patch_ui_state`` behind it.
+
+    NotFound rather than Forbidden: a group in a workspace you are not in should
+    not confirm that it exists.
+    """
     from pocketpaw_ee.cloud.chat.dto import group_to_wire_dict
 
     group = await _get_group_domain_or_404(group_id)
+    if group.workspace_id != workspace_id:
+        log_denial(
+            actor=user_id,
+            action="group.join",
+            code="group.not_found",
+            resource_id=group_id,
+        )
+        raise NotFound("group", group_id)
     if group.type == "channel" and group.visibility == "private":
         raise Forbidden(
             "group.not_joinable",

--- a/ee/pocketpaw_ee/cloud/chat/router.py
+++ b/ee/pocketpaw_ee/cloud/chat/router.py
@@ -168,8 +168,9 @@ async def archive_group(
 async def join_group(
     group_id: str,
     user_id: str = Depends(current_user_id),
+    workspace_id: str = Depends(current_workspace_id),
 ):
-    await group_service.join_group(group_id, user_id)
+    await group_service.join_group(group_id, user_id, workspace_id)
     return {"ok": True}
 
 

--- a/tests/cloud/chat/test_group_emits.py
+++ b/tests/cloud/chat/test_group_emits.py
@@ -161,7 +161,7 @@ async def test_join_group_emits_member_added_and_invalidates_cache(
 ):
     group = await _make_group(owner="u1", type="public", members=["u1"])
 
-    await group_service.join_group(str(group.id), "u2")
+    await group_service.join_group(str(group.id), "u2", "w1")
 
     events = [e for e in recording_bus.events if isinstance(e, GroupMemberAdded)]
     assert len(events) == 1
@@ -177,7 +177,7 @@ async def test_join_group_emits_member_added_and_invalidates_cache(
 async def test_join_group_no_emit_when_already_member(mongo_db, recording_bus, resolver_mock):
     group = await _make_group(owner="u1", type="public", members=["u1", "u2"])
 
-    await group_service.join_group(str(group.id), "u2")
+    await group_service.join_group(str(group.id), "u2", "w1")
 
     assert not [e for e in recording_bus.events if isinstance(e, GroupMemberAdded)]
     resolver_mock.invalidate_group.assert_not_called()
@@ -518,7 +518,7 @@ async def test_join_group_allows_channel_type(
     """Channels should be self-joinable just like public groups."""
     group = await _make_group(owner="u1", type="channel", members=["u1"])
 
-    await group_service.join_group(str(group.id), "u2")
+    await group_service.join_group(str(group.id), "u2", "w1")
 
     events = [e for e in recording_bus.events if isinstance(e, GroupMemberAdded)]
     assert len(events) == 1
@@ -535,4 +535,4 @@ async def test_join_group_still_rejects_private(mongo_db, recording_bus):
     group = await _make_group(owner="u1", type="private", members=["u1"])
 
     with pytest.raises(Forbidden):
-        await group_service.join_group(str(group.id), "u2")
+        await group_service.join_group(str(group.id), "u2", "w1")

--- a/tests/cloud/chat/test_join_group_is_tenant_scoped.py
+++ b/tests/cloud/chat/test_join_group_is_tenant_scoped.py
@@ -1,0 +1,190 @@
+"""Joining a group must be confined to the caller's own workspace.
+
+``join_group`` verified three things — channel visibility, group type, archived
+state — and none of them was tenancy. ``_get_group_domain_or_404`` loads by
+``_id`` alone, so the ``group_id`` in the path could name a group in any
+workspace on the deployment.
+
+Every tenant ships a target: ``seed_default_group`` inserts ``type="public"``
+for each new workspace (called from ``cloud/auth/core.py``), so the default
+"General" group is exactly the type this route admits.
+
+WHY THIS ONE IS WORSE THAN A READ
+
+``_add_member_doc`` appends the caller to ``Group.members``, and membership is
+what the rest of the chat surface gates on. After this write the attacker is a
+real member: ``send_message`` and ``patch_ui_state`` — which mutates
+``message.content`` — both open up. It is a cross-tenant write that converts
+every cross-tenant read in the same subsystem into a write.
+
+NotFound rather than Forbidden, because a group in a workspace you are not in
+should not confirm that it exists.
+
+Mutations that must fail these tests: dropping the workspace comparison,
+comparing against the group's own workspace instead of the caller's, and
+raising Forbidden (which is an existence oracle) instead of NotFound.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pocketpaw_ee.cloud.chat import group_service
+from pocketpaw_ee.cloud.models.group import Group as _GroupDoc
+from pocketpaw_ee.cloud.shared.errors import NotFound
+
+
+async def _empty_lookups(_groups):
+    return {}, {}
+
+
+@pytest.fixture
+def patched_lookups(monkeypatch):
+    """Replace ``_populate_lookups_for_domain_groups`` with an empty stub.
+
+    Mirrors the fixture in ``test_group_emits.py``; the success-path test
+    reaches the wire-dict build, which would otherwise need real user rows.
+    """
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.group_service._populate_lookups_for_domain_groups",
+        _empty_lookups,
+    )
+
+
+@pytest.fixture
+def resolver_mock(monkeypatch):
+    rmock = MagicMock()
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.group_service.get_resolver", lambda: rmock)
+    return rmock
+
+
+async def _group(*, workspace: str, owner: str, type: str = "public", members=None):
+    doc = _GroupDoc(
+        workspace=workspace,
+        name="General",
+        slug=f"general-{workspace}",
+        description="",
+        icon="",
+        color="",
+        type=type,
+        members=members or [owner],
+        member_roles={owner: "admin"},
+        agents=[],
+        pinned_messages=[],
+        owner=owner,
+        archived=False,
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.mark.asyncio
+async def test_an_outsider_cannot_join_another_workspaces_public_group(
+    mongo_db, recording_bus, patched_lookups, resolver_mock
+):
+    """The finding. One POST made an outsider a real member of another tenant."""
+    victim = await _group(workspace="ws-victim", owner="u-victim")
+
+    with pytest.raises(NotFound):
+        await group_service.join_group(str(victim.id), "u-attacker", "ws-attacker")
+
+    after = await _GroupDoc.get(victim.id)
+    assert "u-attacker" not in after.members, "an outsider was added to another workspace's group"
+
+
+@pytest.mark.asyncio
+async def test_the_refusal_does_not_confirm_the_group_exists(
+    mongo_db, recording_bus, patched_lookups, resolver_mock
+):
+    """A foreign group and a nonexistent one must be indistinguishable.
+
+    Forbidden here would be an existence oracle over every group id on the
+    deployment, which is most of what the read findings in this subsystem are.
+    """
+    victim = await _group(workspace="ws-victim", owner="u-victim")
+
+    with pytest.raises(NotFound) as foreign:
+        await group_service.join_group(str(victim.id), "u-attacker", "ws-attacker")
+
+    missing_id = "0" * 24
+    with pytest.raises(NotFound) as absent:
+        await group_service.join_group(missing_id, "u-attacker", "ws-attacker")
+
+    assert type(foreign.value) is type(absent.value)
+
+
+@pytest.mark.asyncio
+async def test_a_member_of_the_same_workspace_still_joins(
+    mongo_db, recording_bus, patched_lookups, resolver_mock
+):
+    """The scoping must not break the feature it guards."""
+    group = await _group(workspace="ws-1", owner="u1")
+
+    await group_service.join_group(str(group.id), "u2", "ws-1")
+
+    after = await _GroupDoc.get(group.id)
+    assert "u2" in after.members
+
+
+@pytest.mark.asyncio
+async def test_the_pre_existing_checks_still_deny_on_their_own(
+    mongo_db, recording_bus, patched_lookups, resolver_mock
+):
+    """This change only ADDS a factor; the other three must be untouched.
+
+    Written with the workspace matching so the new check cannot be what denies
+    — otherwise a mutation deleting any of the original three would escape.
+    """
+    from pocketpaw_ee.cloud.shared.errors import Forbidden
+
+    dm = await _group(workspace="ws-1", owner="u1", type="dm")
+    with pytest.raises(Forbidden):
+        await group_service.join_group(str(dm.id), "u2", "ws-1")
+
+    archived = await _group(workspace="ws-1", owner="u1")
+    archived.archived = True
+    await archived.save()
+    with pytest.raises(Forbidden):
+        await group_service.join_group(str(archived.id), "u2", "ws-1")
+
+
+@pytest.mark.asyncio
+async def test_the_route_passes_the_callers_workspace_not_the_paths(mongo_db):
+    """A helper nobody calls correctly is documentation.
+
+    Asserted against the parsed route rather than by driving it, because the
+    route needs the whole cloud dependency stack to reach a state where
+    ``current_workspace_id`` resolves.
+    """
+    import ast
+    import inspect
+    import sys
+
+    import pocketpaw_ee.cloud.chat.router  # noqa: F401 — registers the module
+
+    # ``sys.modules`` rather than the attribute: ``chat/__init__.py`` rebinds
+    # the name ``router`` to the APIRouter instance, so the dotted attribute
+    # resolves to an object inspect cannot read source from.
+    module = sys.modules["pocketpaw_ee.cloud.chat.router"]
+    tree = ast.parse(inspect.getsource(module))
+    handler = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "join_group"
+    )
+    args = {a.arg for a in handler.args.args} | {a.arg for a in handler.args.kwonlyargs}
+    assert "workspace_id" in args, (
+        "the join route does not bind current_workspace_id, so the service "
+        "check has nothing to compare against"
+    )
+
+    call = next(
+        node
+        for node in ast.walk(handler)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "join_group"
+    )
+    passed = [a.id for a in call.args if isinstance(a, ast.Name)]
+    assert "workspace_id" in passed, "the route resolves a workspace and does not pass it on"

--- a/tests/mutations/join_group_tenant_scope.json
+++ b/tests/mutations/join_group_tenant_scope.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "drop the workspace comparison — the shipped state",
+    "file": "ee/pocketpaw_ee/cloud/chat/group_service.py",
+    "find": "    if group.workspace_id != workspace_id:\n        log_denial(\n            actor=user_id,\n            action=\"group.join\",\n            code=\"group.not_found\",\n            resource_id=group_id,\n        )\n        raise NotFound(\"group\", group_id)\n",
+    "replace": "",
+    "tests": ["tests/cloud/chat/test_join_group_is_tenant_scoped.py"]
+  },
+  {
+    "label": "compare the group's workspace to itself, which always passes",
+    "file": "ee/pocketpaw_ee/cloud/chat/group_service.py",
+    "find": "    if group.workspace_id != workspace_id:",
+    "replace": "    if group.workspace_id != group.workspace_id:",
+    "tests": ["tests/cloud/chat/test_join_group_is_tenant_scoped.py"]
+  },
+  {
+    "label": "raise Forbidden, turning the refusal into an existence oracle",
+    "file": "ee/pocketpaw_ee/cloud/chat/group_service.py",
+    "find": "            resource_id=group_id,\n        )\n        raise NotFound(\"group\", group_id)\n    if group.type == \"channel\" and group.visibility == \"private\":",
+    "replace": "            resource_id=group_id,\n        )\n        raise Forbidden(\"group.not_found\", \"Not a member of that workspace\")\n    if group.type == \"channel\" and group.visibility == \"private\":",
+    "tests": ["tests/cloud/chat/test_join_group_is_tenant_scoped.py"]
+  },
+  {
+    "label": "stop the route passing the caller's workspace to the service",
+    "file": "ee/pocketpaw_ee/cloud/chat/router.py",
+    "find": "    await group_service.join_group(group_id, user_id, workspace_id)",
+    "replace": "    await group_service.join_group(group_id, user_id, group_id)",
+    "tests": ["tests/cloud/chat/test_join_group_is_tenant_scoped.py"]
+  },
+  {
+    "label": "drop the archived check — a pre-existing factor",
+    "file": "ee/pocketpaw_ee/cloud/chat/group_service.py",
+    "find": "    if group.archived:\n        raise Forbidden(\"group.archived\", \"Cannot join an archived group\")",
+    "replace": "    pass",
+    "tests": ["tests/cloud/chat/test_join_group_is_tenant_scoped.py"]
+  },
+  {
+    "label": "drop the group-type check — a pre-existing factor",
+    "file": "ee/pocketpaw_ee/cloud/chat/group_service.py",
+    "find": "    if group.type not in (\"public\", \"channel\"):\n        raise Forbidden(\n            \"group.not_joinable\",\n            \"Only public groups and channels can be joined directly\",\n        )",
+    "replace": "    pass",
+    "tests": ["tests/cloud/chat/test_join_group_is_tenant_scoped.py"]
+  }
+]


### PR DESCRIPTION
From the Mongo query-level tenancy audit — `audits/audit-tenancy.md`, finding **T-1**. This is the one that report ranks as the launch blocker.

## What

`chat/group_service.py:767`

```python
async def join_group(group_id: str, user_id: str) -> None:
    group = await _get_group_domain_or_404(group_id)
    if group.type == "channel" and group.visibility == "private": raise Forbidden(...)
    if group.type not in ("public", "channel"):                   raise Forbidden(...)
    if group.archived:                                            raise Forbidden(...)
    updated = await _add_member_doc(group_id, user_id)
```

Channel visibility, group type, archived state. No workspace. `_get_group_domain_or_404` loads by `_id` alone, so `group_id` could name a group in any workspace on the deployment.

**Every tenant ships a target.** `seed_default_group` inserts `type="public"` for each new workspace (`group_service.py:1105`, called from `auth/core.py:532`), so the default "General" group is precisely the type this route admits.

## Why it ranks above the reads

`_add_member_doc` appends the caller to `Group.members`, and membership is what the rest of the chat surface gates on. After this write the attacker is a genuine member — `send_message` (`message_service.py:404-405`) and `patch_ui_state` (`:759-760`, which mutates `message.content` at `:786`) both open up. One POST converts every cross-tenant read in the subsystem into a write.

## How

The route binds `current_workspace_id` (already imported in that file) and the service compares it against the group's own. `NotFound`, not `Forbidden` — a group in a workspace you are not in should not confirm that it exists, and `Forbidden` here would be an existence oracle over every group id on the deployment.

## Scope, and what is deliberately not in this PR

The six cross-tenant **reads** in `message_service.py` (T-2 in the audit) share a root cause with this — the membership gate is `if group.type in ("private", "dm")`, so public groups skip it entirely. Closing those means threading a workspace through **40 loader call sites across 20 routes**, which is a refactor with a large diff. It is coming as its own PR. This one is a single `if` and should not wait behind that review.

One thing that refactor will have to handle, worth flagging now: `_create_group_message_doc` (`message_service.py:241-273`) never sets `workspace_id`, so every group message written via REST or WebSocket carries `None`. A workspace filter added to the message queries would look correct and return nothing. The predicate belongs on the group load.

## Verification

- 6 mutations, all caught (`tests/mutations/join_group_tenant_scope.json`). Two of them delete a **pre-existing** factor — the archived check and the type check — so the tests demonstrate this change ADDS a fourth check rather than replacing three.
- `tests/cloud/chat/` — 161 passed.
- `mutate.py --validate` — 1391 anchors across 112 plans each resolve exactly once.
- ruff check and format clean.

Four existing `join_group` call sites in `test_group_emits.py` were updated for the new signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)