### PR TITLE
Reversals claim their share before they debit

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -171,6 +171,19 @@
 #   first under a conditional ``credits_reversed <= granted - amount`` filter
 #   and the debit only follows a claim that won.
 #
+#   THAT ORDERING OPENS ITS OWN WINDOW, and it is covered twice. A failure
+#   between the claim and the debit leaves a reversal recorded that never took
+#   the credits, and the redelivery carries this delivery's own id so the row
+#   alone cannot tell it from a routine replay. The debit's failure path
+#   RELEASES the claim (``_release_reversal_claim``, skipped when the ledger
+#   already records the movement, since ``debit`` can raise after the balance
+#   moved) so a redelivery re-drives cleanly; and a hard kill, which runs no
+#   ``except``, is caught on redelivery by an identity check plus
+#   ``is_recorded`` that logs at ERROR instead of "already applied". That
+#   check sits ABOVE the ``remaining <= 0`` return on purpose — below it, a
+#   redelivery of a FULL reversal returns before the claim is ever reached and
+#   the alarm is dead code.
+#
 #   THE TRAP THAT MAKES M5 MORE THAN A ONE-LINER: ``_active_subscription`` used
 #   to filter ``status == "active"`` and is now ``_billable_subscription`` over
 #   {active, on_hold}. Writing "on_hold" into that field WITHOUT widening the
@@ -950,6 +963,42 @@ def _reversal_ack(reversed_credits: int = 0) -> dict:
     return {"ok": True, "granted": False, "reversed": int(reversed_credits)}
 
 
