### PR TITLE
feat(sites): a svelte site could be created but never added to

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -39,6 +39,17 @@ component model, and its paths are root-relative), and why this tool does not
 republish for a DIFFERENT reason than react's — html runs no build at all, so
 there is no gate that could catch a bad edit before it went live.
 
+Updated: 2026-09-11 (feat/sites-svelte-edit-create, SC-1) — added the
+`edit_svelte_component` section, which had no section of its own even though the
+table above has always listed it. That gap mirrored a gap in the tool: svelte was
+the first edit lane to ship and the last to be able to CREATE a file, so "add an
+about page" to a live svelte site was unanswerable and the agent's remaining move
+was a second `create_svelte_site` (a second pocket at a second url). The section
+documents the new `create` arg and the two things about this track that do not
+transfer from the react docs a reader would otherwise reach for: a page here is TWO
+files, and an unlinked route still exists (SvelteKit prerenders it) where an
+unimported react component does not.
+
 Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-4) — documented the build-lane
 fields now on the `publish` tool response and the new read-only
 `get_site_build_status` tool, in the same MCP section. Both are recorded here
@@ -2342,6 +2353,88 @@ A ripple or dynamic site is edited through the pocket specialist's rippleSpec
 merge instead. The leaf-edits REST route above is the *native editor's* html path
 (uid splice) and is a different entry point from `edit_html_file`, which is the
 chat agent's.
+
+### `edit_svelte_component`
+
+Write ONE file of a svelte site's `source` map and build a draft **preview**.
+
+| Arg | Type | Notes |
+|-----|------|-------|
+| `pocket_id` | string | Required. The svelte site pocket. |
+| `component_path` | string | Required. Project-relative, e.g. `src/lib/components/Hero.svelte`, `src/routes/about/+page.svelte`. Must already exist unless `create` is true. |
+| `edits` | array | A list of `{old_string, new_string}` blocks applied to the file's current contents. Each `old_string` must match **exactly once**. Exactly one of `edits` / `new_source`. |
+| `new_source` | string | The full new file contents (replaces the whole file). Required with `create`. |
+| `create` | boolean | Default `false`. Create a NEW file at `component_path`; the path must **not** already exist. |
+| `name` | string | Optional site name override on the republish. |
+
+Returns `{ok: true, status: "draft", is_live: false, site: {...}, component_path,
+created, unreferenced, message}`.
+
+**Adding a page takes three calls, not two.** A SvelteKit route is two files — the
+`+page.svelte` and a `+page.ts` carrying `export const prerender = true`, because
+the root page's prerender flag is declared at page level and does not cascade to a
+child route — and then an `edits` call on the nav or footer to link it. Adding a
+*section* is the familiar two: `create: true` for
+`src/lib/components/<Name>.svelte`, then `edits` on `src/routes/+page.svelte` to
+import and render it.
+
+**`unreferenced` is the outstanding call's reminder**, and svelte answers it two
+ways because a svelte source map holds two kinds of file. A `src/lib/**` module is
+reached by an import specifier, resolved rather than pattern-matched (`$lib/...`,
+relative and root-absolute forms all resolve to the file they mean). A
+`src/routes/**` page is reached by URL, so the question is whether anything links
+to it — an import scan would call every legitimate page an orphan. A `+page.ts` or
+`+layout.svelte` beside a `+page.svelte` counts as reached through its directory,
+since the file-system router claims it with nothing linking to it.
+
+Note the asymmetry with react: an unlinked svelte route still *exists*. SvelteKit's
+default prerender `entries` is every non-dynamic route, so the page is generated and
+reachable by typing the URL; what it lacks is a way for a visitor to find it. An
+unimported react component, by contrast, is absent from the bundle entirely. Either
+way `unreferenced` is advisory and never blocking — call 1 of a multi-call add is
+unreferenced at the instant it lands, so refusing it would make adding a page
+impossible — and it is always `false` for an ordinary edit.
+
+**It publishes a preview, and rolls back.** Unlike its react and html siblings this
+tool republishes: the edit is persisted, a preview is built behind the workerd smoke
+gate, and a `SmokeGateFailed` restores the pocket to its prior state before
+re-raising. The rollback shape differs by mode — an ordinary edit restores the
+file's previous contents, while a failed `create` **removes the key**, because a
+create has no previous contents and writing `""` back would leave an empty file at a
+real route for the next publish to serve.
+
+**Write scope is enforced, not advisory**, and the guard arrived with `create`:
+while the tool could only overwrite existing keys, every writable path had already
+been vetted when `create_svelte_site` landed the map. The resolved path must sit
+under `src/` (there is no `public/` or `static/` on this track), and the
+generator-owned paths are rejected: `src/lib/paw/`, the gated-site auth files
+(`src/hooks.server.ts`, `src/lib/auth.ts`, `src/app.d.ts`) and the build shell
+(`package.json`, `vite.config.ts`, `svelte.config.js`). Paths are normalized
+(backslashes, `.`/`..`) before the check. The policy lives in
+`ee/pocketpaw_ee/sites/svelte_paths.py`.
+
+The guard is checked *before the pocket is read*, and that ordering is load-bearing:
+`svelte-scaffold.ts` throws on a generator-owned path at materialize time, and that
+throw is not a `SmokeGateFailed`, so it would escape the rollback above and leave
+the pocket permanently carrying source every future publish chokes on.
+
+Errors (relayed to the agent as `is_error` with the code, so it can fix and retry):
+
+| Code | When |
+|------|------|
+| `site_edit.invalid_args` | Not exactly one of `edits` / `new_source`. |
+| `site_edit.create_needs_source` | `create` without `new_source`. |
+| `site_edit.reserved_path` | The resolved path is generator-owned. |
+| `site_edit.path_outside_source` | The resolved path is outside `src/`. |
+| `site_edit.no_match` / `site_edit.ambiguous_match` | An `old_string` matched 0 or >1 times. Make it more specific and retry. |
+| `pocket.not_svelte_site` | The pocket is not a svelte Paw Site. |
+| `pocket.svelte_component_exists` | `create` on a path that already exists. |
+| `site_component.not_found` | `create` is false and the path is not in the source map. |
+| `plan.feature_denied` | The workspace's plan lacks the `sites` feature. |
+
+Every write goes through `pockets_service.set_svelte_source_file` (or
+`remove_svelte_source_file` on a create rollback), which emits `PocketUpdated` and
+records a draft `ArtifactVersion` snapshotting the full edited source map.
 
 ### `edit_react_component`
 

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,6 +1,20 @@
 # sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
 # create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
 #
+# Updated: 2026-09-11 (feat/sites-svelte-edit-create, SC-1) — ``edit_svelte_component``
+# gained ``create``, closing the last hole of the set RX-3 and HE-10 closed for react
+# and html. It was the FIRST edit lane to ship and the last to be able to mint a file:
+# its ``component_path`` had to already exist, so "add an about page" to a live svelte
+# site had no reachable tool on this server. Two things made that worse than a missing
+# feature. Its description was also the only one of the three WITHOUT the "NEVER call
+# `create_<engine>_site` again" warning, so the blocked agent's next move was a second
+# ``create_svelte_site`` — a second pocket at a second url, leaving the site the user
+# was looking at untouched — and the /sites surface denies the file built-ins, so there
+# was no fallback. The description now also teaches the shape unique to this track: a
+# SvelteKit page is TWO files (``+page.svelte`` plus the ``+page.ts`` carrying its own
+# prerender flag, which the root page's page-level flag does not cascade to), so adding
+# one is three calls counting the link. Path policy lives in ``sites/svelte_paths.py``.
+#
 # Updated: 2026-09-01 (fix/sites-html-orphan-create) — ``edit_html_file`` carries the
 # same ``unreferenced`` key and its own warning, naming the wiring step this track
 # actually has: a LINK from an existing page, not an import.
@@ -1783,19 +1797,27 @@ async def _edit_svelte_component_handler(args: dict) -> dict:
                 )
     name_raw = args.get("name")
     name = name_raw if isinstance(name_raw, str) else ""
+    create = bool(args.get("create"))
+    if create and not has_new_source:
+        return _error_response(
+            "edit_svelte_component `create` needs `new_source` — the full contents "
+            "of the new file. There is nothing for `edits` to search against in a "
+            "file that does not exist yet."
+        )
 
     from pocketpaw_ee.cloud._core.errors import CloudError
     from pocketpaw_ee.sites import service as sites_service
     from pocketpaw_ee.sites.generator_client import SmokeGateFailed
 
     try:
