### PR TITLE
Usage chart reads zero on a day the wallet was charged

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
@@ -145,6 +145,19 @@
 #   Same defect the REST usage chart had, one hop further out — the tool renders the
 #   same ``billing.usage`` response, so it inherited the rounding and now inherits
 #   the fix. Additive: the whole-credit keys keep their names and meaning.
+#
+#   The unit guidance lives in the ``@tool`` DESCRIPTION, not in the handler's
+#   Python docstring. ``__doc__`` is never transmitted — the SDK serializes
+#   ``SdkMcpTool.description`` (the second positional arg to ``@tool``) and nothing
+#   else, so an instruction written in the docstring reaches the model as silence.
+#   Shipping the micro fields WITHOUT that description would have been worse than
+#   the zero it replaced: handed ``{"total_credits": 0, "total_credits_micro":
+#   750000}`` with no unit defined, the obvious wrong answer is "$750,000" against
+#   a real charge of $0.0075, and a customer can at least tell that 0 is wrong.
+#   The same edit corrects a PRE-EXISTING lie in that description and in the tool
+#   list above: both said any MEMBER may read usage, which stopped being true on
+#   2026-09-02 when the gate moved to ``billing.view`` (ADMIN). It was promising
+#   the model a read the gate then denied.
 """Agent-side MCP surface for workspace administration.
 
 Tools registered:
@@ -168,8 +181,9 @@ Tools registered:
     ``workspace.view`` (MEMBER); the service applies the caller's connector
     permissions.
   - ``billing_usage_read(start, end)`` — READ daily usage/spend over an optional
-    date window. Gated at ``workspace.view`` (MEMBER — matching the
-    membership-only REST usage route).
+    date window. Gated at ``billing.view`` (ADMIN — the same action the REST GET
+    /billing/usage route gates on, so the two cannot drift apart). Spend is
+    reported in BOTH micro-credits (exact) and whole credits (truncated).
   - ``audit_read(limit)`` — READ recent audit-log rows. Gated at ``audit.read``
     (ADMIN — same as the REST audit route).
 
@@ -811,8 +825,15 @@ async def _billing_usage_read_handler(args: dict) -> dict:
 
     Every credit figure is reported twice: ``*_credits`` truncated to whole credits
     for a human-readable answer, and ``*_credits_micro`` exact (1_000_000 micro ==
-    1 credit == $0.01). Read the MICRO field when the answer is about money — a
-    typical run is 375_000 micro, so a light day's whole-credit figures are all 0."""
+    1 credit == $0.01). A typical run is 375_000 micro, so a light day's
+    whole-credit figures are all 0 and only the micro ones carry the spend.
+
+    THIS DOCSTRING IS FOR READERS OF THIS FILE, NOT FOR THE MODEL. ``__doc__`` is
+    never transmitted — the SDK sends ``SdkMcpTool.description``, the second
+    positional arg to ``@tool``. The unit guidance the model actually needs lives
+    there (``build_admin_server``, the ``billing_usage_read`` tool) and is pinned
+    by ``test_billing_usage_read_description_defines_the_micro_unit``. Change both
+    together or the model silently keeps the old instruction."""
     start = args.get("start")
     end = args.get("end")
     if start is not None and not isinstance(start, str):
@@ -1521,11 +1542,20 @@ def build_admin_server() -> tuple[str, Any] | None:
     @tool(
         "billing_usage_read",
         (
-            "Read the CURRENT workspace's usage and spend (daily credits and "
+            "Read the CURRENT workspace's usage and spend (daily spend and "
             "request counts, broken down by model) over an optional date window. "
             "Call this when the user asks how much they've spent or used. Optional "
             "args: `start` and `end` (YYYY-MM-DD); omit both for the last 30 days. "
-            "Any workspace member may read their workspace's usage. If you don't "
+            "UNITS — every spend figure is returned twice and the two are not "
+            "interchangeable. The `credits_micro` / `total_credits_micro` fields "
+            "are EXACT, in micro-credits: 1000000 micro = 1 credit = $0.01, so "
+            "750000 micro = 0.75 credits = $0.0075. The plain `credits` / "
+            "`total_credits` fields are those same amounts truncated to whole "
+            "credits, and one ordinary run costs about 375000 micro, so they read "
+            "0 on a light day. Answer from the micro fields and convert them; "
+            "never repeat a micro number as a credit or dollar figure, and never "
+            "report 'nothing spent' from a 0 in a plain credits field. "
+            "Reading usage requires the ADMIN role. If you don't "
             "have permission, the result says so (denied) — relay that."
         ),
         {

--- a/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py
@@ -136,6 +136,15 @@
 #   who is refused the usage read over HTTP able to ask the agent for the same
 #   numbers — a documented bypass of a gate added in the same commit. The other
 #   four READ tools are unchanged and stay on ``_READ_ACTION`` / ``workspace.view``.
+#
+# Updated: 2026-09-11 (fix/billing-usage-chart-micro) — billing_usage_read now
+#   reports a MICRO-CREDIT figure beside every whole-credit one. The wallet stores
+#   micro-credits and a chat run costs about 375_000 of them, so the whole-credit
+#   fields are 0 for a day of ordinary light usage; an agent answering "what did we
+#   spend?" from those alone told the customer "nothing" while the wallet drained.
+#   Same defect the REST usage chart had, one hop further out — the tool renders the
+#   same ``billing.usage`` response, so it inherited the rounding and now inherits
+#   the fix. Additive: the whole-credit keys keep their names and meaning.
 """Agent-side MCP surface for workspace administration.
 
 Tools registered:
@@ -798,7 +807,12 @@ async def _billing_usage_read_handler(args: dict) -> dict:
     gates on; the two are deliberately the same key so they cannot drift). NOT
     ``billing.manage`` (OWNER): reading the bill is not managing it. EXECUTES
     directly on a gate pass. ``start`` / ``end`` are optional ``YYYY-MM-DD``
-    strings (default: the trailing 30 days)."""
+    strings (default: the trailing 30 days).
+
+    Every credit figure is reported twice: ``*_credits`` truncated to whole credits
+    for a human-readable answer, and ``*_credits_micro`` exact (1_000_000 micro ==
+    1 credit == $0.01). Read the MICRO field when the answer is about money — a
+    typical run is 375_000 micro, so a light day's whole-credit figures are all 0."""
     start = args.get("start")
     end = args.get("end")
     if start is not None and not isinstance(start, str):
@@ -825,6 +839,10 @@ async def _billing_usage_read_handler(args: dict) -> dict:
         logger.warning("billing_usage_read failed", exc_info=True)
         return _error_response(f"billing_usage_read failed: {exc}")
 