+async def _release_reversal_claim(doc: Payment, event: ReversalEvent, amount: int) -> None:
+    """Undo one reversal's claim after its debit raised, so a redelivery can retry.
+
+    GUARDED ON THE LEDGER, because ``credits.debit`` can also raise AFTER the
+    money moved — it stamps the entry and emits once the balance ``$inc`` has
+    landed. Releasing then would hand the remainder back to a later reversal on
+    top of credits already taken, which is the over-reversal the claim-first
+    ordering exists to prevent. "Recorded" is the conservative answer: keep the
+    claim and let the redelivery's identity check classify it.
+
+    Never raises. A release that fails leaves exactly the state a hard kill
+    leaves, which the redelivery already alarms on, and swallowing the original
+    exception to report this one would lose the reason the debit failed.
+    """
+    try:
+        if await credits_service.is_recorded(doc.workspace, event.event_id):
+            return
+        await Payment.get_pymongo_collection().find_one_and_update(
+            {"_id": doc.id, "reversal_event_ids": event.event_id},
+            {
+                "$inc": {"credits_reversed": -amount},
+                "$pull": {"reversal_event_ids": event.event_id},
+                "$currentDate": {"updatedAt": True},
+            },
+        )
+    except Exception:
+        logger.exception(
+            "billing.webhook: could not release the reversal claim for payment=%s "
+            "(event_id=%s) after its debit failed — the row now records %d credits that "
+            "were never taken; the redelivery will alarm",
+            event.payment_id,
+            event.event_id,
+            amount,
+        )
+
+
 async def _handle_reversal_event(event: ReversalEvent) -> dict:
     """Claw credits back for a VERIFIED reversal (signature already checked).
 
@@ -1003,18 +1052,30 @@ async def _handle_reversal_event(event: ReversalEvent) -> dict:
     read-modify-write, so a refund and a lost dispute arriving together both read
     ``credits_reversed`` before either claimed it and both took the full grant.
     Claiming first — under a conditional ``credits_reversed <= granted - amount``
-    filter, in the same atomic operator that increments it — is the ledger's own
-    insert-first-then-apply discipline (``credits.service`` inserts the ledger row
-    before the balance moves for exactly this reason): contenders serialise at the
+    filter, in the same atomic operator that increments it — borrows the SHAPE of
+    the ledger's insert-first-then-apply discipline: contenders serialise at the
     write, not after the money has already moved.
 
-    THE TRADE that ordering makes is deliberate. A crash between the claim and
-    the debit now leaves a reversal recorded that never took the credits, and the
-    ``$ne`` filter stops the redelivery re-driving it, so it needs a human. The
-    old order healed that case and could over-reverse instead. This module's
-    posture, stated above for the unparseable partial, decides it: an
-    under-reversal is recoverable by hand, money taken from a customer who did
-    not owe it is not.
+    IT DOES NOT BORROW THE HEAL, and that difference is the whole of what follows.
+    ``credits.service`` can insert first because ``reconcile`` re-drives every
+    ``applied is False`` phantom it leaves behind. There is no equivalent for a
+    claimed-but-undebited reversal, and nothing calls ``reconcile`` on a schedule
+    in any case. So this path covers its own crash window twice over:
+
+      * the debit's failure path RELEASES the claim (``_release_reversal_claim``)
+        so the gateway's redelivery re-drives the reversal cleanly. The release is
+        keyed on this event's own id and is skipped when the ledger already
+        records the movement, so it can never hand back a share whose money moved;
+      * a hard kill runs no ``except``, so the claim survives with no debit behind
+        it. The redelivery detects that by identity plus ``is_recorded`` and logs
+        at ERROR instead of reporting the routine outcome — see the check above
+        the cap. It is the one state in which "already applied" would be false.
+
+    THE RESIDUAL TRADE is deliberate: a hard kill leaves an under-reversal for a
+    human to settle. The old order healed that case and could over-reverse
+    instead. This module's posture, stated above for the unparseable partial,
+    decides it — an under-reversal is recoverable by hand, money taken from a
+    customer who did not owe it is not.
 
     THE BALANCE IS ALLOWED TO GO NEGATIVE. ``debit(allow_negative=True)`` never
     raises, and a negative balance blocks further spend (``check_balance``
@@ -1062,6 +1123,56 @@ async def _handle_reversal_event(event: ReversalEvent) -> dict:
             event.payment_id,
             event.event_id,
         )
+        return _reversal_ack()
+
+    # HAS THIS DELIVERY ALREADY CLAIMED? Answer it HERE, by identity, before any
+    # arithmetic — the ``remaining <= 0`` return below would otherwise swallow
+    # every redelivery of a FULL reversal and never reach the claim at all.
+    #
+    # Two states reach this line and they are not alike. Since the claim runs
+    # before the debit, a failure between the two leaves a reversal recorded that
+    # never took the credits, and this delivery's own id is already on the row —
+    # so it cannot be told from a routine replay by the row alone. The ledger is
+    # the second fact: ``is_recorded`` asks whether ANY movement exists under
+    # this event id, and the debit keys on exactly that id.
+    #
+    # The window is reachable without a process kill. ``handle_webhook`` is
+    # wrapped in no try/except, so an exception inside the debit is a 500; the
+    # gateway redelivers; the redelivery is acked 200 and it stops retrying. The
+    # release on the debit's own failure path below closes the ordinary case;
+    # this alarm is what covers a hard kill, which no release can.
+    #
+    # TWO HONEST LIMITS. A ledger entry is inserted before the balance moves, so
+    # a crash in that narrow window reads as recorded here and logs routine —
+    # that is ``credits.service``'s own phantom state, and ``reconcile`` is its
+    # named remedy, not this path's. And a SECOND copy of this event arriving
+    # while the first is still mid-debit can read "not recorded" and alarm
+    # spuriously; the window is one round-trip wide, and a false alarm is the
+    # right way to be wrong here.
+    if event.event_id in (doc.reversal_event_ids or []):
+        if await credits_service.is_recorded(doc.workspace, event.event_id):
+            logger.info(
+                "billing.webhook: %s for payment=%s (event_id=%s) was already applied — "
+                "nothing debited, balance unchanged",
+                event.type,
+                event.payment_id,
+                event.event_id,
+            )
+        else:
+            logger.error(
+                "billing.webhook: %s for payment=%s (event_id=%s) is RECORDED ON THE PAYMENT "
+                "ROW BUT NO CREDITS WERE EVER TAKEN, and this redelivery cannot take them — "
+                "the row already lists this event. The reversal died between claiming its "
+                "share and debiting the wallet. workspace=%s is holding credits it was "
+                "refunded for; the row reads credits_reversed=%d against granted=%d. Settle "
+                "it by hand: nothing retries this",
+                event.type,
+                event.payment_id,
+                event.event_id,
+                doc.workspace,
+                int(doc.credits_reversed or 0),
+                int(doc.amount_credits if doc.credits_granted is None else doc.credits_granted),
+            )
         return _reversal_ack()
 
     # A row written before ``credits_granted`` existed carries None. Those rows
@@ -1177,19 +1288,27 @@ async def _handle_reversal_event(event: ReversalEvent) -> dict:
             )
         return _reversal_ack()
 
-    balance = await credits_service.debit(
-        workspace=doc.workspace,
-        amount=amount,
-        cause=_REVERSAL_CAUSE,
-        idempotency_key=event.event_id,
-        allow_negative=True,
-        ref={
-            "gateway": _GATEWAY,
-            "event_id": event.event_id,
-            "payment_id": event.payment_id,
-            "reason": event.type,
-        },
-    )
+    try:
+        balance = await credits_service.debit(
+            workspace=doc.workspace,
+            amount=amount,
+            cause=_REVERSAL_CAUSE,
+            idempotency_key=event.event_id,
+            allow_negative=True,
+            ref={
+                "gateway": _GATEWAY,
+                "event_id": event.event_id,
+                "payment_id": event.payment_id,
+                "reason": event.type,
+            },
+        )
+    except Exception:
+        # RELEASE the claim just made, so the gateway's redelivery re-drives this
+        # reversal from scratch instead of finding its own id on the row and
+        # being refused forever. Both halves of the release are keyed on THIS
+        # event's id, so it can never free a claim some other reversal made.
+        await _release_reversal_claim(doc, event, amount)
+        raise
 
     logger.warning(
         "billing.webhook: %s reversed %d credits from workspace=%s (payment=%s, event_id=%s) — "

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -966,12 +966,22 @@ def _reversal_ack(reversed_credits: int = 0) -> dict:
 async def _release_reversal_claim(doc: Payment, event: ReversalEvent, amount: int) -> None:
     """Undo one reversal's claim after its debit raised, so a redelivery can retry.
 
-    GUARDED ON THE LEDGER, because ``credits.debit`` can also raise AFTER the
-    money moved — it stamps the entry and emits once the balance ``$inc`` has
-    landed. Releasing then would hand the remainder back to a later reversal on
-    top of credits already taken, which is the over-reversal the claim-first
-    ordering exists to prevent. "Recorded" is the conservative answer: keep the
-    claim and let the redelivery's identity check classify it.
+    GUARDED ON THE LEDGER, for two reasons and not one.
+
+    First, ``credits.debit`` can raise AFTER the money moved: it stamps the entry
+    and emits once the balance ``$inc`` has landed, two awaits past the point of
+    no return. Releasing then hands the remainder back to a later reversal on top
+    of credits already taken — the over-reversal this ordering exists to prevent.
+
+    Second, and less obvious: an entry inserted whose ``$inc`` never landed is a
+    PHANTOM, and ``reconcile`` re-drives every ``applied is False`` entry it
+    finds. Release the claim there and reconcile applies the debit later against
+    a row that no longer records it, so the next reversal can take the same share
+    again. That turns a recoverable phantom into an over-reversal. Do not relax
+    this guard to "only the money-already-moved case" — it covers both.
+
+    "Recorded" is therefore the conservative answer in every ambiguous state:
+    keep the claim, and let the redelivery's identity check classify it.
 
     Never raises. A release that fails leaves exactly the state a hard kill
     leaves, which the redelivery already alarms on, and swallowing the original
