### PR TITLE
The shadow compare read half the proxy it was vouching for

### DIFF
--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -214,6 +214,31 @@
 #     live read window's start, so minting a row from a read-only path would move
 #     where billing later begins. Nothing else changes — the compare still debits
 #     nothing, writes no ledger entry, and touches no wallet.
+#
+# ONE WINDOW, RESOLVED ONCE, is the other half of the same fix, and it is the
+# general form of the bug. The first cut wired the second read up but let each
+# half of the compare resolve its own span when the caller passed no ``since``:
+# the LiteLLM side derived a start from the tenant's row while the ledger side
+# got the caller's None and summed all time. That reproduces the exact false
+# alarm — on a freshly provisioned tenant ``_customer_read_window`` returns
+# ``(createdAt, now)``, which is ZERO WIDTH, so the proxy was asked for spend
+# over an empty instant and the compare scored the nothing it got against an
+# all-time ledger sum. A swept tenant got 15 minutes against all time, which is
+# the same error with a smaller number on it.
+#
+# So the window is resolved BEFORE either read and the same pair drives all four
+# consumers: the customer read, ``_in_window``, ``sum_debits_by_cause``, and the
+# ``window_start``/``window_end`` on the persisted audit row (which now reports
+# what was compared, not what the caller typed). An omitted bound becomes
+# concrete here — ``_ALL_TIME_START`` below, and the instant the compare runs —
+# because the proxy read needs two dates and "resolve it for one side only" is
+# precisely the defect. An INVERTED window is refused outright: it compares
+# nothing on either side and would otherwise persist a confident
+# ``delta=0, coverage_gap=False``, a clean bill of health for a question nobody
+# asked, while reaching the proxy as ``start_date > end_date``.
+#
+# Mutation plan: tests/mutations/reconcile_two_reads.json (6 mutations, all
+# observed to fail the suite).
 
 from __future__ import annotations
 