+    # Carry the MICRO figures alongside the whole-credit ones. A chat run costs
+    # about 375_000 micro-credits, so ``credits`` is 0 for a day of ordinary light
+    # usage — an agent answering "what did we spend?" off the whole-credit fields
+    # alone would tell the customer "nothing" while their wallet drained.
     return _success_response(
         {
             "ok": True,
@@ -833,13 +851,16 @@ async def _billing_usage_read_handler(args: dict) -> dict:
             "end_date": usage.end_date,
             "models": usage.models,
             "total_credits": usage.total_credits,
+            "total_credits_micro": usage.total_credits_micro,
             "buckets": [
                 {
                     "date": b.date,
                     "total_credits": b.total_credits,
+                    "total_credits_micro": b.total_credits_micro,
                     "by_model": {
                         model: {
                             "credits": stats.credits,
+                            "credits_micro": stats.credits_micro,
                             "requests": stats.requests,
                             "tokens": stats.tokens,
                         }

--- a/ee/pocketpaw_ee/cloud/billing/dto.py
+++ b/ee/pocketpaw_ee/cloud/billing/dto.py
@@ -33,6 +33,15 @@
 #   ``CancelSubscriptionResponse`` for ``POST /billing/cancel`` (no request body —
 #   the caller's workspace is the scope). Tiny ack; the plan revert is not reflected
 #   here (it lands on the ``subscription.cancelled`` webhook).
+# Updated 2026-09-11 (fix/billing-usage-chart-micro): the usage contract gained a
+#   MICRO-CREDIT figure at every level — ``UsageModelStats.credits_micro``,
+#   ``UsageBucket.total_credits_micro``, ``WorkspaceUsageResponse.total_credits_micro``.
+#   The whole-credit fields were all that existed, and since the micro migration a
+#   chat run costs about 375_000 micro (0 whole credits), so a customer with light
+#   usage read a chart of zeros beside a wallet they could watch draining. Same fix
+#   PR #2071 made for the history rows (``LedgerEntryResponse.amount_delta_micro``);
+#   the chart did not get it at the time. Additive — the existing fields keep their
+#   names and meaning, so no client breaks.
 
 from __future__ import annotations
 
@@ -104,19 +113,38 @@ class WebhookAck(BaseModel):
 class UsageModelStats(BaseModel):
     """One model's usage within a single day.
 
-    ``credits`` is the day-and-model spend in integer CREDITS straight off the
-    wallet's ledger (markup already applied at debit time, 1 credit == $0.01 — this
-    is a credit figure, NOT a USD amount); ``tokens`` is the real total token volume
-    for this model (summed from each debit's ``ref.total_tokens``; a legacy debit
-    written before the ref carried tokens contributes 0); ``requests`` is the count
-    of charged ledger entries for this model on this day. A model whose credit cost
-    is 0 (sub-credit spend) still appears — usage is real even when the credit cost
-    rounds to 0.
+    ``credits_micro`` is the day-and-model spend in MICRO-CREDITS (1_000_000 micro
+    == 1 credit == $0.01) straight off the wallet's ledger, markup already applied
+    at debit time. **Render from it.** ``credits`` is the same figure truncated to
+    whole credits and it is not sufficient on its own: a chat run costs about
+    $0.0015 of compute, which is 375_000 micro and 0 whole credits, so a day of
+    ordinary light usage arrives here as ``credits: 0`` for every model while the
+    wallet visibly drains. (This is the chart's version of the ``amount_delta: 0``
+    debits observed on the history rows on 2026-09-04.)
+
+    ``tokens`` is the real total token volume for this model (summed from each
+    debit's ``ref.total_tokens``; a legacy debit written before the ref carried
+    tokens contributes 0); ``requests`` is the count of charged ledger entries for
+    this model on this day. A model whose spend is under a credit still appears —
+    usage is real even when the whole-credit figure is 0.
     """
 
     credits: int = Field(
         ...,
-        description="Spend for this model on this day, in CREDITS (1 credit == $0.01; not USD).",
+        description=(
+            "Spend for this model on this day, truncated to whole CREDITS "
+            "(1 credit == $0.01; not USD). 0 for sub-credit spend — read "
+            "credits_micro to render it."
+        ),
+    )
+    # Exact, positive, in micro-credits. The whole-credit field above cannot
+    # express a sub-cent day, which is most days for a light workspace.
+    credits_micro: int = Field(
+        default=0,
+        description=(
+            "Exact spend for this model on this day, in MICRO-CREDITS "
+            "(1_000_000 == 1 credit == $0.01). Render the chart from this."
+        ),
     )
     tokens: int = Field(
         ...,
@@ -126,10 +154,15 @@ class UsageModelStats(BaseModel):
 
 
 class UsageBucket(BaseModel):
-    """One day's usage: the per-model breakdown plus the day's credit total.
+    """One day's usage: the per-model breakdown plus the day's total.
 
     ``date`` is ``YYYY-MM-DD``. ``by_model`` maps a model id to its stats for that
-    day; ``total_credits`` is the sum of the bucket's per-model credits.
+    day. ``total_credits_micro`` is the exact sum of the bucket's per-model
+    ``credits_micro``; ``total_credits`` is that total truncated ONCE to whole
+    credits. It is deliberately not the sum of the per-model ``credits`` — summing
+    already-truncated figures compounds the shortfall across every model on the
+    day, so three models at 750_000 micro each would report 0 for a day the wallet
+    was charged two credits for.
     """
 
     date: str = Field(..., description="The bucket day, YYYY-MM-DD.")
@@ -137,7 +170,15 @@ class UsageBucket(BaseModel):
         default_factory=dict, description="Model id -> usage stats for this day."
     )
     total_credits: int = Field(
-        ..., description="Sum of this day's per-model spend, in CREDITS (not USD)."
+        ...,
+        description=(
+            "This day's spend truncated to whole CREDITS (not USD). Derived from "
+            "total_credits_micro, never summed from the per-model credits."
+        ),
+    )
+    total_credits_micro: int = Field(
+        default=0,
+        description="Exact total spend for this day, in MICRO-CREDITS (1_000_000 == 1 credit).",
     )
 
 
@@ -148,11 +189,13 @@ class WorkspaceUsageResponse(BaseModel):
     to the last 30 days when the request omits them). ``models`` is the sorted
     distinct set of model ids seen across the whole range (so the frontend can build
     a stable legend / color map). ``buckets`` is one entry per day WITH usage, oldest
-    first. ``total_credits`` is the grand total over every bucket, in CREDITS (1
-    credit == $0.01 — NOT USD). The shape is kept DAILY on purpose — the frontend
-    aggregates to weekly / monthly and filters by model client-side. A workspace
-    with no spend in the window yields empty ``models`` + ``buckets`` and
-    ``total_credits`` 0 (HTTP 200).
+    first. ``total_credits_micro`` is the exact grand total over every bucket, in
+    MICRO-CREDITS; ``total_credits`` is that figure truncated ONCE to whole credits
+    (1 credit == $0.01 — NOT USD), never a sum of the per-bucket totals. The shape
+    is kept DAILY on purpose — the frontend aggregates to weekly / monthly and
+    filters by model client-side; it must aggregate the MICRO fields and convert at
+    the end, for the same reason this response does. A workspace with no spend in
+    the window yields empty ``models`` + ``buckets`` and both totals 0 (HTTP 200).
     """
 
     start_date: str
@@ -160,3 +203,5 @@ class WorkspaceUsageResponse(BaseModel):
     models: list[str] = Field(default_factory=list)
     buckets: list[UsageBucket] = Field(default_factory=list)
     total_credits: int = 0
+    # Exact. Aggregate from this; total_credits cannot express a sub-credit window.
+    total_credits_micro: int = 0

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -202,8 +202,11 @@ async def get_usage(
     wallet's own meter) and scoped to that workspace — so the chart matches the
     wallet in every metering mode. When both dates are omitted the window defaults
     to the last 30 days. The response stays DAILY — the frontend aggregates to
-    weekly / monthly and filters by model client-side. (``tokens`` is reported as 0:
-    the ledger does not carry a per-entry token count.)
+    weekly / monthly and filters by model client-side, and it must aggregate the
+    ``*_micro`` figures: a chat run costs about 375_000 micro-credits, so the
+    whole-credit fields are 0 for a day of ordinary light usage. (``tokens`` is
+    real volume — the metering path stamps ``total_tokens`` on each debit ref;
+    only debits written before that contribute 0.)
 
     A workspace with no spend in the window returns an empty contract (no models,
     no buckets, total 0) at HTTP 200 — not an error.

--- a/ee/pocketpaw_ee/cloud/billing/usage.py
+++ b/ee/pocketpaw_ee/cloud/billing/usage.py
@@ -15,8 +15,8 @@
 #     off->live cutover the spend-ingest (``llm_provisioning:ingest_tenant_spend``)
 #     debits under ``cause="litellm_spend"``. Only ONE cause is ever active for a
 #     given run, so reading BOTH is safe (no double-count) and the chart matches
-#     the wallet IN EVERY MODE — by construction, since it is literally the
-#     wallet's own decomposition. (The prior version read the proxy's
+#     the wallet IN EVERY MODE — provided nothing rounds on the way out, which is
+#     the whole of the MICRO note below. (The prior version read the proxy's
 #     /user/daily/activity, which a Free/keyless workspace never populates — so a
 #     workspace deep in the negative showed "No usage to chart yet". This is the
 #     fix for that bug.)
@@ -25,6 +25,15 @@
 #     movement), so this read does NO ``to_credits`` and touches NO rate card — it
 #     just surfaces the integers the wallet already holds. That is what makes the
 #     graph and the wallet agree exactly.
+#   * MICRO IS THE UNIT OF THE FOLD. The wallet stores micro-credits (1_000_000
+#     micro == 1 credit == $0.01) and a chat run costs about 375_000 of them, so a
+#     (day, model) group of ordinary light usage is worth 0 whole credits. This
+#     module therefore folds ``row.credits_micro`` and converts to whole credits
+#     exactly ONCE per figure, at the end. Truncating per group and summing the
+#     results compounds the shortfall over every model and every day instead of
+#     cancelling — that is how a day the wallet was charged 1.5 credits for
+#     rendered as a row of zeros. The whole-credit fields stay on the wire for the
+#     existing clients; ``*_micro`` is what anything reasoning about money reads.
 #   * ENTITY ISOLATION. Billing must NOT query ``CreditLedgerEntry`` directly — the
 #     credits entity owns reads of its own ledger doc. The (day, model) breakdown
 #     comes through ``credits.service.spend_by_model`` (a sibling of the existing
@@ -76,6 +85,14 @@
 # hardcoded 0. Sourced from the wallet's own ledger (NOT the blocked LiteLLM path);
 # legacy debits without the ref field contribute 0. The response contract is
 # unchanged (the ``tokens`` field already existed) — only its value became real.
+# Changed 2026-09-11 (fix/billing-usage-chart-micro): the fold now runs in
+# MICRO-CREDITS. ``spend_by_model`` truncated each (day, model) group to whole
+# credits before it reached here, and this module summed the truncations, so light
+# usage charted as zeros and the error compounded across groups rather than
+# cancelling. Per-model, per-day and grand totals now carry a ``*_micro`` figure
+# and every whole-credit figure is derived from its micro total with a single
+# ``micro_to_credits`` at the end. Additive on the wire — the pre-existing fields
+# keep their names, so the frontend is not broken by this, only unblocked.
 
 from __future__ import annotations
 
@@ -90,6 +107,7 @@ from pocketpaw_ee.cloud.billing.dto import (
     WorkspaceUsageResponse,
 )
 from pocketpaw_ee.cloud.credits import service as credits_service
+from pocketpaw_ee.cloud.credits.domain import micro_to_credits
 
 logger = logging.getLogger(__name__)
 
@@ -150,11 +168,16 @@ async def get_workspace_usage(
 
     Reads the workspace's spend straight from its CREDIT LEDGER (via
     ``credits.service.spend_by_model``) and folds it into a ``UsageBucket`` per day
-    with a ``{credits, tokens, requests}`` block per model. Credits are the
-    integers the wallet already holds (markup applied at debit time — NO conversion
-    here), so the graph and the wallet agree by construction in every metering mode
+    with a ``{credits, credits_micro, tokens, requests}`` block per model. The
+    figures are the integers the wallet already holds (markup applied at debit time
+    — NO conversion here), so the graph and the wallet agree in every metering mode
     (the ledger reads both ``compute_spend`` and ``litellm_spend``). Returns a
     ``WorkspaceUsageResponse``.
+
+    The fold is in MICRO-CREDITS and each whole-credit figure is truncated from its
+    own micro total exactly once. A chat run is about 375_000 micro (0 whole
+    credits), so folding the whole-credit field instead would lose a day of light
+    usage entirely and compound the loss across models and days.
 
     ``start_date`` / ``end_date`` are ``YYYY-MM-DD``; when BOTH are omitted the
     window defaults to the trailing 30 days. ``spend_reader`` is injectable for
@@ -162,9 +185,10 @@ async def get_workspace_usage(
 
     ``tokens`` per model is the real volume the ledger now carries (the metering
     path stamps ``total_tokens`` on each debit ref; a legacy debit without it reads
-    0). Credits are integer CREDITS (1 credit == $0.01 — NOT USD). A workspace with
-    no spend in the window returns an empty contract (no models, no buckets, total
-    0) at HTTP 200 — never an error.
+    0). ``credits_micro`` is micro-credits (1_000_000 == 1 credit == $0.01 — NOT
+    USD) and ``credits`` is that truncated for display; a caller rendering money
+    reads the micro field. A workspace with no spend in the window returns an empty
+    contract (no models, no buckets, totals 0) at HTTP 200 — never an error.
     """
     # Rule 6 — validate at entry.
     if not workspace_id:
@@ -193,44 +217,65 @@ async def get_workspace_usage(
     # Fold the (day, model) rows into per-day buckets. ``spend_by_model`` already
     # aggregates one row per (day, model), so we assign directly; a duplicate
     # (day, model) would still accumulate defensively.
-    buckets: dict[str, dict[str, UsageModelStats]] = {}
+    #
+    # The accumulator is MICRO-CREDITS. Accumulating ``row.credits`` would add up
+    # figures that were each truncated to a unit coarser than the thing they charge
+    # for, and the residues never cancel — they are all thrown away in the same
+    # direction. Whole credits are derived once, below, from the micro totals.
+    buckets: dict[str, dict[str, tuple[int, int, int]]] = {}
     models_seen: set[str] = set()
     for row in rows:
         models_seen.add(row.model)
         per_model = buckets.setdefault(row.day, {})
-        existing = per_model.get(row.model)
         # ``tokens`` is the real per-(day, model) volume the ledger now carries
         # (summed from each debit's ``ref.total_tokens`` in ``spend_by_model``); a
-        # legacy row without it reads 0. Credits + requests come off the ledger too.
-        if existing is None:
-            per_model[row.model] = UsageModelStats(
-                credits=row.credits, tokens=row.tokens, requests=row.requests
-            )
-        else:
-            per_model[row.model] = UsageModelStats(
-                credits=existing.credits + row.credits,
-                tokens=existing.tokens + row.tokens,
-                requests=existing.requests + row.requests,
-            )
+        # legacy row without it reads 0. Micro + requests come off the ledger too.
+        micro, tokens, requests = per_model.get(row.model, (0, 0, 0))
+        per_model[row.model] = (
+            micro + row.credits_micro,
+            tokens + row.tokens,
+            requests + row.requests,
+        )
 
-    # Assemble the response: buckets OLDEST-FIRST, each with its credit total; the
-    # grand total over every bucket; the sorted distinct model list (a stable
-    # legend). The "unknown" bucket (debits with no ``ref.model``) is kept so the
-    # total reconciles with the wallet.
+    # Assemble the response: buckets OLDEST-FIRST, each with its exact total and the
+    # whole-credit figure derived from it; the grand total over every bucket; the
+    # sorted distinct model list (a stable legend). The "unknown" bucket (debits
+    # with no ``ref.model``) is kept so the total reconciles with the wallet.
     out_buckets: list[UsageBucket] = []
-    total_credits = 0
+    total_micro = 0
     for day in sorted(buckets):
-        per_model = buckets[day]
-        day_credits = sum(stats.credits for stats in per_model.values())
-        total_credits += day_credits
-        out_buckets.append(UsageBucket(date=day, by_model=per_model, total_credits=day_credits))
+        stats_by_model = {
+            model: UsageModelStats(
+                credits=micro_to_credits(micro),
+                credits_micro=micro,
+                tokens=tokens,
+                requests=requests,
+            )
+            for model, (micro, tokens, requests) in buckets[day].items()
+        }
+        day_micro = sum(stats.credits_micro for stats in stats_by_model.values())
+        total_micro += day_micro
+        out_buckets.append(
+            UsageBucket(
+                date=day,
+                by_model=stats_by_model,
+                # Truncate the DAY's micro total, not the sum of per-model
+                # truncations: three models at 750_000 micro is two credits charged
+                # and would otherwise report 0.
+                total_credits=micro_to_credits(day_micro),
+                total_credits_micro=day_micro,
+            )
+        )
 
     return WorkspaceUsageResponse(
         start_date=resolved_start,
         end_date=resolved_end,
         models=sorted(models_seen),
         buckets=out_buckets,
-        total_credits=total_credits,
+        # Same rule one level up: truncate the grand micro total, never sum the
+        # per-day whole-credit figures.
+        total_credits=micro_to_credits(total_micro),
+        total_credits_micro=total_micro,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/credits/domain.py
+++ b/ee/pocketpaw_ee/cloud/credits/domain.py
@@ -28,6 +28,15 @@
 # ``ref.total_tokens`` the metering path now records. Defaults to 0 so a legacy
 # entry (written before the ref carried tokens) contributes nothing rather than
 # breaking the read; the credits + requests figures are unaffected.
+# Changed 2026-09-11 (fix/billing-usage-chart-micro): ``ModelSpendRow`` gained
+# ``credits_micro`` — the EXACT spend for the group, in micro-credits. ``credits``
+# truncates to whole credits, and since the micro migration a typical chat run is
+# 375_000 micro (0 whole credits), so a (day, model) group of ordinary light usage
+# was handed to the usage chart as a zero. Worse, the chart sums those per-group
+# zeros, so the error compounds across models and days instead of cancelling.
+# ``credits_micro`` carries the stored figure through untouched; ``credits`` stays
+# for display, the same split ``LedgerEntry`` already makes with
+# ``amount_delta_micro``.
 
 from __future__ import annotations
 
@@ -66,6 +75,13 @@ class ModelSpendRow:
     count); ``tokens`` is the real total token volume for the group, summed from
     each debit's ``ref.total_tokens`` (0 for legacy entries written before the ref
     carried tokens — the credits + requests figures stay accurate regardless).
+
+    ``credits_micro`` is the EXACT figure, in micro-credits, and it is the one to
+    reason about money with. ``credits`` truncates toward zero, so a group of
+    ordinary light usage — a chat run is about 375_000 micro — reports 0 whole
+    credits against real spend. Anything that aggregates these rows must fold
+    ``credits_micro`` and convert ONCE at the end; summing the truncated
+    ``credits`` compounds the shortfall over every group it touches.
     """
 
     day: str
@@ -73,6 +89,8 @@ class ModelSpendRow:
     credits: int
     requests: int
     tokens: int = 0
+    # Exact, positive, in micro-credits (1_000_000 == 1 credit == $0.01).
+    credits_micro: int = 0
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -136,6 +136,12 @@
 # token volume instead of a hardcoded 0. A legacy entry whose ref predates the
 # token stamp contributes 0 (the credits + requests figures are unchanged). Read
 # only — no new writes.
+# Changed 2026-09-11 (fix/billing-usage-chart-micro): ``spend_by_model`` now
+# returns the group's EXACT micro-credit sum on ``ModelSpendRow.credits_micro``
+# alongside the truncated ``credits``. The pipeline already summed
+# ``amount_delta_micro`` correctly; this function then threw the precision away per
+# (day, model) group, so a day of sub-credit runs reached the usage chart as zeros.
+# Read only — the pipeline, the causes and every written figure are untouched.
 # Changed 2026-06-30 (feat/billing-quota-enforcement, chunk 2): added the monthly
 # credit-QUOTA reads + assertion. ``month_to_date_spend`` sums this UTC calendar
 # month's APPLIED spend debits (compute_spend + litellm_spend, the same two
@@ -946,12 +952,17 @@ async def spend_by_model(
     Per entry: ``day`` is ``createdAt.date()`` in UTC (``YYYY-MM-DD``); ``model``
     is ``ref.model`` or ``"unknown"`` when the debit carried no model (real
     charged spend with no model still counts toward the day so the chart
-    reconciles with the wallet); ``credits`` is the POSITIVE amount debited (a
-    stray positive delta is clamped out, like ``sum_debits_by_cause``). ``requests``
-    is the COUNT of entries in the (day, model) group. ``tokens`` is the real total
-    token volume for the group, summed from each entry's ``ref.total_tokens`` (the
-    metering path now records it — a legacy entry without it contributes 0, so the
-    figure reflects real volume going forward without breaking historical reads).
+    reconciles with the wallet); ``credits_micro`` is the POSITIVE amount debited in
+    micro-credits (a stray positive delta is clamped out, like
+    ``sum_debits_by_cause``) and ``credits`` is that figure truncated to whole
+    credits for display. READ ``credits_micro`` — a group of ordinary light usage
+    (a chat run is about 375_000 micro) truncates to 0 whole credits, and an
+    aggregate built by summing the truncated field compounds that shortfall over
+    every group. ``requests`` is the COUNT of entries in the (day, model) group.
+    ``tokens`` is the real total token volume for the group, summed from each
+    entry's ``ref.total_tokens`` (the metering path now records it — a legacy entry
+    without it contributes 0, so the figure reflects real volume going forward
+    without breaking historical reads).
 
     The fold runs SERVER-SIDE (``_spend_by_model_pipeline``): a Mongo ``$match``
     on the tenant, causes, applied flag and window feeds a ``$group`` on (day,
@@ -982,12 +993,16 @@ async def spend_by_model(
     rows: list[ModelSpendRow] = []
     async for doc in cursor:
         key = doc.get("_id") or {}
+        # The pipeline sums the micro field. Carry it through EXACTLY — truncating
+        # here is what made a day of sub-credit runs chart as zeros. ``credits``
+        # remains for display; callers that aggregate must fold the micro figure.
+        group_micro = int(doc.get("credits") or 0)
         rows.append(
             ModelSpendRow(
                 day=str(key.get("day") or ""),
                 model=str(key.get("model") or "unknown"),
-                # The pipeline sums the micro field; the graph plots whole credits.
-                credits=micro_to_credits(int(doc.get("credits") or 0)),
+                credits=micro_to_credits(group_micro),
+                credits_micro=group_micro,
                 requests=int(doc.get("requests") or 0),
                 tokens=int(doc.get("tokens") or 0),
             )

--- a/tests/cloud/billing/test_usage_sub_credit_micro.py
+++ b/tests/cloud/billing/test_usage_sub_credit_micro.py
@@ -1,0 +1,162 @@
+# tests/cloud/billing/test_usage_sub_credit_micro.py — REGRESSION for the usage
+# chart reading ZERO against a wallet the customer can watch draining.
+#
+# The wallet stores micro-credits (1_000_000 micro == 1 credit == $0.01) and a
+# typical chat run costs about $0.0015 of compute — 375_000 micro, which is 0
+# whole credits. ``credits.service.spend_by_model`` truncated to whole credits
+# PER (day, model) GROUP before the figure ever reached the chart, so a day of
+# ordinary light usage across two or three models rendered as a row of zeros.
+# Truncating per group also makes the error COMPOUND rather than cancel: the
+# day total and the grand total are sums of already-truncated values, so the
+# chart can report 0 for a day on which the wallet moved a credit and a half.
+#
+# This is the same defect PR #2071 fixed for the history rows, where
+# ``LedgerEntryResponse`` gained ``amount_delta_micro`` because a real debit
+# arrived on the wire as ``amount_delta: 0``. The chart simply did not get the
+# same treatment.
+#
+# Seeds APPLIED debits directly (the READ path is what's under test), back-dating
+# ``createdAt`` through the raw collection because ``TimestampedDocument``'s
+# @before_event(Insert) stamps createdAt=now. The expected total is aggregated
+# straight off the collection so the assertion does not depend on the code it is
+# checking.
+#
+# Created 2026-09-11 (fix/billing-usage-chart-micro): RED anchor for rendering
+# the usage chart from micro-credits.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud.billing import usage
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+
+WS = "ws_usage_sub_credit_test"
+SONNET = "anthropic/claude-3-5-sonnet"
+GPT = "openai/gpt-4o"
+
+# One ordinary chat run: $0.0015 of compute. Three-eighths of a cent, and 0 whole
+# credits however you round it down.
+RUN_MICRO = 375_000
+
+
+async def _seed_micro(
+    ws: str,
+    *,
+    day: tuple[int, int, int],
+    model: str,
+    micro: int,
+    idem: str,
+) -> None:
+    """Insert one APPLIED debit of ``micro`` micro-credits, stamped on ``day``."""
+    entry = CreditLedgerEntry(
+        workspace=ws,
+        kind="spend",
+        amount_delta_micro=-micro,
+        balance_after_micro=0,
+        applied=True,
+        conditional=False,
+        cause="compute_spend",
+        ref={"model": model},
+        idempotency_key=idem,
+    )
+    await entry.insert()
+    await CreditLedgerEntry.get_pymongo_collection().update_one(
+        {"_id": entry.id},
+        {"$set": {"createdAt": datetime(day[0], day[1], day[2], 12, 0, tzinfo=UTC)}},
+    )
+
+
+async def _ledger_spend_micro(ws: str) -> int:
+    """The workspace's total debited micro-credits, read straight off the ledger.
+
+    Deliberately NOT via ``spend_by_model`` — that is the read under test.
+    """
+    cursor = CreditLedgerEntry.get_pymongo_collection().aggregate(
+        [
+            {"$match": {"workspace": ws, "applied": True, "amount_delta_micro": {"$lt": 0}}},
+            {"$group": {"_id": None, "micro": {"$sum": {"$subtract": [0, "$amount_delta_micro"]}}}},
+        ]
+    )
+    if hasattr(cursor, "__await__"):
+        cursor = await cursor
+    async for doc in cursor:
+        return int(doc["micro"])
+    return 0
+
+
+async def _seed_a_light_day(ws: str) -> None:
+    """A day of ordinary light usage: two runs on each of two models.
+
+    4 x 375_000 == 1_500_000 micro == 1.5 credits off the wallet. Each (day, model)
+    group holds 750_000 micro, which truncates to 0 — so the pre-fix chart reported
+    nothing at all for a day the customer was charged a credit and a half for.
+    """
+    await _seed_micro(ws, day=(2026, 9, 1), model=SONNET, micro=RUN_MICRO, idem="run:s1")
+    await _seed_micro(ws, day=(2026, 9, 1), model=SONNET, micro=RUN_MICRO, idem="run:s2")
+    await _seed_micro(ws, day=(2026, 9, 1), model=GPT, micro=RUN_MICRO, idem="run:g1")
+    await _seed_micro(ws, day=(2026, 9, 1), model=GPT, micro=RUN_MICRO, idem="run:g2")
+
+
+async def test_sub_credit_day_charts_non_zero_and_reconciles_with_the_ledger(mongo_db):
+    """A day of sub-credit spend across two models must not render as zeros, and
+    the chart's exact total must equal the ledger's.
+
+    Pre-fix this failed twice over: every ``credits_micro`` field was absent, and
+    ``total_credits`` was 0 against a ledger that had moved 1_500_000 micro.
+    """
+    await _seed_a_light_day(WS)
+    expected_micro = await _ledger_spend_micro(WS)
+    assert expected_micro == 4 * RUN_MICRO  # the wallet really did move 1.5 credits
+
+    result = await usage.get_workspace_usage(WS, start_date="2026-09-01", end_date="2026-09-01")
+
+    assert [b.date for b in result.buckets] == ["2026-09-01"]
+    bucket = result.buckets[0]
+    assert set(bucket.by_model) == {SONNET, GPT}
+
+    # NON-ZERO: the exact per-model figures survive to the chart.
+    assert bucket.by_model[SONNET].credits_micro == 2 * RUN_MICRO
+    assert bucket.by_model[GPT].credits_micro == 2 * RUN_MICRO
+
+    # RECONCILES: the day and the grand total equal what the ledger actually
+    # debited — no truncation compounds across the (day, model) groups.
+    assert bucket.total_credits_micro == expected_micro
+    assert result.total_credits_micro == expected_micro
+
+
+async def test_whole_credit_totals_are_truncated_once_not_per_group(mongo_db):
+    """The whole-credit fields the existing clients read must be derived from the
+    micro total, not summed from per-group truncations.
+
+    1_500_000 micro is 1 whole credit. Pre-fix each group truncated to 0 first and
+    the day reported 0 — the chart disagreeing with the wallet by the whole charge.
+    """
+    await _seed_a_light_day(WS)
+
+    result = await usage.get_workspace_usage(WS, start_date="2026-09-01", end_date="2026-09-01")
+
+    bucket = result.buckets[0]
+    assert bucket.total_credits == 1
+    assert result.total_credits == 1
+    # Per-model whole credits genuinely are 0 here (750_000 micro is under a
+    # credit); that is honest display rounding, and it is exactly why the micro
+    # fields have to exist for anything that reasons about the money.
+    assert bucket.by_model[SONNET].credits == 0
+
+
+async def test_spend_across_days_totals_from_micro(mongo_db):
+    """Two light days each under a credit still add up on the grand total.
+
+    Guards the fold across buckets as well as within one: 750_000 + 750_000 is a
+    whole credit even though neither day is.
+    """
+    await _seed_micro(WS, day=(2026, 9, 1), model=SONNET, micro=2 * RUN_MICRO, idem="run:d1")
+    await _seed_micro(WS, day=(2026, 9, 2), model=SONNET, micro=2 * RUN_MICRO, idem="run:d2")
+    expected_micro = await _ledger_spend_micro(WS)
+
+    result = await usage.get_workspace_usage(WS, start_date="2026-09-01", end_date="2026-09-02")
+
+    assert [b.total_credits_micro for b in result.buckets] == [2 * RUN_MICRO, 2 * RUN_MICRO]
+    assert result.total_credits_micro == expected_micro
+    assert result.total_credits == 1

--- a/tests/cloud/credits/test_spend_by_model.py
+++ b/tests/cloud/credits/test_spend_by_model.py
@@ -43,6 +43,12 @@
 #     sabotaged to raise, the read still returns correct rows.
 #   * the pipeline document itself is asserted, so the ``$group`` can't quietly
 #     regress into a client-side fold that still passes the behavioural cases.
+# Updated 2026-09-11 (fix/billing-usage-chart-micro): the rows now carry
+# ``credits_micro``, the group's EXACT micro-credit sum, and the three exact-row
+# assertions pin it. ``credits`` was the only figure the row returned, and it is
+# truncated — a group of ordinary chat runs (about 375_000 micro each) is 0 whole
+# credits, so the usage chart read zeros against a draining wallet. A new case
+# covers a purely sub-credit group: ``credits`` 0, ``credits_micro`` exact.
 
 from __future__ import annotations
 
@@ -342,7 +348,12 @@ async def test_non_negative_delta_is_skipped_not_clamped(mongo_db):
 
     assert len(rows) == 1  # the zero-delta row invented no second group
     assert rows[0] == ModelSpendRow(
-        day="2026-06-01", model=SONNET, credits=10, requests=1, tokens=100
+        day="2026-06-01",
+        model=SONNET,
+        credits=10,
+        requests=1,
+        tokens=100,
+        credits_micro=credits_to_micro(10),
     )
 
 
@@ -426,12 +437,34 @@ async def test_folds_a_mixed_window_into_the_exact_row_set(mongo_db):
     )
 
     assert rows == [
-        ModelSpendRow(day="2026-06-01", model=SONNET, credits=10, requests=2, tokens=1000),
-        ModelSpendRow(day="2026-06-01", model=GPT, credits=5, requests=1, tokens=250),
-        ModelSpendRow(day="2026-06-02", model="unknown", credits=25, requests=1, tokens=42),
+        ModelSpendRow(
+            day="2026-06-01",
+            model=SONNET,
+            credits=10,
+            requests=2,
+            tokens=1000,
+            credits_micro=credits_to_micro(10),
+        ),
+        ModelSpendRow(
+            day="2026-06-01",
+            model=GPT,
+            credits=5,
+            requests=1,
+            tokens=250,
+            credits_micro=credits_to_micro(5),
+        ),
+        ModelSpendRow(
+            day="2026-06-02",
+            model="unknown",
+            credits=25,
+            requests=1,
+            tokens=42,
+            credits_micro=credits_to_micro(25),
+        ),
     ]
     # The wallet's own total for the window: 4 + 6 + 5 + 25. The chart reconciles.
     assert sum(r.credits for r in rows) == 40
+    assert sum(r.credits_micro for r in rows) == credits_to_micro(40)
 
 
 async def test_reads_without_loading_ledger_documents(mongo_db, monkeypatch):
@@ -458,7 +491,55 @@ async def test_reads_without_loading_ledger_documents(mongo_db, monkeypatch):
         until=datetime(2026, 6, 2, tzinfo=UTC),
     )
 
-    assert rows == [ModelSpendRow(day="2026-06-01", model=SONNET, credits=8, requests=1, tokens=64)]
+    assert rows == [
+        ModelSpendRow(
+            day="2026-06-01",
+            model=SONNET,
+            credits=8,
+            requests=1,
+            tokens=64,
+            credits_micro=credits_to_micro(8),
+        )
+    ]
+
+
+async def test_sub_credit_group_keeps_its_exact_micro_figure(mongo_db):
+    """A group of ordinary chat runs reports 0 whole credits and the EXACT micro.
+
+    $0.0015 of compute is 375_000 micro; two of them is 750_000, under a credit.
+    ``credits`` truncating to 0 is correct display rounding — throwing the micro
+    figure away with it is what left the usage chart reading zeros while the
+    wallet drained. Mutation that breaks this: return ``credits_micro=0`` from
+    ``spend_by_model``.
+    """
+    for n, micro in enumerate((375_000, 375_000)):
+        entry = CreditLedgerEntry(
+            workspace=WS,
+            kind="spend",
+            amount_delta_micro=-micro,
+            balance_after_micro=0,
+            applied=True,
+            conditional=False,
+            cause="compute_spend",
+            ref={"model": SONNET},
+            idempotency_key=f"sub_credit_{n}",
+        )
+        await entry.insert()
+        await CreditLedgerEntry.get_pymongo_collection().update_one(
+            {"_id": entry.id},
+            {"$set": {"createdAt": datetime(2026, 6, 1, 9, 0, tzinfo=UTC)}},
+        )
+
+    rows = await credits.spend_by_model(
+        WS,
+        since=datetime(2026, 6, 1, tzinfo=UTC),
+        until=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+
+    assert len(rows) == 1
+    assert rows[0].credits == 0  # honest display rounding
+    assert rows[0].credits_micro == 750_000  # the figure that must survive
+    assert rows[0].requests == 2  # the runs were real
 
 
 def test_pipeline_groups_server_side():

--- a/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
+++ b/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
@@ -381,6 +381,15 @@ async def test_member_update_role_outside_stream_errors():
 
 from types import SimpleNamespace  # noqa: E402
 
+# The billing usage doubles below build the REAL response DTOs rather than a
+# SimpleNamespace: the handler renders every field, so a stand-in that omits one
+# tests the double instead of the contract. Importing them here keeps that honest.
+from pocketpaw_ee.cloud.billing.dto import (  # noqa: E402
+    UsageBucket,
+    UsageModelStats,
+    WorkspaceUsageResponse,
+)
+
 
 def _allow(role=WorkspaceRole.MEMBER):
     """Patch factory: check_workspace_action passes, returning ``role``.
@@ -645,20 +654,33 @@ async def test_billing_usage_read_admin_allowed(monkeypatch, _patch_user):
 
     called = {}
 
+    # The REAL response DTOs, not a SimpleNamespace. A hand-built double cannot go
+    # stale against the contract, which is how this test would otherwise keep
+    # passing while the handler dropped a field the service had started returning.
+    #
+    # The figures are a SUB-CREDIT day, which is the ordinary case: 750_000 micro
+    # is three-quarters of a cent, and 0 whole credits. An agent answering "what
+    # did we spend?" must not report that as nothing.
     async def _get_workspace_usage(workspace_id, *, start_date=None, end_date=None):  # noqa: ANN001
         called["ws"] = workspace_id
         called["start_date"] = start_date
         called["end_date"] = end_date
-        return SimpleNamespace(
+        return WorkspaceUsageResponse(
             start_date="2026-06-01",
             end_date="2026-06-30",
             models=["gpt-4o"],
-            total_credits=42,
+            total_credits=0,
+            total_credits_micro=750_000,
             buckets=[
-                SimpleNamespace(
+                UsageBucket(
                     date="2026-06-01",
-                    total_credits=42,
-                    by_model={"gpt-4o": SimpleNamespace(credits=42, requests=3, tokens=0)},
+                    total_credits=0,
+                    total_credits_micro=750_000,
+                    by_model={
+                        "gpt-4o": UsageModelStats(
+                            credits=0, credits_micro=750_000, requests=3, tokens=0
+                        )
+                    },
                 )
             ],
         )
@@ -672,9 +694,15 @@ async def test_billing_usage_read_admin_allowed(monkeypatch, _patch_user):
 
     body = _body(res)
     assert body["ok"] is True
-    assert body["total_credits"] == 42
     assert body["models"] == ["gpt-4o"]
-    assert body["buckets"][0]["by_model"]["gpt-4o"]["credits"] == 42
+    # The whole-credit figures are an honest 0 — and on their own they are the
+    # answer "you spent nothing", which is false.
+    assert body["total_credits"] == 0
+    assert body["buckets"][0]["by_model"]["gpt-4o"]["credits"] == 0
+    # The exact figures are what make the answer true.
+    assert body["total_credits_micro"] == 750_000
+    assert body["buckets"][0]["total_credits_micro"] == 750_000
+    assert body["buckets"][0]["by_model"]["gpt-4o"]["credits_micro"] == 750_000
     assert called == {"ws": "w1", "start_date": "2026-06-01", "end_date": "2026-06-30"}
 
 
@@ -732,7 +760,7 @@ async def test_billing_usage_read_gates_on_the_billing_action(monkeypatch, _patc
     monkeypatch.setattr("pocketpaw_ee.guards.deps.check_workspace_action", _record)
 
     async def _get_workspace_usage(workspace_id, *, start_date=None, end_date=None):  # noqa: ANN001
-        return SimpleNamespace(
+        return WorkspaceUsageResponse(
             start_date="2026-06-01",
             end_date="2026-06-30",
             models=[],

--- a/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
+++ b/tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py
@@ -782,6 +782,82 @@ async def test_billing_usage_read_gates_on_the_billing_action(monkeypatch, _patc
 
 
 # ---------------------------------------------------------------------------
+# billing_usage_read — the MODEL-VISIBLE description
+#
+# The handler's Python docstring is NOT the contract and never reaches the model:
+# the SDK serializes ``SdkMcpTool.description`` (the second positional arg to
+# ``@tool``) — see claude_agent_sdk/_internal/query.py — and ``__doc__`` appears
+# nowhere in its source. Guidance written in the docstring is silence.
+#
+# That is not theoretical. The micro-credit fields shipped with their "read the
+# micro field" instruction in the docstring, so the model got the fields and no
+# unit. Handed ``{"total_credits": 0, "total_credits_micro": 750000}`` with the
+# unit undefined, the plausible wrong answers are "nothing" (the original bug) and
+# "$750,000" (new, and worse — a customer can tell that 0 is wrong).
+#
+# These read the description back through the REAL server's tools/list handler,
+# which is the exact string the SDK puts on the wire, rather than a stand-in.
+# ---------------------------------------------------------------------------
+
+
+async def _tool_description(name: str) -> str:
+    """The description the MODEL receives for ``name``, off the built server."""
+    import mcp.types as mcp_types
+    from pocketpaw_ee.agent.mcp_servers.workspace_admin import build_admin_server
+
+    built = build_admin_server()
+    assert built is not None, "claude_agent_sdk is required for this test"
+    _server_name, config = built
+    handler = config["instance"].request_handlers[mcp_types.ListToolsRequest]
+    result = await handler(mcp_types.ListToolsRequest(method="tools/list"))
+    for listed in result.root.tools:
+        if listed.name == name:
+            return listed.description
+    raise AssertionError(f"{name} is not on the server the model sees")
+
+
+@pytest.mark.asyncio
+async def test_billing_usage_read_description_defines_the_micro_unit():
+    """The model is told what a micro-credit is, and told to answer from it.
+
+    Both halves matter. Without the conversion the model can quote 750000 as
+    dollars; without "answer from the micro fields" it falls back to the
+    whole-credit 0 and reports a light day as no spend at all.
+
+    Mutation that breaks this: drop the UNITS sentence from the ``@tool``
+    description at workspace_admin.py, or move it back into the handler docstring.
+    """
+    description = await _tool_description("billing_usage_read")
+
+    # The unit chain, end to end — micro to credit to dollars.
+    assert "micro" in description.lower()
+    assert "1000000" in description
+    assert "$0.01" in description
+    # Name the fields, so the model can tell which key is which unit.
+    assert "credits_micro" in description
+    # And say which one to answer from.
+    assert "micro fields" in description
+
+
+@pytest.mark.asyncio
+async def test_billing_usage_read_description_does_not_promise_member_access():
+    """The description must not tell the model a MEMBER may read usage.
+
+    It said exactly that until this commit, while the gate had moved to
+    ``billing.view`` (ADMIN) on 2026-09-02 — so the tool advertised a read the
+    gate then denied, and the model would promise it to the user before finding
+    out. The gate tier is read from the canonical table, not a copied string.
+    """
+    from pocketpaw_ee.guards.actions import ACTIONS
+
+    description = await _tool_description("billing_usage_read")
+
+    assert ACTIONS[wa_mcp._BILLING_READ_ACTION].minimum == WorkspaceRole.ADMIN
+    assert "ADMIN" in description
+    assert "Any workspace member may read" not in description
+
+
+# ---------------------------------------------------------------------------
 # audit_read — READ (audit.read / ADMIN)
 # ---------------------------------------------------------------------------
 

--- a/tests/mutations/usage_chart_micro.json
+++ b/tests/mutations/usage_chart_micro.json
@@ -1,0 +1,48 @@
+[
+  {
+    "label": "usage chart: spend_by_model throws the exact figure away again (the original bug)",
+    "file": "ee/pocketpaw_ee/cloud/credits/service.py",
+    "find": "                credits_micro=group_micro,",
+    "replace": "                credits_micro=0,",
+    "tests": [
+      "tests/cloud/billing/test_usage_sub_credit_micro.py",
+      "tests/cloud/credits/test_spend_by_model.py"
+    ]
+  },
+  {
+    "label": "usage chart: the fold accumulates truncated credits instead of micro",
+    "file": "ee/pocketpaw_ee/cloud/billing/usage.py",
+    "find": "            micro + row.credits_micro,",
+    "replace": "            micro + row.credits,",
+    "tests": [
+      "tests/cloud/billing/test_usage_sub_credit_micro.py"
+    ]
+  },
+  {
+    "label": "usage chart: the day total sums the per-model truncations",
+    "file": "ee/pocketpaw_ee/cloud/billing/usage.py",
+    "find": "                total_credits=micro_to_credits(day_micro),",
+    "replace": "                total_credits=sum(s.credits for s in stats_by_model.values()),",
+    "tests": [
+      "tests/cloud/billing/test_usage_sub_credit_micro.py"
+    ]
+  },
+  {
+    "label": "usage chart: the grand total sums the per-day truncations",
+    "file": "ee/pocketpaw_ee/cloud/billing/usage.py",
+    "find": "        total_credits=micro_to_credits(total_micro),",
+    "replace": "        total_credits=sum(b.total_credits for b in out_buckets),",
+    "tests": [
+      "tests/cloud/billing/test_usage_sub_credit_micro.py"
+    ]
+  },
+  {
+    "label": "usage chart: the day's exact total never reaches the wire",
+    "file": "ee/pocketpaw_ee/cloud/billing/usage.py",
+    "find": "                total_credits_micro=day_micro,",
+    "replace": "                total_credits_micro=0,",
+    "tests": [
+      "tests/cloud/billing/test_usage_sub_credit_micro.py"
+    ]
+  }
+]

--- a/tests/mutations/usage_chart_micro.json
+++ b/tests/mutations/usage_chart_micro.json
@@ -44,5 +44,32 @@
     "tests": [
       "tests/cloud/billing/test_usage_sub_credit_micro.py"
     ]
+  },
+  {
+    "label": "usage chart: the model is handed micro figures with no unit defined",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py",
+    "find": "            \"are EXACT, in micro-credits: 1000000 micro = 1 credit = $0.01, so \"",
+    "replace": "            \"are the exact ones, so \"",
+    "tests": [
+      "tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py"
+    ]
+  },
+  {
+    "label": "usage chart: the model is not told which field to answer from",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py",
+    "find": "            \"0 on a light day. Answer from the micro fields and convert them; \"",
+    "replace": "            \"0 on a light day. \"",
+    "tests": [
+      "tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py"
+    ]
+  },
+  {
+    "label": "usage chart: the description promises a MEMBER the read the gate denies",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/workspace_admin.py",
+    "find": "            \"Reading usage requires the ADMIN role. If you don't \"",
+    "replace": "            \"Any workspace member may read their workspace's usage. If you don't \"",
+    "tests": [
+      "tests/ee/agent/test_workspace_admin_mcp/test_mcp_tool.py"
+    ]
   }
 ]


### PR DESCRIPTION
A customer with ordinary light usage saw a usage chart of zeros while their balance visibly dropped.

## What was wrong

`spend_by_model` truncated each (day, model) group to whole credits before the numbers reached `get_workspace_usage`. A typical chat run costs about $0.0015 of compute, which is 375_000 micro-credits, which truncates to 0. Two or three models across a handful of runs a day, and every cell in the chart reads zero against a wallet that is genuinely draining.

`total_credits` was worse than a display problem: it summed already-truncated values at both the day and window level, so the error compounded instead of cancelling. Two days at 750_000 micro each still reported 0 against a 1.5-credit charge.

The ledger and the Mongo aggregation were both correct throughout. Only the render truncated.

## What changed

`ModelSpendRow` carries `credits_micro`, `spend_by_model` stops truncating per group, and the fold in `usage.py` accumulates micro so every whole-credit figure is truncated exactly once from its own micro total. This is the same treatment #2071 gave the history rows, which already carry `amount_delta_micro`; the chart never got it.

Both fields ship. Existing clients reading `credits` and `total_credits` keep working and still get the truncate-toward-zero behaviour, which is deliberate — showing a customer a credit they cannot spend is worse than showing one fewer than they hold.

## The chart had a second renderer

`billing_usage_read` on the workspace-admin MCP server builds its own dict from the same `WorkspaceUsageResponse`, behind the same `billing.view` gate. So an agent asked "what did we spend?" answered "nothing" for a light workspace, from the same defect. Fixing only the REST path would have shipped half the fix.

That half needed care the REST half did not. The SDK sends a tool's `@tool` description and never its Python docstring, so unit guidance written in the docstring reaches the model as nothing. Handing an agent `{"total_credits": 0, "total_credits_micro": 750000}` with neither unit defined is worse than the zero it replaces: the chain is two conversions, so a plausible wrong answer is "$7,500" against a real charge of $0.0075, and a customer can tell that zero is wrong but cannot tell that $7,500 is. The unit chain now lives in the description, on the wire, with a test that reads the string back through the server's own `tools/list` handler rather than a stand-in.

## Also fixed, pre-existing

Three docstrings asserted the behaviour this PR removes — `billing/dto.py` said a sub-credit model "still appears" with a cost that "rounds to 0", `billing/usage.py` claimed the chart matches the wallet by construction, and `billing/router.py` still described `tokens` as always 0. All three would have had a reviewer reinstate the bug in good faith.

The MCP tool description also promised "any workspace member may read their workspace's usage". The gate moved to `billing.view` (ADMIN) on 2026-09-02 and the file disagreed with itself in four places. It now agrees, and a test pins the tier from `ACTIONS` rather than a copied string.

## Evidence

Reproduction written first and failing first: a day of sub-credit spend across two models charging the wallet 1_500_000 micro, charting as `total_credits == 0`. Green after.

405 passed across `tests/cloud/billing`, `credits` and `llm_provisioning` against a 401 baseline on `dev`, and 48 on the MCP suite. Eight mutations, all caught, including both "sum the truncations" regressions and three on the model-visible string. Repo-wide mutation validate clean at 1444 anchors.

No docs reference `GET /billing/usage`, and the API change is additive, so there is nothing to update there.

## Worth a separate ticket

The model-visible strings for the other 16 tools on this server have no coverage either, and several carry the same kind of gate claim in prose. The helper added here is the place to build that sweep from.

Found during a re-verification of the billing audit against `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
