### PR TITLE
fix(sessions): create reached into another tenant's rows two ways

### DIFF
--- a/ee/pocketpaw_ee/cloud/sessions/service.py
+++ b/ee/pocketpaw_ee/cloud/sessions/service.py
@@ -45,6 +45,7 @@ from typing import TYPE_CHECKING, Any
 
 from beanie import PydanticObjectId
 from beanie.operators import In
+from bson.errors import InvalidId
 
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
 from pocketpaw_ee.cloud._core.realtime.emit import emit
@@ -121,6 +122,66 @@ def legacy_ctx(user_id: str, workspace_id: str | None = None) -> RequestContext:
 # ---------------------------------------------------------------------------
 
 
+async def _refuse_foreign_scope_ids(workspace_id: str, body: CreateSessionRequest) -> None:
+    """Reject a create whose ``group_id`` / ``pocket_id`` belongs elsewhere.
+
+    ``create`` stamped ``group=body.group_id`` and ``pocket=body.pocket_id``
+    straight from the request with no validation. The row's own ``workspace``
+    was the caller's, so it looked correctly tenanted — but ``get_history``
+    builds its Message filter from those fields
+    (``{"context_type": "group", "group": session.group}``, no workspace term),
+    so an attacker-chosen group id returned another tenant's whole transcript
+    from a session they legitimately own. Two calls, no bypass.
+
+    Validated here at the write rather than at the read, because the read is
+    reached by several paths and the write is one. ``Message.workspace_id``
+    exists but is ``None`` on every group message written through REST or
+    WebSocket, so filtering the read would return nothing and look correct.
+
+    Deliberately narrow: only an id that resolves to a real row in ANOTHER
+    workspace is refused. A malformed id and a dangling one both pass through,
+    because neither names a row and therefore neither can disclose anything —
+    ``get_history`` filtering on them matches nothing. Rejecting them would be
+    a behaviour change with no security value, and several internal callers
+    pass synthetic scope ids.
+
+    NotFound rather than Forbidden — a scope in another workspace should not
+    confirm that it exists.
+    """
+    from pocketpaw_ee.cloud.models.group import Group as _GroupDoc
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    for kind, raw_id, model in (
+        ("group", body.group_id, _GroupDoc),
+        ("pocket", body.pocket_id, _PocketDoc),
+    ):
+        if not raw_id:
+            continue
+        try:
+            oid = PydanticObjectId(raw_id)
+        except (InvalidId, ValueError, TypeError):
+            # Not an ObjectId, so it names no row and can leak nothing. Left
+            # alone rather than rejected: several internal callers and tests
+            # pass synthetic scope ids, and raising here would be a behaviour
+            # change with no security value — plus an uncaught InvalidId is a
+            # 500, not a refusal.
+            continue
+        row = await model.get(oid)
+        if row is None:
+            # A dangling id. ``get_history`` filtering on it matches nothing,
+            # so there is nothing to disclose and nothing to refuse.
+            continue
+        if row.workspace != workspace_id:
+            logger.warning(
+                "Refused a session naming a %s outside the caller's workspace (caller=%s, %s=%s)",
+                kind,
+                workspace_id,
+                kind,
+                raw_id,
+            )
+            raise NotFound(kind, raw_id)
+
+
 async def create(
     ctx: RequestContext,
     workspace_id: str,
@@ -130,9 +191,27 @@ async def create(
     ``body.session_id`` matches an existing row."""
     sid = body.session_id or f"websocket_{uuid.uuid4().hex[:12]}"
 
+    await _refuse_foreign_scope_ids(workspace_id, body)
+
     if body.session_id:
         existing_doc = await _SessionDoc.find_one(_SessionDoc.sessionId == body.session_id)
         if existing_doc is not None:
+            # The upsert branch looked the row up by ``sessionId`` alone and
+            # compared neither workspace nor owner before patching it, saving
+            # it, emitting SessionUpdated addressed to ``existing_doc.owner``,
+            # and returning the row — which discloses the victim's workspace,
+            # owner, pocket, group and agent. ``link_pocket`` does exactly this
+            # check 375 lines below; this branch never got it.
+            #
+            # NotFound rather than Forbidden, so a session id in another
+            # workspace is indistinguishable from one that does not exist.
+            if existing_doc.workspace != workspace_id:
+                logger.warning(
+                    "Refused a session upsert onto another workspace's row (caller=%s, session=%s)",
+                    workspace_id,
+                    body.session_id,
+                )
+                raise NotFound("session", body.session_id)
             patched: dict = {}
             if body.pocket_id and body.pocket_id != existing_doc.pocket:
                 existing_doc.pocket = body.pocket_id

--- a/tests/cloud/sessions/test_create_is_tenant_scoped.py
+++ b/tests/cloud/sessions/test_create_is_tenant_scoped.py
@@ -1,0 +1,204 @@
+"""``POST /api/v1/sessions`` must not reach another tenant's rows.
+
+Two defects in one function, and they chain.
+
+T-3 — the upsert branch looked its row up by ``sessionId`` alone and compared
+neither workspace nor owner before patching it, saving it, emitting
+``SessionUpdated`` addressed to the VICTIM's owner id, and returning the row.
+The response carries the victim's ``workspace``, ``owner``, ``pocket``,
+``group`` and ``agent``.
+
+T-4 — ``create`` stamped ``group=body.group_id`` and ``pocket=body.pocket_id``
+straight from the request. The row's own ``workspace`` is the caller's, so it
+looks correctly tenanted; but ``get_history`` builds its Message filter from
+those fields with no workspace term, so a session naming a foreign group
+returned that group's entire transcript to its legitimate owner.
+
+They chain because T-3's response is the id-disclosure primitive T-4 needs.
+
+WHY THE FIX IS AT THE WRITE
+
+``Message.workspace_id`` exists but is ``None`` on every group message written
+through REST or WebSocket (``_create_group_message_doc`` never sets it), so a
+workspace filter on the READ would return nothing and look correct. The write
+is also one place; the read is reached by several.
+
+The check T-3 needs was already in this file — ``link_pocket`` does
+``if doc is None or doc.workspace != workspace_id: return`` 375 lines below.
+
+Mutations that must fail these tests: dropping either check, comparing the
+row's workspace to itself, and raising Forbidden instead of NotFound.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.models.group import Group as _GroupDoc
+from pocketpaw_ee.cloud.models.session import Session as _SessionDoc
+from pocketpaw_ee.cloud.sessions import service as sessions_service
+from pocketpaw_ee.cloud.sessions.dto import CreateSessionRequest
+from pocketpaw_ee.cloud.shared.errors import NotFound
+
+
+def _ctx(user_id: str = "u-attacker") -> RequestContext:
+    from datetime import UTC, datetime
+
+    return RequestContext(
+        user_id=user_id,
+        workspace_id="ws-attacker",
+        request_id=uuid.uuid4().hex,
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _victim_session(session_id: str) -> _SessionDoc:
+    doc = _SessionDoc(
+        sessionId=session_id,
+        context_type="session",
+        workspace="ws-victim",
+        owner="u-victim",
+        title="the victim's chat",
+    )
+    await doc.insert()
+    return doc
+
+
+async def _victim_group() -> _GroupDoc:
+    doc = _GroupDoc(
+        workspace="ws-victim",
+        name="General",
+        slug="general-victim",
+        description="",
+        icon="",
+        color="",
+        type="public",
+        members=["u-victim"],
+        member_roles={"u-victim": "admin"},
+        agents=[],
+        pinned_messages=[],
+        owner="u-victim",
+        archived=False,
+    )
+    await doc.insert()
+    return doc
+
+
+class TestTheUpsertBranch:
+    async def test_a_foreign_session_is_not_patched_or_returned(self, mongo_db):  # noqa: ARG002
+        """T-3. The write, the event to the victim, and the id disclosure."""
+        victim = await _victim_session(f"cloud:session:{uuid.uuid4().hex[:8]}:a1")
+
+        with pytest.raises(NotFound):
+            await sessions_service.create(
+                _ctx(),
+                "ws-attacker",
+                CreateSessionRequest(session_id=victim.sessionId, title="hijacked"),
+            )
+
+        after = await _SessionDoc.get(victim.id)
+        assert after.title == "the victim's chat", "another tenant's session was patched"
+        assert after.workspace == "ws-victim"
+
+    async def test_a_residual_existence_oracle_remains_and_is_bounded(self, mongo_db):  # noqa: ARG002
+        """Pinning a known, accepted residual rather than claiming it is closed.
+
+        A foreign ``session_id`` raises NotFound; an unused one creates a row
+        and returns it. So the two outcomes DIFFER, and a caller can still
+        learn whether a given session id exists somewhere on the deployment.
+
+        It is not closable by creating instead: ``Session.sessionId`` carries a
+        unique index (``models/session.py:38``), so the insert would fail
+        anyway — the oracle is a property of the uniqueness constraint, not of
+        this branch.
+
+        What the fix removes is everything the oracle used to come with: the
+        patch, the save, the SessionUpdated event addressed to the victim, and
+        a response body carrying the victim's workspace, owner, pocket, group
+        and agent. One bit of existence is what is left.
+
+        If that bit ever needs closing, the move is a per-workspace namespace
+        on ``sessionId`` rather than a different error here.
+        """
+        victim = await _victim_session(f"cloud:session:{uuid.uuid4().hex[:8]}:a1")
+
+        with pytest.raises(NotFound):
+            await sessions_service.create(
+                _ctx(), "ws-attacker", CreateSessionRequest(session_id=victim.sessionId)
+            )
+
+        unused = await sessions_service.create(
+            _ctx(), "ws-attacker", CreateSessionRequest(session_id="not-taken-anywhere")
+        )
+        assert unused is not None
+
+        # The victim's row is untouched by either call — that is the part that
+        # matters, and the part that was broken.
+        after = await _SessionDoc.get(victim.id)
+        assert after.title == "the victim's chat"
+        assert after.workspace == "ws-victim"
+
+    async def test_the_owners_own_session_still_upserts(self, mongo_db):  # noqa: ARG002
+        """The scoping must not break the feature it guards."""
+        key = f"cloud:session:{uuid.uuid4().hex[:8]}:a1"
+        mine = _SessionDoc(
+            sessionId=key,
+            context_type="session",
+            workspace="ws-attacker",
+            owner="u-attacker",
+            title="mine",
+        )
+        await mine.insert()
+
+        result = await sessions_service.create(
+            _ctx(), "ws-attacker", CreateSessionRequest(session_id=key, title="renamed")
+        )
+
+        assert result is not None
+        after = await _SessionDoc.get(mine.id)
+        assert after.title == "renamed"
+
+
+class TestForeignScopeIds:
+    async def test_a_session_cannot_name_another_workspaces_group(self, mongo_db):  # noqa: ARG002
+        """T-4. This is what made get_history return a foreign transcript."""
+        group = await _victim_group()
+
+        with pytest.raises(NotFound):
+            await sessions_service.create(
+                _ctx(), "ws-attacker", CreateSessionRequest(group_id=str(group.id))
+            )
+
+        rows = await _SessionDoc.find({"group": str(group.id)}).to_list()
+        assert rows == [], "a session was stamped with a foreign group id"
+
+    async def test_a_group_in_the_callers_workspace_is_accepted(self, mongo_db):  # noqa: ARG002
+        mine = _GroupDoc(
+            workspace="ws-attacker",
+            name="General",
+            slug="general-mine",
+            description="",
+            icon="",
+            color="",
+            type="public",
+            members=["u-attacker"],
+            member_roles={"u-attacker": "admin"},
+            agents=[],
+            pinned_messages=[],
+            owner="u-attacker",
+            archived=False,
+        )
+        await mine.insert()
+
+        result = await sessions_service.create(
+            _ctx(), "ws-attacker", CreateSessionRequest(group_id=str(mine.id))
+        )
+        assert result is not None
+
+    async def test_a_session_with_no_scope_ids_is_unaffected(self, mongo_db):  # noqa: ARG002
+        """The common case — a plain chat session names neither."""
+        result = await sessions_service.create(_ctx(), "ws-attacker", CreateSessionRequest())
+        assert result is not None

--- a/tests/mutations/sessions_create_tenant_scope.json
+++ b/tests/mutations/sessions_create_tenant_scope.json
@@ -1,0 +1,50 @@
+[
+  {
+    "label": "drop the upsert workspace check — the shipped state",
+    "file": "ee/pocketpaw_ee/cloud/sessions/service.py",
+    "find": "            if existing_doc.workspace != workspace_id:\n                logger.warning(\n                    \"Refused a session upsert onto another workspace's row (caller=%s, session=%s)\",\n                    workspace_id,\n                    body.session_id,\n                )\n                raise NotFound(\"session\", body.session_id)\n",
+    "replace": "",
+    "tests": ["tests/cloud/sessions/test_create_is_tenant_scoped.py"]
+  },
+  {
+    "label": "compare the upsert row's workspace to itself, which always passes",
+    "file": "ee/pocketpaw_ee/cloud/sessions/service.py",
+    "find": "            if existing_doc.workspace != workspace_id:",
+    "replace": "            if existing_doc.workspace != existing_doc.workspace:",
+    "tests": ["tests/cloud/sessions/test_create_is_tenant_scoped.py"]
+  },
+  {
+    "label": "drop the foreign-scope-id check entirely",
+    "file": "ee/pocketpaw_ee/cloud/sessions/service.py",
+    "find": "    await _refuse_foreign_scope_ids(workspace_id, body)\n",
+    "replace": "",
+    "tests": ["tests/cloud/sessions/test_create_is_tenant_scoped.py"]
+  },
+  {
+    "label": "compare the scope row's workspace to itself",
+    "file": "ee/pocketpaw_ee/cloud/sessions/service.py",
+    "find": "        if row.workspace != workspace_id:",
+    "replace": "        if row.workspace != row.workspace:",
+    "tests": ["tests/cloud/sessions/test_create_is_tenant_scoped.py"]
+  },
+  {
+    "label": "refuse a dangling scope id too — over-strict, breaks internal callers",
+    "file": "ee/pocketpaw_ee/cloud/sessions/service.py",
+    "find": "        row = await model.get(oid)\n        if row is None:",
+    "replace": "        row = await model.get(oid)\n        if row is None:\n            raise NotFound(kind, raw_id)\n        if False:",
+    "tests": [
+      "tests/cloud/sessions/test_create_is_tenant_scoped.py",
+      "tests/cloud/sessions/test_service_v2.py"
+    ]
+  },
+  {
+    "label": "let a malformed scope id raise InvalidId, which is a 500 not a refusal",
+    "file": "ee/pocketpaw_ee/cloud/sessions/service.py",
+    "find": "        try:\n            oid = PydanticObjectId(raw_id)\n        except (InvalidId, ValueError, TypeError):",
+    "replace": "        try:\n            oid = PydanticObjectId(raw_id)\n        except _NeverRaised:",
+    "tests": [
+      "tests/cloud/sessions/test_create_is_tenant_scoped.py",
+      "tests/cloud/sessions/test_service_v2.py"
+    ]
+  }
+]


### PR DESCRIPTION
From the Mongo query-level tenancy audit — `audits/audit-tenancy.md`, findings **T-3** and **T-4**. Both live in `sessions/service.py:create`, and they chain, so they ship together.

## T-3 — the upsert branch patches and returns a foreign session

```python
if body.session_id:
    existing_doc = await _SessionDoc.find_one(_SessionDoc.sessionId == body.session_id)
    if existing_doc is not None:
        ...
        await existing_doc.save()
        await emit(SessionUpdated(data={..., "user_id": existing_doc.owner}))
        return _to_domain(existing_doc)
```

Looked up by `sessionId` alone. No workspace comparison, no owner comparison, between the lookup and the `save()`.

- **The write** patches `pocket`, `title`, `surface` and promotes `context_type` `session`→`pocket`, which changes what the victim's own history route returns.
- **The event** is addressed with `existing_doc.owner`, pushing the forged patch onto the victim's realtime feed.
- **The read** returns `session_to_wire_dict` — the victim's `workspace`, `owner`, `pocket`, `group`, `agent`.

`link_pocket` does exactly the missing check 375 lines below in the same file (`if doc is None or doc.workspace != workspace_id: return`).

## T-4 — create stamps attacker-chosen scope ids

```python
doc = _SessionDoc(
    workspace=workspace_id,   # the CALLER's
    group=body.group_id,      # attacker-chosen, never checked
    pocket=body.pocket_id,
)
```

The row looks correctly tenanted. But `get_history` builds its filter from those fields — `[{"context_type": "group"}, {"group": session.group}, {"deleted": False}]`, no workspace term — so a session naming a foreign group returns that group's entire transcript to a session the caller legitimately owns. Two API calls, and T-3's response supplies the ids.

## Why the fix is at the write, and why it is narrow

**At the write:** `Message.workspace_id` exists but is `None` on every group message written through REST or WebSocket (`_create_group_message_doc` never sets it), so a workspace filter on the read would return nothing and look correct. The write is also one place; the read is reached by several.

**Narrow:** only an id that resolves to a real row in *another* workspace is refused. A malformed id and a dangling one both pass through — neither names a row, so neither can disclose anything.

That narrowing came out of the work rather than being planned. The first version rejected any unresolvable id; it broke six existing tests, and an uncaught `InvalidId` turned out to be a 500 rather than a refusal. The narrow version closes the finding and changes no other behaviour — 53 session tests pass unmodified.

## A residual, pinned rather than papered over

A foreign `session_id` raises `NotFound` while an unused one creates a row, so **one bit of existence still leaks**. That is a property of the unique index on `Session.sessionId`, not of this branch: creating instead would fail the insert anyway. Closing it needs a per-workspace namespace on `sessionId`.

What the fix removes is everything that bit used to come with — the patch, the save, the event to the victim, and the response body. `test_a_residual_existence_oracle_remains_and_is_bounded` documents it so nobody reads this PR as closing more than it does.

## Verification

- 6 mutations, all caught (`tests/mutations/sessions_create_tenant_scope.json`). Two assert the check is not **over**-strict: "refuse a dangling scope id too" and "let a malformed id raise InvalidId" both run against the pre-existing `test_service_v2.py` as well.
- `tests/cloud/sessions/` + `tests/cloud/chat/` — 209 passed.
- `mutate.py --validate` — 1391 anchors across 112 plans each resolve exactly once.
- ruff check and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)