### PR TITLE
fix(livekit): any member of any group could revoke any invite

### DIFF
--- a/ee/pocketpaw_ee/cloud/livekit/invites.py
+++ b/ee/pocketpaw_ee/cloud/livekit/invites.py
@@ -284,12 +284,31 @@ async def list_meeting_invites(
 async def revoke_meeting_invite(
     invite_id: str,
     revoked_by: str,
+    group_id: str,
 ) -> dict[str, Any]:
-    """Revoke a meeting invite so it can no longer be used."""
+    """Revoke a meeting invite so it can no longer be used.
+
+    ``group_id`` is the group the CALLER proved membership of, and the check
+    below is why it is a required parameter. Until 2026-09-11 this function took
+    only ``invite_id`` and fetched by primary key, so the route's membership
+    check on the path ``{group_id}`` was decorative: satisfy it with a group you
+    created yourself, then pass any invite id on the deployment. Three response
+    classes made it sweepable rather than targeted — 404 for an unknown id, 200
+    carrying the victim's ``group_id`` for a valid foreign one — and every hit
+    set ``revoked=True`` permanently, so a sweep destroyed what it found.
+
+    This is the shape ``/rooms/{group_id}/leave`` had until 2026-08-11 (see the
+    module docstring in ``router.py``). It was fixed there and left standing
+    here. ``create_meeting_invite`` cross-checks its room against the group at
+    line 55; this is the same check on the other side.
+
+    NotFound rather than Forbidden, and the SAME NotFound an unknown id raises,
+    so the response cannot separate "exists elsewhere" from "does not exist".
+    """
     from beanie import PydanticObjectId
 
     doc = await _MeetingInviteDoc.get(PydanticObjectId(invite_id))
-    if doc is None:
+    if doc is None or doc.group_id != group_id:
         raise NotFound("meeting_invite", invite_id)
 
     doc.revoked = True

--- a/ee/pocketpaw_ee/cloud/livekit/router.py
+++ b/ee/pocketpaw_ee/cloud/livekit/router.py
@@ -704,5 +704,5 @@ async def revoke_invite(
 
     from pocketpaw_ee.cloud.livekit import invites as invite_service
 
-    result = await invite_service.revoke_meeting_invite(invite_id, str(user.id))
+    result = await invite_service.revoke_meeting_invite(invite_id, str(user.id), group_id)
     return RevokeInviteResponse(**result)

--- a/tests/cloud/livekit/test_revoke_invite_is_group_scoped.py
+++ b/tests/cloud/livekit/test_revoke_invite_is_group_scoped.py
@@ -1,0 +1,143 @@
+"""Revoking a meeting invite must be confined to the group the caller proved.
+
+``DELETE /api/v1/livekit/rooms/{group_id}/invites/{invite_id}`` checks that the
+caller is a member of the group named in the PATH, then passed only
+``invite_id`` to ``revoke_meeting_invite``, which fetched by primary key with no
+group or workspace comparison. The path ``group_id`` was decorative: satisfy it
+with a group you created yourself, then pass any invite id on the deployment.
+
+SWEEPABLE, NOT MERELY TARGETED
+
+Three distinguishable responses — 404 for an unknown id, 200 carrying the
+victim's ``group_id`` for a valid foreign one, and an uncaught ``InvalidId`` for
+a malformed one. An attacker mints an invite in their own workspace and reads
+the id back, which discloses the 5-byte per-process random and the counter
+stride shared by every ObjectId that backend mints, collapsing the search to a
+timestamp window by counter. Every hit sets ``revoked=True`` permanently, so the
+sweep destroys what it finds.
+
+THIS IS A REPEAT
+
+``router.py``'s own module docstring records ``/rooms/{group_id}/leave`` having
+the identical defect, fixed 2026-08-11 with a regression test. The pattern was
+fixed on one route and left standing on its sibling. ``create_meeting_invite``
+cross-checks its room against the group at ``invites.py:55``; this is that check
+on the other side.
+
+Mutations that must fail these tests: dropping the group comparison, comparing
+the doc's group to itself, and raising a DIFFERENT error for a foreign invite
+than for an unknown one (which restores the oracle even while blocking the
+write).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.livekit import invites as invite_service
+from pocketpaw_ee.cloud.models.invite import MeetingInvite as _MeetingInviteDoc
+from pocketpaw_ee.cloud.shared.errors import NotFound
+
+
+async def _invite(*, group_id: str, workspace: str = "ws-victim") -> _MeetingInviteDoc:
+    import hashlib
+    from datetime import UTC, datetime, timedelta
+
+    doc = _MeetingInviteDoc(
+        group_id=group_id,
+        workspace=workspace,
+        room_name=f"room-{group_id}",
+        token_hash=hashlib.sha256(group_id.encode()).hexdigest(),
+        display_name="Standup",
+        created_by="u-victim",
+        max_uses=10,
+        use_count=0,
+        guest_identities=[],
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        revoked=False,
+    )
+    await doc.insert()
+    return doc
+
+
+async def test_an_invite_in_another_group_cannot_be_revoked(mongo_db):  # noqa: ARG001
+    """The finding. The path group_id was decorative."""
+    victim = await _invite(group_id="g-victim")
+
+    with pytest.raises(NotFound):
+        await invite_service.revoke_meeting_invite(str(victim.id), "u-attacker", "g-attackers-own")
+
+    after = await _MeetingInviteDoc.get(victim.id)
+    assert after.revoked is False, "another group's invite was revoked"
+
+
+async def test_a_foreign_invite_is_indistinguishable_from_a_missing_one(mongo_db):  # noqa: ARG001
+    """Blocking the write is not enough — the response was the oracle.
+
+    A different error class for "exists but is not yours" would still let a
+    sweep enumerate every invite id on the deployment, just without destroying
+    them. Both paths must raise the same thing.
+    """
+    victim = await _invite(group_id="g-victim")
+
+    with pytest.raises(NotFound) as foreign:
+        await invite_service.revoke_meeting_invite(str(victim.id), "u-attacker", "g-mine")
+
+    missing = "0" * 24
+    with pytest.raises(NotFound) as absent:
+        await invite_service.revoke_meeting_invite(missing, "u-attacker", "g-mine")
+
+    assert type(foreign.value) is type(absent.value)
+
+
+async def test_the_owning_group_can_still_revoke(mongo_db):  # noqa: ARG001
+    """The scoping must not break the feature it guards."""
+    mine = await _invite(group_id="g-mine", workspace="ws-mine")
+
+    result = await invite_service.revoke_meeting_invite(str(mine.id), "u-owner", "g-mine")
+
+    assert result["revoked"] is True
+    after = await _MeetingInviteDoc.get(mine.id)
+    assert after.revoked is True
+
+
+def test_the_route_passes_the_group_it_checked_membership_of():
+    """The guard and the sink must be given the same id.
+
+    Asserted against the parsed route: the defect was never that the check was
+    missing from the route, it was that the checked id never reached the sink.
+    """
+    import ast
+    import inspect
+    import sys
+
+    import pocketpaw_ee.cloud.livekit.router  # noqa: F401
+
+    module = sys.modules["pocketpaw_ee.cloud.livekit.router"]
+    tree = ast.parse(inspect.getsource(module))
+    handler = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "revoke_invite"
+    )
+
+    guarded = [
+        node
+        for node in ast.walk(handler)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_require_domain_group_member"
+    ]
+    assert guarded, "the route no longer checks group membership at all"
+
+    call = next(
+        node
+        for node in ast.walk(handler)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "revoke_meeting_invite"
+    )
+    passed = [a.id for a in call.args if isinstance(a, ast.Name)]
+    assert "group_id" in passed, (
+        "the route checks membership of group_id and does not pass it to the "
+        "sink, so the path parameter is decorative again"
+    )

--- a/tests/mutations/livekit_revoke_invite_scope.json
+++ b/tests/mutations/livekit_revoke_invite_scope.json
@@ -1,0 +1,37 @@
+[
+  {
+    "label": "drop the group comparison — the shipped state",
+    "file": "ee/pocketpaw_ee/cloud/livekit/invites.py",
+    "find": "    if doc is None or doc.group_id != group_id:\n        raise NotFound(\"meeting_invite\", invite_id)",
+    "replace": "    if doc is None:\n        raise NotFound(\"meeting_invite\", invite_id)",
+    "tests": ["tests/cloud/livekit/test_revoke_invite_is_group_scoped.py"]
+  },
+  {
+    "label": "compare the doc's group to itself, which always passes",
+    "file": "ee/pocketpaw_ee/cloud/livekit/invites.py",
+    "find": "    if doc is None or doc.group_id != group_id:",
+    "replace": "    if doc is None or doc.group_id != doc.group_id:",
+    "tests": ["tests/cloud/livekit/test_revoke_invite_is_group_scoped.py"]
+  },
+  {
+    "label": "block the write but keep the oracle, with a distinct error",
+    "file": "ee/pocketpaw_ee/cloud/livekit/invites.py",
+    "find": "    doc = await _MeetingInviteDoc.get(PydanticObjectId(invite_id))\n    if doc is None or doc.group_id != group_id:\n        raise NotFound(\"meeting_invite\", invite_id)",
+    "replace": "    doc = await _MeetingInviteDoc.get(PydanticObjectId(invite_id))\n    if doc is None:\n        raise NotFound(\"meeting_invite\", invite_id)\n    if doc.group_id != group_id:\n        raise Forbidden(\"meeting_invite.not_yours\", \"Not your invite\")",
+    "tests": ["tests/cloud/livekit/test_revoke_invite_is_group_scoped.py"]
+  },
+  {
+    "label": "stop the route passing the group it checked membership of",
+    "file": "ee/pocketpaw_ee/cloud/livekit/router.py",
+    "find": "    result = await invite_service.revoke_meeting_invite(invite_id, str(user.id), group_id)",
+    "replace": "    result = await invite_service.revoke_meeting_invite(invite_id, str(user.id), invite_id)",
+    "tests": ["tests/cloud/livekit/test_revoke_invite_is_group_scoped.py"]
+  },
+  {
+    "label": "drop the route's membership check, leaving only the sink's",
+    "file": "ee/pocketpaw_ee/cloud/livekit/router.py",
+    "find": "    group = await _get_group_domain_or_404(group_id)\n    _require_domain_group_member(group, str(user.id))\n\n    from pocketpaw_ee.cloud.livekit import invites as invite_service\n\n    result = await invite_service.revoke_meeting_invite(invite_id, str(user.id), group_id)",
+    "replace": "    from pocketpaw_ee.cloud.livekit import invites as invite_service\n\n    result = await invite_service.revoke_meeting_invite(invite_id, str(user.id), group_id)",
+    "tests": ["tests/cloud/livekit/test_revoke_invite_is_group_scoped.py"]
+  }
+]


### PR DESCRIPTION
From the Mongo query-level tenancy audit — `audits/audit-tenancy.md`, finding **T-5**.

## What

Route (`livekit/router.py:687`):

```python
group = await _get_group_domain_or_404(group_id)
_require_domain_group_member(group, str(user.id))

result = await invite_service.revoke_meeting_invite(invite_id, str(user.id))
```

Sink (`invites.py:284`):

```python
doc = await _MeetingInviteDoc.get(PydanticObjectId(invite_id))
if doc is None:
    raise NotFound("meeting_invite", invite_id)
doc.revoked = True
await doc.save()
```

The guard validates membership of the group in the **path**; the sink acts on `invite_id` and never compares `doc.group_id` to it. The path parameter is decorative — satisfy it with a group you created yourself, then pass any invite id on the deployment.

## Sweepable, not merely targeted

Three distinguishable responses: 404 for an unknown id, 200 carrying the victim's `group_id` for a valid foreign one, and an uncaught `InvalidId` for a malformed one.

An attacker mints an invite in their own workspace and reads the id back, which discloses the 5-byte per-process random and the counter stride shared by every ObjectId that backend process mints — collapsing the search to a timestamp window by counter. Every hit sets `revoked=True` permanently, so a sweep destroys what it finds. Loud rather than passive, but destructive while it runs.

## This is a repeat

`router.py`'s own module docstring, lines 23-28:

> `/rooms/{group_id}/leave` was the one exception to that guarantee until 2026-08-11 — it emitted `CallParticipantLeft` to the group's members with no license and no membership check, so any authenticated user could inject a fabricated participant-left event into any group in any workspace.

Same shape, sibling route, fixed there and left standing here. `create_meeting_invite` already cross-checks `room_name == room_name_for_group(group_id)` at `invites.py:55` — this is that check on the other side.

## Blocking the write alone would not have been enough

The response **was** the oracle. A foreign invite now raises the same `NotFound` an unknown id does, so the two cannot be told apart.

One mutation asserts exactly that: it blocks the write correctly and returns a distinct `Forbidden`. The tests catch it. Without that case, a fix that stops the destruction while leaving a full enumeration primitive would have looked complete.

## Verification

- 5 mutations, all caught (`tests/mutations/livekit_revoke_invite_scope.json`), including "block the write but keep the oracle" and "drop the route's membership check, leaving only the sink's".
- `tests/cloud/livekit/` — 20 passed.
- `mutate.py --validate` — 1390 anchors across 112 plans each resolve exactly once.
- ruff check and format clean.

Note for review: the audit found three adjacent non-tenancy issues in this file that are **not** in this PR — guest calls billed to nobody (`create_room` is called with `workspace_id=""`, so no `MeetingDoc` is inserted and `_daily_call_usage` counts nothing), an unauthenticated `workspace_id` disclosure on `GET /livekit/invites/{token}`, and a guest being able to restart a reaped meeting for up to 72h. They are in `audit-tenancy.md` under "Adjacent".

🤖 Generated with [Claude Code](https://claude.com/claude-code)