@@ -291,6 +316,19 @@ _PROXY_INTERNAL_TEAMS = frozenset({"litellm-dashboard", "litellm-internal-health
 # precision keeps the window tight enough that the overlap above is the only
 # deliberate re-read.
 _PROXY_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+# An OPEN lower bound, made concrete. The shadow compare's ``since`` is optional
+# ("compare everything"), and the credit-ledger side takes that literally — a None
+# bound is simply not filtered. The proxy read cannot: /spend/logs/v2 needs two
+# dates. Resolving the open side to the epoch is what keeps the two halves reading
+# the SAME span; the alternative (deriving a start for one half only) is how the
+# compare came to report a 15-minute proxy read against an all-time ledger sum.
+#
+# It is not an unbounded read in practice: ``spend_logs_by_end_user`` stops at 200
+# pages of 100, and the per-key half of the merge has always been all-time anyway.
+# The cutover sweep passes a 24h window, so this is the open-ended call's floor,
+# not the sweep's.
+_ALL_TIME_START = datetime(1970, 1, 1, tzinfo=UTC)
 
 
 # ---------------------------------------------------------------------------
@@ -1262,13 +1300,43 @@ async def reconcile_tenant_spend(
 
     ``since`` / ``until`` bound the window (datetimes; ``until`` exclusive). The
     LiteLLM rows are filtered on their parsed ``startTime``; the BC-3 debits on
-    ``createdAt`` — the same window on both sides. ``spend_card`` / ``threshold``
-    are injectable for tests; they default to the settings-derived values.
+    ``createdAt`` — the same window on both sides. That is enforced by resolving
+    the window ONCE, before either read: an omitted bound becomes concrete here
+    (the epoch below, and the instant the compare runs), and the SAME pair then
+    drives the proxy read, the row filter, the ledger sum, and the ``window_start``
+    /``window_end`` the audit row reports. Resolving them per-side is a bug with a
+    specific shape — a short proxy read scored against an all-time ledger sum is a
+    coverage gap that nothing spent — so there is one window or there is none.
+    An INVERTED window (``since`` after ``until``) raises rather than recording a
+    vacuous agreement. ``spend_card`` / ``threshold`` are injectable for tests;
+    they default to the settings-derived values.
     """
     _require_workspace(workspace)
 
     card = spend_card if spend_card is not None else load_spend_credits()
     gap_threshold = threshold if threshold is not None else reconcile_gap_threshold()
+
+    # --- The window, resolved ONCE for both meters. --------------------------
+    # An inverted window compares nothing on either side and would still persist a
+    # confident ``litellm=0, bc3=0, delta=0, coverage_gap=False`` — a clean bill of
+    # health for a question nobody asked. It also reaches the proxy as
+    # ``start_date > end_date``, which /spend/logs/v2 answers however it likes.
+    # Refuse it before any read and before any record.
+    if since is not None and until is not None and since > until:
+        raise ValidationError(
+            "llm_provisioning.invalid_window",
+            f"reconcile window is inverted: since={since.isoformat()} is after "
+            f"until={until.isoformat()}",
+        )
+    # Open bounds become concrete HERE, once, so that every consumer downstream
+    # measures the same span: the proxy read (which needs two dates), ``_in_window``
+    # on the LiteLLM rows, ``sum_debits_by_cause`` on the BC-3 debits, and the
+    # window the audit row reports. Resolving them separately is what made the two
+    # halves disagree — a 15-minute proxy read scored against an all-time ledger
+    # sum reads as a coverage gap, which is the exact false alarm this function was
+    # fixed to stop manufacturing.
+    window_since = since if since is not None else _ALL_TIME_START
+    window_until = until if until is not None else datetime.now(UTC)
 
     # --- LiteLLM side: proxy spend over the window -> credits. ---------------
     litellm_rows = 0
@@ -1284,29 +1352,20 @@ async def reconcile_tenant_spend(
     # meters agreeing because both looked away. This is the number an operator
     # reads before making LiteLLM the sole meter; it has to see what LiteLLM sees.
     #
-    # The window is the CALLER's, not the ingest's high-water mark: shadow neither
-    # honours nor advances that mark, so the merge flag is discarded here. Rows are
-    # then filtered on their own ``startTime`` by ``_in_window`` exactly as before,
-    # which is also what bounds the (unbounded) per-key read.
+    # The window is ``window_since``/``window_until`` above — the CALLER's, resolved
+    # ONCE and used by all four consumers below (the customer read, ``_in_window``,
+    # the BC-3 sum, and the persisted row). NOT the ingest's high-water mark: shadow
+    # neither honours nor advances that mark, so the merge's per-row flag is
+    # discarded here and ``_in_window`` stays the only filter, exactly as it already
+    # was for the unbounded per-key read.
     #
     # ``doc`` may be None and stays None. The compare must not mint the bookkeeping
     # row the ingest creates: that row's ``createdAt`` becomes the live read
     # window's start, so creating one from a read-only path would move where
     # billing later begins.
-    now = datetime.now(UTC)
-    read_until = until if until is not None else now
-    if since is not None:
-        read_since = since
-    elif doc is not None:
-        # No caller bound: fall back to the span the ingest would read for this
-        # tenant (its mark, less the overlap, or the row's creation).
-        read_since, _ = _customer_read_window(doc, now=now)
-    else:
-        # Nothing to anchor on — no caller window, no row. The sweep always passes
-        # a window, so this is the degenerate path, and reading the overlap is the
-        # conservative answer over reading all of time on a shared proxy.
-        read_since = now - _SPEND_READ_OVERLAP
-    rows = await _read_tenant_spend_rows(workspace, doc, client, window=(read_since, read_until))
+    rows = await _read_tenant_spend_rows(
+        workspace, doc, client, window=(window_since, window_until)
+    )
     # Sum the USD and convert ONCE. Converting per row and adding the results
     # up rounds each row separately, so every call worth less than half a credit
     # contributes nothing — and this is the compare an operator reads to decide
@@ -1316,7 +1375,7 @@ async def reconcile_tenant_spend(
     litellm_usd = 0.0
     for row, _honour_mark in rows:
         row_dt = _parse_iso(_row_start_time(row))
-        if not _in_window(row_dt, since, until):
+        if not _in_window(row_dt, window_since, window_until):
             continue
         litellm_rows += 1
         litellm_usd += _num(row.get("spend"))
@@ -1326,14 +1385,18 @@ async def reconcile_tenant_spend(
     # Read through the credits service (entity-isolation: it owns its ledger doc).
     # This is a READ — no debit, no write.
     bc3_credits, bc3_entries = await credits_service.sum_debits_by_cause(
-        workspace, _BC3_COMPUTE_SPEND_CAUSE, since=since, until=until
+        workspace, _BC3_COMPUTE_SPEND_CAUSE, since=window_since, until=window_until
     )
 
     delta = litellm_credits - bc3_credits
     coverage_gap = abs(delta) > gap_threshold
 
-    window_start = since.isoformat() if since is not None else None
-    window_end = until.isoformat() if until is not None else None
+    # What was ACTUALLY compared, not what the caller typed. An open-ended call
+    # records the resolved bounds (the epoch, and the instant the compare ran)
+    # rather than a null, so an operator reading the audit row can tell which
+    # span produced the delta in front of them.
+    window_start = window_since.isoformat()
+    window_end = window_until.isoformat()
 
     # Persist the reconciliation row (append-only audit — NOT a ledger; recording
     # one moves no money). One row per tenant per window.

--- a/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
+++ b/ee/pocketpaw_ee/cloud/llm_provisioning/service.py
@@ -187,6 +187,33 @@
 #      permanently red while the runbook said to treat any non-zero count as
 #      blocking. Measured on the production proxy 2026-09-03: all 8 flagged rows
 #      were exactly that, worth $0.00014545 between them.
+#
+# Updated 2026-09-11 (fix/billing-reconcile-two-reads): the SHADOW compare reads
+# the proxy TWICE, like the ingest it is meant to vouch for.
+#
+# ``reconcile_tenant_spend`` performed the per-KEY read alone — the half a chat run
+# never appears in, for the reason stated above ``_read_tenant_spend_rows``: chat
+# authenticates with the deployment key and names its workspace in the body. This
+# is the one instrument an operator is told to read before making LiteLLM the sole
+# meter, and it could not see the product's main cost centre. On the deployment
+# shape recorded 2026-09-02 (three tenants with keys and no spend, three customers
+# with spend and no keys) it reported ``litellm=0, bc3=N, delta=-N`` on healthy
+# tenants — a coverage gap manufactured out of a read that never happened — and
+# ``litellm=0, bc3=0`` on the ones actually spending, two meters agreeing because
+# both looked away.
+#
+# It now calls ``_read_tenant_spend_rows``, which already merges both reads for the
+# ingest. Two things that helper had to gain, both additive (the ingest's call is
+# unchanged):
+#   * an explicit ``window``. Shadow compares the CALLER's ``[since, until)``; the
+#     high-water mark bounds the ingest and shadow must neither honour nor advance
+#     it, so the merge's per-row mark flag is discarded here and ``_in_window``
+#     stays the only filter, as it already was for the unbounded per-key read.
+#   * a nullable ``doc``. The compare reads workspaces with no provisioning row and
+#     must not create one: ``_spend_bookkeeping_row``'s ``createdAt`` becomes the
+#     live read window's start, so minting a row from a read-only path would move
+#     where billing later begins. Nothing else changes — the compare still debits
+#     nothing, writes no ledger entry, and touches no wallet.
 
 from __future__ import annotations
 
@@ -839,8 +866,10 @@ async def _spend_bookkeeping_row(workspace: str) -> LiteLLMTenantKey:
 
 async def _read_tenant_spend_rows(
     workspace: str,
-    doc: LiteLLMTenantKey,
+    doc: LiteLLMTenantKey | None,
     client: LiteLLMAdminClient,
+    *,
+    window: tuple[datetime, datetime] | None = None,
 ) -> list[tuple[dict[str, Any], bool]]:
     """Every spend row that could belong to ``workspace``, from both reads.
 
@@ -858,9 +887,29 @@ async def _read_tenant_spend_rows(
     A failure of the customer read does not sink the key read, or vice versa. One
     of them returning nothing is normal; both being skipped because the other
     raised would turn a partial outage into a total one, and the sweep retries.
+
+    ``window`` overrides the customer read's bounds for a caller that has its own
+    — the SHADOW compare reconciles an explicit ``[since, until)`` and must not be
+    bounded by the ingest's high-water mark, which it neither honours nor
+    advances. Omitted (the live ingest), the mark-derived
+    ``_customer_read_window`` applies as before.
+
+    ``doc`` may be None: the compare reads a workspace that has no provisioning
+    row at all, and must not create one to read it. Only the per-KEY half needs
+    the row, and that half is skipped without a key either way.
     """
     customer_rows: list[dict[str, Any]] = []
-    since, until = _customer_read_window(doc, now=datetime.now(UTC))
+    if window is None:
+        if doc is None:
+            # The live ingest always has a row (``_spend_bookkeeping_row`` creates
+            # one), and every windowless caller is that ingest. Raising here beats
+            # inventing a window, which would silently read the wrong span of time.
+            raise ValueError(
+                "_read_tenant_spend_rows needs either a tenant spend row or an "
+                f"explicit window (workspace={workspace})"
+            )
+        window = _customer_read_window(doc, now=datetime.now(UTC))
+    since, until = window
     start_date, end_date = _proxy_window(since, until)
     try:
         customer_rows = await client.spend_logs_by_end_user(
@@ -878,7 +927,7 @@ async def _read_tenant_spend_rows(
         )
 
     key_rows: list[dict[str, Any]] = []
-    if doc.litellm_key:
+    if doc is not None and doc.litellm_key:
         try:
             key_rows = await client.spend_logs(api_key=doc.litellm_key)
         except Exception:
@@ -1201,9 +1250,15 @@ async def reconcile_tenant_spend(
     CRITICAL — this performs ZERO debits. It NEVER calls ``credits.service.debit``
     and NEVER advances the spend high-water mark. BC-3 keeps billing untouched
     during shadow. The credit ledger is read (via the credits service's own
-    tenant-filtered ``sum_debits_by_cause``) but never written. A workspace with no
-    provisioned key still produces a record (litellm_credits=0) so the operator
-    sees every tenant in the compare, not a silent gap.
+    tenant-filtered ``sum_debits_by_cause``) but never written, and no provisioning
+    row is created — the compare reads a keyless workspace without minting the
+    bookkeeping row the ingest would.
+
+    Reads the proxy TWICE and merges, the same way ``ingest_tenant_spend`` does
+    (``_read_tenant_spend_rows``): customer-scoped, which is the only read that
+    sees a chat run, plus per-virtual-key. A workspace with no provisioned key is
+    still read — by customer — instead of producing the litellm_credits=0 this
+    used to report for it.
 
     ``since`` / ``until`` bound the window (datetimes; ``until`` exclusive). The
     LiteLLM rows are filtered on their parsed ``startTime``; the BC-3 debits on
@@ -1216,26 +1271,56 @@ async def reconcile_tenant_spend(
     gap_threshold = threshold if threshold is not None else reconcile_gap_threshold()
 
     # --- LiteLLM side: proxy spend over the window -> credits. ---------------
-    litellm_credits = 0
     litellm_rows = 0
     doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)
-    if doc is not None and doc.litellm_key:
-        client = admin_client if admin_client is not None else LiteLLMAdminClient()
-        rows = await client.spend_logs(api_key=doc.litellm_key)
-        # Sum the USD and convert ONCE. Converting per row and adding the results
-        # up rounds each row separately, so every call worth less than half a credit
-        # contributes nothing — and this is the compare an operator reads to decide
-        # whether LiteLLM can be trusted as the only meter. It understated the
-        # LiteLLM side against BC-3's per-run figure by exactly the rows the live
-        # ingest was also dropping, which made the cutover look safer than it was.
-        litellm_usd = 0.0
-        for row in rows:
-            row_dt = _parse_iso(_row_start_time(row))
-            if not _in_window(row_dt, since, until):
-                continue
-            litellm_rows += 1
-            litellm_usd += _num(row.get("spend"))
-        litellm_credits = card.to_credits(litellm_usd)
+    client = admin_client if admin_client is not None else LiteLLMAdminClient()
+    # BOTH reads, the same two the live ingest merges — the customer-scoped one is
+    # the only read that sees a chat run (chat authenticates with the deployment
+    # key), and this compare used to perform the per-KEY read alone. That made the
+    # instrument blind to the product's main cost centre in exactly the shape
+    # production has: tenants whose spend is chat reported ``litellm=0, bc3=N`` and
+    # a coverage gap manufactured out of a read that never happened, and the
+    # workspaces spending with no key at all reported ``litellm=0, bc3=0`` — two
+    # meters agreeing because both looked away. This is the number an operator
+    # reads before making LiteLLM the sole meter; it has to see what LiteLLM sees.
+    #
+    # The window is the CALLER's, not the ingest's high-water mark: shadow neither
+    # honours nor advances that mark, so the merge flag is discarded here. Rows are
+    # then filtered on their own ``startTime`` by ``_in_window`` exactly as before,
+    # which is also what bounds the (unbounded) per-key read.
+    #
+    # ``doc`` may be None and stays None. The compare must not mint the bookkeeping
+    # row the ingest creates: that row's ``createdAt`` becomes the live read
+    # window's start, so creating one from a read-only path would move where
+    # billing later begins.
+    now = datetime.now(UTC)
+    read_until = until if until is not None else now
+    if since is not None:
+        read_since = since
+    elif doc is not None:
+        # No caller bound: fall back to the span the ingest would read for this
+        # tenant (its mark, less the overlap, or the row's creation).
+        read_since, _ = _customer_read_window(doc, now=now)
+    else:
+        # Nothing to anchor on — no caller window, no row. The sweep always passes
+        # a window, so this is the degenerate path, and reading the overlap is the
+        # conservative answer over reading all of time on a shared proxy.
+        read_since = now - _SPEND_READ_OVERLAP
+    rows = await _read_tenant_spend_rows(workspace, doc, client, window=(read_since, read_until))
+    # Sum the USD and convert ONCE. Converting per row and adding the results
+    # up rounds each row separately, so every call worth less than half a credit
+    # contributes nothing — and this is the compare an operator reads to decide
+    # whether LiteLLM can be trusted as the only meter. It understated the
+    # LiteLLM side against BC-3's per-run figure by exactly the rows the live
+    # ingest was also dropping, which made the cutover look safer than it was.
+    litellm_usd = 0.0
+    for row, _honour_mark in rows:
+        row_dt = _parse_iso(_row_start_time(row))
+        if not _in_window(row_dt, since, until):
+            continue
+        litellm_rows += 1
+        litellm_usd += _num(row.get("spend"))
+    litellm_credits = card.to_credits(litellm_usd)
 
     # --- BC-3 side: the metered compute_spend debits over the SAME window. ---
     # Read through the credits service (entity-isolation: it owns its ledger doc).

--- a/tests/cloud/llm_provisioning/test_reconcile_two_reads.py
+++ b/tests/cloud/llm_provisioning/test_reconcile_two_reads.py
@@ -27,21 +27,44 @@
 #   * and the critical invariant survives the second read: shadow still debits
 #     nothing, and still creates no provisioning row.
 #
+# ONE WINDOW, BOTH METERS. The bug has a general form the second read alone does
+# not close: the two halves resolving their span separately. Wiring the proxy read
+# up without that produced it again on the windowless path — the LiteLLM side
+# derived a start from the tenant's own row (zero-width on a freshly provisioned
+# tenant, 15 minutes on a swept one) while the ledger side summed all time, which
+# is a coverage gap nothing spent. So three tests pin the window itself:
+#
+#   * no window at all -> both sides measure the same span, and the audit row
+#     reports the span actually compared rather than a null;
+#   * an open UPPER bound -> both sides stop at the same instant, proven with a
+#     row and a debit stamped past it;
+#   * an inverted window -> refused, rather than recorded as a vacuous agreement.
+#
+# Mutation-proven: tests/mutations/reconcile_two_reads.json breaks the per-key-only
+# read, both halves of the window resolution, the recorded bounds, the inverted-
+# window guard, and the read-only discipline. All six were observed to fail here.
+#
 # Uses the shared ``mongo_db`` + autouse ``recording_bus`` fixtures from
 # tests/cloud/conftest.py. A FAKE admin client stands in for the proxy.
 #
 # Created 2026-09-11 (fix/billing-reconcile-two-reads): new test module.
+# Updated 2026-09-11 (same branch, review): added the three window tests + the
+#   mutation plan, after review found the windowless path reproducing the very
+#   false gap this module exists to prevent.
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
 from pocketpaw_ee.catalog.admin_client import LiteLLMAdminError
+from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.credits import service as credits
 from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
 from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
 from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
 from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+from pocketpaw_ee.cloud.models.spend_reconciliation import SpendReconciliation
 
 WS = "ws_reconcile_two_reads"
 
@@ -237,6 +260,145 @@ async def test_reconcile_survives_one_read_failing(mongo_db):
         WS, since=SINCE, until=UNTIL, spend_card=SPEND, threshold=2, admin_client=admin
     )
     assert rec.litellm_credits == 20  # the customer half still read
+
+
+async def test_reconcile_without_a_window_compares_the_same_span_on_both_sides(mongo_db):
+    """The windowless call is where the two meters drifted apart.
+
+    The LiteLLM side used to derive its own start (the tenant's mark, or its row's
+    ``createdAt``) while the BC-3 side got the caller's ``None`` and summed all
+    time. On a freshly provisioned tenant — no mark, ``createdAt`` ≈ now — that
+    derived window is ZERO WIDTH: the proxy was asked for spend over
+    ``[now, now]``, returned nothing, and the compare reported a coverage gap
+    against an all-time ledger sum. Both halves now resolve from one window.
+    """
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await credits.debit(
+        WS, 30, cause="compute_spend", idempotency_key="run:r1", allow_negative=True
+    )
+    await _provision()  # fresh row: no high-water mark, createdAt ≈ now
+
+    admin = FakeAdmin(
+        key_rows=[_row("req-key", usd=0.04)],  # 10 credits, dated months back
+        customer_rows=[_row("req-chat", usd=0.08)],  # 20 credits, dated months back
+    )
+
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+
+    # The customer read covered a real span, not the zero-width one the tenant's
+    # own row would have produced.
+    assert len(admin.windows) == 1
+    start_date, end_date = admin.windows[0]
+    assert start_date == "1970-01-01 00:00:00"
+    assert start_date < end_date
+
+    # Both meters saw their spend, so the compare agrees instead of manufacturing
+    # a gap out of a window only one side used.
+    assert rec.litellm_rows == 2
+    assert rec.litellm_credits == 30
+    assert rec.bc3_credits == 30
+    assert rec.delta == 0
+    assert rec.coverage_gap is False
+
+    # And the audit row reports the span that was actually compared — an operator
+    # reading it back can tell which window produced the delta.
+    records = await SpendReconciliation.find(SpendReconciliation.workspace == WS).to_list()
+    assert len(records) == 1
+    assert records[0].window_start == start_date.replace(" ", "T") + "+00:00"
+    assert records[0].window_start == rec.window_start
+    assert records[0].window_end == rec.window_end
+
+
+async def test_reconcile_ends_both_sides_at_the_same_instant(mongo_db):
+    """The open UPPER bound, which is where the two sides can still drift apart.
+
+    With no ``until`` the compare ends at the instant it runs. If the ledger half
+    keeps the caller's raw ``None`` while the proxy half gets that resolved
+    instant, a row dated in the FUTURE is dropped from one meter and counted by
+    the other — a delta out of a span only one side measured. Same bug as the
+    original, one bound over. Both halves must stop at the same instant.
+    """
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    # One settled debit, and one stamped ahead of the compare. Proxy rows are
+    # recorded with a ``startTime`` the tenant's own clock supplies, so a row
+    # ahead of ours is not hypothetical.
+    await credits.debit(
+        WS, 10, cause="compute_spend", idempotency_key="run:past", allow_negative=True
+    )
+    await credits.debit(
+        WS, 99, cause="compute_spend", idempotency_key="run:ahead", allow_negative=True
+    )
+    ahead = await CreditLedgerEntry.find_one(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "run:ahead",
+    )
+    assert ahead is not None
+    await ahead.set({CreditLedgerEntry.createdAt: datetime(2099, 1, 1, tzinfo=UTC)})
+
+    admin = FakeAdmin(
+        customer_rows=[
+            _row("req-past", usd=0.04),  # 10 credits, months back
+            _row("req-ahead", usd=0.40, at="2099-01-01T00:00:00"),  # 100, ahead of now
+        ]
+    )
+
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+
+    # Each side counted the settled row and neither counted the one past the end
+    # of the window.
+    assert rec.litellm_rows == 1
+    assert rec.litellm_credits == 10
+    assert rec.bc3_entries == 1
+    assert rec.bc3_credits == 10
+    assert rec.delta == 0
+    assert rec.coverage_gap is False
+
+
+async def test_reconcile_refuses_an_inverted_window(mongo_db):
+    """``since`` after ``until`` compares nothing on either side, so it would
+    persist a confident ``delta=0, coverage_gap=False`` — a clean bill of health
+    for a question nobody asked — and reach the proxy as ``start_date >
+    end_date``, which /spend/logs/v2 answers however it likes."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(customer_rows=[_row("req-chat", usd=0.08)])
+
+    with pytest.raises(ValidationError):
+        await provisioning.reconcile_tenant_spend(
+            WS, since=UNTIL, until=SINCE, spend_card=SPEND, threshold=2, admin_client=admin
+        )
+
+    assert admin.windows == []  # refused before the proxy was touched
+    assert await SpendReconciliation.find(SpendReconciliation.workspace == WS).to_list() == []
+
+
+async def test_reconcile_with_only_until_reads_from_the_epoch(mongo_db):
+    """The backfill shape: "everything before last week". The open lower bound
+    must widen the read, never invert it — the proxy gets epoch..until, and the
+    BC-3 sum is bounded by the same pair."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(customer_rows=[_row("req-chat", usd=0.08, at="2026-08-01T10:00:00")])
+
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, until=UNTIL, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+
+    assert admin.windows == [("1970-01-01 00:00:00", "2026-09-03 00:00:00")]
+    assert rec.litellm_credits == 20
+    assert rec.window_start == "1970-01-01T00:00:00+00:00"
+    assert rec.window_end == UNTIL.isoformat()
+    # The ledger side is bounded by the same pair, so a debit made now — after
+    # ``until`` — is outside the compare on BOTH sides rather than on one.
+    assert rec.bc3_credits == 0
 
 
 async def test_reconcile_still_debits_nothing_with_both_reads(mongo_db):

--- a/tests/cloud/llm_provisioning/test_reconcile_two_reads.py
+++ b/tests/cloud/llm_provisioning/test_reconcile_two_reads.py
@@ -1,0 +1,269 @@
+# tests/cloud/llm_provisioning/test_reconcile_two_reads.py — proves the SHADOW
+# compare reads the same two halves of the proxy the live ingest reads.
+#
+# THE BUG. ``reconcile_tenant_spend`` is the one instrument an operator is told to
+# trust before making LiteLLM the sole meter, and it read the proxy ONCE:
+# ``/spend/logs?api_key=<tenant virtual key>``. The live ingest reads TWICE —
+# customer-scoped (``/spend/logs/v2?end_user=<workspace>``) plus per-key — because
+# the customer read is the only one that sees a chat run, chat having
+# authenticated with the deployment key. The compare never got that second read.
+#
+# So in shadow the instrument reported, on the deployment shape recorded
+# 2026-09-02 (three tenants with keys and no spend, three customers with spend and
+# no keys):
+#
+#   * a provisioned tenant whose spend is chat -> ``litellm=0, bc3=N, delta=-N``,
+#     a coverage gap manufactured out of a read it never performed;
+#   * a workspace spending with no key at all -> ``litellm=0, bc3=0``, the
+#     agreement of two meters that both looked away.
+#
+# These tests are written against that shape, not against the new code:
+#
+#   * spend visible on BOTH reads is SUMMED (the failing assertion before the fix);
+#   * a row both reads return is counted ONCE;
+#   * a workspace with spend and NO tenant key no longer reconciles to zero;
+#   * the compare bounds the customer read by the CALLER's window, not by the
+#     ingest high-water mark (shadow must neither honour nor advance it);
+#   * and the critical invariant survives the second read: shadow still debits
+#     nothing, and still creates no provisioning row.
+#
+# Uses the shared ``mongo_db`` + autouse ``recording_bus`` fixtures from
+# tests/cloud/conftest.py. A FAKE admin client stands in for the proxy.
+#
+# Created 2026-09-11 (fix/billing-reconcile-two-reads): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pocketpaw_ee.catalog.admin_client import LiteLLMAdminError
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.llm_provisioning import service as provisioning
+from pocketpaw_ee.cloud.llm_provisioning.domain import KeyBudget, SpendCredits
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+from pocketpaw_ee.cloud.models.litellm_key import LiteLLMTenantKey
+
+WS = "ws_reconcile_two_reads"
+
+# Pinned so credits never depend on ambient settings: round(usd * 250).
+SPEND = SpendCredits(markup=2.5, credit_usd=0.01)
+
+# The window every test reconciles over. Wide enough to hold the rows below, and
+# explicit so the compare never depends on wall-clock or on a high-water mark.
+SINCE = datetime(2026, 9, 1, tzinfo=UTC)
+UNTIL = datetime(2026, 9, 3, tzinfo=UTC)
+
+
+class FakeAdmin:
+    """In-memory stand-in for LiteLLMAdminClient, with BOTH spend reads.
+
+    ``key_rows`` is what ``/spend/logs?api_key=`` returns — what a tenant's own
+    virtual key accrued. ``customer_rows`` is what ``/spend/logs/v2?end_user=``
+    returns — every row tagged with the workspace, whichever key paid. A chat row
+    appears only in the second. ``windows`` records the window the customer read
+    was asked for, so a test can prove where that bound came from.
+    """
+
+    def __init__(
+        self,
+        *,
+        key_rows: list[dict] | None = None,
+        customer_rows: list[dict] | None = None,
+        fail_customer_read: bool = False,
+        fail_key_read: bool = False,
+    ) -> None:
+        self.key_rows = key_rows or []
+        self.customer_rows = customer_rows or []
+        self.fail_customer_read = fail_customer_read
+        self.fail_key_read = fail_key_read
+        self.windows: list[tuple[str, str]] = []
+        self.key_reads: list[str] = []
+
+    async def generate_key(self, **kwargs):
+        return {"key": f"sk-{kwargs.get('key_alias', 'x')}", **kwargs}
+
+    async def spend_logs(self, *, api_key: str):
+        self.key_reads.append(api_key)
+        if self.fail_key_read:
+            raise LiteLLMAdminError("per-key read failed (simulated)")
+        return list(self.key_rows)
+
+    async def spend_logs_by_end_user(self, *, end_user, start_date, end_date, page_size=100):
+        self.windows.append((start_date, end_date))
+        if self.fail_customer_read:
+            raise LiteLLMAdminError("customer read failed (simulated)")
+        return list(self.customer_rows)
+
+
+def _row(rid: str, *, usd: float, at: str = "2026-09-02T10:00:00") -> dict:
+    return {"request_id": rid, "spend": usd, "startTime": at, "model": "gpt-5.2"}
+
+
+async def _ledger_snapshot(workspace: str) -> tuple[int, int]:
+    """(#ledger entries, balance) — the two things shadow must NOT change."""
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == workspace).to_list()
+    return len(entries), await credits.balance(workspace)
+
+
+async def _provision(workspace: str = WS) -> None:
+    await provisioning.ensure_tenant_key(workspace, budget=KeyBudget(), admin_client=FakeAdmin())
+
+
+# ===========================================================================
+# The bug: half the proxy.
+# ===========================================================================
+
+
+async def test_reconcile_sums_both_reads(mongo_db):
+    """The whole point. A chat row rides the deployment key and appears ONLY in
+    the customer-scoped read; a Studio row the tenant key paid for appears in the
+    per-key read. The compare must count both, or it invents a gap."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(
+        key_rows=[_row("req-key", usd=0.04)],  # 10 credits
+        customer_rows=[_row("req-chat", usd=0.08)],  # 20 credits
+    )
+
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, since=SINCE, until=UNTIL, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+
+    assert rec.litellm_rows == 2, "the customer-scoped read was never performed"
+    assert rec.litellm_credits == 30  # round((0.04 + 0.08) * 250)
+
+
+async def test_reconcile_counts_a_row_both_reads_return_once(mongo_db):
+    """Studio and the media server send the tenant key AND tag ``user``, so their
+    rows come back from both reads. Merging on ``request_id`` keeps the compare
+    from double-counting them into a gap that is not there."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    shared = _row("req-both", usd=0.04)
+    admin = FakeAdmin(key_rows=[shared], customer_rows=[dict(shared)])
+
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, since=SINCE, until=UNTIL, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+
+    assert rec.litellm_rows == 1, "the same row was counted twice"
+    assert rec.litellm_credits == 10
+
+
+async def test_reconcile_sees_a_workspace_with_spend_and_no_key(mongo_db):
+    """The production shape. Three customers had spend and no key; every one of
+    them reconciled to ``litellm=0, bc3=0`` — two meters agreeing because both
+    looked away. No provisioning row exists here at all."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await credits.debit(
+        WS, 20, cause="compute_spend", idempotency_key="run:r1", allow_negative=True
+    )
+    assert await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS) is None
+
+    admin = FakeAdmin(customer_rows=[_row("req-chat", usd=0.08)])  # 20 credits
+
+    # Open-ended at the top so the BC-3 debit, whose ``createdAt`` is wall-clock
+    # now, lands in the same window as the pinned proxy row — this test is about
+    # the two meters agreeing, so both sides have to be inside the compare.
+    rec = await provisioning.reconcile_tenant_spend(
+        WS,
+        since=SINCE,
+        until=datetime(2999, 1, 1, tzinfo=UTC),
+        spend_card=SPEND,
+        threshold=2,
+        admin_client=admin,
+    )
+
+    assert rec.litellm_credits == 20, "a keyless workspace still reconciles to zero"
+    assert rec.litellm_rows == 1
+    assert rec.bc3_credits == 20
+    assert rec.delta == 0
+    assert rec.coverage_gap is False
+
+    # The compare is a READ. It must not mint the bookkeeping row the ingest does:
+    # that row's ``createdAt`` becomes the live read window's start, so creating it
+    # here would move where billing later begins.
+    assert await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS) is None
+
+
+async def test_reconcile_bounds_the_customer_read_by_the_callers_window(mongo_db):
+    """Shadow compares ``[since, until)``. The ingest's high-water mark bounds the
+    ingest; it must neither bound nor be advanced by the compare."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
+    assert doc is not None
+    doc.last_spend_ingest_ts = "2026-09-02T23:00:00"  # well after the row below
+    await doc.save()
+
+    admin = FakeAdmin(customer_rows=[_row("req-chat", usd=0.08)])
+
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, since=SINCE, until=UNTIL, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+
+    assert admin.windows == [("2026-09-01 00:00:00", "2026-09-03 00:00:00")]
+    assert rec.litellm_credits == 20  # the mark did not filter the compare
+
+    after = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == WS)
+    assert after is not None
+    assert after.last_spend_ingest_ts == "2026-09-02T23:00:00"  # never advanced
+
+
+async def test_reconcile_survives_one_read_failing(mongo_db):
+    """One half of the proxy being unreachable must not zero the other half — the
+    compare degrades to a partial reading, it does not report no spend."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _provision()
+
+    admin = FakeAdmin(
+        key_rows=[_row("req-key", usd=0.04)],
+        customer_rows=[_row("req-chat", usd=0.08)],
+        fail_customer_read=True,
+    )
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, since=SINCE, until=UNTIL, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+    assert rec.litellm_credits == 10  # the per-key half still read
+
+    admin = FakeAdmin(
+        key_rows=[_row("req-key", usd=0.04)],
+        customer_rows=[_row("req-chat", usd=0.08)],
+        fail_key_read=True,
+    )
+    rec = await provisioning.reconcile_tenant_spend(
+        WS, since=SINCE, until=UNTIL, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+    assert rec.litellm_credits == 20  # the customer half still read
+
+
+async def test_reconcile_still_debits_nothing_with_both_reads(mongo_db):
+    """The invariant the second read must not break: shadow moves no money."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await credits.debit(
+        WS, 10, cause="compute_spend", idempotency_key="run:r1", allow_negative=True
+    )
+    await _provision()
+
+    admin = FakeAdmin(
+        key_rows=[_row("req-key", usd=0.04)],
+        customer_rows=[_row("req-chat", usd=0.08)],
+    )
+    before_entries, before_balance = await _ledger_snapshot(WS)
+
+    await provisioning.reconcile_tenant_spend(
+        WS, since=SINCE, until=UNTIL, spend_card=SPEND, threshold=2, admin_client=admin
+    )
+
+    after_entries, after_balance = await _ledger_snapshot(WS)
+    assert after_entries == before_entries
+    assert after_balance == before_balance
+    assert (
+        await CreditLedgerEntry.find(
+            CreditLedgerEntry.workspace == WS,
+            CreditLedgerEntry.cause == "litellm_spend",
+        ).to_list()
+        == []
+    )

--- a/tests/mutations/reconcile_two_reads.json
+++ b/tests/mutations/reconcile_two_reads.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "read only the per-key half, as the compare used to",
+    "file": "ee/pocketpaw_ee/cloud/llm_provisioning/service.py",
+    "find": "    customer_rows: list[dict[str, Any]] = []\n    if window is None:",
+    "replace": "    customer_rows: list[dict[str, Any]] = []\n    if True:\n        return [(row, True) for row in (await client.spend_logs(api_key=doc.litellm_key) if doc is not None and doc.litellm_key else [])]\n    if window is None:",
+    "tests": ["tests/cloud/llm_provisioning/test_reconcile_two_reads.py"]
+  },
+  {
+    "label": "derive the compare's start from the tenant row, not the caller",
+    "file": "ee/pocketpaw_ee/cloud/llm_provisioning/service.py",
+    "find": "    window_since = since if since is not None else _ALL_TIME_START",
+    "replace": "    window_since = since if since is not None else datetime.now(UTC) - _SPEND_READ_OVERLAP",
+    "tests": ["tests/cloud/llm_provisioning/test_reconcile_two_reads.py::test_reconcile_without_a_window_compares_the_same_span_on_both_sides"]
+  },
+  {
+    "label": "let the ledger side keep the caller's open bound while the proxy side is resolved",
+    "file": "ee/pocketpaw_ee/cloud/llm_provisioning/service.py",
+    "find": "        workspace, _BC3_COMPUTE_SPEND_CAUSE, since=window_since, until=window_until",
+    "replace": "        workspace, _BC3_COMPUTE_SPEND_CAUSE, since=since, until=until",
+    "tests": ["tests/cloud/llm_provisioning/test_reconcile_two_reads.py"]
+  },
+  {
+    "label": "record the caller's bounds instead of the span actually compared",
+    "file": "ee/pocketpaw_ee/cloud/llm_provisioning/service.py",
+    "find": "    window_start = window_since.isoformat()\n    window_end = window_until.isoformat()",
+    "replace": "    window_start = since.isoformat() if since is not None else None\n    window_end = until.isoformat() if until is not None else None",
+    "tests": ["tests/cloud/llm_provisioning/test_reconcile_two_reads.py::test_reconcile_without_a_window_compares_the_same_span_on_both_sides"]
+  },
+  {
+    "label": "accept an inverted window",
+    "file": "ee/pocketpaw_ee/cloud/llm_provisioning/service.py",
+    "find": "    if since is not None and until is not None and since > until:",
+    "replace": "    if False:",
+    "tests": ["tests/cloud/llm_provisioning/test_reconcile_two_reads.py::test_reconcile_refuses_an_inverted_window"]
+  },
+  {
+    "label": "mint the bookkeeping row from the read-only compare",
+    "file": "ee/pocketpaw_ee/cloud/llm_provisioning/service.py",
+    "find": "    doc = await LiteLLMTenantKey.find_one(LiteLLMTenantKey.workspace == workspace)\n    client = admin_client if admin_client is not None else LiteLLMAdminClient()",
+    "replace": "    doc = await _spend_bookkeeping_row(workspace)\n    client = admin_client if admin_client is not None else LiteLLMAdminClient()",
+    "tests": ["tests/cloud/llm_provisioning/test_reconcile_two_reads.py::test_reconcile_sees_a_workspace_with_spend_and_no_key"]
+  }
+]