-        doc = await sites_service.edit_svelte_component(
+        doc, unreferenced = await sites_service.edit_svelte_component(
             workspace_id=workspace_id,
             user_id=user_id,
             pocket_id=pocket_id,
             component_path=component_path,
             new_source=new_source if has_new_source else None,
             edits=edits if has_edits else None,
+            create=create,
             name=name,
         )
     except SmokeGateFailed as exc:
@@ -1820,12 +1842,26 @@ async def _edit_svelte_component_handler(args: dict) -> dict:
     # the live site), and the user must Submit for review to publish. The wording
     # deliberately avoids "published"/"republished"/"live at" so the agent does not
     # tell the user the change is live.
+    # A create is HALF of adding a page or a section — the other half is the edit
+    # that links or imports it. Saying so in the ``message`` (not only in the flag)
+    # is what keeps the agent from reading a clean success as "done" and telling the
+    # user about a page nothing navigates to.
+    orphan_note = (
+        " NOTE: nothing in the site reaches this file yet — no other file links to "
+        "or imports it, so visitors cannot get to it. You are half-done: make the "
+        "follow-up edit that wires it in (a nav/footer link for a route, an import "
+        "for a component) before you tell the user it was added."
+        if unreferenced
+        else ""
+    )
     return _success_response(
         {
             "ok": True,
             "status": "draft",
             "is_live": False,
             "component_path": component_path,
+            "created": create,
+            "unreferenced": unreferenced,
             "site": {
                 "id": str(doc.id),
                 "pocket_id": doc.pocket_id,
@@ -1838,7 +1874,7 @@ async def _edit_svelte_component_handler(args: dict) -> dict:
                 "Your change is staged as a draft preview — it is NOT live yet. "
                 "The preview_url shows a preview of the edit, not the live site. "
                 "To take it live, the user clicks 'Submit for review' (which sends "
-                "the draft for approval)."
+                "the draft for approval)." + orphan_note
             ),
         }
     )
@@ -1855,11 +1891,15 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
     @tool(
         "edit_svelte_component",
         (
-            "Edit ONE component of an EXISTING svelte Paw Site and stage it as a "
-            "DRAFT PREVIEW. Use this when the user asks to change a section of a "
-            "svelte site — 'add a background color to the nav', 'make the hero "
-            "headline bolder', 'change the pricing copy', 'restyle the FAQ'. The "
-            "edit is NOT published and does NOT go live — it is staged for review. "
+            "Change ONE file of an EXISTING svelte Paw Site and stage it as a "
+            "DRAFT PREVIEW. Use this WHENEVER the user asks to alter a svelte site "
+            "that already exists — 'add a background color to the nav', 'make the "
+            "hero headline bolder', 'change the pricing copy', 'restyle the FAQ', "
+            "'add an about page', 'add a testimonials section'. NEVER call "
+            "`create_svelte_site` again for a change: that mints a SECOND site "
+            "pocket at a SECOND url and leaves the one the user is looking at "
+            "untouched. The edit is NOT published and does NOT go live — it is "
+            "staged for review. "
             "Give the edit ONE of two ways (exactly one, not both):\n"
             "  * `edits` — PREFER THIS for small/targeted changes. A list of "
             "search/replace blocks [{old_string, new_string}, ...], exactly like "
@@ -1875,14 +1915,37 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
             "  * `new_source` — the FULL new file contents as a string (REPLACES "
             "the whole file, not a patch). Reserve this for LARGE rewrites where "
             "most of the file changes; for a small tweak use `edits`.\n"
+            "To ADD A PAGE: a SvelteKit route is TWO files, so call this three "
+            "times — `create=true` with `new_source` for "
+            "`src/routes/<slug>/+page.svelte`, again for "
+            "`src/routes/<slug>/+page.ts` containing `export const prerender = "
+            "true;` (the root page's prerender flag is page-level and does NOT "
+            "cascade to a child route), then once with `edits` on the nav/footer "
+            "component to link `/<slug>`. To ADD A SECTION: `create=true` for the "
+            "new `src/lib/components/<Name>.svelte`, then `edits` on "
+            "`src/routes/+page.svelte` to import and render it. `create=true` "
+            "REQUIRES the path to be new; editing an existing file with it is "
+            "rejected so you cannot overwrite a component by accident. Without "
+            "`create` the path must already exist, so a typo is an error and never "
+            "a stray new file.\n"
+            "You may only write under `src/`. `package.json`, `vite.config.ts`, "
+            "`svelte.config.js`, `src/lib/paw/`, `src/hooks.server.ts`, "
+            "`src/lib/auth.ts` and `src/app.d.ts` are GENERATED and rejected — they "
+            "carry the dependency allowlist, the adapter/prerender configuration and "
+            "a gated site's session gate. There is no way to add a dependency.\n"
             "Other args: `pocket_id` (the svelte site pocket), `component_path` (the "
-            "relative path of the file to edit — it must already exist in the source "
-            "map, e.g. 'src/lib/components/Hero.svelte'), optional `name`. CRITICAL "
+            "relative path of the file to write, e.g. "
+            "'src/lib/components/Hero.svelte'), optional `create`, optional `name`. "
+            "CRITICAL "
             "authoring rule (same as create_svelte_site): the component must render "
             "its resting/final state in MARKUP — never set it only in onMount — "
             "because the page is PRERENDERED. Returns {ok, status:'draft', "
             "is_live:false, site: {id, name, preview_url, deployed:false, "
-            "pocket_id}, component_path, message}. Relay the `message` to the user: "
+            "pocket_id}, component_path, created, unreferenced, message}. "
+            "`unreferenced:true` means nothing in the site links to or imports the "
+            "file you just created — visitors cannot reach it — so the follow-up "
+            "call is still outstanding and you must NOT report the page or section "
+            "as added yet. Relay the `message` to the user: "
             "the change is a DRAFT PREVIEW (not live), `preview_url` is a PREVIEW "
             "(not the published site), and to publish it the user clicks 'Submit for "
             "review'. Do NOT tell the user the change is published or live. ok=false "
@@ -1904,9 +1967,12 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
                     "type": "string",
                     "minLength": 1,
                     "description": (
-                        "Relative path of the file to edit — must already exist "
-                        "in the site's source map (e.g. "
-                        "'src/lib/components/Hero.svelte')."
+                        "Relative path of the file to write (e.g. "
+                        "'src/lib/components/Hero.svelte', "
+                        "'src/routes/about/+page.svelte'). Must already exist in "
+                        "the site's source map unless `create` is true. Only "
+                        "`src/` may be written, and the generated build-config / "
+                        "auth files are reserved."
                     ),
                 },
                 "edits": {
@@ -1942,6 +2008,18 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
                         "The FULL new contents of the file as a string (REPLACES the "
                         "whole file — not a diff). Use for large rewrites; for small "
                         "changes prefer `edits`."
+                    ),
+                },
+                "create": {
+                    "type": "boolean",
+                    "description": (
+                        "Create a NEW file at `component_path` instead of editing "
+                        "an existing one. Requires `new_source`, and the path must "
+                        "NOT already exist. Use it to add a page "
+                        "(`src/routes/<slug>/+page.svelte` AND "
+                        "`src/routes/<slug>/+page.ts`) or a section "
+                        "(`src/lib/components/<Name>.svelte`), then edit the nav or "
+                        "`src/routes/+page.svelte` to wire it in."
                     ),
                 },
                 "name": {

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -4,6 +4,14 @@ Sole owner of writes to the ``Pocket`` Beanie document. Module-level
 ``async def`` API. The doc → domain mapping helpers (formerly in
 ``repositories.py``) live alongside the public API as private helpers.
 
+Updated: 2026-09-11 (SC-1, feat/sites-svelte-edit-create) —
+``set_svelte_source_file`` gained ``create`` (the inversion its react peer has
+carried since RX-3: without it the path must exist, with it the path must not) and
+now returns ``None`` for ``previous_source`` on a create, where there is no prior
+version to hand back for rollback. ``remove_svelte_source_file`` is new and exists
+for exactly that rollback: a failed create must remove the key rather than restore
+an empty string, which would leave a blank file at a real route.
+
 Updated: 2026-07-23 (SI-5, feat/sites-import-crawler) — added
 ``set_imported_source``: the sites URL-import crawler persists its harvested
 html source map on the imported pocket through THIS service (entity isolation —
@@ -2188,8 +2196,9 @@ async def set_svelte_source_file(
     *,
     component_path: str,
     new_source: str,
-) -> tuple[dict, str]:
-    """Rewrite ONE file in a svelte-engine pocket's ``source`` map and persist it.
+    create: bool = False,
+) -> tuple[dict, str | None]:
+    """Write ONE file in a svelte-engine pocket's ``source`` map and persist it.
 
     The svelte analog of editing a single component of a Paw Site: ``source`` is
     a ``{relative_path: file_contents}`` map (the hand-written SvelteKit files),
@@ -2199,18 +2208,30 @@ async def set_svelte_source_file(
 
     Access mirrors ``update``: explicit ``(pocket_id, user_id)`` with
     ``_check_domain_edit_access`` (owner / shared_with / workspace-visible). A
-    missing pocket raises ``NotFound``; a non-svelte pocket or a non-existent
-    component path raise the obvious cloud errors rather than silently creating a
-    file or dereferencing ``None``:
-      * not a svelte pocket (``engine != "svelte"`` or no ``source`` map) →
-        ``ValidationError`` (422);
-      * ``component_path`` absent from the map → ``NotFound`` (404) on the
-        component, so a typo'd path is not a silent create.
+    missing pocket raises ``NotFound``; a non-svelte pocket raises
+    ``ValidationError`` (422) rather than a write against the wrong content model.
+
+    ``create`` mirrors the react peer ``set_react_source_file``, and arrived for the
+    same reason: "add an about page" needs a NEW file (two, on this track — a
+    SvelteKit route is ``+page.svelte`` plus the ``+page.ts`` carrying its prerender
+    flag) plus an edit to a nav component, and with an existence-only contract the
+    agent could not add a page at all. It FLIPS the path check rather than relaxing
+    it, so exactly one of the two mistakes is impossible in each mode:
+
+      * ``create=False`` (default) — ``component_path`` MUST already exist, else
+        ``NotFound`` (404). A typo'd path is never a silent create.
+      * ``create=True`` — ``component_path`` must NOT already exist, else
+        ``ValidationError`` (422). Silently overwriting a real component the agent
+        thought it was adding is worse than a rejected call it can retry.
 
     Returns ``(resolved_wire_dict, previous_source)`` — the wire dict every other
     write returns, plus the file's PRIOR contents so the caller can roll the edit
     back if the downstream republish fails its smoke gate (the sites service does
     exactly this so a broken edit never leaves stale source on the pocket).
+    ``previous_source`` is ``None`` on a create, where there is no prior version to
+    restore: the caller rolls THAT back by removing the key outright
+    (:func:`remove_svelte_source_file`), because writing an empty string instead
+    would leave a blank route the build still has to serve.
     """
     doc = await _fetch_pocket(pocket_id)
     _check_domain_edit_access(_pocket_to_domain(doc), user_id)
@@ -2220,10 +2241,16 @@ async def set_svelte_source_file(
             "pocket.not_svelte_site",
             "This pocket is not a svelte Paw Site — it has no component source map to edit.",
         )
-    if component_path not in doc.source:
+    if create and component_path in doc.source:
+        raise ValidationError(
+            "pocket.svelte_component_exists",
+            f"`{component_path}` already exists in this site's source map. Edit it "
+            "without `create`, or choose a path that does not exist yet.",
+        )
+    if not create and component_path not in doc.source:
         raise NotFound("site_component", component_path)
 
-    previous_source = doc.source[component_path]
+    previous_source = doc.source[component_path] if not create else None
     # Reassign a fresh dict so Beanie tracks the change (in-place mutation of a
     # dict field is not always detected as dirty by the ODM).
     updated = dict(doc.source)
@@ -2242,6 +2269,51 @@ async def set_svelte_source_file(
         doc, author=user_id, label=_edit_label(component_path)
     )
     return await _resolved_wire_dict(doc, user_id), previous_source
+
+
+async def remove_svelte_source_file(
+    pocket_id: str,
+    user_id: str,
+    *,
+    component_path: str,
+) -> dict:
+    """Drop ONE file from a svelte-engine pocket's ``source`` map and persist it.
+
+    Exists for exactly one caller: the sites service's smoke-gate rollback on a
+    CREATE. An ordinary edit rolls back by writing the prior contents, but a create
+    has no prior contents, and restoring ``""`` would leave the pocket carrying an
+    empty file at a real route — a blank page the next publish still has to serve,
+    which is the failure the rollback exists to prevent rather than a recovery from
+    it. Removing the key returns the map to precisely its pre-create state.
+
+    Access and engine checks mirror :func:`set_svelte_source_file`. A path that is
+    already absent is NOT an error: the rollback must be safe to run against a write
+    that never landed, and raising there would replace a recoverable smoke failure
+    with an unrecoverable one.
+    """
+    doc = await _fetch_pocket(pocket_id)
+    _check_domain_edit_access(_pocket_to_domain(doc), user_id)
+
+    if getattr(doc, "engine", "ripple") != "svelte" or not isinstance(doc.source, dict):
+        raise ValidationError(
+            "pocket.not_svelte_site",
+            "This pocket is not a svelte Paw Site — it has no component source map to edit.",
+        )
+    if component_path not in doc.source:
+        return await _resolved_wire_dict(doc, user_id)
+
+    # Reassign a fresh dict so Beanie tracks the change (in-place mutation of a
+    # dict field is not always detected as dirty by the ODM) — same reason the
+    # sibling writer rebuilds the map rather than popping in place.
+    updated = dict(doc.source)
+    del updated[component_path]
+    doc.source = updated
+    await doc.save()
+    await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+    await _record_pocket_svelte_draft_version(
+        doc, author=user_id, label=_edit_label(component_path)
+    )
+    return await _resolved_wire_dict(doc, user_id)
 
 
 async def set_react_source_file(

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,19 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-09-11 (SC-1, feat/sites-svelte-edit-create): ``edit_svelte_component``
+# gained ``create`` and now returns ``(site_doc, unreferenced)`` rather than the doc
+# alone. Three things came with it. It reads the pocket UNCONDITIONALLY now (the create
+# branch needs the map for the reachability answer, where before only the ``edits``
+# branch read it). It checks ``svelte_path_rejection`` BEFORE the pocket is read, which
+# is load-bearing rather than tidy: the scaffold throws on a generator-owned path at
+# materialize time, that throw is not a ``SmokeGateFailed``, and so it would escape the
+# rollback below and leave the pocket permanently carrying source every future publish
+# chokes on. And the rollback FORKS by mode — an ordinary edit still restores the prior
+# contents, but a failed create REMOVES the key, because a create has no prior contents
+# and writing "" back would leave an empty file at a real route for the next publish to
+# serve.
+#
 # Updated 2026-09-04 (AD-4 — the overview chart's data): ``site_analytics`` answers a
 # ``series`` block, the same totals grouped by a time bucket. SEVEN queries per uncached
 # read now, up from six. The bucket is an HOUR for the 24-hour window and a DAY for the
@@ -1126,6 +1139,11 @@ from pocketpaw_ee.sites.react_paths import (
     is_reserved_react_path,
     react_path_is_referenced,
     react_path_rejection,
+)
+from pocketpaw_ee.sites.svelte_paths import (
+    is_reserved_svelte_path,
+    svelte_path_is_referenced,
+    svelte_path_rejection,
 )
 
 logger = logging.getLogger(__name__)
@@ -8070,12 +8088,13 @@ async def edit_svelte_component(
     component_path: str,
     new_source: str | None = None,
     edits: list[dict[str, str]] | None = None,
+    create: bool = False,
     name: str = "",
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
     _local_deploy: Callable[[str, str], str] | None = None,
-) -> _SiteDoc:
+) -> tuple[_SiteDoc, bool]:
     """Rewrite ONE component of a svelte Paw Site pocket and safely republish.
 
     The chat-agent entry point for a targeted component edit. The edit can be
@@ -8088,12 +8107,35 @@ async def edit_svelte_component(
         exactly once), and uses the COMPUTED new source. The agent sends only the
         diff — the dominant token / latency saving over a full rewrite.
       * ``new_source`` (full rewrite, the SE-2 fallback) — the whole new file
-        contents; used as-is. Reserve this for large rewrites.
+        contents; used as-is. Reserve this for large rewrites, and it is the ONLY
+        form accepted with ``create=True`` (there is nothing to diff against a file
+        that does not exist yet).
 
     Either way the resolved new source replaces the file at ``component_path`` in
     the pocket's svelte ``source`` map and the site is republished. The Pocket
     write is owned by the pockets service (``set_svelte_source_file`` — entity
     isolation); this function only orchestrates resolve → persist → republish.
+
+    ``create=True`` (SC-1) mints a NEW path instead of editing an existing one. It
+    exists because "add an about page" needs new FILES — on this track two, since a
+    SvelteKit route is ``+page.svelte`` plus the ``+page.ts`` carrying its own
+    ``prerender`` flag (the root page's flag is page-level and does not cascade) —
+    plus an edit to a nav component to link it. Without it the agent could not add a
+    page at all, and the react (RX-3) and html (HE-10) lanes both grew the same flag
+    for the same reason; svelte shipped first and was the last to get it. It INVERTS
+    the existence check rather than relaxing it: ``create=False`` requires the path
+    to exist (a typo is never a silent create), ``create=True`` requires it not to
+    (an accidental overwrite of a real component is worse than a rejected call).
+
+    The path guard is load-bearing, not hygiene, and it is NEW with ``create``:
+    while this lane could only overwrite keys that already existed, every writable
+    path had been vetted when ``create_svelte_site`` landed the map. A minted path
+    has not been, and a reserved one does not merely fail — it fails in the worst
+    place. ``svelte-scaffold.ts`` THROWS on a generator-owned path at materialize
+    time, which is not a ``SmokeGateFailed``, so it would slip past the rollback
+    below and leave the pocket permanently carrying source that every future publish
+    chokes on. :func:`pocketpaw_ee.sites.svelte_paths.svelte_path_rejection` is
+    therefore checked BEFORE the pocket is even read.
 
     Safety contract — a broken edit must leave NEITHER a broken deploy NOR stale
     source on the pocket:
@@ -8128,27 +8170,52 @@ async def edit_svelte_component(
             "edit_svelte_component requires exactly one of `edits` (a targeted "
             "search/replace diff) or `new_source` (a full file rewrite).",
         )
+    if create and new_source is None:
+        raise ValidationError(
+            "site_edit.create_needs_source",
+            "Creating a new svelte file needs `new_source` — the full contents of "
+            "the new component or route. There is nothing for `edits` to search "
+            "against in a file that does not exist yet.",
+        )
+
+    # The path guard. FIRST, before the pocket is even read: a call that names a
+    # generator-owned path is rejected on the path alone, so no amount of pocket
+    # state can make it land. See the docstring for why a reserved path is worse
+    # here than a rejected one — the scaffold's throw is not a SmokeGateFailed and
+    # would escape the rollback below.
+    if (reason := svelte_path_rejection(component_path)) is not None:
+        code = (
+            "site_edit.reserved_path"
+            if is_reserved_svelte_path(component_path)
+            else "site_edit.path_outside_source"
+        )
+        raise ValidationError(code, reason)
+
+    # Read the pocket's CURRENT source map. The read goes through the pockets
+    # service's PUBLIC ``get`` (wire dict — entity isolation; it raises
+    # NotFound/Forbidden itself) so everything below runs against the source of
+    # truth. Unconditional since SC-1: the ``edits`` branch needs the file to diff
+    # against, and the ``create`` branch needs the map to answer the reachability
+    # question at the end.
+    pocket = await pockets_service.get(pocket_id, user_id)
+    # KEPT svelte-specific (not is_source_engine): edits a single named SvelteKit
+    # component by ``component_path`` and persists via ``set_svelte_source_file``.
+    # html has no per-component model — it edits by uid splice (HE-9), not here.
+    if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(pocket.get("source"), dict):
+        raise ValidationError(
+            "pocket.not_svelte_site",
+            "This pocket is not a svelte Paw Site — it has no component source map to edit.",
+        )
+    source_map = pocket["source"]
+    # The MISSING-path half of the inversion is enforced here as well as at the
+    # write, because the ``edits`` branch below indexes the map: without it a typo'd
+    # path is a KeyError instead of the NotFound the caller has to relay. The
+    # EXISTING-path half (``create`` onto a live component) is NOT duplicated —
+    # nothing here reads the file on the create path, so the write chokepoint in the
+    # pockets service owns that rule for every caller.
+    if not create and component_path not in source_map:
+        raise NotFound("site_component", component_path)
     if edits is not None:
-        # Targeted/diff edit: read the pocket's CURRENT component source and apply
-        # the blocks to compute the new source. The read goes through the pockets
-        # service's PUBLIC ``get`` (wire dict — entity isolation; it raises
-        # NotFound/Forbidden itself) so the apply runs against the source of truth.
-        # A missing component path is a NotFound (same contract as the full-rewrite
-        # path, where set_svelte_source_file raises it) — not a silent create.
-        pocket = await pockets_service.get(pocket_id, user_id)
-        # KEPT svelte-specific (not is_source_engine): edits a single named SvelteKit
-        # component by ``component_path`` and persists via ``set_svelte_source_file``.
-        # html has no per-component model — it edits by uid splice (HE-9), not here.
-        if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(
-            pocket.get("source"), dict
-        ):
-            raise ValidationError(
-                "pocket.not_svelte_site",
-                "This pocket is not a svelte Paw Site — it has no component source map to edit.",
-            )
-        source_map = pocket["source"]
-        if component_path not in source_map:
-            raise NotFound("site_component", component_path)
         # apply_edits raises ValidationError (clear, retry-able) on any match-count
         # violation, BEFORE anything is persisted or rebuilt.
         new_source = apply_edits(source_map[component_path], edits)
@@ -8160,12 +8227,15 @@ async def edit_svelte_component(
     builder_origin = prior.builder_origin if prior else ""
 
     # 1. Persist the edit (pockets service owns the Pocket write + validation).
-    #    ``previous_source`` is the file's prior contents, held for rollback.
+    #    ``previous_source`` is the file's prior contents, held for rollback — None
+    #    on a create, where the rollback removes the key instead.
+    assert new_source is not None  # narrowing: the arg checks above guarantee it
     _wire, previous_source = await pockets_service.set_svelte_source_file(
         pocket_id,
         user_id,
         component_path=component_path,
         new_source=new_source,
+        create=create,
     )
 
     # 2. Build a PREVIEW of the edit (Branch primitive). The persist above already
@@ -8193,12 +8263,24 @@ async def edit_svelte_component(
             _local_deploy=_local_deploy,
         )
     except SmokeGateFailed:
-        await pockets_service.set_svelte_source_file(
-            pocket_id,
-            user_id,
-            component_path=component_path,
-            new_source=previous_source,
-        )
+        if create:
+            # A create has no prior contents to restore. Writing ``""`` back would
+            # leave the pocket carrying an empty file at a real route — a blank page
+            # the next publish still has to serve, which is the state this rollback
+            # exists to prevent rather than a recovery from it. Remove the key so the
+            # map returns to precisely what it was before the create.
+            await pockets_service.remove_svelte_source_file(
+                pocket_id,
+                user_id,
+                component_path=component_path,
+            )
+        else:
+            await pockets_service.set_svelte_source_file(
+                pocket_id,
+                user_id,
+                component_path=component_path,
+                new_source=previous_source or "",
+            )
         raise
 
     # feat/sites-native-artifact-no-build: the component source changed → pre-warm the
@@ -8211,7 +8293,23 @@ async def edit_svelte_component(
         pocket_id=pocket_id,
         builder_origin=builder_origin or None,
     )
-    return doc
+
+    # Does anything reach the file we just wrote? A create is HALF of adding a page
+    # — the other half is the nav/footer edit that links it — and a create that
+    # landed call 1 and never got call 2 would otherwise return a flat success for a
+    # page no visitor can navigate to. The react and html lanes each learned this
+    # from a real orphan-create incident; svelte gets the answer from the start.
+    #
+    # Scoped to ``create`` deliberately. An ordinary edit touches a file that is
+    # already part of the site, and re-litigating its wiring on every headline change
+    # is noise on the common path — which is how the signal on the rare path gets
+    # skimmed. The map scanned is the POST-write one: the write set exactly this one
+    # key, so re-reading the pocket to learn what we just sent it would be a round
+    # trip for an answer we already hold.
+    unreferenced = create and not svelte_path_is_referenced(
+        {**source_map, component_path: new_source}, component_path
+    )
+    return doc, unreferenced
 
 
 async def edit_react_component(

--- a/ee/pocketpaw_ee/sites/svelte_paths.py
+++ b/ee/pocketpaw_ee/sites/svelte_paths.py
@@ -1,0 +1,354 @@
+# svelte_paths.py — the ONE place the svelte-track source-map path policy lives.
+#
+# Created: 2026-09-11 (feat/sites-svelte-edit-create, SC-1) — the svelte peer of
+# ``react_paths.py`` / ``html_paths.py``, written for the same reason those were:
+# the EDIT lane is about to become a second WRITER of a svelte source map, and a
+# second writer is only safe once the guard it needs exists in one place.
+#
+# Until now the svelte edit lane needed no path policy at all, and that was sound:
+# ``set_svelte_source_file`` could only OVERWRITE a key that already existed, so
+# every writable path had already been vetted when ``create_svelte_site`` landed the
+# map. Adding ``create`` removes that property — an edit can now mint an arbitrary
+# path — so "may this path be written" has to be asked, and asked before the write.
+#
+# It is deliberately NOT a copy of ``react_paths``. The tracks differ in both rules:
+#
+#   * react reserves four generator-owned files plus ``src/paw/``; svelte's
+#     generator (``svelte-scaffold.ts::isReservedPath``) reserves the
+#     ``src/lib/paw/`` namespace plus the three gated-site auth files, and THROWS on
+#     a collision. Those are mirrored here exactly — checking in Python turns a
+#     build-time throw far from the authoring turn into an actionable error.
+#   * react's authored files may live under ``src/`` or ``public/``. A svelte Paw
+#     Site has no ``public/`` and no ``static/`` (neither appears in the generator's
+#     templates), so the authorable tree is ``src/`` alone.
+#
+# WHY THE BUILD SHELL IS RESERVED HERE BUT NOT IN THE SCAFFOLD. The scaffold writes
+# ``package.json`` / ``vite.config.ts`` / ``svelte.config.js`` BEFORE it overlays the
+# source map, with an explicit comment that a map "MAY override them if it ever ships
+# its own". That tolerance is fine for create, where the whole map is authored in one
+# reviewed act; it is not fine as a per-file edit verb. An edit that could write
+# ``package.json`` would be a way to rewrite the dependency manifest one call at a
+# time. It is NOT the only thing standing there — ``materializeSource`` step 7 runs
+# ``assertAllowed()`` over whatever package.json it actually emitted, so an unvetted
+# dependency still throws — but a guard that keeps the edit lane away from the build
+# config entirely is cheaper than relying on that post-emit check to be the only one.
+#
+# NOT reserved, deliberately: ``src/app.html``. The scaffold injects the SE-1 edit
+# bridge and the EP-6 leaf manifest into it at step 6, AFTER the overlay, so an
+# authored app.html still receives both. The rule this module follows is to mirror
+# the generator's contract rather than invent a stricter one.
+"""Svelte-track source-map path policy for Paw Sites.
+
+A svelte-engine pocket's ``source`` is a ``{relative_path: file_contents}`` map of
+hand-written SvelteKit files that the paw-sites generator materializes ON TOP of a
+project skeleton it owns. Two rules govern which paths an author may write:
+
+1. **Generator-owned paths are the generator's.** The ``src/lib/paw/`` namespace and
+   the gated-site auth files (``src/hooks.server.ts``, ``src/lib/auth.ts``,
+   ``src/app.d.ts``) carry the session gate; the build shell (``package.json``,
+   ``vite.config.ts``, ``svelte.config.js``) carries the dependency manifest and the
+   adapter/prerender configuration.
+
+2. **Authored files live under ``src/``.** Everything else at the project root
+   belongs to the skeleton, so a path outside that prefix is rejected rather than
+   silently written somewhere the build ignores.
+
+Both rules are applied to the NORMALIZED path: backslashes become forward slashes
+and ``.``/``..`` segments collapse (``posixpath``, not ``os.path`` — source-map keys
+are POSIX-style project-relative paths regardless of the host OS). A guard a trivial
+path spelling defeats is not a guard, and ``./package.json`` / ``src\\lib\\paw\\x.ts``
+/ ``src/lib/paw/../paw/x.ts`` are trivial spellings.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from collections.abc import Mapping
+from typing import Any
+
+# The namespace + files paw-sites' ``svelte-scaffold.ts`` refuses to let a source
+# map write (``RESERVED_NAMESPACE`` / ``RESERVED_FILES``, enforced by its
+# ``isReservedPath``). Mirrored exactly — drift here means a path this module
+# accepts blows up at materialize time instead.
+SVELTE_RESERVED_PREFIX = "src/lib/paw/"
+SVELTE_RESERVED_AUTH_FILES: tuple[str, ...] = (
+    "src/hooks.server.ts",
+    "src/lib/auth.ts",
+    "src/app.d.ts",
+)
+
+# The build shell. The scaffold tolerates an override from a whole authored map;
+# the per-file edit lane does not (see the module header for why).
+SVELTE_RESERVED_SHELL_FILES: tuple[str, ...] = (
+    "package.json",
+    "vite.config.ts",
+    "svelte.config.js",
+)
+
+SVELTE_RESERVED_FILES: tuple[str, ...] = (
+    *SVELTE_RESERVED_AUTH_FILES,
+    *SVELTE_RESERVED_SHELL_FILES,
+)
+
+# The one directory an author may write into. A svelte Paw Site has no ``public/``
+# and no ``static/`` — neither exists in the generator's templates — so unlike the
+# react peer this is a single prefix.
+SVELTE_AUTHORABLE_PREFIXES: tuple[str, ...] = ("src/",)
+
+
+def normalize_svelte_path(path: str) -> str:
+    """Collapse a source-map key to the path the generator will actually write.
+
+    Backslashes become forward slashes (a Windows-authored key, or an agent that
+    guessed the separator) and ``.``/``..`` segments collapse. The generator
+    normalizes the same way before it throws, so normalizing first is what makes
+    the guards below agree with it.
+    """
+    return posixpath.normpath(path.replace("\\", "/"))
+
+
+def is_reserved_svelte_path(path: str) -> bool:
+    """True when ``path`` resolves onto a generator-owned file or namespace."""
+    norm = normalize_svelte_path(path)
+    return (
+        norm in SVELTE_RESERVED_FILES
+        or norm == SVELTE_RESERVED_PREFIX.rstrip("/")
+        or norm.startswith(SVELTE_RESERVED_PREFIX)
+    )
+
+
+def is_authorable_svelte_path(path: str) -> bool:
+    """True when ``path`` resolves inside ``src/``.
+
+    Note this is about the RESOLVED path: ``src/../package.json`` normalizes to
+    ``package.json`` and is not authorable, which is the point.
+    """
+    norm = normalize_svelte_path(path)
+    return any(norm.startswith(prefix) for prefix in SVELTE_AUTHORABLE_PREFIXES)
+
+
+def svelte_path_rejection(path: str) -> str | None:
+    """Return why ``path`` may not be written, or ``None`` when it may.
+
+    Two rejections, checked in this order because the reserved one is the more
+    specific and more useful message:
+
+      * a generator-owned path (rule 1) — names what owns it and why;
+      * anything outside ``src/`` (rule 2) — catches root-level files, ``..``
+        escapes and absolute paths in one check.
+
+    Returns a message fragment the caller wraps in its own error, so the error code
+    is the caller's choice and this module stays free of any dependency on the cloud
+    error hierarchy (the same contract ``react_path_rejection`` keeps).
+    """
+    norm = normalize_svelte_path(path)
+    if is_reserved_svelte_path(norm):
+        return (
+            f"`{path}` resolves to `{norm}`, which the generator owns. The "
+            "`src/lib/paw/` namespace and the auth files (src/hooks.server.ts, "
+            "src/lib/auth.ts, src/app.d.ts) are what keep a gated site's session "
+            "gate from being shadowed, and the build shell (package.json, "
+            "vite.config.ts, svelte.config.js) carries the dependency allowlist "
+            "and the adapter/prerender configuration. Edit under `src/` outside "
+            "`src/lib/paw/`."
+        )
+    if not is_authorable_svelte_path(norm):
+        return (
+            f"`{path}` resolves to `{norm}`, which is outside the authored source "
+            "tree. A svelte Paw Site's own files live under `src/` — its routes "
+            "under `src/routes/`, its components under `src/lib/components/`; "
+            "everything else at the project root belongs to the generated skeleton."
+        )
+    return None
+
+
+def reserved_svelte_keys(source: Mapping[str, Any]) -> list[str]:
+    """Return the source-map keys that collide with a generator-owned path.
+
+    The whole-map form, for a caller that wants to name every offending key at once
+    instead of failing on the first. Returns the keys AS THE AUTHOR SPELLED THEM
+    (not normalized) so the error points at something findable in the payload.
+    """
+    return sorted(key for key in source if is_reserved_svelte_path(key))
+
+
+# ---------------------------------------------------------------------------
+# Is this path reached by anything? (the two-call contract's missing half)
+# ---------------------------------------------------------------------------
+#
+# The react and html peers each grew this after an orphan-create incident: a
+# ``create`` that landed call 1 and never got call 2 returned a flat success for a
+# file nothing reached, and the agent read the clean success and reported the work
+# as done over a page that never changed. Svelte gets it at birth rather than after
+# the same incident.
+#
+# Svelte is the only track where the question has TWO answers, because a svelte
+# source map holds two different kinds of file:
+#
+#   * ``src/lib/**`` is a MODULE tree, reached by an import specifier — resolved
+#     here rather than pattern-matched, so ``$lib/components/Hero.svelte`` from
+#     ``src/routes/+page.svelte`` and ``./Hero.svelte`` from a sibling both resolve
+#     to the one file they mean.
+#   * ``src/routes/**`` is a ROUTE tree, reached by URL. SvelteKit's file-system
+#     router picks a route up with nothing importing it, so an import scan would
+#     call every legitimate page an orphan. What matters for a page is whether a
+#     visitor can FIND it: does anything link to its URL.
+#
+# The verdict is advisory either way. Call 1 of a two-call add is unreferenced by
+# definition at the instant it happens, so a create that refused on it would close
+# the only lane that can add a page at all.
+
+# Extensions a specifier may omit. A resolved specifier and a source-map key are
+# compared with these stripped.
+_SVELTE_MODULE_EXTS: tuple[str, ...] = (".svelte", ".ts", ".js", ".mjs", ".css")
+
+# Quoted module specifiers: ``from '...'``, a side-effect or dynamic ``import '...'``
+# / ``import('...')``. Deliberately NOT a general string scan — matching any quoted
+# text would let body copy mentioning a component name pass for an import, and a
+# false "it is referenced" is the silence this exists to break.
+_SVELTE_SPECIFIER_RE = re.compile(r"""(?:\bfrom\s*|\bimport\s*\(?\s*)['"]([^'"\n]+)['"]""")
+
+# SvelteKit's file-system routing conventions. A file whose basename starts with
+# ``+`` is claimed by the router for the directory it sits in, not by an import.
+_ROUTE_CONVENTION_PREFIX = "+"
+_ROUTES_ROOT = "src/routes/"
+# The one route file that IS a page rather than configuration for one.
+_ROUTE_PAGE_FILE = "+page.svelte"
+
+# A route segment wrapped in parentheses is a LAYOUT GROUP — organisational only,
+# contributing nothing to the URL. One in square brackets is a dynamic PARAMETER.
+_GROUP_SEGMENT_RE = re.compile(r"^\(.*\)$")
+_PARAM_SEGMENT_RE = re.compile(r"\[.*\]")
+
+
+def _strip_module_ext(path: str) -> str:
+    """Drop a module extension so a specifier and a map key compare equal."""
+    for ext in _SVELTE_MODULE_EXTS:
+        if path.endswith(ext):
+            return path[: -len(ext)]
+    return path
+
+
+def _resolve_specifier(importer: str, specifier: str) -> str | None:
+    """Resolve one import specifier to a project-relative path, or ``None``.
+
+    ``None`` means "not a local file" — a bare package specifier (``svelte``,
+    ``@sveltejs/kit``) resolves into node_modules and can never name a source-map
+    key. Relative specifiers resolve against the IMPORTER's directory, which is the
+    whole reason this is a resolver and not a substring search: ``./Hero.svelte``
+    means a different file depending on who wrote it.
+    """
+    if specifier.startswith("$lib/"):
+        # SvelteKit's built-in alias, and the form the create-svelte-site skill
+        # teaches — by far the dominant spelling in a real site's +page.svelte.
+        return posixpath.normpath("src/lib/" + specifier[len("$lib/") :])
+    if specifier == "$lib":
+        return "src/lib"
+    if specifier.startswith("."):
+        return posixpath.normpath(posixpath.join(posixpath.dirname(importer), specifier))
+    if specifier.startswith("/"):
+        return posixpath.normpath(specifier.lstrip("/"))
+    return None
+
+
+def route_url_for(path: str) -> str | None:
+    """The URL a ``src/routes/**`` router file is served at, or ``None``.
+
+    ``None`` means the path is not a route file whose URL can be named literally:
+    it is not under ``src/routes/``, it is not a router convention file, or it
+    carries a dynamic ``[param]`` segment no fixed href can be compared against.
+
+        src/routes/+page.svelte             -> "/"
+        src/routes/about/+page.svelte       -> "/about"
+        src/routes/(marketing)/faq/+page.ts -> "/faq"   (group adds no segment)
+        src/routes/blog/[slug]/+page.svelte -> None     (dynamic)
+    """
+    norm = normalize_svelte_path(path)
+    if not norm.startswith(_ROUTES_ROOT):
+        return None
+    rel = norm[len(_ROUTES_ROOT) :]
+    segments = rel.split("/")
+    if not segments or not segments[-1].startswith(_ROUTE_CONVENTION_PREFIX):
+        return None
+    dir_segments = segments[:-1]
+    if any(_PARAM_SEGMENT_RE.search(seg) for seg in dir_segments):
+        return None
+    url_segments = [seg for seg in dir_segments if not _GROUP_SEGMENT_RE.match(seg)]
+    return "/" + "/".join(url_segments) if url_segments else "/"
+
+
+def _links_to(text: str, url: str) -> bool:
+    """Does ``text`` contain a link to ``url``?
+
+    Matched on the quoted attribute value so that ``/about`` is not satisfied by a
+    link to ``/about-us``, and a trailing slash is accepted because both spellings
+    reach the same prerendered page.
+    """
+    pattern = r"""(?:href|action)\s*=\s*['"]""" + re.escape(url) + r"""/?['"]"""
+    return bool(re.search(pattern, str(text)))
+
+
+def svelte_path_is_referenced(source: Mapping[str, Any], path: str) -> bool:
+    """Does any OTHER file in ``source`` reach ``path``?
+
+    ``source`` is the source map AFTER the write, so the created file is present and
+    is skipped — a module that imports itself is still unreachable from the page.
+
+    Three shapes, because a svelte source map holds three kinds of file:
+
+      * a ROUTE PAGE (``src/routes/**/+page.svelte``) is reached by URL, so the
+        question is whether anything links to it. SvelteKit WILL still prerender an
+        unlinked route — its default ``entries`` is every non-dynamic route — so the
+        page exists either way; what an unlinked page lacks is a way for a visitor
+        to find it, which is exactly what the caller needs to be told;
+      * a SIBLING CONVENTION FILE (``+page.ts``, ``+layout.svelte``, ...) is claimed
+        by the file-system router because of the directory it sits in, so it counts
+        as reached as soon as that directory holds the ``+page.svelte`` it serves;
+      * anything else (``src/lib/**``) is a MODULE, reached by an import specifier.
+    """
+    norm = normalize_svelte_path(path)
+    others = {key: text for key, text in source.items() if normalize_svelte_path(key) != norm}
+
+    url = route_url_for(norm)
+    if url is not None:
+        # ``+page.svelte`` IS the page — the thing a visitor navigates to, so the
+        # question for it is whether anything links to its URL. Every other ``+``
+        # file in the directory (``+page.ts``, ``+layout.svelte``, ``+error.svelte``)
+        # CONFIGURES that page: the router reaches it through the directory, never
+        # through a link of its own, so the page's presence is the whole answer.
+        if norm.rsplit("/", 1)[-1] != _ROUTE_PAGE_FILE:
+            directory = norm.rsplit("/", 1)[0]
+            return any(
+                normalize_svelte_path(key).rsplit("/", 1)[0] == directory
+                and normalize_svelte_path(key).rsplit("/", 1)[-1] == _ROUTE_PAGE_FILE
+                for key in others
+            )
+        if url == "/":
+            return True  # the root page is the site's entry; nothing needs to link it
+        return any(_links_to(text, url) for text in others.values())
+
+    target = _strip_module_ext(norm)
+    for key, text in others.items():
+        importer = normalize_svelte_path(key)
+        for specifier in _SVELTE_SPECIFIER_RE.findall(str(text)):
+            resolved = _resolve_specifier(importer, specifier)
+            if resolved is not None and _strip_module_ext(resolved) == target:
+                return True
+    return False
+
+
+__all__ = [
+    "SVELTE_AUTHORABLE_PREFIXES",
+    "SVELTE_RESERVED_AUTH_FILES",
+    "SVELTE_RESERVED_FILES",
+    "SVELTE_RESERVED_PREFIX",
+    "SVELTE_RESERVED_SHELL_FILES",
+    "is_authorable_svelte_path",
+    "is_reserved_svelte_path",
+    "normalize_svelte_path",
+    "reserved_svelte_keys",
+    "route_url_for",
+    "svelte_path_is_referenced",
+    "svelte_path_rejection",
+]

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-svelte-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-svelte-site/SKILL.md
@@ -369,6 +369,48 @@ did, publish the pocket:
 mcp__pocketpaw_sites_manager__publish(pocket_id = <the id from STEP 3>)
 ```
 
+### If the user then asks for a CHANGE — edit, never re-create
+
+"Shorten the headline", "make the nav sticky", "add a testimonials section",
+"add an about page" is an **edit of the site you just made**, not a new one.
+`create_svelte_site` has no update mode: calling it again mints a **second**
+site pocket at a **second url** and leaves the one the user is looking at
+untouched. Edit the existing pocket instead:
+
+```
+mcp__pocketpaw_sites_manager__edit_svelte_component(
+  pocket_id      = <the id from STEP 3>,
+  component_path = "src/lib/components/Hero.svelte",
+  edits          = [{"old_string": "<copied verbatim, must match exactly once>",
+                     "new_string": "<the replacement>"}]
+)
+```
+
+- Send a targeted **`edits`** diff, not the whole file. Pass `new_source`
+  instead only for a genuine rewrite — **exactly one** of the two per call.
+- Each `old_string` must match that file **exactly once**; include surrounding
+  context so it is unique. Read it first with `read_site_source` rather than
+  recalling it — a remembered `old_string` does not match.
+- **Adding a section is TWO calls**: `create=True` + `new_source` to write
+  `src/lib/components/Testimonials.svelte`, then a second call with `edits` on
+  `src/routes/+page.svelte` to import and render it. Stop after the first and
+  you have shipped a component nothing renders.
+- **Adding a page is THREE calls**, because a SvelteKit route is two files:
+  `create=True` for `src/routes/<slug>/+page.svelte`, again for
+  `src/routes/<slug>/+page.ts` containing `export const prerender = true;`
+  (the root page's flag is page-level and does **not** cascade to a child
+  route), then `edits` on the nav or footer to link `/<slug>`. Skip the link
+  and the page exists but nobody can find it — the tool tells you so with
+  `unreferenced: true`, and you must not report the page as added until you
+  have cleared it.
+- The generator-owned paths stay refused — `package.json`, `vite.config.ts`,
+  `svelte.config.js`, `src/lib/paw/` and the auth files — so an edit **cannot**
+  add a dependency, and everything you write lives under `src/`.
+- Every rule in this skill still binds — above all the **prerender rule**: an
+  edit that moves a resting value into `onMount` ships a blank section.
+- **The edit stages a DRAFT preview**; it does not publish. Say what changed
+  and publish only when they ask.
+
 The generator materializes your `source` onto the skeleton, prerenders to
 static HTML, runs the smoke gate, and deploys. Show the user the returned
 `url` plus a pointer to **/sites**. Relay any `ok: false` error — never

--- a/tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py
@@ -96,7 +96,7 @@ class TestEditHandler:
         from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
 
         ws_patch, user_patch = _identity("ws1", "u1")
-        fake = AsyncMock(return_value=_FakeSiteDoc())
+        fake = AsyncMock(return_value=(_FakeSiteDoc(), False))
         with (
             ws_patch,
             user_patch,
@@ -141,7 +141,7 @@ class TestEditHandler:
             patch.object(mcp, "_identity", return_value=("ws1", "u1")),
             patch(
                 "pocketpaw_ee.sites.service.edit_svelte_component",
-                new=AsyncMock(return_value=_FakeSiteDoc()),
+                new=AsyncMock(return_value=(_FakeSiteDoc(), False)),
             ),
         ):
             out = await mcp._edit_svelte_component_handler(
@@ -184,7 +184,7 @@ class TestEditHandler:
         require ``new_source``."""
         from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
 
-        fake = AsyncMock(return_value=_FakeSiteDoc())
+        fake = AsyncMock(return_value=(_FakeSiteDoc(), False))
         with (
             patch.object(mcp, "_identity", return_value=("ws1", "u1")),
             patch("pocketpaw_ee.sites.service.edit_svelte_component", new=fake),
@@ -363,3 +363,172 @@ class TestEditHandler:
             )
         assert out.get("is_error") is True
         assert "site_component.not_found" in out["content"][0]["text"]
+
+
+class TestCreateLane:
+    """SC-1 — the tool can MINT a file, not only rewrite one.
+
+    Until this landed the svelte tool was existence-only, so "add an about page" had
+    no reachable tool on the sites server and the agent's remaining move was a second
+    ``create_svelte_site`` — a second pocket at a second url.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_is_forwarded_to_the_service(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=(_FakeSiteDoc(), True))
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_svelte_component", new=fake),
+        ):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/routes/about/+page.svelte",
+                    "new_source": "<h1>About</h1>",
+                    "create": True,
+                }
+            )
+
+        assert not out.get("is_error"), out
+        fake.assert_awaited_once()
+        assert fake.await_args.kwargs["create"] is True
+
+    @pytest.mark.asyncio
+    async def test_create_defaults_to_false(self) -> None:
+        """An ordinary edit must not accidentally mint a file."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=(_FakeSiteDoc(), False))
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_svelte_component", new=fake),
+        ):
+            await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/Hero.svelte",
+                    "new_source": "<section/>",
+                }
+            )
+
+        assert fake.await_args.kwargs["create"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_without_new_source_is_rejected_before_the_service(self) -> None:
+        """``edits`` has nothing to search against in a file that does not exist."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=(_FakeSiteDoc(), False))
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_svelte_component", new=fake),
+        ):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/routes/about/+page.svelte",
+                    "edits": [{"old_string": "a", "new_string": "b"}],
+                    "create": True,
+                }
+            )
+
+        assert out.get("is_error") is True
+        fake.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_unreferenced_create_is_narrated_not_only_flagged(self) -> None:
+        """The flag alone is not enough — the agent narrates ``message``, and a clean
+        success read as "done" over a page nothing links to is the exact incident the
+        react and html lanes each had before they grew this."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_svelte_component",
+                new=AsyncMock(return_value=(_FakeSiteDoc(), True)),
+            ),
+        ):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/routes/about/+page.svelte",
+                    "new_source": "<h1>About</h1>",
+                    "create": True,
+                }
+            )
+
+        body = json.loads(out["content"][0]["text"])
+        assert body["created"] is True
+        assert body["unreferenced"] is True
+        message = (body.get("message") or "").lower()
+        assert "nothing in the site reaches this file yet" in message
+        assert "half-done" in message
+
+    @pytest.mark.asyncio
+    async def test_a_referenced_create_carries_no_orphan_warning(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_svelte_component",
+                new=AsyncMock(return_value=(_FakeSiteDoc(), False)),
+            ),
+        ):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/routes/about/+page.ts",
+                    "new_source": "export const prerender = true",
+                    "create": True,
+                }
+            )
+
+        body = json.loads(out["content"][0]["text"])
+        assert body["unreferenced"] is False
+        assert "half-done" not in (body.get("message") or "").lower()
+
+
+class TestToolContractTeachesTheCreateFlow:
+    """The description is the only thing the agent reads before choosing a tool, so
+    the two gaps that made this bug reachable are pinned here."""
+
+    def _description(self) -> str:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        captured = {}
+
+        def _tool(name, description, schema):
+            captured["name"] = name
+            captured["description"] = description
+            captured["schema"] = schema
+
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+        mcp.make_edit_svelte_component_tool(_tool)
+        return captured
+
+    def test_the_schema_exposes_create(self) -> None:
+        schema = self._description()["schema"]
+        assert "create" in schema["properties"]
+        assert schema["properties"]["create"]["type"] == "boolean"
+
+    def test_the_description_warns_against_minting_a_second_site(self) -> None:
+        """The react and html descriptions both carry this warning; svelte's did not,
+        which is what turned "add a page" into a second pocket at a second url."""
+        description = self._description()["description"]
+        assert "NEVER call `create_svelte_site` again" in description
+
+    def test_the_description_teaches_the_two_file_route(self) -> None:
+        """A SvelteKit page is +page.svelte AND +page.ts — the root page's prerender
+        flag is page-level and does not cascade to a child route."""
+        description = self._description()["description"]
+        assert "+page.svelte" in description
+        assert "+page.ts" in description
+        assert "prerender" in description

--- a/tests/ee/sites/test_builder_origin.py
+++ b/tests/ee/sites/test_builder_origin.py
@@ -193,7 +193,7 @@ async def test_edit_component_preserves_stored_builder_origin(beanie_test_db):
 
     # Now edit a component. The republish must re-apply the stored origin.
     gen = _FakeGenerator()
-    site = await sites_service.edit_svelte_component(
+    site, _unreferenced = await sites_service.edit_svelte_component(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
@@ -223,7 +223,7 @@ async def test_edit_component_on_non_editable_site_stays_non_editable(beanie_tes
         _bundle_reader=lambda d: b"x",
     )
     gen = _FakeGenerator()
-    site = await sites_service.edit_svelte_component(
+    site, _unreferenced = await sites_service.edit_svelte_component(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,

--- a/tests/ee/sites/test_component_edit.py
+++ b/tests/ee/sites/test_component_edit.py
@@ -143,7 +143,7 @@ async def test_edit_component_republishes_with_new_source(beanie_test_db):
     pocket_id = await _make_svelte_pocket("ws1", "u1")
     gen, cf = _FakeGenerator(), _FakeCF()
 
-    site = await sites_service.edit_svelte_component(
+    site, _unreferenced = await sites_service.edit_svelte_component(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,

--- a/tests/ee/sites/test_diff_edit.py
+++ b/tests/ee/sites/test_diff_edit.py
@@ -195,7 +195,7 @@ async def test_targeted_edit_applies_and_reaches_build(beanie_test_db):
     pocket_id = await _make_svelte_pocket("ws1", "u1")
     gen, cf = _FakeGenerator(), _FakeCF()
 
-    site = await sites_service.edit_svelte_component(
+    site, _unreferenced = await sites_service.edit_svelte_component(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,
@@ -259,7 +259,7 @@ async def test_full_new_source_path_still_works(beanie_test_db):
     gen, cf = _FakeGenerator(), _FakeCF()
     whole = "<section class='hero'><h1>Totally Rewritten</h1></section>"
 
-    site = await sites_service.edit_svelte_component(
+    site, _unreferenced = await sites_service.edit_svelte_component(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,

--- a/tests/ee/sites/test_edit_draft_not_publish.py
+++ b/tests/ee/sites/test_edit_draft_not_publish.py
@@ -267,7 +267,7 @@ async def test_consecutive_previews_serve_at_a_stable_url(beanie_test_db):
         _bundle_reader=lambda d: b"export default {}",
         _local_deploy=_recording_local_deploy,
     )
-    edit = await sites_service.edit_svelte_component(
+    edit, _unreferenced = await sites_service.edit_svelte_component(
         workspace_id="ws1",
         user_id="u1",
         pocket_id=pocket_id,

--- a/tests/ee/sites/test_svelte_component_create.py
+++ b/tests/ee/sites/test_svelte_component_create.py
@@ -1,0 +1,591 @@
+# tests/ee/sites/test_svelte_component_create.py — the svelte-track CREATE lane
+# (sites_service.edit_svelte_component(..., create=True)). Created: 2026-09-11
+# (feat/sites-svelte-edit-create, SC-1).
+#
+# WHAT WAS MISSING. ``edit_svelte_component`` shipped first of the three edit lanes
+# and could only ever REWRITE a file that already existed: both the sites service and
+# ``set_svelte_source_file`` raised NotFound on an unknown ``component_path``,
+# described there as "not a silent create". React (RX-3) and html (HE-10) each grew a
+# ``create`` flag afterwards for exactly this reason; svelte never did. So "add an
+# about page" to a LIVE svelte site was unanswerable — and because the svelte tool
+# description also lacked the "NEVER call create_svelte_site again" warning its two
+# siblings carry, the agent's remaining move was a second ``create_svelte_site``: a
+# second pocket at a second url, leaving the site the user was looking at untouched.
+#
+# These tests live in their own file rather than in test_component_edit.py because
+# that module is about the EDIT + republish contract; this is a new capability with
+# its own guard, its own inversion and its own rollback shape. Same split react and
+# html already have.
+#
+# FOUR PROPERTIES ARE LOAD BEARING and get their own sections below:
+#   (a) THE HEADLINE CASE — a published svelte site can gain a second ROUTE. On this
+#       track a page is TWO files (``+page.svelte`` plus the ``+page.ts`` carrying
+#       its own prerender flag, because the root page's flag is page-level and does
+#       not cascade), so adding one is three calls counting the nav link.
+#   (b) THE PATH GUARD — new with ``create``. While the lane could only overwrite
+#       existing keys, every writable path had been vetted when create_svelte_site
+#       landed the map; a minted path has not been. And a reserved path does not
+#       merely fail, it fails in the worst place: svelte-scaffold.ts THROWS at
+#       materialize time, which is NOT a SmokeGateFailed, so it would escape the
+#       rollback and leave the pocket permanently unpublishable.
+#   (c) THE CREATE/EXISTS INVERSION — ``create=False`` demands the path exist (a typo
+#       is never a silent create); ``create=True`` demands it not (an accidental
+#       overwrite of a real component is worse than a rejected call).
+#   (d) THE ROLLBACK SHAPE — a create has no previous contents, so a failed one must
+#       REMOVE the key. Restoring "" would leave an empty file at a real route.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+_HERO_V1 = "<section class='hero'><h1>Bright Smile</h1></section>"
+_HERO_V2 = "<section class='hero'><h1>Brighter Smiles, Whiter Teeth</h1></section>"
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css'</script><slot/>",
+    "src/routes/+page.ts": "export const prerender = true",
+    "src/app.css": ":root{--brand:#0A84FF}",
+    "src/lib/components/Hero.svelte": _HERO_V1,
+}
+
+
+class _FakeGenerator:
+    """Records the source map it was asked to build so a test can assert the created
+    file reached the regenerated build."""
+
+    def __init__(self):
+        self.built = None
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version=None)
+
+
+class _SmokeFailGenerator:
+    """Stands in for a generator whose workerd smoke render fails — how
+    ``GeneratorClient.build`` signals a broken site (it raises BEFORE any deploy)."""
+
+    async def build(self, **kw):
+        raise SmokeGateFailed("workerd SSR failure: document is not defined")
+
+
+class _FakeCF:
+    def __init__(self):
+        self.put_calls = []
+
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        self.put_calls.append(script_name)
+        return True
+
+
+def _fake_local_deploy(site_id: str, project_dir: str) -> str:
+    return f"http://127.0.0.1:9999/{site_id}/"
+
+
+async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
+    """Persist a real svelte-engine Pocket via the pockets service and return its id.
+    Mirrors how ``create_svelte_site`` lands a pocket."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source=dict(_SVELTE_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+async def _edit(pocket_id: str, **kw):
+    """Call the lane with the build seams stubbed, so no Bun / workerd / Cloudflare
+    is touched. ``_generator`` may be overridden per-test."""
+    kw.setdefault("_generator", _FakeGenerator())
+    kw.setdefault("_cloudflare", _FakeCF())
+    kw.setdefault("_local_deploy", _fake_local_deploy)
+    return await sites_service.edit_svelte_component(
+        workspace_id="w1", user_id="u1", pocket_id=pocket_id, **kw
+    )
+
+
+# ── (a) the headline case ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_adds_a_new_page_to_a_live_svelte_site(beanie_test_db):
+    """The repro: a published svelte site gains a second ROUTE.
+
+    Before SC-1 the first call raised NotFound("site_component") and there was no
+    other tool on the sites server that would accept it.
+    """
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    await _edit(
+        pocket_id,
+        component_path="src/routes/about/+page.svelte",
+        new_source="<h1>About us</h1>",
+        create=True,
+    )
+    await _edit(
+        pocket_id,
+        component_path="src/routes/about/+page.ts",
+        new_source="export const prerender = true",
+        create=True,
+    )
+
+    pocket = await pockets_service.get(pocket_id, "u1")
+    assert pocket["source"]["src/routes/about/+page.svelte"] == "<h1>About us</h1>"
+    assert "prerender" in pocket["source"]["src/routes/about/+page.ts"]
+    # The pre-existing files are untouched — a create adds, it does not rewrite.
+    assert pocket["source"]["src/lib/components/Hero.svelte"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_the_created_file_reaches_the_regenerated_build(beanie_test_db):
+    """Persisting is not enough — the new route has to be in the map the generator
+    is handed, or the page exists on the pocket and nowhere else."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+    gen = _FakeGenerator()
+
+    await _edit(
+        pocket_id,
+        component_path="src/routes/about/+page.svelte",
+        new_source="<h1>About us</h1>",
+        create=True,
+        _generator=gen,
+    )
+
+    assert gen.built is not None
+    built_source = gen.built.get("source") or {}
+    assert built_source.get("src/routes/about/+page.svelte") == "<h1>About us</h1>"
+
+
+@pytest.mark.asyncio
+async def test_create_adds_a_new_section_component(beanie_test_db):
+    """The other shape of the two-call contract: a component, wired in by an import
+    rather than a link."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    await _edit(
+        pocket_id,
+        component_path="src/lib/components/Testimonials.svelte",
+        new_source="<section>Lovely people</section>",
+        create=True,
+    )
+    await _edit(
+        pocket_id,
+        component_path="src/routes/+page.svelte",
+        edits=[
+            {
+                "old_string": "<Hero/>",
+                "new_string": (
+                    "<Hero/>\n<script>import Testimonials from "
+                    "'$lib/components/Testimonials.svelte'</script>\n<Testimonials/>"
+                ),
+            }
+        ],
+    )
+
+    pocket = await pockets_service.get(pocket_id, "u1")
+    assert "Testimonials" in pocket["source"]["src/routes/+page.svelte"]
+
+
+# ── (b) the path guard ──────────────────────────────────────────────────────
+
+_BS = chr(92)  # a literal backslash, built rather than written so no quoting layer
+# between the editor and the file can eat it.
+
+_RESERVED_SPELLINGS = [
+    "src/lib/paw/helpers.ts",
+    "src/lib/paw/../paw/helpers.ts",
+    _BS.join(["src", "lib", "paw", "helpers.ts"]),
+    "./src/lib/paw/helpers.ts",
+    "src/hooks.server.ts",
+    "src/lib/auth.ts",
+    "src/app.d.ts",
+    "package.json",
+    "./package.json",
+    "src/../package.json",
+    "vite.config.ts",
+    "svelte.config.js",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", _RESERVED_SPELLINGS)
+async def test_every_reserved_path_spelling_is_rejected(beanie_test_db, path: str):
+    """A generator-owned path is refused however it is spelled.
+
+    A guard a trivial path spelling defeats is not a guard, so each spelling the
+    normalizer is supposed to collapse gets its own case.
+    """
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    with pytest.raises(CloudError) as exc:
+        await _edit(pocket_id, component_path=path, new_source="whatever", create=True)
+    assert exc.value.code == "site_edit.reserved_path"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path", ["README.md", "../etc/passwd", "src/../../escape.ts", "/abs/path.ts"]
+)
+async def test_path_outside_src_is_rejected(beanie_test_db, path: str):
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    with pytest.raises(CloudError) as exc:
+        await _edit(pocket_id, component_path=path, new_source="whatever", create=True)
+    assert exc.value.code == "site_edit.path_outside_source"
+
+
+@pytest.mark.asyncio
+async def test_the_guard_runs_before_the_pocket_is_read(beanie_test_db):
+    """A reserved path is rejected on the path ALONE, so no pocket state can make it
+    land — asserted by the verdict coming back for a pocket that does not exist."""
+    with pytest.raises(CloudError) as exc:
+        await _edit(
+            "pocket-that-does-not-exist",
+            component_path="package.json",
+            new_source="{}",
+            create=True,
+        )
+    assert exc.value.code == "site_edit.reserved_path"
+
+
+@pytest.mark.asyncio
+async def test_a_reserved_path_writes_nothing(beanie_test_db):
+    """The rejection is not merely an error code — the map must be untouched, which
+    is the property that keeps the scaffold's materialize-time throw unreachable."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    with pytest.raises(CloudError):
+        await _edit(
+            pocket_id,
+            component_path="src/lib/paw/evil.ts",
+            new_source="export const x = 1",
+            create=True,
+        )
+
+    pocket = await pockets_service.get(pocket_id, "u1")
+    assert set(pocket["source"]) == set(_SVELTE_SOURCE)
+
+
+# ── (c) the create/exists inversion ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_onto_an_existing_path_is_rejected(beanie_test_db):
+    """Silently overwriting a real component the agent thought it was adding is
+    worse than a rejected call it can retry."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    with pytest.raises(CloudError) as exc:
+        await _edit(
+            pocket_id,
+            component_path="src/lib/components/Hero.svelte",
+            new_source="<section>clobbered</section>",
+            create=True,
+        )
+    assert exc.value.code == "pocket.svelte_component_exists"
+
+    pocket = await pockets_service.get(pocket_id, "u1")
+    assert pocket["source"]["src/lib/components/Hero.svelte"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_a_missing_path_without_create_is_still_not_found(beanie_test_db):
+    """The other half of the inversion, and the pre-SC-1 contract: a typo'd path is
+    an error, never a stray new file."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    with pytest.raises(NotFound):
+        await _edit(
+            pocket_id,
+            component_path="src/lib/components/Heroo.svelte",
+            new_source="<p/>",
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_missing_path_with_edits_is_not_found_not_a_key_error(beanie_test_db):
+    """The sites service keeps its OWN existence check, separate from the write
+    chokepoint's, because the ``edits`` branch indexes the source map.
+
+    Worth its own case next to the ``new_source`` one above: there, removing the
+    service-level check changes nothing observable (the pockets service still raises
+    NotFound at the write). Here it turns a relayable NotFound into a bare KeyError,
+    which the agent cannot act on.
+    """
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    with pytest.raises(NotFound):
+        await _edit(
+            pocket_id,
+            component_path="src/lib/components/Heroo.svelte",
+            edits=[{"old_string": "Bright", "new_string": "Brighter"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_without_new_source_is_rejected(beanie_test_db):
+    """``edits`` has nothing to search against in a file that does not exist yet."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    with pytest.raises(CloudError) as exc:
+        await _edit(
+            pocket_id,
+            component_path="src/routes/about/+page.svelte",
+            edits=[{"old_string": "x", "new_string": "y"}],
+            create=True,
+        )
+    assert exc.value.code == "site_edit.create_needs_source"
+
+
+@pytest.mark.asyncio
+async def test_pockets_service_enforces_the_inversion_itself(beanie_test_db):
+    """The rule lives at the write chokepoint, so it holds for EVERY caller — not
+    only the ones that come through the sites service."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    with pytest.raises(NotFound):
+        await pockets_service.set_svelte_source_file(
+            pocket_id,
+            "u1",
+            component_path="src/lib/components/Nope.svelte",
+            new_source="<p/>",
+        )
+    with pytest.raises(CloudError) as exc:
+        await pockets_service.set_svelte_source_file(
+            pocket_id,
+            "u1",
+            component_path="src/lib/components/Hero.svelte",
+            new_source="<p/>",
+            create=True,
+        )
+    assert exc.value.code == "pocket.svelte_component_exists"
+
+
+@pytest.mark.asyncio
+async def test_create_returns_no_previous_source_to_roll_back_to(beanie_test_db):
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    _wire, previous = await pockets_service.set_svelte_source_file(
+        pocket_id,
+        "u1",
+        component_path="src/lib/components/New.svelte",
+        new_source="<p>new</p>",
+        create=True,
+    )
+    assert previous is None
+
+
+# ── (d) the rollback shape ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_failed_create_removes_the_key_rather_than_blanking_it(beanie_test_db):
+    """A create that fails the smoke gate must leave the map exactly as it was.
+
+    The pre-existing rollback restores ``previous_source``; a create HAS none, and
+    writing an empty string back would leave an empty file at a real route — a blank
+    page the next publish still has to serve, which is the state the rollback exists
+    to prevent rather than a recovery from it.
+    """
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    with pytest.raises(SmokeGateFailed):
+        await _edit(
+            pocket_id,
+            component_path="src/routes/about/+page.svelte",
+            new_source="<h1>boom</h1>",
+            create=True,
+            _generator=_SmokeFailGenerator(),
+        )
+
+    pocket = await pockets_service.get(pocket_id, "u1")
+    assert "src/routes/about/+page.svelte" not in pocket["source"], (
+        "a rolled-back create must REMOVE the key, not leave an empty file behind"
+    )
+    assert set(pocket["source"]) == set(_SVELTE_SOURCE)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_ordinary_edit_still_restores_the_prior_contents(beanie_test_db):
+    """The create branch must not have broken the rollback it forked from."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    with pytest.raises(SmokeGateFailed):
+        await _edit(
+            pocket_id,
+            component_path="src/lib/components/Hero.svelte",
+            new_source=_HERO_V2,
+            _generator=_SmokeFailGenerator(),
+        )
+
+    pocket = await pockets_service.get(pocket_id, "u1")
+    assert pocket["source"]["src/lib/components/Hero.svelte"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_removing_an_absent_path_is_not_an_error(beanie_test_db):
+    """The rollback must be safe to run against a write that never landed — raising
+    there would replace a recoverable smoke failure with an unrecoverable one."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    await pockets_service.remove_svelte_source_file(
+        pocket_id, "u1", component_path="src/routes/never/+page.svelte"
+    )
+    pocket = await pockets_service.get(pocket_id, "u1")
+    assert set(pocket["source"]) == set(_SVELTE_SOURCE)
+
+
+# ── the reachability advisory ───────────────────────────────────────────────
+#
+# A create is HALF of adding a page. The react and html lanes each grew this after a
+# real orphan-create incident: call 1 landed, call 2 never came, and the flat success
+# was read as "done" over a page that never changed. Svelte gets it at birth.
+
+
+@pytest.mark.asyncio
+async def test_a_new_page_nothing_links_to_reports_unreferenced(beanie_test_db):
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    _site, unreferenced = await _edit(
+        pocket_id,
+        component_path="src/routes/about/+page.svelte",
+        new_source="<h1>About</h1>",
+        create=True,
+    )
+    assert unreferenced is True
+
+
+@pytest.mark.asyncio
+async def test_a_new_page_is_referenced_once_something_links_it(beanie_test_db):
+    """Call 2 of the two-call contract clears the advisory."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    await _edit(
+        pocket_id,
+        component_path="src/routes/+page.svelte",
+        edits=[{"old_string": "<Hero/>", "new_string": "<Hero/><a href='/about'>About</a>"}],
+    )
+    _site, unreferenced = await _edit(
+        pocket_id,
+        component_path="src/routes/about/+page.svelte",
+        new_source="<h1>About</h1>",
+        create=True,
+    )
+    assert unreferenced is False
+
+
+@pytest.mark.asyncio
+async def test_a_near_miss_link_does_not_count_as_a_reference(beanie_test_db):
+    """``/about-us`` must not satisfy ``/about`` — a false "it is referenced" is the
+    silence the advisory exists to break."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    await _edit(
+        pocket_id,
+        component_path="src/routes/+page.svelte",
+        edits=[
+            {
+                "old_string": "<Hero/>",
+                "new_string": "<Hero/><a href='/about-us'>About us</a>",
+            }
+        ],
+    )
+    _site, unreferenced = await _edit(
+        pocket_id,
+        component_path="src/routes/about/+page.svelte",
+        new_source="<h1>About</h1>",
+        create=True,
+    )
+    assert unreferenced is True
+
+
+@pytest.mark.asyncio
+async def test_a_sibling_convention_file_is_reached_through_its_directory(
+    beanie_test_db,
+):
+    """``+page.ts`` is claimed by the file-system router because of where it sits,
+    not by an import — so it counts as reached once its ``+page.svelte`` exists."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    await _edit(
+        pocket_id,
+        component_path="src/routes/about/+page.svelte",
+        new_source="<h1>About</h1>",
+        create=True,
+    )
+    _site, unreferenced = await _edit(
+        pocket_id,
+        component_path="src/routes/about/+page.ts",
+        new_source="export const prerender = true",
+        create=True,
+    )
+    assert unreferenced is False
+
+
+@pytest.mark.asyncio
+async def test_a_new_component_nothing_imports_reports_unreferenced(beanie_test_db):
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    _site, unreferenced = await _edit(
+        pocket_id,
+        component_path="src/lib/components/Testimonials.svelte",
+        new_source="<section>Lovely people</section>",
+        create=True,
+    )
+    assert unreferenced is True
+
+
+@pytest.mark.asyncio
+async def test_a_new_component_is_referenced_once_imported(beanie_test_db):
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    await _edit(
+        pocket_id,
+        component_path="src/routes/+page.svelte",
+        edits=[
+            {
+                "old_string": "<Hero/>",
+                "new_string": (
+                    "<Hero/><script>import T from '$lib/components/Testimonials.svelte'</script>"
+                ),
+            }
+        ],
+    )
+    _site, unreferenced = await _edit(
+        pocket_id,
+        component_path="src/lib/components/Testimonials.svelte",
+        new_source="<section>Lovely people</section>",
+        create=True,
+    )
+    assert unreferenced is False
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_edit_never_reports_unreferenced(beanie_test_db):
+    """Scoped to create deliberately — re-litigating wiring on every headline change
+    is noise on the common path, which is how the signal on the rare path gets
+    skimmed."""
+    pocket_id = await _make_svelte_pocket("w1", "u1")
+
+    _site, unreferenced = await _edit(
+        pocket_id,
+        component_path="src/lib/components/Hero.svelte",
+        new_source=_HERO_V2,
+    )
+    assert unreferenced is False

--- a/tests/mutations/react_edit_lane.json
+++ b/tests/mutations/react_edit_lane.json
@@ -77,8 +77,8 @@
   {
     "label": "the sites service stops requiring an existing path, so an `edits` call on a typo'd path is a KeyError instead of a relayable NotFound",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    if not create and component_path not in source_map:\n        raise NotFound(\"site_component\", component_path)",
-    "replace": "    if False:\n        raise NotFound(\"site_component\", component_path)",
+    "find": "    # the chokepoint caught the write anyway.\n    if not create and component_path not in source_map:\n        raise NotFound(\"site_component\", component_path)",
+    "replace": "    # the chokepoint caught the write anyway.\n    if False:\n        raise NotFound(\"site_component\", component_path)",
     "tests": [
       "tests/ee/sites/test_react_component_edit.py::test_missing_path_with_edits_is_not_found_not_a_key_error"
     ]

--- a/tests/mutations/svelte_edit_create.json
+++ b/tests/mutations/svelte_edit_create.json
@@ -1,0 +1,180 @@
+[
+  {
+    "label": "the reserved-path guard is gone: a svelte edit can write package.json or shadow the session gate, and because the scaffold's throw is not a SmokeGateFailed the rollback never fires",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if (reason := svelte_path_rejection(component_path)) is not None:",
+    "replace": "    if False and (reason := svelte_path_rejection(component_path)) is not None:",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_every_reserved_path_spelling_is_rejected",
+      "tests/ee/sites/test_svelte_component_create.py::test_path_outside_src_is_rejected",
+      "tests/ee/sites/test_svelte_component_create.py::test_a_reserved_path_writes_nothing"
+    ]
+  },
+  {
+    "label": "the path guard stops running before the pocket read, so a reserved path is only caught after state has been touched",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if (reason := svelte_path_rejection(component_path)) is not None:\n        code = (\n            \"site_edit.reserved_path\"\n            if is_reserved_svelte_path(component_path)\n            else \"site_edit.path_outside_source\"\n        )\n        raise ValidationError(code, reason)",
+    "replace": "    pass",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_the_guard_runs_before_the_pocket_is_read"
+    ]
+  },
+  {
+    "label": "the path normalizer stops collapsing separators and dot segments, so `./package.json` and a backslash spelling walk straight past the reserved set",
+    "file": "ee/pocketpaw_ee/sites/svelte_paths.py",
+    "find": "    return posixpath.normpath(path.replace(\"\\\\\", \"/\"))",
+    "replace": "    return path",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_every_reserved_path_spelling_is_rejected"
+    ]
+  },
+  {
+    "label": "the build shell drops out of the reserved set, so the edit lane can rewrite the dependency manifest one call at a time",
+    "file": "ee/pocketpaw_ee/sites/svelte_paths.py",
+    "find": "SVELTE_RESERVED_SHELL_FILES: tuple[str, ...] = (\n    \"package.json\",\n    \"vite.config.ts\",\n    \"svelte.config.js\",\n)",
+    "replace": "SVELTE_RESERVED_SHELL_FILES: tuple[str, ...] = ()",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_every_reserved_path_spelling_is_rejected"
+    ]
+  },
+  {
+    "label": "the gated-site auth files drop out of the reserved set, so an author can shadow the session gate",
+    "file": "ee/pocketpaw_ee/sites/svelte_paths.py",
+    "find": "SVELTE_RESERVED_AUTH_FILES: tuple[str, ...] = (\n    \"src/hooks.server.ts\",\n    \"src/lib/auth.ts\",\n    \"src/app.d.ts\",\n)",
+    "replace": "SVELTE_RESERVED_AUTH_FILES: tuple[str, ...] = ()",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_every_reserved_path_spelling_is_rejected"
+    ]
+  },
+  {
+    "label": "the authorable-prefix rule is gone, so a create can mint a root-level file the build ignores or climb out of the project entirely",
+    "file": "ee/pocketpaw_ee/sites/svelte_paths.py",
+    "find": "    if not is_authorable_svelte_path(norm):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_path_outside_src_is_rejected"
+    ]
+  },
+  {
+    "label": "create stops requiring the path to be new, so `create=true` silently overwrites a real component the agent thought it was adding",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    if create and component_path in doc.source:\n        raise ValidationError(\n            \"pocket.svelte_component_exists\",",
+    "replace": "    if False:\n        raise ValidationError(\n            \"pocket.svelte_component_exists\",",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_create_onto_an_existing_path_is_rejected",
+      "tests/ee/sites/test_svelte_component_create.py::test_pockets_service_enforces_the_inversion_itself"
+    ]
+  },
+  {
+    "label": "the write chokepoint stops requiring an existing path without create, so a typo'd component_path becomes a silent new file",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    if not create and component_path not in doc.source:\n        raise NotFound(\"site_component\", component_path)",
+    "replace": "    if False:\n        raise NotFound(\"site_component\", component_path)",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_a_missing_path_without_create_is_still_not_found",
+      "tests/ee/sites/test_svelte_component_create.py::test_pockets_service_enforces_the_inversion_itself"
+    ]
+  },
+  {
+    "label": "the sites service stops requiring an existing path, so an `edits` call on a typo'd path is a KeyError instead of a relayable NotFound",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    # pockets service owns that rule for every caller.\n    if not create and component_path not in source_map:\n        raise NotFound(\"site_component\", component_path)",
+    "replace": "    # pockets service owns that rule for every caller.\n    if False:\n        raise NotFound(\"site_component\", component_path)",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_a_missing_path_with_edits_is_not_found_not_a_key_error"
+    ]
+  },
+  {
+    "label": "create no longer requires new_source, so `create` with `edits` reaches the write with nothing to write",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if create and new_source is None:\n        raise ValidationError(\n            \"site_edit.create_needs_source\",\n            \"Creating a new svelte file needs `new_source` — the full contents of \"\n            \"the new component or route. There is nothing for `edits` to search \"\n            \"against in a file that does not exist yet.\",\n        )",
+    "replace": "    pass",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_create_without_new_source_is_rejected"
+    ]
+  },
+  {
+    "label": "a failed create rolls back by blanking the file instead of removing it, leaving an empty page at a real route for the next publish to serve",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            await pockets_service.remove_svelte_source_file(\n                pocket_id,\n                user_id,\n                component_path=component_path,\n            )",
+    "replace": "            await pockets_service.set_svelte_source_file(\n                pocket_id,\n                user_id,\n                component_path=component_path,\n                new_source=\"\",\n            )",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_a_failed_create_removes_the_key_rather_than_blanking_it"
+    ]
+  },
+  {
+    "label": "the create branch of the rollback is gone, so a failed create restores nothing and the pocket keeps source the renderer rejected",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    except SmokeGateFailed:\n        if create:",
+    "replace": "    except SmokeGateFailed:\n        if False:",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_a_failed_create_removes_the_key_rather_than_blanking_it"
+    ]
+  },
+  {
+    "label": "the reachability advisory always reports referenced, so a create that nothing links to returns an unqualified success and the agent reports a page no visitor can reach",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    unreferenced = create and not svelte_path_is_referenced(\n        {**source_map, component_path: new_source}, component_path\n    )",
+    "replace": "    unreferenced = False",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_a_new_page_nothing_links_to_reports_unreferenced",
+      "tests/ee/sites/test_svelte_component_create.py::test_a_new_component_nothing_imports_reports_unreferenced",
+      "tests/ee/sites/test_svelte_component_create.py::test_a_near_miss_link_does_not_count_as_a_reference"
+    ]
+  },
+  {
+    "label": "a route's reachability falls back to the import scan, so every legitimately-linked page is called an orphan",
+    "file": "ee/pocketpaw_ee/sites/svelte_paths.py",
+    "find": "    url = route_url_for(norm)\n    if url is not None:",
+    "replace": "    url = route_url_for(norm)\n    if False:",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_a_new_page_is_referenced_once_something_links_it",
+      "tests/ee/sites/test_svelte_component_create.py::test_a_sibling_convention_file_is_reached_through_its_directory"
+    ]
+  },
+  {
+    "label": "the link matcher stops anchoring on the quoted attribute value, so a link to /about-us counts as a link to /about",
+    "file": "ee/pocketpaw_ee/sites/svelte_paths.py",
+    "find": "    pattern = r\"\"\"(?:href|action)\\s*=\\s*['\"]\"\"\" + re.escape(url) + r\"\"\"/?['\"]\"\"\"",
+    "replace": "    pattern = re.escape(url)",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_a_near_miss_link_does_not_count_as_a_reference"
+    ]
+  },
+  {
+    "label": "a sibling convention file is treated as the page itself, so a +page.ts is called an orphan unless something links to it directly",
+    "file": "ee/pocketpaw_ee/sites/svelte_paths.py",
+    "find": "        if norm.rsplit(\"/\", 1)[-1] != _ROUTE_PAGE_FILE:",
+    "replace": "        if False:",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_a_sibling_convention_file_is_reached_through_its_directory"
+    ]
+  },
+  {
+    "label": "the $lib alias stops resolving, so the dominant import spelling in a real site reports every imported component as unreferenced",
+    "file": "ee/pocketpaw_ee/sites/svelte_paths.py",
+    "find": "    if specifier.startswith(\"$lib/\"):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_svelte_component_create.py::test_a_new_component_is_referenced_once_imported"
+    ]
+  },
+  {
+    "label": "the MCP handler stops forwarding create, so every create call is silently an edit and fails as not-found",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
+    "find": "    create = bool(args.get(\"create\"))\n    if create and not has_new_source:\n        return _error_response(\n            \"edit_svelte_component `create` needs `new_source`",
+    "replace": "    create = False\n    if create and not has_new_source:\n        return _error_response(\n            \"edit_svelte_component `create` needs `new_source`",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py::TestCreateLane::test_create_is_forwarded_to_the_service"
+    ]
+  },
+  {
+    "label": "the orphan warning drops out of the narrated message, so the agent reads a clean success and reports a page nothing links to as added",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
+    "find": "        if unreferenced\n        else \"\"\n    )",
+    "replace": "        if False\n        else \"\"\n    )",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py::TestCreateLane::test_an_unreferenced_create_is_narrated_not_only_flagged"
+    ]
+  }
+]


