### PR TITLE
fix(context): 24 foresight routes took their tenant from a request header

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/context.py
+++ b/ee/pocketpaw_ee/cloud/_core/context.py
@@ -28,6 +28,8 @@ Updates:
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -156,10 +158,17 @@ WORKSPACE_HEADER: str = "X-PocketPaw-Workspace-Id"
 USER_HEADER: str = "X-PocketPaw-User-Id"
 
 # Hostnames / IPs the bypass trusts. The dashboard always binds to one of
-# these; outbound traffic from the chat agent inherits the same host. A
-# real attacker either has to forge ``X-Forwarded-For`` upstream of the
-# ASGI server (uvicorn doesn't honor the header by default) or land code
-# execution on the host, in which case the bypass isn't the weakest link.
+# these; outbound traffic from the chat agent inherits the same host.
+#
+# This comment used to claim that uvicorn ignores forwarded headers unless
+# configured. That is WRONG, and it was load-bearing for how safe this looked.
+# uvicorn's Config defaults ``proxy_headers=True``; what bounds it is
+# ``forwarded_allow_ips``, which defaults to ``127.0.0.1`` — and
+# ``_core/rate_limit.py`` already records that ours is unset. So a proxy on the
+# same host both terminates as loopback AND can set the forwarded header.
+#
+# That is why this trio is now refused outright in multi-tenant cloud
+# (``_header_bypass_allowed_here``) rather than relying on the peer address.
 _LOOPBACK_HOSTS: frozenset[str] = frozenset(
     {
         "127.0.0.1",
@@ -170,6 +179,49 @@ _LOOPBACK_HOSTS: frozenset[str] = frozenset(
         "::ffff:127.0.0.1",
     }
 )
+
+
+logger = logging.getLogger(__name__)
+
+_ALLOW_HEADER_BYPASS_ENV = "POCKETPAW_INTERNAL_HEADER_CONTEXT_ENABLED"
+
+
+def _header_bypass_allowed_here() -> bool:
+    """False when this deployment holds more than one tenant.
+
+    Mirrors ``pockets/router.py:_bypass_allowed_here`` (PR #2126) deliberately,
+    including the failure direction: if the signal cannot be read we refuse,
+    because opening the bypass is the dangerous answer.
+
+    A local desktop install has no cloud DB and is unaffected — which matters,
+    since that is the deployment where this bypass is how the local chat agent
+    reaches its own backend.
+    """
+    if os.environ.get(_ALLOW_HEADER_BYPASS_ENV, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    ):
+        logger.warning(
+            "%s is set — the internal header context is accepted in a "
+            "multi-tenant deployment. X-PocketPaw-Workspace-Id is then the whole "
+            "of the tenancy check for every route that uses it.",
+            _ALLOW_HEADER_BYPASS_ENV,
+        )
+        return True
+    try:
+        from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
+
+        if is_multi_tenant_cloud():
+            return False
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Could not determine whether this deployment is multi-tenant; "
+            "refusing the internal header context (fail-closed)."
+        )
+        return False
+    return True
 
 
 def _is_loopback_client(request: Request) -> bool:
@@ -199,8 +251,22 @@ def _try_loopback_context(request: Request) -> RequestContext | None:
     closes the loophole where a chained process on the same host could
     forge the headers; until then, the loopback host check is the only
     boundary between the local chat agent and full workspace access.