### PR DESCRIPTION
The shadow compare is the one instrument an operator is told to trust before making LiteLLM the sole billing meter. It was reading half the proxy, and reporting the half it missed as a coverage gap.

## What was wrong

`reconcile_tenant_spend` called the per-key read alone. The live ingest reads twice — customer-scoped plus per-key — and this module says why: the customer-scoped read is the only one that sees a chat run, because chat authenticates with the deployment key. The compare never got that second read.

So it returned `litellm_credits = 0` for any workspace without a tenant key, which is the actual production shape: three tenants with keys and no spend, three customers with spend and no keys. In shadow mode that reads `litellm=0, bc3=N, delta=-N, coverage_gap=true` on healthy tenants and `litellm=0, bc3=0` on the ones actually spending.

## What changed

It now goes through `_read_tenant_spend_rows`, the helper the ingest already uses, which merges both reads on `request_id`. That helper needed two additive options, and the ingest's call is unchanged:

- **An explicit window.** Its customer read derives bounds from the ingest's high-water mark. A compare must neither honour nor advance that mark, and a seeded cutover mark would have filtered the compare down to nearly nothing.
- **A nullable row.** The compare's lookup returns `None` for exactly the production shape. The obvious wiring — `_spend_bookkeeping_row` — *inserts*, and that row's `createdAt` becomes the live read window's start, so minting one from a read-only path would have moved where real billing later begins.