### PR DESCRIPTION
## The bug

A teammate built a svelte Paw Site, then asked the agent to add one more page. It couldn't. Before the site existed, the same request worked fine.

`edit_svelte_component` could only rewrite a path that already existed. Both the sites service and `set_svelte_source_file` raised `NotFound` on an unknown `component_path`, described there as "not a silent create", so "add an about page" to a live svelte site had no tool on the sites server that would accept it.

React (RX-3) and html (HE-10) each grew a `create` flag for exactly this. Svelte shipped first and never got one. `set_react_source_file`'s docstring has said so in passing ever since:

> `create` is the one place this DIVERGES from the svelte peer, and it exists because "add a testimonials section" needs a new component FILE plus an edit to `src/App.tsx` — with an existence-only contract the agent could not add a section at all.

Two things made it worse than a missing feature. The svelte tool description was the only one of the three without the "NEVER call `create_<engine>_site` again" warning, so the blocked agent's next move was a second `create_svelte_site`: a second pocket at a second url, leaving the site the user was looking at untouched. And /sites denies the file built-ins, so there was no fallback.

On the other engines, for the record. html already works (`create=true`, and "add a contact page" is in its description). React can create component files but is single-route by design, so a second *page* there is a roadmap item, not a bug.

## What changed

`create` on `edit_svelte_component`, mirroring the react peer.