+
+    **Refused entirely in multi-tenant cloud since 2026-09-11.** The sentence
+    above is precise about what this is worth, and behind a reverse proxy on the
+    same host it is worth nothing — ``request.client.host`` resolves to the
+    proxy, so every external client presents as loopback and the header trio is
+    the whole of the tenancy. This dependency is bound on all 24 foresight
+    routes, and it has one FEWER factor than ``pockets/router.py``'s equivalent,
+    which also requires a ``compare_digest`` against a process-local secret and
+    was still judged insufficient in PR #2126. Same gate as that PR, same
+    reason: ``is_multi_tenant_cloud()`` is not a thing an operator has to
+    remember to set on the deployment that gains a second tenant.
     """
     if request.headers.get(INTERNAL_HEADER, "").strip().lower() != "true":
+        return None
+
+    if not _header_bypass_allowed_here():
         return None
 
     if not _is_loopback_client(request):

--- a/tests/cloud/test_internal_header_context_gate.py
+++ b/tests/cloud/test_internal_header_context_gate.py
@@ -1,0 +1,144 @@
+"""The internal-header context is refused in multi-tenant cloud.
+
+``loopback_or_request_context`` accepts the caller's workspace and user straight
+from ``X-PocketPaw-Workspace-Id`` / ``X-PocketPaw-User-Id`` when the peer address
+is loopback. It is bound on all 24 routes of ``foresight/router.py``.
+
+Two factors, and the docstring is candid about the second:
+
+    the loopback host check is the only boundary between the local chat agent
+    and full workspace access
+
+Behind a reverse proxy on the same host that boundary is nothing — every
+external client presents as loopback. And the comment that made it look safer,
+"uvicorn doesn't honor the header by default", is wrong: uvicorn's Config
+defaults ``proxy_headers=True``, bounded by ``forwarded_allow_ips`` (default
+``127.0.0.1``), which ``_core/rate_limit.py`` records as unset here.
+
+WEAKER THAN THE ONE ALREADY JUDGED INSUFFICIENT
+
+``pockets/router.py:_loopback_bypass_active`` requires a FOURTH factor — a
+``compare_digest`` against a process-local secret — and PR #2126 still gated it
+on ``is_multi_tenant_cloud()``. This path has no token and no compare. Same
+gate, same reason.
+
+Mutations that must fail these tests: dropping the gate call from
+``loopback_or_request_context``, returning True when the signal cannot be read,
+and treating any present value of the opt-in as truthy.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+from pocketpaw_ee.cloud._core import context as ctx
+
+
+@pytest.fixture
+def in_cloud(monkeypatch):
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+    module.is_multi_tenant_cloud = lambda: True
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+    monkeypatch.delenv(ctx._ALLOW_HEADER_BYPASS_ENV, raising=False)
+
+
+def test_the_header_context_is_refused_in_multi_tenant_cloud(in_cloud):  # noqa: ARG001
+    """The finding. The header trio was the whole of the tenancy check."""
+    assert ctx._header_bypass_allowed_here() is False
+
+
+def test_a_local_install_is_unaffected(monkeypatch):
+    """No cloud DB means one tenant, and the local agent still reaches itself."""
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+    module.is_multi_tenant_cloud = lambda: False
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+    monkeypatch.delenv(ctx._ALLOW_HEADER_BYPASS_ENV, raising=False)
+
+    assert ctx._header_bypass_allowed_here() is True
+
+
+def test_an_unreadable_signal_refuses(monkeypatch):
+    """If we cannot tell whether this is cloud, we do not open the bypass."""
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+
+    def _explode():
+        raise RuntimeError("no db")
+
+    module.is_multi_tenant_cloud = _explode
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+    monkeypatch.delenv(ctx._ALLOW_HEADER_BYPASS_ENV, raising=False)
+
+    assert ctx._header_bypass_allowed_here() is False
+
+
+def test_the_escape_hatch_re_enables_it(in_cloud, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv(ctx._ALLOW_HEADER_BYPASS_ENV, "1")
+    assert ctx._header_bypass_allowed_here() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+def test_only_an_explicit_opt_in_re_enables_it(in_cloud, monkeypatch, value):  # noqa: ARG001
+    """``...=0`` must not mean yes."""
+    monkeypatch.setenv(ctx._ALLOW_HEADER_BYPASS_ENV, value)
+    assert ctx._header_bypass_allowed_here() is False
+
+
+def test_the_resolver_consults_the_gate_with_every_other_factor_satisfied(in_cloud, monkeypatch):  # noqa: ARG001
+    """End to end, with the loopback check stubbed TRUE.
+
+    Written this way on purpose: a test that fails because the peer address is
+    wrong would also pass with the gate deleted.
+    """
+    monkeypatch.setattr(ctx, "_is_loopback_client", lambda request: True)
+
+    class _Req:
+        headers = {
+            ctx.INTERNAL_HEADER: "true",
+            ctx.WORKSPACE_HEADER: "ws-victim",
+            ctx.USER_HEADER: "u-victim",
+        }
+
+    assert ctx._try_loopback_context(_Req()) is None
+
+
+def test_the_loopback_factor_still_denies_on_its_own(monkeypatch):
+    """The pre-existing factor is untouched — this change only ADDS one.
+
+    With ``_is_loopback_client`` NOT stubbed, so a mutation deleting it cannot
+    escape behind the new gate.
+    """
+    module = types.ModuleType("pocketpaw_ee.cloud.shared.db")
+    module.is_multi_tenant_cloud = lambda: False
+    monkeypatch.setitem(sys.modules, "pocketpaw_ee.cloud.shared.db", module)
+    monkeypatch.delenv(ctx._ALLOW_HEADER_BYPASS_ENV, raising=False)
+
+    class _OffBox:
+        headers = {
+            ctx.INTERNAL_HEADER: "true",
+            ctx.WORKSPACE_HEADER: "ws",
+            ctx.USER_HEADER: "u",
+        }
+        client = types.SimpleNamespace(host="203.0.113.7")
+
+    assert ctx._try_loopback_context(_OffBox()) is None
+
+    class _Loopback(_OffBox):
+        client = types.SimpleNamespace(host="127.0.0.1")
+
+    assert ctx._try_loopback_context(_Loopback()) is not None
+
+
+def test_the_uvicorn_claim_is_not_restated_anywhere(monkeypatch):  # noqa: ARG001
+    """The comment that made this look safe was factually wrong.
+
+    uvicorn's Config defaults ``proxy_headers=True``. Pinned because the claim
+    is the kind that gets re-added by someone reasoning from memory.
+    """
+    import inspect
+
+    source = inspect.getsource(ctx)
+    assert "doesn't honor the header by default" not in source, (
+        "the incorrect uvicorn claim is back; uvicorn defaults proxy_headers=True"
+    )

--- a/tests/mutations/internal_header_context_gate.json
+++ b/tests/mutations/internal_header_context_gate.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "drop the gate from the resolver — the shipped state",
+    "file": "ee/pocketpaw_ee/cloud/_core/context.py",
+    "find": "    if not _header_bypass_allowed_here():\n        return None\n\n    if not _is_loopback_client(request):",
+    "replace": "    if not _is_loopback_client(request):",
+    "tests": ["tests/cloud/test_internal_header_context_gate.py"]
+  },
+  {
+    "label": "return True when the multi-tenant signal cannot be read",
+    "file": "ee/pocketpaw_ee/cloud/_core/context.py",
+    "find": "            \"refusing the internal header context (fail-closed).\"\n        )\n        return False\n    return True",
+    "replace": "            \"refusing the internal header context (fail-closed).\"\n        )\n        return True\n    return True",
+    "tests": ["tests/cloud/test_internal_header_context_gate.py"]
+  },
+  {
+    "label": "treat any present value of the opt-in as truthy, so =0 means yes",
+    "file": "ee/pocketpaw_ee/cloud/_core/context.py",
+    "find": "    if os.environ.get(_ALLOW_HEADER_BYPASS_ENV, \"\").strip().lower() in (\n        \"1\",\n        \"true\",\n        \"yes\",\n        \"on\",\n    ):",
+    "replace": "    if _ALLOW_HEADER_BYPASS_ENV in os.environ:",
+    "tests": ["tests/cloud/test_internal_header_context_gate.py"]
+  },
+  {
+    "label": "allow the bypass in cloud outright",
+    "file": "ee/pocketpaw_ee/cloud/_core/context.py",
+    "find": "        if is_multi_tenant_cloud():\n            return False",
+    "replace": "        if is_multi_tenant_cloud():\n            return True",
+    "tests": ["tests/cloud/test_internal_header_context_gate.py"]
+  },
+  {
+    "label": "drop the loopback factor — a pre-existing check",
+    "file": "ee/pocketpaw_ee/cloud/_core/context.py",
+    "find": "    if not _is_loopback_client(request):\n        return None\n\n    workspace_id = request.headers.get(WORKSPACE_HEADER, \"\").strip()",
+    "replace": "    workspace_id = request.headers.get(WORKSPACE_HEADER, \"\").strip()",
+    "tests": ["tests/cloud/test_internal_header_context_gate.py"]
+  },
+  {
+    "label": "restore the incorrect uvicorn claim",
+    "file": "ee/pocketpaw_ee/cloud/_core/context.py",
+    "find": "# This comment used to claim that uvicorn ignores forwarded headers unless\n# configured. That is WRONG, and it was load-bearing for how safe this looked.",
+    "replace": "# An attacker has to forge X-Forwarded-For upstream of the ASGI server\n# (uvicorn doesn't honor the header by default).",
+    "tests": ["tests/cloud/test_internal_header_context_gate.py"]
+  }
+]