## The first fix was half a fix

Review caught that the windowless path still resolved each half's span separately: the proxy side got a bounded window, the ledger side got the caller's `since` unchanged, and the persisted row recorded `window_start = None` while a bounded span had actually been read.

That is the general form of the bug this PR is about. A freshly provisioned tenant has no mark, so the customer read was asked for spend over an empty instant — the logs showed `over [2026-09-11 09:06:49, 2026-09-11 09:06:49]`, zero width, on a test that passed. In steady state it is a 15-minute proxy read scored against an all-time ledger sum, which manufactures the same false coverage gap on the sibling path.

The window now resolves once, before either read, and the same pair drives all four consumers: the customer read, the row filter, the ledger sum, and the persisted `window_start` / `window_end`. Open bounds become concrete at that single point — the epoch below, now above.

## Behaviour change worth knowing about

A windowless call's audit row now records `window_start = "1970-01-01T00:00:00+00:00"` and a concrete `window_end`, where it used to record two nulls. That is the intent — the row should state the span it compared — but it changes what operators read back, and rows written before this still carry nulls.

An inverted window now raises `ValidationError("llm_provisioning.invalid_window")` before the proxy is touched and before any row is written. Clamping would have fixed the HTTP call and left the nonsense: an inverted compare measures nothing on either side and persists a confident `delta=0, coverage_gap=False`.

## Evidence

Written failing-first: the customer-scoped read never performed (`litellm_rows 1 == 2`), and a keyless workspace still reconciling to zero (`litellm_credits 0 == 20` against `bc3=20`) — the production shape reproduced.

411 passed across `tests/cloud/billing`, `credits` and `llm_provisioning` against a 401 baseline on `dev`. Six mutations, all caught — **one escaped on the first run**: binding the ledger side to the caller's raw bounds is invisible while every fixture lives inside `epoch..now`. The test written to catch it stamps a spend row and a ledger debit past the compare's end, which correct code drops from both sides and the mutant drops from one. Without it the claim that both halves share a window would have been assertion-shaped and unproven.

The ledger is untouched: no debit, no ledger write, no mark advance, no provisioning row created, each asserted.

## Follow-up, deliberately not here

`SpendReconciliation` still cannot distinguish "the customer read failed" from "there was no spend". For the ingest that swallow is right and self-healing, since the sweep retries and the ledger key makes the catch-up exactly-once. For a compare written once and never revisited it is not, and an operator reading the audit rows sees the same shape as the bug this PR fixes. A `customer_read_ok` flag would close it; that is a schema addition and wants its own PR.

Found during a re-verification of the billing audit against `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