It needs a path guard that did not exist here before. While the lane could only overwrite existing keys, every writable path had been vetted when `create_svelte_site` landed the map. A minted path has not been. A reserved path also fails in the worst place: `svelte-scaffold.ts` throws at materialize time, and that throw is not a `SmokeGateFailed`, so it would escape the rollback and leave the pocket permanently unpublishable. The guard therefore runs before the pocket is read. It lives in a new `sites/svelte_paths.py`, the svelte peer of `react_paths.py` and `html_paths.py`.

The rollback forks by mode. An ordinary edit still restores the file's prior contents. A failed create removes the key instead, because a create has no prior contents, and writing `""` back would leave an empty file at a real route for the next publish to serve.

`unreferenced` comes along now rather than after the orphan-create incident react and html each had first. Svelte answers it two ways, because its source map holds two kinds of file: a `src/lib/**` module is reached by a resolved import specifier, a `src/routes/**` page by a link to its URL. It differs from react in one way worth knowing. An unlinked svelte route still exists, since SvelteKit prerenders every non-dynamic route; what it lacks is a way for a visitor to find it. An unimported react component is absent from the bundle entirely.

The tool description and the create skill now both teach the shape unique to this track: a SvelteKit page is two files, `+page.svelte` plus the `+page.ts` carrying its own prerender flag, since the root page's flag is page-level and does not cascade to a child route. Adding a page is three calls counting the link.

## Docs

`docs/api-reference.md` gains an `edit_svelte_component` section, which it never had even though the table there has always listed the tool.

## Known gaps, deliberately not in this PR

- `create_svelte_site` still has no path guard, so a whole authored map can still write `package.json`. The generator's post-emit `assertAllowed()` still catches an unvetted dependency. It is pre-existing, and widening this PR to change create's behaviour felt like the wrong call.
- There is no `pocketpaw-edit-svelte-site` skill to match `pocketpaw-edit-react-site`. The tool description carries the guidance the agent actually reads at tool-choice time.

## Verification

- 19 mutations in a new `tests/mutations/svelte_edit_create.json`, all caught.
- Re-ran the react (37) and html (25) plans. Both still fully caught. One react anchor is repointed here because the svelte and react existence checks are now textually identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