### PR DESCRIPTION
From the Mongo query-level tenancy audit — `audits/audit-tenancy.md`, finding **T-9**.

## What

`_core/context.py` accepts the caller's workspace and user straight from `X-PocketPaw-Workspace-Id` / `X-PocketPaw-User-Id` when the peer address is loopback. Bound on all 24 routes of `foresight/router.py` (import `:147`, first use `:185`).

Two factors: the header trio, and `_is_loopback_client`, which tests `request.client.host` against four loopback literals. The docstring is candid about the second:

> the loopback host check is the only boundary between the local chat agent and full workspace access

Behind a reverse proxy on the same host, that boundary is nothing — every external client presents as loopback.

## Why this is the same decision as #2126, applied to a weaker path

`pockets/router.py:_loopback_bypass_active` requires a **fourth** factor: `_bypass_token_matches`, a `compare_digest` against a process-local secret whose own header comment says it exists because "a same-machine adversary could forge the tenancy". PR #2126 gated that one on `is_multi_tenant_cloud()` anyway.

This path has no token and no compare, and `is_multi_tenant_cloud()` appeared nowhere in `_core/context.py` or `foresight/router.py`. Strictly weaker, ungated.

`_header_bypass_allowed_here` mirrors #2126's `_bypass_allowed_here` deliberately, including the failure direction — an unreadable signal refuses. `POCKETPAW_INTERNAL_HEADER_CONTEXT_ENABLED=1` is the escape hatch, and it logs every time it is consulted.