@@ -1069,7 +1079,11 @@ async def _handle_reversal_event(event: ReversalEvent) -> dict:
       * a hard kill runs no ``except``, so the claim survives with no debit behind
         it. The redelivery detects that by identity plus ``is_recorded`` and logs
         at ERROR instead of reporting the routine outcome — see the check above
-        the cap. It is the one state in which "already applied" would be false.
+        the cap. It is NOT the only state in which "already applied" would be
+        false: a phantom ledger entry is the other, and this path deliberately
+        reports that one as routine. The difference is that a phantom still has
+        an entry for ``reconcile`` to re-drive, and an orphaned claim has nothing
+        — no other mechanism will ever resolve it, which is why it alarms.
 
     THE RESIDUAL TRADE is deliberate: a hard kill leaves an under-reversal for a
     human to settle. The old order healed that case and could over-reverse
@@ -1144,11 +1158,18 @@ async def _handle_reversal_event(event: ReversalEvent) -> dict:
     #
     # TWO HONEST LIMITS. A ledger entry is inserted before the balance moves, so
     # a crash in that narrow window reads as recorded here and logs routine —
-    # that is ``credits.service``'s own phantom state, and ``reconcile`` is its
-    # named remedy, not this path's. And a SECOND copy of this event arriving
-    # while the first is still mid-debit can read "not recorded" and alarm
-    # spuriously; the window is one round-trip wide, and a false alarm is the
-    # right way to be wrong here.
+    # that is ``credits.service``'s own phantom state, whose remedy is
+    # ``reconcile``, run BY HAND. Nothing schedules it, so "reconcile covers it"
+    # means a person has to run it; it is still the right owner for that state,
+    # because the entry exists to be re-driven and a claimed-but-undebited
+    # reversal has nothing at all.
+    #
+    # And a SECOND copy of this event arriving while the first is still mid-debit
+    # can read "not recorded" and alarm spuriously; the window is one round-trip
+    # wide. A false alarm is the right way to be wrong here — it is noisy and
+    # resolves the moment someone reads the ledger, where a missed orphan is
+    # silent, permanent, and costs the customer money. The message below says so
+    # rather than asserting a certainty this check does not have.
     if event.event_id in (doc.reversal_event_ids or []):
         if await credits_service.is_recorded(doc.workspace, event.event_id):
             logger.info(
@@ -1160,12 +1181,15 @@ async def _handle_reversal_event(event: ReversalEvent) -> dict:
             )
         else:
             logger.error(
-                "billing.webhook: %s for payment=%s (event_id=%s) is RECORDED ON THE PAYMENT "
-                "ROW BUT NO CREDITS WERE EVER TAKEN, and this redelivery cannot take them — "
-                "the row already lists this event. The reversal died between claiming its "
-                "share and debiting the wallet. workspace=%s is holding credits it was "
-                "refunded for; the row reads credits_reversed=%d against granted=%d. Settle "
-                "it by hand: nothing retries this",
+                "billing.webhook: %s for payment=%s (event_id=%s) is RECORDED ON THE "
+                "PAYMENT ROW WITH NO LEDGER MOVEMENT BEHIND IT, and this redelivery cannot "
+                "make one — the row already lists this event. Almost certainly the reversal "
+                "died between claiming its share and debiting the wallet, leaving "
+                "workspace=%s holding credits it was refunded for; the row reads "
+                "credits_reversed=%d against granted=%d, and nothing retries it. CHECK THE "
+                "LEDGER BEFORE SETTLING BY HAND: a duplicate delivery of this same event "
+                "still in flight reads identically here for about one round-trip, and its "
+                "debit may land a moment from now",
                 event.type,
                 event.payment_id,
                 event.event_id,

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -158,6 +158,19 @@
 #   rather than Dodo's ``dunning.*`` events, which are a per-business toggle that
 #   may be off and carry no metadata to route on.
 #
+#   (T-4) REVERSALS CLAIM BEFORE THEY DEBIT. ``_handle_reversal_event`` used to
+#   debit and only then claim the running total under a ``$ne`` filter on the
+#   event id. That filter guards a REDELIVERY of one event and nothing else, so
+#   a refund and a lost dispute on the same payment — routine, because Verifi
+#   RDR resolves disputes by refunding — both read ``credits_reversed`` before
+#   either claimed it, both cleared the same cap, and both debited under their
+#   own idempotency keys: twice the grant clawed back and the wallet driven
+#   negative, which ``check_balance`` turns into a lockout. It needs no second
+#   process; the two deliveries interleave at an ``await`` inside ONE event
+#   loop, so a single-worker deploy was never protected. The claim now runs
+#   first under a conditional ``credits_reversed <= granted - amount`` filter
+#   and the debit only follows a claim that won.
+#
 #   THE TRAP THAT MAKES M5 MORE THAN A ONE-LINER: ``_active_subscription`` used
 #   to filter ``status == "active"`` and is now ``_billable_subscription`` over
 #   {active, on_hold}. Writing "on_hold" into that field WITHOUT widening the
@@ -982,10 +995,26 @@ async def _handle_reversal_event(event: ReversalEvent) -> dict:
 
     IDEMPOTENCY is the ledger's, keyed on the webhook event id exactly as the
     grant path keys on it, so a redelivery collides on BC-1's unique
-    ``(workspace, idempotency_key)`` index and moves nothing. The debit runs
-    FIRST and the row's running total is claimed second under a ``$ne`` filter on
-    the event id: money is never left un-moved because a bookkeeping write
-    failed, and a crash between the two heals on the next delivery.
+    ``(workspace, idempotency_key)`` index and moves nothing.
+
+    THE CLAIM RUNS FIRST, THE DEBIT SECOND, and the order is the whole defence
+    against two DIFFERENT reversals on one payment. The ``$ne`` filter on the
+    event id only ever guarded a redelivery of the SAME event; the cap above is a
+    read-modify-write, so a refund and a lost dispute arriving together both read
+    ``credits_reversed`` before either claimed it and both took the full grant.
+    Claiming first — under a conditional ``credits_reversed <= granted - amount``
+    filter, in the same atomic operator that increments it — is the ledger's own
+    insert-first-then-apply discipline (``credits.service`` inserts the ledger row
+    before the balance moves for exactly this reason): contenders serialise at the
+    write, not after the money has already moved.
+
+    THE TRADE that ordering makes is deliberate. A crash between the claim and
+    the debit now leaves a reversal recorded that never took the credits, and the
+    ``$ne`` filter stops the redelivery re-driving it, so it needs a human. The
+    old order healed that case and could over-reverse instead. This module's
+    posture, stated above for the unparseable partial, decides it: an
+    under-reversal is recoverable by hand, money taken from a customer who did
+    not owe it is not.
 
     THE BALANCE IS ALLOWED TO GO NEGATIVE. ``debit(allow_negative=True)`` never
     raises, and a negative balance blocks further spend (``check_balance``
@@ -1077,6 +1106,77 @@ async def _handle_reversal_event(event: ReversalEvent) -> dict:
     else:
         amount = remaining
 
+    # CLAIM the reversal on the payment row BEFORE any money moves. The filter
+    # carries two independent guards:
+    #
+    #   * ``reversal_event_ids: {$ne: ...}`` — the REDELIVERY guard. A second
+    #     copy of THIS event finds its own id already listed and adds nothing.
+    #     Unchanged, and it was never the guard the concurrent case needed.
+    #   * ``credits_reversed <= granted - amount`` — the CONCURRENCY guard. The
+    #     ``remaining`` computed above is a read-modify-write: two DIFFERENT
+    #     deliveries on one payment (a refund AND a lost dispute, routine because
+    #     Verifi RDR resolves disputes by refunding) both read ``already`` before
+    #     either had claimed it, so both were cleared to take the whole grant and
+    #     the running total landed at twice what was handed out — with the wallet
+    #     driven negative and the customer locked out by ``check_balance``. This
+    #     re-checks the cap against the row AS IT IS NOW, inside the same atomic
+    #     operator that increments it, so the loser is turned away instead. It
+    #     needs no second process: the read, the awaited debit and the claim are
+    #     ordered so two deliveries interleave at an ``await`` in ONE event loop.
+    #
+    # A legacy row has no ``credits_reversed`` field at all and ``$lte`` never
+    # matches a missing field, so the ``$exists`` arm lets it through — it reads
+    # as 0, which is under every cap (``amount <= remaining``, so ``cap >= 0``).
+    cap = int(granted) - amount
+    claimed = await Payment.get_pymongo_collection().find_one_and_update(
+        {
+            "_id": doc.id,
+            "reversal_event_ids": {"$ne": event.event_id},
+            "$or": [
+                {"credits_reversed": {"$lte": cap}},
+                {"credits_reversed": {"$exists": False}},
+            ],
+        },
+        {
+            "$inc": {"credits_reversed": amount},
+            "$push": {"reversal_event_ids": event.event_id},
+            "$currentDate": {"updatedAt": True},
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if claimed is None:
+        # WHICH guard turned it away? A redelivery is routine and silent. Losing
+        # the CAP to a concurrent reversal is the alarm: nothing anywhere
+        # compares the running total against the grant after the fact, so an
+        # attempted over-reversal would otherwise be invisible right up until
+        # ``check_balance`` locks the customer out of a wallet they never
+        # overdrew. It is also the signal that two reversals landed on one
+        # payment, which a human wants to see whatever the outcome.
+        current = await Payment.get_pymongo_collection().find_one({"_id": doc.id})
+        if event.event_id in ((current or {}).get("reversal_event_ids") or []):
+            logger.info(
+                "billing.webhook: %s for payment=%s (event_id=%s) was already applied — "
+                "nothing debited, balance unchanged",
+                event.type,
+                event.payment_id,
+                event.event_id,
+            )
+        else:
+            logger.error(
+                "billing.webhook: %s for payment=%s (event_id=%s) would have reversed %d "
+                "credits past the grant — REFUSED before debiting. granted=%d, already "
+                "reversed=%d (was %d when this delivery read it): a concurrent reversal on "
+                "the same payment claimed the remainder first",
+                event.type,
+                event.payment_id,
+                event.event_id,
+                amount,
+                int(granted),
+                int((current or {}).get("credits_reversed") or 0),
+                already,
+            )
+        return _reversal_ack()
+
     balance = await credits_service.debit(
         workspace=doc.workspace,
         amount=amount,
@@ -1090,29 +1190,6 @@ async def _handle_reversal_event(event: ReversalEvent) -> dict:
             "reason": event.type,
         },
     )
-
-    # Claim the reversal on the payment row. The ``$ne`` filter is the
-    # exactly-once guard for the running total: a redelivery that somehow got
-    # past the remaining-credits check above finds its event id already listed
-    # and adds nothing.
-    claimed = await Payment.get_pymongo_collection().find_one_and_update(
-        {"_id": doc.id, "reversal_event_ids": {"$ne": event.event_id}},
-        {
-            "$inc": {"credits_reversed": amount},
-            "$push": {"reversal_event_ids": event.event_id},
-            "$currentDate": {"updatedAt": True},
-        },
-        return_document=ReturnDocument.AFTER,
-    )
-    if claimed is None:
-        logger.info(
-            "billing.webhook: %s for payment=%s (event_id=%s) was already applied — the debit "
-            "was a no-op, balance unchanged",
-            event.type,
-            event.payment_id,
-            event.event_id,
-        )
-        return _reversal_ack()
 
     logger.warning(
         "billing.webhook: %s reversed %d credits from workspace=%s (payment=%s, event_id=%s) — "

--- a/tests/cloud/billing/test_reversals.py
+++ b/tests/cloud/billing/test_reversals.py
@@ -29,8 +29,16 @@
 #   mongomock's awaits never actually suspend, so ``asyncio.gather`` alone runs
 #   the two deliveries end to end; ``_interleave_at_the_read_and_the_debit``
 #   restores the suspension production's real I/O has at the row read and the
-#   debit, and nothing else about the deliveries is faked. Mutation plan:
-#   ``tests/mutations/billing_reversal_claim.json``.
+#   debit, and nothing else about the deliveries is faked.
+# Updated 2026-09-11 (fix/billing-reversal-claim-first, T-4 review): four more
+#   tests for the window claim-first opens. A failed debit must RELEASE its
+#   claim so the redelivery heals; a debit that raised AFTER the balance moved
+#   must KEEP it (releasing there hands the remainder to the next reversal on
+#   top of credits already taken); a hard kill — modelled as ``CancelledError``,
+#   which no ``except Exception`` catches — must alarm on redelivery rather than
+#   log "already applied", which is the one state where that line is false; and
+#   a genuine redelivery must stay quiet, or the alarm trains people to ignore
+#   it. Mutation plan: ``tests/mutations/billing_reversal_claim.json``.
 
 from __future__ import annotations
 
@@ -39,6 +47,7 @@ import base64
 import json
 from datetime import UTC, datetime
 
+import pytest
 from pocketpaw_ee.cloud.billing import service as billing
 from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
 from pocketpaw_ee.cloud.credits import service as credits
@@ -648,3 +657,163 @@ async def test_a_racing_reversal_that_loses_the_claim_debits_nothing(mongo_db, m
     reversals = [e for e in entries if e.cause == billing._REVERSAL_CAUSE]
     assert len(reversals) == 1
     assert reversals[0].amount_delta == -500
+
+
+# ---------------------------------------------------------------------------
+# T-4 — the crash window the claim-first ordering opens, and what tells a human.
+#
+# Claiming before debiting means a failure BETWEEN the two leaves a reversal
+# recorded on the payment row that never took the credits. The redelivery is
+# refused by the ``$ne`` filter — the dead delivery put its own id there — so
+# without a second distinguishing fact it reads as a routine replay and logs
+# "already applied", which is a lie in this one state: the customer is holding
+# credits they were refunded for and the row says otherwise.
+#
+# The window is reachable without a process kill. ``webhooks.py`` wraps
+# ``handle_webhook`` in no try/except, so an exception inside the debit is a
+# 500; Dodo redelivers; the redelivery is acked 200 and the gateway stops.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_failed_debit_releases_the_claim_so_the_redelivery_heals(mongo_db, monkeypatch):
+    """An ordinary Mongo hiccup inside the debit (``socketTimeoutMS`` is 30s)
+    must leave NO trace on the payment row, so the gateway's redelivery re-drives
+    the reversal from scratch. The release is keyed on this delivery's own event
+    id, so it cannot free a claim some other reversal made."""
+    await _grant_topup(amount=500)
+
+    async def _mongo_went_away(*_args, **_kwargs):
+        raise RuntimeError("connection closed mid-debit")
+
+    monkeypatch.setattr(billing.credits_service, "debit", _mongo_went_away)
+
+    body = _refund_body()
+    headers = _sign(body, msg_id="evt_debit_failed")
+    with pytest.raises(RuntimeError):
+        await billing.handle_webhook(payload=body.encode(), headers=headers, provider=_provider())
+
+    row = await Payment.find_one(Payment.workspace == WS)
+    assert row is not None
+    assert row.credits_reversed == 0
+    assert row.reversal_event_ids == []
+    assert await credits.balance(WS) == 500  # no money moved either way
+
+    monkeypatch.undo()
+    result = await billing.handle_webhook(
+        payload=body.encode(), headers=headers, provider=_provider()
+    )
+
+    assert result == {"ok": True, "granted": False, "reversed": 500}
+    assert await credits.balance(WS) == 0
+
+
+async def test_a_claim_whose_debit_never_ran_alarms_instead_of_reporting_it_applied(
+    mongo_db, monkeypatch, caplog
+):
+    """The hard-kill half, which no compensating release can cover: a SIGTERM
+    during a deploy cancels the task mid-debit, and ``CancelledError`` is a
+    ``BaseException`` so no ``except Exception`` runs. The claim stands, the
+    credits were never taken, and the redelivery is refused by the ``$ne``
+    filter. That state MUST alarm — it is the one case where "already applied"
+    is false, and nothing else in the system compares the two."""
+    await _grant_topup(amount=500)
+
+    async def _killed_mid_debit(*_args, **_kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(billing.credits_service, "debit", _killed_mid_debit)
+
+    body = _refund_body()
+    headers = _sign(body, msg_id="evt_orphan_claim")
+    with pytest.raises(asyncio.CancelledError):
+        await billing.handle_webhook(payload=body.encode(), headers=headers, provider=_provider())
+
+    monkeypatch.undo()
+
+    # The orphan: the row says 500 was reversed, the wallet says otherwise.
+    row = await Payment.find_one(Payment.workspace == WS)
+    assert row is not None
+    assert row.credits_reversed == 500
+    assert row.reversal_event_ids == ["evt_orphan_claim"]
+    assert await credits.balance(WS) == 500
+
+    with caplog.at_level("INFO"):
+        result = await billing.handle_webhook(
+            payload=body.encode(), headers=headers, provider=_provider()
+        )
+
+    # Still acked and still no double-debit — the guard itself is unchanged.
+    assert result == {"ok": True, "granted": False, "reversed": 0}
+    assert await credits.balance(WS) == 500
+
+    errors = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
+    assert any("evt_orphan_claim" in m for m in errors), "the orphan claim must alarm"
+    # And it must NOT report the routine outcome, which is what makes the line a
+    # lie: no credits were taken and none ever will be for this delivery.
+    infos = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+    assert not any("already applied" in m for m in infos)
+
+
+async def test_a_genuine_redelivery_still_reports_the_routine_outcome(mongo_db, caplog):
+    """The other side of that branch. When the debit DID land, the redelivery is
+    ordinary and must stay quiet — an ERROR here would train a human to ignore
+    the one that matters."""
+    await _grant_topup(amount=500)
+    body = _refund_body()
+    headers = _sign(body, msg_id="evt_real_replay")
+
+    await billing.handle_webhook(payload=body.encode(), headers=headers, provider=_provider())
+    assert await credits.balance(WS) == 0
+
+    with caplog.at_level("INFO"):
+        result = await billing.handle_webhook(
+            payload=body.encode(), headers=headers, provider=_provider()
+        )
+
+    assert result == {"ok": True, "granted": False, "reversed": 0}
+    assert not [r for r in caplog.records if r.levelname == "ERROR"]
+    assert any("already applied" in r.getMessage() for r in caplog.records)
+
+
+async def test_a_debit_that_moved_the_money_before_raising_keeps_its_claim(mongo_db, monkeypatch):
+    """The release has to be guarded, not reflexive. ``credits.debit`` stamps the
+    ledger entry and emits AFTER the balance ``$inc`` has landed, so it can raise
+    with the money already gone. Releasing the claim there would hand the
+    remainder back to the next reversal on top of credits already taken — the
+    exact over-reversal this ordering exists to prevent."""
+    await _grant_topup(amount=500)
+    real_debit = credits.debit
+
+    async def _raise_after_the_money_moved(*args, **kwargs):
+        await real_debit(*args, **kwargs)
+        raise RuntimeError("emit failed after the balance moved")
+
+    monkeypatch.setattr(billing.credits_service, "debit", _raise_after_the_money_moved)
+
+    refund = _refund_body()
+    with pytest.raises(RuntimeError):
+        await billing.handle_webhook(
+            payload=refund.encode(),
+            headers=_sign(refund, msg_id="evt_late_raise"),
+            provider=_provider(),
+        )
+
+    monkeypatch.undo()
+
+    # The money moved, so the claim must STAND.
+    row = await Payment.find_one(Payment.workspace == WS)
+    assert row is not None
+    assert row.credits_reversed == 500
+    assert row.reversal_event_ids == ["evt_late_raise"]
+    assert await credits.balance(WS) == 0
+
+    # And because it stands, a lost dispute on the same payment now finds the
+    # grant fully reversed and takes nothing, instead of clawing a second 500.
+    dispute = _dispute_body()
+    result = await billing.handle_webhook(
+        payload=dispute.encode(),
+        headers=_sign(dispute, msg_id="evt_late_dispute"),
+        provider=_provider(),
+    )
+    assert result == {"ok": True, "granted": False, "reversed": 0}
+    assert await credits.balance(WS) == 0

--- a/tests/cloud/billing/test_reversals.py
+++ b/tests/cloud/billing/test_reversals.py
@@ -19,9 +19,22 @@
 #
 # Created 2026-09-02 (fix/billing-reversals-and-dunning, M1 + M1a + F8): new
 #   test module.
+# Updated 2026-09-11 (fix/billing-reversal-claim-first, T-4): added the three
+#   racing-reversal tests at the foot of the module. The per-payment cap was a
+#   read-modify-write, so a refund and a lost dispute on one payment could each
+#   read ``credits_reversed`` before either claimed it and each take the whole
+#   grant — 1000 clawed back against a 500 grant, wallet at -500. The existing
+#   ``test_a_refund_then_a_lost_dispute_cannot_double_claw`` misses it because it
+#   awaits the first delivery to completion before starting the second.
+#   mongomock's awaits never actually suspend, so ``asyncio.gather`` alone runs
+#   the two deliveries end to end; ``_interleave_at_the_read_and_the_debit``
+#   restores the suspension production's real I/O has at the row read and the
+#   debit, and nothing else about the deliveries is faked. Mutation plan:
+#   ``tests/mutations/billing_reversal_claim.json``.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 from datetime import UTC, datetime
@@ -483,3 +496,155 @@ async def test_provider_refuses_to_guess_a_malformed_amount():
         payload=body.encode(), headers=_sign(body, msg_id="evt_parse_bad")
     )
     assert event.amount_credits == 0
+
+
+# ---------------------------------------------------------------------------
+# T-4 — two DIFFERENT reversals on one payment, interleaved in ONE event loop.
+#
+# The ``$ne`` filter on ``reversal_event_ids`` guards a REDELIVERY of the same
+# event. It does nothing for a refund and a lost dispute arriving together,
+# which is the routine case (Verifi RDR resolves disputes by refunding). Both
+# read ``credits_reversed`` before either has claimed it, both compute the same
+# ``remaining``, both debit under distinct idempotency keys, and the running
+# total lands at twice the grant with the wallet driven negative.
+#
+# This needs NO second process. The read, the awaited debit and the claim are
+# ordered so two deliveries interleave at an ``await`` inside a single loop, so
+# a single-worker deployment gives no protection at all. mongomock's awaits
+# never actually suspend, so the two helpers below restore the suspension that
+# production's real I/O has at exactly those two points — nothing else about
+# the deliveries is faked.
+# ---------------------------------------------------------------------------
+
+
+def _interleave_at_the_read_and_the_debit(monkeypatch) -> None:
+    """Make ``Payment.find_one`` and ``credits.debit`` yield to the loop.
+
+    Both are network round-trips in production and neither is under mongomock,
+    so without this ``asyncio.gather`` runs the two deliveries end to end, one
+    after the other, and no interleaving is possible to observe.
+    """
+    real_find_one = Payment.find_one
+    real_debit = credits.debit
+
+    async def _find_one_that_yields(*args, **kwargs):
+        doc = await real_find_one(*args, **kwargs)
+        await asyncio.sleep(0)
+        return doc
+
+    async def _debit_that_yields(*args, **kwargs):
+        await asyncio.sleep(0)
+        return await real_debit(*args, **kwargs)
+
+    monkeypatch.setattr(Payment, "find_one", _find_one_that_yields)
+    monkeypatch.setattr(billing.credits_service, "debit", _debit_that_yields)
+
+
+async def test_a_racing_refund_and_lost_dispute_cannot_claw_back_more_than_the_grant(
+    mongo_db, monkeypatch, caplog
+):
+    """The T-4 over-clawback. Granted 500; a refund and a lost dispute land
+    together and the pair must still only ever take 500."""
+    await _grant_topup(amount=500)
+    assert await credits.balance(WS) == 500
+
+    _interleave_at_the_read_and_the_debit(monkeypatch)
+
+    refund = _refund_body()
+    dispute = _dispute_body()
+    with caplog.at_level("ERROR"):
+        results = await asyncio.gather(
+            billing.handle_webhook(
+                payload=refund.encode(),
+                headers=_sign(refund, msg_id="evt_race_refund"),
+                provider=_provider(),
+            ),
+            billing.handle_webhook(
+                payload=dispute.encode(),
+                headers=_sign(dispute, msg_id="evt_race_dispute"),
+                provider=_provider(),
+            ),
+        )
+
+    # Exactly one of the two took the money; the other took nothing.
+    assert sorted(r["reversed"] for r in results) == [0, 500]
+
+    row = await Payment.find_one(Payment.workspace == WS)
+    assert row is not None
+    assert row.credits_reversed == 500  # NOT 1000
+    assert len(row.reversal_event_ids) == 1
+
+    # 500 granted, 500 clawed back, nothing spent — the wallet lands at zero and
+    # the customer is not locked out by a shortfall they never owed.
+    assert await credits.balance(WS) == 0
+
+    # Nothing compares the running total against the grant after the fact, so
+    # the loser has to alarm here or an attempted over-reversal is silent until
+    # ``check_balance`` locks the customer out.
+    assert any(
+        "evt_race_dispute" in r.getMessage() or "evt_race_refund" in r.getMessage()
+        for r in caplog.records
+        if r.levelname == "ERROR"
+    )
+
+
+async def test_a_racing_pair_of_partial_refunds_cannot_exceed_the_grant(mongo_db, monkeypatch):
+    """The same race with amounts that each fit under the cap on their own.
+    300 + 300 against a 500 grant must settle at 500, never 600."""
+    await _grant_topup(amount=500)
+
+    _interleave_at_the_read_and_the_debit(monkeypatch)
+
+    first = _refund_body(amount=300, is_partial=True)
+    second = _refund_body(amount=300, is_partial=True)
+    results = await asyncio.gather(
+        billing.handle_webhook(
+            payload=first.encode(),
+            headers=_sign(first, msg_id="evt_race_part_1"),
+            provider=_provider(),
+        ),
+        billing.handle_webhook(
+            payload=second.encode(),
+            headers=_sign(second, msg_id="evt_race_part_2"),
+            provider=_provider(),
+        ),
+    )
+
+    row = await Payment.find_one(Payment.workspace == WS)
+    assert row is not None
+    assert row.credits_reversed <= 500
+    assert sum(r["reversed"] for r in results) == row.credits_reversed
+    assert await credits.balance(WS) >= 0
+
+
+async def test_a_racing_reversal_that_loses_the_claim_debits_nothing(mongo_db, monkeypatch):
+    """The heart of the fix: the loser must be turned away BEFORE the money
+    moves. A loser that debits first and discovers the cap afterwards has
+    already taken the credits — the ledger is append-only and the wallet is
+    already short."""
+    await _grant_topup(amount=500)
+
+    _interleave_at_the_read_and_the_debit(monkeypatch)
+
+    refund = _refund_body()
+    dispute = _dispute_body()
+    await asyncio.gather(
+        billing.handle_webhook(
+            payload=refund.encode(),
+            headers=_sign(refund, msg_id="evt_race_ledger_r"),
+            provider=_provider(),
+        ),
+        billing.handle_webhook(
+            payload=dispute.encode(),
+            headers=_sign(dispute, msg_id="evt_race_ledger_d"),
+            provider=_provider(),
+        ),
+    )
+
+    # One reversal debit in the ledger, not two. The ledger is append-only, so a
+    # loser that debits and only then discovers the cap has already taken the
+    # credits — there is no entry here to take back.
+    entries, _ = await credits.history(WS, limit=200)
+    reversals = [e for e in entries if e.cause == billing._REVERSAL_CAUSE]
+    assert len(reversals) == 1
+    assert reversals[0].amount_delta == -500

--- a/tests/mutations/billing_reversal_claim.json
+++ b/tests/mutations/billing_reversal_claim.json
@@ -1,0 +1,38 @@
+[
+  {
+    "label": "reversal: drop the cap from the claim filter (back to the $ne-only guard)",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "            \"$or\": [\n                {\"credits_reversed\": {\"$lte\": cap}},\n                {\"credits_reversed\": {\"$exists\": False}},\n            ],\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/billing/test_reversals.py"
+    ]
+  },
+  {
+    "label": "reversal: cap ignores this delivery's own amount",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "    cap = int(granted) - amount",
+    "replace": "    cap = int(granted)",
+    "tests": [
+      "tests/cloud/billing/test_reversals.py"
+    ]
+  },
+  {
+    "label": "reversal: a legacy row with no credits_reversed field is excluded",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "                {\"credits_reversed\": {\"$exists\": False}},",
+    "replace": "                {\"credits_reversed\": {\"$exists\": True}},",
+    "tests": [
+      "tests/cloud/billing/test_reversals.py"
+    ]
+  },
+  {
+    "label": "reversal: the refused claim is logged as a routine redelivery, not an alarm",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "        if event.event_id in ((current or {}).get(\"reversal_event_ids\") or []):",
+    "replace": "        if True:",
+    "tests": [
+      "tests/cloud/billing/test_reversals.py"
+    ]
+  }
+]

--- a/tests/mutations/billing_reversal_claim.json
+++ b/tests/mutations/billing_reversal_claim.json
@@ -27,10 +27,46 @@
     ]
   },
   {
-    "label": "reversal: the refused claim is logged as a routine redelivery, not an alarm",
+    "label": "reversal: a claim refused by the cap is logged as a routine redelivery",
     "file": "ee/pocketpaw_ee/cloud/billing/service.py",
     "find": "        if event.event_id in ((current or {}).get(\"reversal_event_ids\") or []):",
     "replace": "        if True:",
+    "tests": [
+      "tests/cloud/billing/test_reversals.py"
+    ]
+  },
+  {
+    "label": "reversal: an orphaned claim reports the routine outcome instead of alarming",
+    "find": "    if event.event_id in (doc.reversal_event_ids or []):\n        if await credits_service.is_recorded(doc.workspace, event.event_id):",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "replace": "    if event.event_id in (doc.reversal_event_ids or []):\n        if True:",
+    "tests": [
+      "tests/cloud/billing/test_reversals.py"
+    ]
+  },
+  {
+    "label": "reversal: the redelivery check is moved below the remaining<=0 return",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "    if event.event_id in (doc.reversal_event_ids or []):",
+    "replace": "    if False and event.event_id in (doc.reversal_event_ids or []):",
+    "tests": [
+      "tests/cloud/billing/test_reversals.py"
+    ]
+  },
+  {
+    "label": "reversal: a failed debit leaves its claim on the row",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "        await _release_reversal_claim(doc, event, amount)\n        raise",
+    "replace": "        raise",
+    "tests": [
+      "tests/cloud/billing/test_reversals.py"
+    ]
+  },
+  {
+    "label": "reversal: the release runs even when the money already moved",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "    try:\n        if await credits_service.is_recorded(doc.workspace, event.event_id):\n            return",
+    "replace": "    try:\n        if False:\n            return",
     "tests": [
       "tests/cloud/billing/test_reversals.py"
     ]


### PR DESCRIPTION
Two reversals on the same payment could claw back twice what was granted, drive the wallet negative, and lock the customer out of an account they never overdrew.

## What was wrong

`_handle_reversal_event` computed its cap by read-modify-write: read `credits_reversed`, debit, then claim the running total under a `$ne` filter on the event id. That filter only ever guarded a redelivery of the *same* event. A refund and a lost dispute on one payment — routine, because Verifi RDR resolves disputes by refunding — both read `credits_reversed` before either claimed it, both cleared the same cap, and both debited under their own idempotency keys.

It needs no second process. The read, the awaited debit and the claim are ordered so two deliveries interleave at an `await` inside one event loop, so a single-worker deployment was never protected.

## What changed

The claim runs first, under a conditional `credits_reversed <= granted - amount` filter in the same atomic operator that increments it. The debit only follows a claim that won. Contenders serialise at the write rather than after the money has moved, which is the discipline the credit ledger already uses when it inserts the ledger row before moving the balance.

The filter keeps an `$exists` arm because `$lte` never matches a missing field, and rows written before `credits_reversed` existed carry none. Without it every pre-cutover payment would have become un-reversible.

## The trade, stated plainly

Claim-first inverts the crash window. Previously a crash between debit and claim healed on redelivery; now a crash between claim and debit records a reversal that never took the credits. The debit's failure path releases the claim, guarded on whether the ledger already moved, which covers the exception case. A hard kill it cannot cover, so the redelivery now alarms at ERROR instead of reporting "already applied".

That direction follows the posture this module already takes: an under-reversal is recoverable by hand, money taken from a customer who did not owe it is not.

Two limits are written into the code rather than left implicit. A crash between the ledger insert and the balance increment reads as recorded and logs routine — that is the ledger's phantom state, which `reconcile` owns, and `reconcile` is run by hand. And a duplicate delivery still in flight reads identically to an orphan for about one round-trip, so the alarm says to check the ledger before settling.

## Evidence

Three race tests written first and failing first: a refund and a dispute each taking the full grant (`[500, 500] == [0, 500]`, wallet at −500), two racing partial refunds (`600 <= 500`), and two reversal rows where there should be one. Four more for the release, the guard on the release, the orphan alarm, and a genuine redelivery staying quiet so the alarm does not get trained away. The hard kill is modelled as `CancelledError`, which no `except Exception` catches.

`tests/cloud/billing` 214 passed. With `tests/cloud/credits` and `tests/cloud/llm_provisioning`, 408 passed against a 401 baseline on `dev` — the seven new tests, no regressions. Eight mutations, all caught, including one that moves the redelivery check back below the `remaining <= 0` return, so the placement is itself a gate now.

## Not in this PR

Storing a per-event reversal amount. The row holds only a running total, so a full reversal's amount cannot be recomputed after its own claim landed, which is what would let the redelivery path re-drive the debit and restore the old self-heal. That is a schema change and wants its own PR.

Found during a re-verification of the billing audit against `dev`; the same pass has two sibling fixes coming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
