### PR TITLE
Teach the agent to open timeline lanes and arrange across them

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/timeline_ops.contract.json
+++ b/ee/pocketpaw_ee/agent/mcp_servers/timeline_ops.contract.json
@@ -18,13 +18,20 @@
     "",
     "v2 (2026-09-08): the styling surface the Inspector exposes — text presets,",
     "colour, align, motion in/out, transform and keyframes — so the agent can do",
-    "what a person can do in that panel, not just place and trim."
+    "what a person can do in that panel, not just place and trim.",
+    "",
+    "v3 (2026-09-11): add_lane, plus `track` accepting a lane NAME as well as an",
+    "id. Lanes existed but nothing could ask for one, so layering was reachable",
+    "only as a side effect of the store's collision stacking. Names are what make",
+    "a lane usable in the batch that creates it — track ids are minted at apply",
+    "time, the same reason `after` cannot anchor to a clip the batch is adding."
   ],
-  "version": 2,
+  "version": 3,
   "maxOpsPerBatch": 50,
   "ops": [
     "add_caption",
     "add_keyframe",
+    "add_lane",
     "add_text",
     "clear_keyframes",
     "move_clip",

--- a/ee/pocketpaw_ee/agent/mcp_servers/timeline_ops.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/timeline_ops.py
@@ -4,6 +4,15 @@
 # whose TS half is paw-enterprise/src/lib/core/studio/editor/agent-ops.ts.
 # Design: docs/design/drafts/2026-09-08-agentic-studio-editor.md in paw-workspace.
 #
+# 2026-09-11 (feat/agent-lane-ops): `add_lane`, and `track` resolving by lane
+# NAME as well as id. The name path is load-bearing — track ids are minted when
+# the batch applies in the browser, so a lane this batch creates has no id to
+# quote, and validating names against the summary alone would reject the very
+# sequence the verb exists for. Names are therefore checked against the lanes the
+# agent was shown PLUS the ones earlier ops in the batch claim, and a duplicate
+# is refused: two rows answering to one word makes placement a coin flip decided
+# by document order.
+#
 # Validates VERBS and IDS, never geometry — whether a transition fits or a split
 # lands too near an edge depends on document state this process does not have.
 # The store decides that and refuses per-op.
@@ -23,6 +32,7 @@ from typing import Any
 OP_KINDS: frozenset[str] = frozenset(
     {
         "add_caption",
+        "add_lane",
         "add_text",
         "move_clip",
         "place_audio",
@@ -96,6 +106,19 @@ _CAPTION_STYLES: frozenset[str] = frozenset({"plain", "boxed", "outlined"})
 # AnimatableProp in schema.ts.
 _ANIM_PROPS: frozenset[str] = frozenset({"x", "y", "scale", "rotation", "opacity", "volume"})
 
+# TrackKind in schema.ts. 'overlay' is in the enum and nothing authors one yet;
+# it stays accepted because the document already allows it and refusing here
+# would be this file inventing a narrower contract than the one it validates.
+_LANE_KINDS: frozenset[str] = frozenset({"video", "audio", "text", "overlay"})
+
+# TrackRole. One member, and it is the one that matters: a cue lane and a plain
+# text lane are different groups, and the store keeps titles out of the cue list.
+_LANE_ROLES: frozenset[str] = frozenset({"captions"})
+
+# Long enough to say what a lane carries, short enough to stay a chip on a
+# timeline row. Mirrors AddLaneOp's z.string().min(1).max(40).
+_MAX_LANE_NAME = 40
+
 # Named easings. The tuple form (cubic bezier) is deliberately not offered: it
 # is four numbers with a throwing domain and nothing an agent can reason about.
 _EASINGS: frozenset[str] = frozenset({"linear", "easeIn", "easeOut", "easeInOut", "hold"})
@@ -116,11 +139,18 @@ class TimelineSummary:
         clip_ids: set[str] | None = None,
         asset_ids: set[str] | None = None,
         track_ids: set[str] | None = None,
+        track_names: set[str] | None = None,
         has_timeline: bool = True,
     ) -> None:
         self.clip_ids = clip_ids or set()
         self.asset_ids = asset_ids or set()
         self.track_ids = track_ids or set()
+        # Lanes are addressable by NAME as well as id, which is what lets one
+        # batch create a lane and then put something on it: track ids are minted
+        # at apply time, so a lane the batch is adding has no id to quote. Kept
+        # case-folded because the agent is quoting a name it wrote in another op,
+        # not copying an id out of the preamble.
+        self.track_names = {n.strip().casefold() for n in (track_names or set()) if n.strip()}
         self.has_timeline = has_timeline
 
     @classmethod
@@ -150,10 +180,21 @@ class TimelineSummary:
                     out.add(row)
             return out
 
+        def _names(key: str) -> set[str]:
+            rows = timeline.get(key)
+            if not isinstance(rows, list):
+                return set()
+            return {
+                row["name"]
+                for row in rows
+                if isinstance(row, dict) and isinstance(row.get("name"), str)
+            }
+
         return cls(
             clip_ids=_ids("clips"),
             asset_ids=_ids("assets"),
             track_ids=_ids("tracks"),
+            track_names=_names("tracks"),
             has_timeline=True,
         )
 
@@ -257,6 +298,9 @@ def validate_ops(
         )
 
     clean: list[dict[str, Any]] = []
+    # Lane names minted by `add_lane` ops earlier in this batch. A later op may
+    # address them even though no id exists yet — see TimelineSummary.track_names.
+    batch_lane_names: set[str] = set()
 
     for i, raw in enumerate(ops):
         if not isinstance(raw, dict):
@@ -314,25 +358,79 @@ def validate_ops(
             op["after"] = full
 
         if raw.get("track") is not None:
-            full, err = _resolve(
-                raw["track"],
-                summary.track_ids,
-                field="track",
-                noun="a track on this timeline",
-                index=i,
-            )
-            if err:
-                return None, err
-            op["track"] = full
+            track_ref = raw["track"]
+            # A NAME resolves as-is and is passed through untouched — the client
+            # matches it against live track names. Checked against the lanes the
+            # agent was shown PLUS the ones earlier ops in this batch create, so
+            # "open a Score lane, put the music on it" validates as one batch
+            # even though the lane has no id until the batch applies.
+            if isinstance(track_ref, str) and track_ref.strip().casefold() in (
+                summary.track_names | batch_lane_names
+            ):
+                op["track"] = track_ref
+            else:
+                full, err = _resolve(
+                    track_ref,
+                    summary.track_ids,
+                    field="track",
+                    noun="a track on this timeline",
+                    index=i,
+                )
+                if err:
+                    known_names = sorted(summary.track_names | batch_lane_names)
+                    extra = (
+                        f" Lanes can also be named directly: {', '.join(known_names)}."
+                        if known_names
+                        else ""
+                    )
+                    return None, f"{err}{extra}"
+                op["track"] = full
 
         # ── per-verb argument checks ───────────────────────────────────────
         err = _validate_verb(kind, op, i, summary)
         if err:
             return None, err
 
+        if kind == "add_lane":
+            err = _check_lane_name(op, i, summary, batch_lane_names)
+            if err:
+                return None, err
+            name = op.get("name")
+            if isinstance(name, str) and name.strip():
+                batch_lane_names.add(name.strip().casefold())
+
         clean.append(op)
 
     return clean, None
+
+
+def _check_lane_name(
+    raw: dict[str, Any], i: int, summary: TimelineSummary, batch_names: set[str]
+) -> str | None:
+    """A lane name has to be unique, because `track` resolves by it.
+
+    Two rows answering to one word would make placement a coin flip decided by
+    document order, and the agent would be told the clip went somewhere it did
+    not. Checked against the lanes on the timeline AND the ones earlier ops in
+    this batch already claimed.
+    """
+    name = raw.get("name")
+    if name is None:
+        return None
+    if not isinstance(name, str) or not name.strip():
+        return f"ops[{i}].name must be a non-empty string when given."
+    if len(name.strip()) > _MAX_LANE_NAME:
+        return f"ops[{i}].name is longer than {_MAX_LANE_NAME} characters."
+    folded = name.strip().casefold()
+    if folded in summary.track_names:
+        return (
+            f"ops[{i}].name {name!r} is already a lane on this timeline. Pick a "
+            "different name, or target the existing lane with `track` instead of "
+            "opening a second one."
+        )
+    if folded in batch_names:
+        return f"ops[{i}].name {name!r} was already used by an earlier add_lane in this batch."
+    return None
 
 
 def _validate_verb(kind: str, raw: dict[str, Any], i: int, summary: TimelineSummary) -> str | None:
@@ -346,6 +444,27 @@ def _validate_verb(kind: str, raw: dict[str, Any], i: int, summary: TimelineSumm
     if kind == "split_clip":
         if "atMs" not in raw or raw["atMs"] is None:
             return f"ops[{i}].atMs is required for split_clip — where should the cut land?"
+
+    elif kind == "add_lane":
+        lane_kind = raw.get("kind")
+        if not isinstance(lane_kind, str) or lane_kind not in _LANE_KINDS:
+            hint = _suggest(str(lane_kind), set(_LANE_KINDS))
+            return (
+                f"ops[{i}].kind {lane_kind!r} is not a lane kind.{hint} "
+                f"Valid kinds: {', '.join(sorted(_LANE_KINDS))}."
+            )
+        role = raw.get("role")
+        if role is not None and (not isinstance(role, str) or role not in _LANE_ROLES):
+            return (
+                f"ops[{i}].role {role!r} is not a lane role. The only role is "
+                "'captions', which makes a text lane a cue lane; omit it for a "
+                "plain lane."
+            )
+        if role == "captions" and lane_kind != "text":
+            return (
+                f"ops[{i}] asked for a {lane_kind} lane with role 'captions'. A cue "
+                "lane is a TEXT lane wearing that role — pass kind 'text'."
+            )
 
     elif kind == "set_transition":
         tk = raw.get("kind")

--- a/ee/pocketpaw_ee/cloud/surface/handlers/studio_editor.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/studio_editor.py
@@ -152,7 +152,7 @@ def _timeline_block(timeline: dict[str, Any]) -> str:
     tracks = [t for t in (timeline.get("tracks") or []) if isinstance(t, dict)]
     if tracks:
         lines.append("")
-        lines.append("TRACKS (lanes clips sit on):")
+        lines.append("LANES (rows clips sit on — target one by id or by name, add_lane for more):")
         lines.extend(
             _rows(
                 tracks,
@@ -223,11 +223,12 @@ the result presses Ctrl+Z once.
 Operations (this list is closed — an invented verb is rejected):
 - place_clip    {assetId, atMs|after, track?, inMs?, outMs?}
 - move_clip     {clipId, atMs|after, track?}
+- add_lane      {kind: video|audio|text|overlay, role?: 'captions', name?}
 - trim_clip     {clipId, inMs?, outMs?}     absolute SOURCE points, not a delta
 - split_clip    {clipId, atMs}
 - remove_clip   {clipId}
 - set_transition{clipId, kind, durationMs?, direction?, color?, softness?}
-- add_text      {text, fromMs, toMs, + any style field below}
+- add_text      {text, fromMs, toMs, track?, + any style field below}
 - style_text    {clipId, text?, + any style field below}   restyle what exists
 - add_caption   {text, fromMs, toMs, anchorClip?, style?}
 - style_captions{style?, fontSize?, y?}                    the whole cue set
@@ -256,6 +257,29 @@ Rules that matter:
   id yet. `after: <clipId>` is for anchoring to a clip ALREADY on the timeline
   (one listed above); it is resolved against the live document, so it stays right
   even when an earlier op in the same batch changed a length.
+- LANES ARE THE LAYOUT. A timeline is rows, not one line. Things that play AT
+  THE SAME TIME go on DIFFERENT lanes; things that play one after another go on
+  ONE lane. Music under narration is two audio lanes. A logo over a shot is two
+  video lanes (the LATER lane draws on top). Three shots in a row is one lane.
+  Put a clip on a specific lane with `track`, and open a new one with add_lane
+  when the arrangement needs a row that is not there.
+- NAME A LANE YOU OPEN, AND ADDRESS IT BY THAT NAME. `track` takes a lane id OR
+  a lane name, and the name is the only way to use a lane in the batch that
+  creates it — lane ids, like clip ids, are minted when the batch applies. So
+  "score under the whole thing" is:
+      {op: add_lane, kind: audio, name: "Score"}
+      {op: place_audio, assetId: …, track: "Score", atMs: 0, volume: 0.3}
+  Name it for what it carries — Score, VO, Lower thirds — not Audio 2. A name
+  already on the timeline is rejected: target that lane instead of opening a
+  second one with the same name.
+- DO NOT OPEN A LANE YOU DO NOT NEED. Sequential clips belong on one lane, and
+  a row per clip makes a five-shot cut five rows tall. Open a lane when things
+  must overlap, or when the user asked for a separate one.
+- A CUE LANE IS A TEXT LANE WITH role 'captions'. add_lane {kind: text, role:
+  'captions'} when the timeline has no caption row yet. Loose titles never land
+  on it and cues never land off it, so a text lane and a cue lane are not
+  interchangeable. add_caption always fills the FIRST caption lane — a second
+  one is for cues the user drags there, not a thing to target.
 - ANCHOR CAPTIONS. Caption times are timeline-absolute and do NOT move when a
   clip moves. If a caption belongs to a clip's dialogue, pass
   `anchorClip: <clipId>` and give fromMs/toMs as offsets from that clip's start.
@@ -324,7 +348,8 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         "The user is looking at a VIDEO TIMELINE EDITOR — tracks, clips, "
         "captions, transitions. Your job here is to ARRANGE what is already on "
         "the timeline: order clips, trim them, place titles and captions, and "
-        "lay audio into lanes. This is NOT a dashboard: do not build widgets, "
+        "lay things out across lanes — opening new ones when the arrangement "
+        "needs a row that is not there. This is NOT a dashboard: do not build widgets, "
         "charts, a pocket or a ui-spec. It is also NOT the generation surface: "
         "you cannot make new footage here. Talk about 'clips', 'tracks', "
         "'captions' and 'the timeline'.\n"

--- a/tests/ee/agent/test_timeline_ops.py
+++ b/tests/ee/agent/test_timeline_ops.py
@@ -50,6 +50,7 @@ def summary() -> TimelineSummary:
         clip_ids={"clip_aaa", "clip_bbb", "clip_ccc"},
         asset_ids={"asset_one", "asset_two", "asset_three", "asset_music"},
         track_ids={"track_video", "track_audio"},
+        track_names={"Video", "Audio", "Lower thirds"},
     )
 
 
@@ -123,6 +124,7 @@ def test_every_contract_op_is_reachable(summary: TimelineSummary) -> None:
         "set_transform": {"clipId": "clip_aaa", "x": 384, "y": 389, "scale": 1.2},
         "add_keyframe": {"clipId": "clip_aaa", "prop": "opacity", "atMs": 500, "value": 0.5},
         "clear_keyframes": {"clipId": "clip_aaa", "prop": "opacity"},
+        "add_lane": {"kind": "audio", "name": "Score"},
     }
     assert set(minimal) == set(OP_KINDS), "a verb was added without a case here"
     for kind, args in minimal.items():
@@ -477,3 +479,121 @@ def test_the_motivating_request_validates_as_one_batch(summary: TimelineSummary)
     assert error is None
     assert clean is not None
     assert len(clean) == 6
+
+
+# ── 6. Lanes ───────────────────────────────────────────────────────────────
+#
+# `add_lane` is the verb that makes layering a decision rather than a side
+# effect of the store's collision stacking. What can go wrong is addressing: a
+# lane's id does not exist until the batch applies, so the batch has to be able
+# to name the lane it just asked for — and two lanes answering to one name would
+# make that a coin flip.
+
+
+def test_a_lane_can_be_opened_and_used_in_the_same_batch(summary: TimelineSummary) -> None:
+    """The whole reason lanes are addressable by name.
+
+    Mutation: validate `track` against summary.track_ids only, so the name of a
+    lane this batch creates is rejected as an unknown track."""
+    clean, error = validate_ops(
+        [
+            {"op": "add_lane", "kind": "audio", "name": "Score"},
+            {"op": "place_audio", "assetId": "asset_music", "track": "Score", "atMs": 0},
+        ],
+        summary,
+    )
+    assert error is None
+    assert clean is not None
+    # Passed through untouched — the client matches it against live track names.
+    assert clean[1]["track"] == "Score"
+
+
+def test_an_existing_lane_can_be_targeted_by_name(summary: TimelineSummary) -> None:
+    """Mutation: drop the name branch and resolve ids only."""
+    clean, error = validate_ops(
+        [{"op": "place_audio", "assetId": "asset_music", "track": "Audio"}], summary
+    )
+    assert error is None
+    assert clean is not None
+
+
+def test_lane_names_are_case_insensitive(summary: TimelineSummary) -> None:
+    """The agent is quoting a name it wrote in another op, or read off a
+    preamble row, not copying an id — so the case it sends back is not
+    guaranteed to match.
+
+    Both tables have to fold: the lanes already on the timeline, and the ones
+    this batch is creating.
+
+    Mutation: compare names without casefolding, in either table."""
+    # An EXISTING lane, addressed in the wrong case. Deliberately a name that
+    # is NOT a tail of any track id: `_resolve` matches id tails, so "audio"
+    # would resolve off "track_audio" and prove nothing about name folding.
+    clean, error = validate_ops(
+        [{"op": "add_text", "text": "hi", "fromMs": 0, "toMs": 1, "track": "LOWER THIRDS"}],
+        summary,
+    )
+    assert error is None, error
+    assert clean is not None
+
+    # A lane created by this batch, addressed in the wrong case.
+    clean, error = validate_ops(
+        [
+            {"op": "add_lane", "kind": "video", "name": "Overlay"},
+            {"op": "place_clip", "assetId": "asset_one", "track": "overlay"},
+        ],
+        summary,
+    )
+    assert error is None, error
+    assert clean is not None
+
+
+def test_a_duplicate_lane_name_is_refused(summary: TimelineSummary) -> None:
+    """Two rows answering to one word would make `track` a coin flip decided by
+    document order.
+
+    Mutation: drop the _check_lane_name collision branch."""
+    _, error = validate_ops([{"op": "add_lane", "kind": "audio", "name": "Audio"}], summary)
+    assert error is not None
+    assert "already a lane" in error
+
+    _, error = validate_ops(
+        [
+            {"op": "add_lane", "kind": "audio", "name": "Score"},
+            {"op": "add_lane", "kind": "audio", "name": "score"},
+        ],
+        summary,
+    )
+    assert error is not None
+    assert "earlier add_lane" in error
+
+
+def test_an_unknown_lane_kind_is_refused_with_the_valid_set(summary: TimelineSummary) -> None:
+    """Mutation: accept any string as a lane kind."""
+    _, error = validate_ops([{"op": "add_lane", "kind": "music"}], summary)
+    assert error is not None
+    assert "is not a lane kind" in error
+
+
+def test_a_cue_lane_must_be_a_text_lane(summary: TimelineSummary) -> None:
+    """A caption lane is a TEXT track wearing role 'captions' — an audio one
+    would be a row the cue list can never find.
+
+    Mutation: drop the kind check on the captions role."""
+    _, error = validate_ops([{"op": "add_lane", "kind": "audio", "role": "captions"}], summary)
+    assert error is not None
+    assert "TEXT lane" in error
+
+    clean, error = validate_ops([{"op": "add_lane", "kind": "text", "role": "captions"}], summary)
+    assert error is None
+    assert clean is not None
+
+
+def test_an_unknown_track_name_still_fails(summary: TimelineSummary) -> None:
+    """Name addressing must not turn every typo into a silently-accepted lane.
+
+    Mutation: accept any string as a track reference."""
+    _, error = validate_ops(
+        [{"op": "place_audio", "assetId": "asset_music", "track": "Scoer"}], summary
+    )
+    assert error is not None

--- a/tests/mutations/timeline_ops.json
+++ b/tests/mutations/timeline_ops.json
@@ -194,5 +194,51 @@
     "tests": [
       "tests/ee/agent/test_timeline_ops.py::test_an_empty_transform_is_rejected"
     ]
+  },
+  {
+    "label": "resolve `track` by id only, so a lane the batch just opened is unusable",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/timeline_ops.py",
+    "find": "            if isinstance(track_ref, str) and track_ref.strip().casefold() in (",
+    "replace": "            if False and isinstance(track_ref, str) and track_ref.strip().casefold() in (",
+    "tests": [
+      "tests/ee/agent/test_timeline_ops.py::test_a_lane_can_be_opened_and_used_in_the_same_batch",
+      "tests/ee/agent/test_timeline_ops.py::test_an_existing_lane_can_be_targeted_by_name"
+    ]
+  },
+  {
+    "label": "compare lane names without casefolding",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/timeline_ops.py",
+    "find": "        self.track_names = {n.strip().casefold() for n in (track_names or set()) if n.strip()}",
+    "replace": "        self.track_names = {n.strip() for n in (track_names or set()) if n.strip()}",
+    "tests": [
+      "tests/ee/agent/test_timeline_ops.py::test_lane_names_are_case_insensitive"
+    ]
+  },
+  {
+    "label": "let two lanes share a name, making `track` a coin flip",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/timeline_ops.py",
+    "find": "    if folded in summary.track_names:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/agent/test_timeline_ops.py::test_a_duplicate_lane_name_is_refused"
+    ]
+  },
+  {
+    "label": "accept any string as a lane kind",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/timeline_ops.py",
+    "find": "        if not isinstance(lane_kind, str) or lane_kind not in _LANE_KINDS:",
+    "replace": "        if False:",
+    "tests": [
+      "tests/ee/agent/test_timeline_ops.py::test_an_unknown_lane_kind_is_refused_with_the_valid_set"
+    ]
+  },
+  {
+    "label": "allow a cue lane on a non-text kind, where the cue list can never find it",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/timeline_ops.py",
+    "find": "        if role == \"captions\" and lane_kind != \"text\":",
+    "replace": "        if False:",
+    "tests": [
+      "tests/ee/agent/test_timeline_ops.py::test_a_cue_lane_must_be_a_text_lane"
+    ]
   }
 ]


### PR DESCRIPTION
> Pairs with qbtrix/paw-enterprise#907. The op contract is committed byte-identical in both trees and each side's suite checks itself against its own copy, so these two land in the same wave.

## What's wrong

The editor has stacked lanes. The agent could only target the ones that happened to exist.

`place_clip` has always taken a `track`, but nothing in the vocabulary could CREATE a row. So "put the score on its own lane, under the clips" was reachable only by accident: place two things at the same instant and let the client's collision stacking react to it. The agent inherited a layout instead of deciding one.

## What changed

**`add_lane {kind, role?, name?}`** joins the closed set, and **`track` resolves by lane name as well as id.**

The name is load-bearing, not a convenience. Track ids are minted when the batch applies in the browser — the same reason `after` can't anchor to a clip the batch is adding — so a lane this batch creates has no id to quote. Validating names against the summary alone would reject the exact sequence the verb exists for, so they're checked against the lanes the agent was shown **plus** the ones earlier ops in the batch claim:

```
{op: add_lane,    kind: audio, name: "Score"}
{op: place_audio, assetId: …,  track: "Score", atMs: 0, volume: 0.3}
```

Two refusals worth naming:

- **A duplicate name.** Two rows answering to one word makes placement a coin flip decided by document order, and the agent gets told the clip went somewhere it didn't.
- **A cue lane that isn't kind `text`.** `role: 'captions'` on an audio row would be a lane the cue list can never find.

**The preamble teaches the layout rule, not just the verb.** Things that play at the same time go on different lanes; things that play one after another go on one; don't open a row you don't need, because a lane per clip makes a five-shot cut five rows tall. It also spells out the open-then-address pair, which isn't guessable from the schema. The LANES block now says lanes are targetable by name and that `add_lane` exists.

Contract bumped to v3.

## Gates proven, not assumed

Per the repo rule, five mutations added to `tests/mutations/timeline_ops.json` — all five caught:

```
caught  resolve `track` by id only, so a lane the batch just opened is unusable
caught  compare lane names without casefolding
caught  let two lanes share a name, making `track` a coin flip
caught  accept any string as a lane kind
caught  allow a cue lane on a non-text kind, where the cue list can never find it
```

The first run had one ESCAPE. My case-folding test addressed a lane named `Audio`, which is also a tail of the fixture's `track_audio` id — so `resolve_id`'s tail matching rescued the mutant and the assertion proved nothing. Fixed the fixture (a name with a space, which can't tail-match) rather than weakening the plan. Worth knowing for anyone adding lane tests: real track ids are nanoids, so the fixture's readable ids make name/id collisions easy to write by accident.

## Checks

- 1109 tests pass across `tests/ee/agent`, `tests/cloud/surface`, `tests/cloud/chat`; the reachability test now requires an `add_lane` case, so the verb can't be listed-but-unusable
- `ruff check` and `ruff format --check` clean on the changed files
- `tests/cloud/extraction` doesn't collect in my env (`pypdf` not installed) — pre-existing and unrelated; I ran around it rather than touching it