**Local installs are unaffected.** No cloud DB means one tenant, and that is the deployment where this bypass is how the local chat agent reaches its own backend.

## A comment that was load-bearing, and wrong

`context.py:157` said an attacker would have to forge `X-Forwarded-For` upstream "(uvicorn doesn't honor the header by default)".

uvicorn's `Config` defaults `proxy_headers=True`. What bounds it is `forwarded_allow_ips`, default `127.0.0.1` — and `_core/rate_limit.py:56` already records that ours is unset. So a proxy on the same host both terminates as loopback **and** can set the forwarded header. The comment is corrected, and a mutation restores the wrong claim so the tests catch its return.

## Verification

- 6 mutations, all caught (`tests/mutations/internal_header_context_gate.json`), including "drop the loopback factor" — a pre-existing check, so this change is shown to ADD a factor rather than replace one — and "restore the incorrect uvicorn claim".
- `tests/cloud/test_internal_header_context_gate.py` — 13 passed.
- `mutate.py --validate` — 1391 anchors across 112 plans each resolve exactly once.
- ruff check and format clean.

**Baseline note:** `tests/cloud/test_foresight_*.py` runs 350 passed / 2 failed on this branch, and **the same 2 fail identically on clean `dev`** (`test_insights_empty_workspace_returns_empty_items`, `test_insights_tenant_isolation`). Measured, not assumed — they are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)