### PR TITLE
Daily abuse ceilings on uploads and agent runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,40 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   env-configurable), marking queued/running `ChatRunDoc`s older than 10 minutes as
   `interrupted` so runs abandoned by a backend restart surface a retry affordance
   instead of leaving clients subscribed forever.
+- **Abuse ceilings (always on, NOT gated on billing)**: four knobs that bound what
+  one account can do in a day, regardless of whether billing is configured. They
+  exist because the priced ceilings — the per-plan storage cap in
+  `cloud/storage/service.py` and the credit quota in `chat/runs/run_core.py` —
+  are both gated on `billing_enforced`, which defaults to False. On a deployment
+  that has not switched billing on, those are not ceilings at all, and the only
+  remaining bound is the per-IP limiter in `dashboard_auth` (10 req/s, in-memory
+  per process, so N replicas means N buckets).
+  `POCKETPAW_WORKSPACE_TURNS_DAILY` (default `500`) — agent runs per workspace
+  per UTC day. ONE counter covers every model call the platform pays for,
+  because they all happen inside a run: the reply, plus image generation,
+  speech, OCR, translate, research and web search when a run calls them.
+  `POCKETPAW_WORKSPACE_UPLOAD_FILES_DAILY` (default `2000`) and
+  `POCKETPAW_WORKSPACE_UPLOAD_BYTES_DAILY` (default `20000000000`, 20 GB) — both
+  ceilings on the same daily row, because a file count alone is beaten by fifty
+  25 MiB files and a byte total alone is beaten by a hundred thousand one-byte
+  ones.
+  `POCKETPAW_MAX_OWNED_WORKSPACES` (default `10`) — the one that makes the other
+  three mean anything. Every ceiling above is keyed on the workspace, so an
+  account that can mint workspaces in a loop gets a fresh empty counter each
+  time. Counts only workspaces the account OWNS; being invited to many is normal
+  collaboration and is governed by the inviter's seat limit.
+  All four read `0` as UNCAPPED, which DIVERGES from
+  `POCKETPAW_FILE_COMPREHENSION_DAILY`, where `0` disables the feature and
+  therefore blocks everything. Deliberate: a comprehension is an extra a
+  workspace can live without for a day, whereas uploading, chatting and creating
+  a workspace are the product, and an env typo must not take them off the air.
+  A non-integer value warns and uses the default rather than reading as `0`.
+  The two daily counters fail CLOSED on a database error, which costs nothing
+  because both paths persist to the same Mongo. Rejections are 429 with codes
+  `runs.daily_limit`, `uploads.daily_limit` and `workspace.owned_limit` —
+  deliberately not the 402 `billing.*` / `credits.*` codes, because nothing is
+  for sale here and the answer is to wait, not to upgrade.
+  Crude flood protection belongs at the proxy (Traefik on Coolify), not here.
 - **Concurrency / capacity config**: five ceilings that are easy to confuse. In a
   cloud deploy the first two are the ones that bound how much work executes at once.
   `POCKETPAW_ARQ_MAX_JOBS` (default `10`, arq's own) — the **chat lane's** ceiling:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,8 +279,11 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   workspace can live without for a day, whereas uploading, chatting and creating
   a workspace are the product, and an env typo must not take them off the air.
   A non-integer value warns and uses the default rather than reading as `0`.
-  The two daily counters fail CLOSED on a database error, which costs nothing
-  because both paths persist to the same Mongo. Rejections are 429 with codes
+  The two daily counters fail OPEN on a database error, logged at WARNING.
+  Both paths persist to the same Mongo a statement later, so an unreadable
+  counter never lets through work the database would have refused, and a
+  fail-closed draft refused every run in any harness that had not bound the
+  collection. Rejections are 429 with codes
   `runs.daily_limit`, `uploads.daily_limit` and `workspace.owned_limit` —
   deliberately not the 402 `billing.*` / `credits.*` codes, because nothing is
   for sale here and the answer is to wait, not to upgrade.

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -393,6 +393,61 @@ class StorageLimitError(CloudError):
         super().__init__(402, "billing.storage_limit", f"Storage limit: {label}")
 
 
+class WorkspaceLimitError(CloudError):
+    """Account already owns as many workspaces as it may (429).
+
+    An abuse ceiling, not a plan feature. Every per-workspace bound in the
+    product is keyed on the workspace, so an account that can mint workspaces
+    in a loop gets a fresh empty counter each time and is bounded by nothing.
+    Being INVITED to many workspaces is normal and unaffected — only owning is
+    counted, and deleting one frees a slot.
+    """
+
+    def __init__(self, cap: int) -> None:
+        super().__init__(
+            429,
+            "workspace.owned_limit",
+            f"You already own {cap} workspaces. Delete one to create another.",
+        )
+
+
+class DailyUploadLimitError(CloudError):
+    """Workspace hit its daily upload ceiling (429).
+
+    Distinct from ``StorageLimitError`` in both cause and cure. That one is a
+    PLAN cap, priced, cleared by upgrading, and only enforced when billing is
+    on. This is an ABUSE ceiling that is always on and clears at the next UTC
+    midnight, so the code is ``uploads.daily_limit`` and the status is 429
+    rather than 402 — nothing is for sale here, the answer is to wait.
+    """
+
+    def __init__(self, dimension: str) -> None:
+        label = {
+            "files": "too many files uploaded today",
+            "bytes": "too much uploaded today",
+            "workspace": "no workspace on this upload",
+            "unavailable": "upload budget unavailable",
+        }.get(dimension, "daily upload limit reached")
+        super().__init__(429, "uploads.daily_limit", f"Daily upload limit: {label}")
+
+
+class DailyTurnLimitError(CloudError):
+    """Workspace hit its daily agent-run ceiling (429).
+
+    Sibling of ``DailyUploadLimitError`` on the RUN seam, and deliberately not
+    ``credits.quota_exceeded``: that one is the priced quota and is gated on
+    ``billing_enforced``, while this is always on and resets at the next UTC
+    midnight.
+    """
+
+    def __init__(self, cap: int) -> None:
+        super().__init__(
+            429,
+            "runs.daily_limit",
+            f"Daily limit of {cap} agent runs reached for this workspace",
+        )
+
+
 class InsufficientCredits(CloudError):
     """Credit wallet has too few credits for the requested debit (402)."""
 
@@ -500,7 +555,10 @@ __all__ = [
     "QuotaExceeded",
     "RateLimited",
     "SeatLimitError",
+    "DailyTurnLimitError",
+    "DailyUploadLimitError",
     "StorageLimitError",
+    "WorkspaceLimitError",
     "ValidationError",
     "with_cause",
 ]

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -426,7 +426,6 @@ class DailyUploadLimitError(CloudError):
             "files": "too many files uploaded today",
             "bytes": "too much uploaded today",
             "workspace": "no workspace on this upload",
-            "unavailable": "upload budget unavailable",
         }.get(dimension, "daily upload limit reached")
         super().__init__(429, "uploads.daily_limit", f"Daily upload limit: {label}")
 

--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -221,6 +221,19 @@ async def post_agent_chat(
 
     await assert_guest_turn_allowed(user_id, ctx.workspace_id)
 
+    # Workspace daily turn ceiling, CHECK-ONLY (feat/abuse-budgets). Same
+    # reason as the two fast-rejects above: without it a capped account still
+    # creates a run doc, opens a stream and sets a TTL on every send, and the
+    # per-IP limiter allows ten of those a second. Does NOT increment — the
+    # executor owns the single atomic spend — and fails OPEN, because the
+    # executor's gate is the one that has to be right.
+    from pocketpaw_ee.cloud.chat.runs import turn_budget
+
+    if await turn_budget.is_over_cap(ctx.workspace_id):
+        from pocketpaw_ee.cloud._core.errors import DailyTurnLimitError
+
+        raise DailyTurnLimitError(turn_budget.daily_cap())
+
     transport = get_stream_transport()
     # Resolve the surface-aware context preamble AFTER scope is resolved
     # (so we have ``workspace_id`` / ``user_id`` confirmed) and BEFORE any

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -2198,6 +2198,53 @@ async def _reject_if_over_jail_quota(spec: RunSpec, ctx: ScopeContext, transport
     return True
 
 
+async def _reject_if_over_daily_turns(spec: RunSpec, ctx: ScopeContext, transport: Any) -> bool:
+    """Per-workspace daily agent-run ceiling (feat/abuse-budgets).
+
+    The always-on sibling of ``_reject_if_over_credit_quota``. That gate is the
+    priced ceiling and is a no-op unless ``billing_enforced``, which defaults
+    off — so on a deployment that has not configured billing, nothing bounds
+    what one signed-up account can spend on models. Guests have had a daily
+    turn cap since ``guest_budget``; this is its signed-up equivalent, and it
+    is deliberately NOT flag-gated.
+
+    Sits with the other run-start gates so it covers every path into the
+    executor (HTTP, WebSocket, queued, resumed) and fires BEFORE prewarm,
+    mark-running and any model call. Only this seam increments, so a turn costs
+    exactly one. Rejection uses the same shape as its neighbours: a terminal
+    ``error`` frame, ``mark_terminal(failed)``, then the stream TTL.
+
+    Returns ``True`` when the run was rejected.
+    """
+    from pocketpaw_ee.cloud.chat.runs import turn_budget
+
+    allowed, spent, cap = await turn_budget.try_spend(ctx.workspace_id)
+    if allowed:
+        if cap:
+            logger.debug("workspace turn %d/%d for %s", spent, cap, ctx.workspace_id)
+        return False
+
+    from pocketpaw_ee.cloud._core.errors import DailyTurnLimitError
+
+    exc = DailyTurnLimitError(cap)
+    logger.warning("run %s rejected — workspace daily turn cap (%d)", spec.run_id, cap)
+    try:
+        await transport.append_event(
+            spec.run_id, "error", {"code": exc.code, "message": exc.message}
+        )
+    except Exception:
+        logger.debug("turn-cap error frame append failed for %s", spec.run_id, exc_info=True)
+    try:
+        await run_service.mark_terminal(spec.run_id, status="failed", error=exc.message)
+    except Exception:
+        logger.exception("mark_terminal(failed) failed for turn-capped run %s", spec.run_id)
+    try:
+        await transport.set_ttl(spec.run_id, _stream_ttl())
+    except Exception:
+        logger.debug("turn-cap stream ttl set failed for %s", spec.run_id, exc_info=True)
+    return True
+
+
 async def _reject_if_over_credit_quota(spec: RunSpec, ctx: ScopeContext, transport: Any) -> bool:
     """Universal run-start BILLING gate on the worker/executor path.
 
@@ -2366,6 +2413,16 @@ async def execute_run(spec: RunSpec) -> None:
     # turn costs exactly one. No-op for non-guest users; fail-CLOSED for
     # guests (an unreadable counter refuses the run).
     if await _reject_if_guest_over_limit(spec, ctx, transport):
+        return
+
+    # Workspace daily turn ceiling (feat/abuse-budgets) — the always-on abuse
+    # bound, sitting LAST of the four run-start gates so a more specific and
+    # more actionable rejection wins: over jail quota, out of credit, or a
+    # guest over their allowance all say something the user can act on, where
+    # this one only says "come back tomorrow". No-op when the cap is 0;
+    # fail-CLOSED on an unreadable counter, which costs nothing because the run
+    # persists to the same database.
+    if await _reject_if_over_daily_turns(spec, ctx, transport):
         return
 
     # Mark this dispatch as a live cloud CHAT run for the per-tenant cwd jail's

--- a/ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py
@@ -74,6 +74,32 @@ def _today() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%d")
 
 
+async def is_over_cap(workspace_id: str | None) -> bool:
+    """Is this workspace already at today's ceiling? READ-ONLY.
+
+    The check-only half, for the synchronous HTTP route. It deliberately does
+    NOT increment: ``try_spend`` in the executor owns the single atomic spend,
+    so a turn costs exactly one however many seams look at the counter first.
+
+    Fails OPEN, which is the opposite of ``try_spend`` and is right for the
+    same reason the guest fast-reject is check-only: this is an optimisation
+    that saves a capped account a run doc, a Redis stream and a TTL, and the
+    executor still refuses the run. A database blip must cost latency, not
+    correctness, and correctness lives in ``try_spend``.
+    """
+    cap = daily_cap()
+    if cap <= 0 or not workspace_id:
+        return False
+    try:
+        doc = await WorkspaceTurnUsage.get_pymongo_collection().find_one(
+            {"key": f"{workspace_id}:{_today()}"}
+        )
+    except Exception:
+        logger.debug("turn budget pre-check unavailable for %s", workspace_id, exc_info=True)
+        return False
+    return int((doc or {}).get("used", 0)) >= cap
+
+
 async def try_spend(workspace_id: str | None) -> tuple[bool, int, int]:
     """Claim one agent run against today's budget for ``workspace_id``.
 
@@ -133,4 +159,4 @@ async def try_spend(workspace_id: str | None) -> tuple[bool, int, int]:
     return True, spent, cap
 
 
-__all__ = ["daily_cap", "try_spend"]
+__all__ = ["daily_cap", "is_over_cap", "try_spend"]

--- a/ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py
@@ -1,0 +1,136 @@
+# ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py — a hard daily ceiling on how
+# many agent runs one workspace may start.
+#
+# Created 2026-09-11 (feat/abuse-budgets).
+#
+# The gap this closes: the credit quota already in ``run_core`` is the right
+# long-term ceiling on spend, and it is gated on ``billing_enforced``, which
+# defaults to False. A deployment that has not switched billing on therefore
+# has NO bound on what one signed-up account can spend on models. Guests have
+# had one since ``guest_budget`` (40 turns a day); a free signup had less
+# protection than a guest, which is backwards — a guest cannot even upload.
+#
+# ONE counter, not six. Every model call the platform pays for happens inside
+# a run: the reply itself, and any tool the run calls (image generation,
+# speech, OCR, translate, research, web search). Bounding runs bounds all of
+# them, and six separate counters would be six places for the bound to be
+# missing.
+#
+# NOT gated on ``billing_enforced`` — it is an abuse ceiling, not a plan. A
+# workspace that pays for more usage raises its credit allowance; this only
+# stops a single day from being pathological, so the default sits far above a
+# heavy human day and far below a script.
+#
+# ``0`` means NO CAP. This DIVERGES from ``comprehension_budget``, where ``0``
+# disables the feature and so blocks everything. Deliberate: a comprehension is
+# an extra a workspace can live without for a day, whereas the agent answering
+# IS the product. An env typo that reads as ``0`` must not take chat off the
+# air for every tenant at once.
+#
+# It fails CLOSED on a database error. That costs nothing here: a run persists
+# its messages to the same Mongo, so a database that cannot serve this counter
+# cannot serve the run either.
+#
+# Structure copied from ``uploads/comprehension_budget.py``, including the
+# increment-then-compare ordering and the rollback of an over-cap claim.
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+
+from pymongo import ReturnDocument
+
+from pocketpaw_ee.cloud.models.workspace_turn_usage import WorkspaceTurnUsage
+
+logger = logging.getLogger(__name__)
+
+_ENV_CAP = "POCKETPAW_WORKSPACE_TURNS_DAILY"
+
+#: Agent runs per workspace per UTC day. 500 is well past a heavy day of human
+#: conversation across a whole workspace, and well short of a loop. Guests get
+#: 40; this is the signed-up equivalent.
+_DEFAULT_CAP = 500
+
+
+def daily_cap() -> int:
+    """Runs per workspace per UTC day. ``0`` means uncapped.
+
+    A non-integer value is a misconfiguration, not an instruction: warn and use
+    the default rather than reading ``"five hundred"`` as ``0``.
+    """
+    raw = (os.environ.get(_ENV_CAP) or "").strip()
+    if not raw:
+        return _DEFAULT_CAP
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning("%s is not an integer (%r) — using the default", _ENV_CAP, raw)
+        return _DEFAULT_CAP
+
+
+def _today() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+async def try_spend(workspace_id: str | None) -> tuple[bool, int, int]:
+    """Claim one agent run against today's budget for ``workspace_id``.
+
+    Returns ``(allowed, spent, cap)``. ``spent`` INCLUDES this one when
+    allowed, so a caller can log "3/500" honestly.
+
+    Increments FIRST and compares after: a check-then-increment lets two
+    concurrent sends both read 499 and both spend. An over-cap claim is rolled
+    back so a refused run does not hold a slot a later one could have used.
+    """
+    cap = daily_cap()
+    if cap <= 0:
+        return True, 0, 0
+
+    if not workspace_id:
+        # No tenant means no counter to charge, and an uncharged run is exactly
+        # what this file exists to prevent.
+        logger.warning("agent run refused — no workspace to charge")
+        return False, 0, cap
+
+    day = _today()
+    key = f"{workspace_id}:{day}"
+    try:
+        # ``get_pymongo_collection``, NOT ``get_motor_collection`` — see the
+        # note in ``uploads/comprehension_budget.py``; the wrong name fails
+        # closed and reads as "chat is down" rather than as a bug here.
+        coll = WorkspaceTurnUsage.get_pymongo_collection()
+        doc = await coll.find_one_and_update(
+            {"key": key},
+            {
+                "$inc": {"used": 1},
+                "$setOnInsert": {
+                    "workspace": workspace_id,
+                    "day": day,
+                    "createdAt": datetime.now(UTC),
+                },
+                "$set": {"updatedAt": datetime.now(UTC)},
+            },
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        # A successful update with no returned document should not happen, but
+        # reading it as "0 spent" would be a permanently open gate.
+        spent = int((doc or {}).get("used", cap + 1))
+    except Exception:
+        logger.warning(
+            "turn budget unavailable for workspace=%s; refusing", workspace_id, exc_info=True
+        )
+        return False, 0, cap
+
+    if spent > cap:
+        try:
+            await coll.update_one({"key": key}, {"$inc": {"used": -1}})
+        except Exception:
+            logger.debug("could not roll back an over-cap run claim", exc_info=True)
+        return False, cap, cap
+    return True, spent, cap
+
+
+__all__ = ["daily_cap", "try_spend"]

--- a/ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py
@@ -27,9 +27,11 @@
 # IS the product. An env typo that reads as ``0`` must not take chat off the
 # air for every tenant at once.
 #
-# It fails CLOSED on a database error. That costs nothing here: a run persists
-# its messages to the same Mongo, so a database that cannot serve this counter
-# cannot serve the run either.
+# It fails OPEN on a database error, logged at WARNING. A run persists its
+# messages to the same Mongo, so a database that cannot serve this counter
+# cannot serve the run either — refusing here would protect nothing and, as the
+# first draft proved, refuses every run in any harness that has not bound the
+# collection.
 #
 # Structure copied from ``uploads/comprehension_budget.py``, including the
 # increment-then-compare ordering and the rollback of an over-cap claim.
@@ -145,10 +147,23 @@ async def try_spend(workspace_id: str | None) -> tuple[bool, int, int]:
         # reading it as "0 spent" would be a permanently open gate.
         spent = int((doc or {}).get("used", cap + 1))
     except Exception:
+        # Fails OPEN (reversed 2026-09-12, before this ever shipped). The first
+        # draft refused the run here, on the argument that a database that
+        # cannot serve this counter cannot serve the run either. True in
+        # production, and irrelevant to the case that actually bit: a hermetic
+        # test harness with no Beanie binding, where every run was refused
+        # with a cap message and nothing said why. An unreadable counter is
+        # not an attack — an attacker cannot make Mongo unreachable without
+        # also taking the run down at message persistence — so refusing here
+        # buys no protection and leaves a trap for the next harness. The guest
+        # gate beside this one made the same call: ``load_guest`` answers "not
+        # a guest" on any error. Logged at WARNING so a real outage is visible.
         logger.warning(
-            "turn budget unavailable for workspace=%s; refusing", workspace_id, exc_info=True
+            "turn budget unavailable for workspace=%s; allowing this run",
+            workspace_id,
+            exc_info=True,
         )
-        return False, 0, cap
+        return True, 0, cap
 
     if spent > cap:
         try:

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -10,6 +10,13 @@ Registering it here is load-bearing — an unregistered document makes
 ``get_pymongo_collection()`` raise inside that budget's fail-CLOSED except, so
 every transcription is refused and the feature reads as switched off.
 
+Updated: 2026-09-11 (feat/abuse-budgets) — added ``WorkspaceUploadUsage`` and
+``WorkspaceTurnUsage`` (one row per workspace per UTC day each, the atomic
+counters behind the upload and agent-run daily caps) to the imports and
+``get_all_documents()`` so both collections are wired into ``init_beanie``.
+Kept out of ``__all__``: only ``ee.cloud.uploads.upload_budget`` and
+``ee.cloud.chat.runs.turn_budget`` import the doc classes directly.
+
 Updated: 2026-08-28 (FC-3 "File comprehension") — added
 ``FileComprehensionUsage`` (one row per workspace per UTC day, the atomic
 counter behind the comprehension daily cap) to the imports and
@@ -278,6 +285,8 @@ from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
 from pocketpaw_ee.cloud.models.workspace_automation_config import WorkspaceAutomationConfig
 from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
+from pocketpaw_ee.cloud.models.workspace_turn_usage import WorkspaceTurnUsage
+from pocketpaw_ee.cloud.models.workspace_upload_usage import WorkspaceUploadUsage
 from pocketpaw_ee.cloud.models.workspace_vm import WorkspaceVm
 
 # Lazy import to avoid circular imports
@@ -504,6 +513,8 @@ def get_all_documents():
         # bills, and one shared row would let a bulk photo import exhaust the
         # ceiling that exists to stop a podcast library.
         FileTranscriptionUsage,
+        WorkspaceTurnUsage,
+        WorkspaceUploadUsage,
         # file_versions edit history (ART-1). Only ``file_versions.service``
         # imports this class (import-linter "FileVersions" contract).
         FileVersionDoc,

--- a/ee/pocketpaw_ee/cloud/models/workspace_turn_usage.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace_turn_usage.py
@@ -1,0 +1,37 @@
+# ee/pocketpaw_ee/cloud/models/workspace_turn_usage.py — the per-workspace
+# daily agent-run counter.
+#
+# Created 2026-09-11 (feat/abuse-budgets) — every model call the product makes
+# on the PLATFORM's account happens inside an agent run: the reply itself, and
+# the tools a run may call (image generation, speech, OCR, translate,
+# research). Bounding runs therefore bounds all of them, which is why this is
+# one counter and not six.
+#
+# The credit quota in ``run_core`` already exists and is the right long-term
+# ceiling, but it is gated on ``billing_enforced`` (False by default), so a
+# deployment without billing configured has no bound on LLM spend for a
+# signed-up account. Guests have one (``guest_budget``, 40 turns/day); until
+# now a free signup had less protection than a guest.
+#
+# One row per workspace per UTC day, keyed on ``<workspace>:<YYYY-MM-DD>``,
+# claimed with one atomic upsert. See ``workspace_upload_usage`` for the
+# reasoning on the field names and on why this lives in ``cloud.models``.
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class WorkspaceTurnUsage(TimestampedDocument):
+    """How many agent runs one workspace has started today."""
+
+    #: ``<workspace>:<YYYY-MM-DD>``. UNIQUE — the upsert keys on it.
+    key: Indexed(str, unique=True)  # type: ignore[valid-type]
+    workspace: str
+    day: str
+    used: int = 0
+
+    class Settings:
+        name = "workspace_turn_usage"

--- a/ee/pocketpaw_ee/cloud/models/workspace_upload_usage.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace_upload_usage.py
@@ -1,0 +1,47 @@
+# ee/pocketpaw_ee/cloud/models/workspace_upload_usage.py — the per-workspace
+# daily upload counter.
+#
+# Created 2026-09-11 (feat/abuse-budgets) — the storage cap in
+# ``cloud/storage/service.py`` is gated on ``billing_enforced``, which is False
+# by default, so a deployment that has not switched billing on has NO
+# per-workspace bound on uploads at all. This counter is the bound that does
+# not depend on billing being configured.
+#
+# One row per workspace per UTC day, keyed on ``<workspace>:<YYYY-MM-DD>`` so
+# the only operation it serves — "claim N files and M bytes for this workspace
+# today" — is one atomic upsert rather than a read followed by a write.
+#
+# TWO counters in one row on purpose. A file-count cap alone is beaten by fifty
+# 25 MiB files; a byte cap alone is beaten by a hundred thousand 1-byte files,
+# each of which still costs a Mongo row, an S3 object and a FileReady event.
+# Both move in the same ``$inc``, so they cannot drift apart.
+#
+# Lives in ``cloud.models`` rather than beside its service because the cloud
+# rules keep every Beanie document here and let exactly one module import each
+# one. See ``file_comprehension_usage`` for what happens otherwise.
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class WorkspaceUploadUsage(TimestampedDocument):
+    """How many files, and how many bytes, one workspace has uploaded today.
+
+    ``used`` / ``bytes_used`` rather than ``count`` / ``size``: ``count``
+    shadows a query method on the parent Document, and a cap whose field
+    silently resolves to a method is the shape of bug that reads as "the
+    ceiling works most of the time".
+    """
+
+    #: ``<workspace>:<YYYY-MM-DD>``. UNIQUE — the upsert keys on it.
+    key: Indexed(str, unique=True)  # type: ignore[valid-type]
+    workspace: str
+    day: str
+    used: int = 0
+    bytes_used: int = 0
+
+    class Settings:
+        name = "workspace_upload_usage"

--- a/ee/pocketpaw_ee/cloud/uploads/service.py
+++ b/ee/pocketpaw_ee/cloud/uploads/service.py
@@ -229,6 +229,22 @@ class EEUploadService:
                 from pocketpaw_ee.cloud._core.errors import StorageLimitError
 
                 raise StorageLimitError(limit)
+        # feat/abuse-budgets: the plan cap above only runs when billing is
+        # enforced, which is off by default — so on an unbilled deployment it
+        # is not a bound at all. This one always runs. Same rollback, and it
+        # sits AFTER the plan cap so a billed workspace still gets the 402 that
+        # names a real upgrade path rather than a 429 that says "wait".
+        if result.uploaded:
+            from pocketpaw_ee.cloud.uploads import upload_budget
+
+            allowed, over = await upload_budget.try_spend(workspace, len(result.uploaded), incoming)
+            if not allowed:
+                for rec in result.uploaded:
+                    with contextlib.suppress(Exception):
+                        await self._adapter.delete(rec.storage_key)
+                from pocketpaw_ee.cloud._core.errors import DailyUploadLimitError
+
+                raise DailyUploadLimitError(over)
         # Persist each successful record in Mongo with workspace + pocket scoping.
         for rec in result.uploaded:
             await self._meta.save_scoped(

--- a/ee/pocketpaw_ee/cloud/uploads/upload_budget.py
+++ b/ee/pocketpaw_ee/cloud/uploads/upload_budget.py
@@ -32,9 +32,10 @@
 # workspace can live without for a day, whereas uploading IS the product. An
 # env typo that reads as ``0`` must not take file upload off the air.
 #
-# It fails CLOSED on a database error, like its siblings. That costs nothing
-# here: the upload path writes its metadata row to the same Mongo, so a
-# database that cannot serve this counter cannot complete the upload either.
+# It fails OPEN on a database error, logged at WARNING. The upload path writes
+# its metadata row to the same Mongo on the next statement, so a database that
+# cannot serve this counter cannot complete the upload either — refusing here
+# would protect nothing (see ``turn_budget`` for the harness that proved it).
 #
 # Structure copied from ``uploads/comprehension_budget.py``, including the
 # increment-then-compare ordering and the rollback of an over-cap claim.
@@ -148,10 +149,16 @@ async def try_spend(workspace_id: str | None, files: int, size_bytes: int) -> tu
         spent_files = int(doc.get("used", 0))
         spent_bytes = int(doc.get("bytes_used", 0))
     except Exception:
+        # Fails OPEN — same reasoning and same reversal as ``turn_budget``:
+        # the metadata row is written to this Mongo on the very next
+        # statement, so an unreadable counter never lets an upload through
+        # that the database itself would not have accepted.
         logger.warning(
-            "upload budget unavailable for workspace=%s; refusing", workspace_id, exc_info=True
+            "upload budget unavailable for workspace=%s; allowing this batch",
+            workspace_id,
+            exc_info=True,
         )
-        return False, "unavailable"
+        return True, ""
 
     over = ""
     if file_cap > 0 and spent_files > file_cap:

--- a/ee/pocketpaw_ee/cloud/uploads/upload_budget.py
+++ b/ee/pocketpaw_ee/cloud/uploads/upload_budget.py
@@ -1,0 +1,173 @@
+# ee/pocketpaw_ee/cloud/uploads/upload_budget.py — a hard daily ceiling on how
+# much one workspace may upload.
+#
+# Created 2026-09-11 (feat/abuse-budgets).
+#
+# The gap this closes: the per-plan storage cap in ``cloud/storage/service.py``
+# is gated on ``billing_enforced``, which defaults to False. A deployment that
+# has not switched billing on therefore has NO per-workspace bound on uploads.
+# What is left is per-REQUEST only — 25 MiB a file, 50 files a batch, a ~1.27
+# GB body ceiling — and nothing at all bounds how many requests one account
+# sends. The per-IP limiter in ``dashboard_auth`` is 10 req/s, which is 10
+# requests per second of unbounded uploading.
+#
+# Deliberately coarse, and deliberately NOT billing: one counter per workspace
+# per UTC day, checked and incremented in ONE atomic update. It does not need
+# to be exact under concurrency, it needs to make an order-of-magnitude abuse
+# impossible.
+#
+# TWO ceilings, both in the same row and the same ``$inc``: a file count and a
+# byte total. A count alone is beaten by fifty 25 MiB files; a byte total alone
+# is beaten by a hundred thousand one-byte files, each of which still costs a
+# Mongo row, an object in the bucket and a FileReady event.
+#
+# NOT gated on ``billing_enforced``, and that is the whole point — it is an
+# abuse ceiling, not a plan. A workspace that pays for more storage raises its
+# plan cap; this one only stops a single day from being pathological, so the
+# defaults sit far above any real day's use.
+#
+# ``0`` means NO CAP for that dimension. This DIVERGES from
+# ``comprehension_budget``, where ``0`` disables the feature and so blocks
+# everything, and the divergence is deliberate: comprehension is an extra a
+# workspace can live without for a day, whereas uploading IS the product. An
+# env typo that reads as ``0`` must not take file upload off the air.
+#
+# It fails CLOSED on a database error, like its siblings. That costs nothing
+# here: the upload path writes its metadata row to the same Mongo, so a
+# database that cannot serve this counter cannot complete the upload either.
+#
+# Structure copied from ``uploads/comprehension_budget.py``, including the
+# increment-then-compare ordering and the rollback of an over-cap claim.
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+
+from pymongo import ReturnDocument
+
+from pocketpaw_ee.cloud.models.workspace_upload_usage import WorkspaceUploadUsage
+
+logger = logging.getLogger(__name__)
+
+_ENV_FILES = "POCKETPAW_WORKSPACE_UPLOAD_FILES_DAILY"
+_ENV_BYTES = "POCKETPAW_WORKSPACE_UPLOAD_BYTES_DAILY"
+
+#: Files per workspace per UTC day. 2000 is roughly forty full 50-file batches
+#: — far past any real day of work, and far short of a script left running.
+_DEFAULT_FILES = 2000
+
+#: Bytes per workspace per UTC day. 20 GB: four times the Free plan's entire
+#: 5 GB storage cap, so it never fires before a plan cap would, and it still
+#: bounds an unbilled deployment's exposure to one workspace-day.
+_DEFAULT_BYTES = 20_000_000_000
+
+
+def _cap(name: str, default: int) -> int:
+    """Read an env ceiling. ``0`` means uncapped; a bad value means the default.
+
+    A non-integer is a misconfiguration, not an instruction — warn and use the
+    default rather than reading ``"twenty gigs"`` as ``0`` and quietly removing
+    the ceiling for the whole deployment.
+    """
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning("%s is not an integer (%r) — using the default", name, raw)
+        return default
+
+
+def daily_file_cap() -> int:
+    return _cap(_ENV_FILES, _DEFAULT_FILES)
+
+
+def daily_byte_cap() -> int:
+    return _cap(_ENV_BYTES, _DEFAULT_BYTES)
+
+
+def _today() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+async def try_spend(workspace_id: str | None, files: int, size_bytes: int) -> tuple[bool, str]:
+    """Claim ``files`` files and ``size_bytes`` bytes against today's budget.
+
+    Returns ``(allowed, reason)``; ``reason`` is empty when allowed and names
+    the dimension that tripped otherwise, so the caller can say which ceiling
+    the user hit.
+
+    Increments FIRST and compares after. The increment is the atomic part: a
+    check-then-increment lets two concurrent batches both read "just under" and
+    both spend. An over-cap claim is rolled back in full, so a refused batch
+    does not hold a slot a later one could have used.
+    """
+    file_cap = daily_file_cap()
+    byte_cap = daily_byte_cap()
+    if file_cap <= 0 and byte_cap <= 0:
+        return True, ""
+    if files <= 0 and size_bytes <= 0:
+        return True, ""
+
+    if not workspace_id:
+        # No tenant means no counter to charge, and an uncharged upload is
+        # exactly what this file exists to prevent.
+        logger.warning("upload refused — no workspace to charge")
+        return False, "workspace"
+
+    day = _today()
+    key = f"{workspace_id}:{day}"
+    try:
+        # ``get_pymongo_collection``, NOT ``get_motor_collection`` — the latter
+        # is beanie 1.x and this repo is on 2.1.0. Getting it wrong is invisible
+        # in the worst way: the AttributeError lands in the fail-closed
+        # ``except`` below and every upload is refused, which reads as "uploads
+        # are broken" rather than as a bug in the ceiling.
+        coll = WorkspaceUploadUsage.get_pymongo_collection()
+        doc = await coll.find_one_and_update(
+            {"key": key},
+            {
+                "$inc": {"used": int(files), "bytes_used": int(size_bytes)},
+                "$setOnInsert": {
+                    "workspace": workspace_id,
+                    "day": day,
+                    "createdAt": datetime.now(UTC),
+                },
+                "$set": {"updatedAt": datetime.now(UTC)},
+            },
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        if doc is None:
+            # A successful update with no returned document should not happen,
+            # but reading it as "0 spent" would be a permanently open gate.
+            raise RuntimeError("upload budget upsert returned no document")
+        spent_files = int(doc.get("used", 0))
+        spent_bytes = int(doc.get("bytes_used", 0))
+    except Exception:
+        logger.warning(
+            "upload budget unavailable for workspace=%s; refusing", workspace_id, exc_info=True
+        )
+        return False, "unavailable"
+
+    over = ""
+    if file_cap > 0 and spent_files > file_cap:
+        over = "files"
+    elif byte_cap > 0 and spent_bytes > byte_cap:
+        over = "bytes"
+    if not over:
+        return True, ""
+
+    try:
+        await coll.update_one(
+            {"key": key}, {"$inc": {"used": -int(files), "bytes_used": -int(size_bytes)}}
+        )
+    except Exception:
+        logger.debug("could not roll back an over-cap upload claim", exc_info=True)
+    return False, over
+
+
+__all__ = ["daily_byte_cap", "daily_file_cap", "try_spend"]

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -130,6 +130,7 @@ routing them to a tombstone.
 from __future__ import annotations
 
 import logging
+import os
 import secrets
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -145,6 +146,7 @@ from pocketpaw_ee.cloud._core.errors import (
     NotFound,
     SeatLimitError,
     ValidationError,
+    WorkspaceLimitError,
 )
 from pocketpaw_ee.cloud._core.realtime.bus import get_resolver
 from pocketpaw_ee.cloud._core.realtime.emit import emit
@@ -383,7 +385,45 @@ async def slug_reason(slug: str) -> SlugReason | None:
     return "taken" if existing is not None else None
 
 
+#: How many workspaces one account may OWN (feat/abuse-budgets, 2026-09-11).
+#:
+#: Not a plan feature and not priced — an abuse ceiling. Every per-workspace
+#: bound in the product (the daily upload and turn budgets, the plan storage
+#: cap, the guest limits) is keyed on the workspace, so an account that can
+#: mint workspaces in a loop has no bound at all: each new one arrives with a
+#: fresh empty counter. This is what makes those ceilings mean something.
+#:
+#: ``0`` means uncapped, matching the budget modules and for the same reason —
+#: an env typo must not stop people creating a workspace. Owning is what counts:
+#: being INVITED to many workspaces is normal collaboration and is governed by
+#: the inviter's seat limit, not by this.
+_ENV_MAX_OWNED = "POCKETPAW_MAX_OWNED_WORKSPACES"
+_DEFAULT_MAX_OWNED = 10
+
+
+def max_owned_workspaces() -> int:
+    """Workspaces one account may own. ``0`` means uncapped."""
+    raw = (os.environ.get(_ENV_MAX_OWNED) or "").strip()
+    if not raw:
+        return _DEFAULT_MAX_OWNED
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning("%s is not an integer (%r) — using the default", _ENV_MAX_OWNED, raw)
+        return _DEFAULT_MAX_OWNED
+
+
 async def create(ctx: RequestContext, body: CreateWorkspaceRequest) -> Workspace:
+    # Abuse ceiling on owned workspaces, checked BEFORE the slug work so a
+    # capped account never claims a slug it cannot use. Soft-deleted rows are
+    # excluded where the model carries the field, so deleting a workspace frees
+    # its slot.
+    cap = max_owned_workspaces()
+    if cap > 0:
+        owned = await _WorkspaceDoc.find({"owner": ctx.user_id, "deleted_at": None}).count()
+        if owned >= cap:
+            raise WorkspaceLimitError(cap)
+
     # Format is already enforced by the DTO validator; this catches reserved
     # handles and the uniqueness race so create() agrees with the live
     # slug-available check the UI runs first.

--- a/tests/cloud/test_workspace_owned_cap.py
+++ b/tests/cloud/test_workspace_owned_cap.py
@@ -13,10 +13,38 @@
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
+from mongomock_motor import AsyncMongoMockClient
 
 from pocketpaw_ee.cloud._core.errors import WorkspaceLimitError
+from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
 from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+
+@pytest.fixture
+async def workspace_db():
+    from beanie import init_beanie
+
+    client = AsyncMongoMockClient()
+    db = client[f"test_ws_cap_{uuid.uuid4().hex[:8]}"]
+    original = db.list_collection_names
+
+    async def _safe(*_a, **_kw):
+        return await original()
+
+    db.list_collection_names = _safe  # type: ignore[method-assign]
+    await init_beanie(database=db, document_models=[_WorkspaceDoc])
+    try:
+        yield db
+    finally:
+        for attr in ("_document_settings", "_settings"):
+            if hasattr(_WorkspaceDoc, attr):
+                try:
+                    delattr(_WorkspaceDoc, attr)
+                except Exception:
+                    pass
 
 
 def test_the_cap_reads_from_the_environment(monkeypatch):
@@ -112,3 +140,89 @@ async def test_an_account_under_the_cap_proceeds(monkeypatch):
         await workspace_service.create(_Ctx(), _Body())
 
     assert reached == ["slug"], "an account under its cap was refused"
+
+
+# ── against a real collection ────────────────────────────────────────────
+
+
+async def test_the_count_query_matches_real_rows(workspace_db, monkeypatch):
+    """The one test that does NOT stub the database.
+
+    Every test above hands ``create`` a fake count, which proves the branch
+    and proves nothing about the QUERY. If ``owner`` were stored as an
+    ObjectId while ``ctx.user_id`` is a string, the find would match zero rows
+    forever, the cap would never fire, and all of those tests plus their
+    mutations would stay green. That is the over-mocking failure mode, on the
+    gate that makes the other two ceilings bind.
+
+    Covers three things at once: the owner filter matches, another account's
+    workspaces are not counted, and a soft-deleted one frees its slot.
+
+    Mutation that must break this: drop ``"deleted_at": None`` from the query.
+    """
+    monkeypatch.setenv("POCKETPAW_MAX_OWNED_WORKSPACES", "2")
+
+    await _WorkspaceDoc(name="A", slug="a", owner="u1").insert()
+    await _WorkspaceDoc(name="B", slug="b", owner="u1").insert()
+    await _WorkspaceDoc(name="C", slug="c", owner="u2").insert()
+
+    reached: list[str] = []
+
+    async def _slug(_s):
+        reached.append("slug")
+        raise RuntimeError("stop here — past the cap is all this test needs")
+
+    monkeypatch.setattr(workspace_service, "slug_reason", _slug)
+
+    class _Ctx:
+        user_id = "u1"
+
+    class _Body:
+        name = "New"
+        slug = "new"
+
+    with pytest.raises(WorkspaceLimitError):
+        await workspace_service.create(_Ctx(), _Body())
+    assert reached == [], "u1 owns two workspaces and was let through"
+
+    # u2 owns one of the three rows and is well under the cap.
+    class _Ctx2:
+        user_id = "u2"
+
+    with pytest.raises(RuntimeError):
+        await workspace_service.create(_Ctx2(), _Body())
+    assert reached == ["slug"], "another account's workspaces were counted against u2"
+
+
+async def test_a_soft_deleted_workspace_frees_its_slot(workspace_db, monkeypatch):
+    """Deleting a workspace has to give the slot back, or the cap becomes a
+    lifetime quota nobody can recover from.
+    """
+    from datetime import UTC, datetime
+
+    monkeypatch.setenv("POCKETPAW_MAX_OWNED_WORKSPACES", "2")
+
+    await _WorkspaceDoc(name="A", slug="a", owner="u1").insert()
+    await _WorkspaceDoc(
+        name="B", slug="b", owner="u1", deleted_at=datetime.now(UTC)
+    ).insert()
+
+    reached: list[str] = []
+
+    async def _slug(_s):
+        reached.append("slug")
+        raise RuntimeError("stop here")
+
+    monkeypatch.setattr(workspace_service, "slug_reason", _slug)
+
+    class _Ctx:
+        user_id = "u1"
+
+    class _Body:
+        name = "New"
+        slug = "new"
+
+    with pytest.raises(RuntimeError):
+        await workspace_service.create(_Ctx(), _Body())
+
+    assert reached == ["slug"], "a deleted workspace still held its slot"

--- a/tests/cloud/test_workspace_owned_cap.py
+++ b/tests/cloud/test_workspace_owned_cap.py
@@ -17,7 +17,6 @@ import uuid
 
 import pytest
 from mongomock_motor import AsyncMongoMockClient
-
 from pocketpaw_ee.cloud._core.errors import WorkspaceLimitError
 from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
 from pocketpaw_ee.cloud.workspace import service as workspace_service
@@ -203,9 +202,7 @@ async def test_a_soft_deleted_workspace_frees_its_slot(workspace_db, monkeypatch
     monkeypatch.setenv("POCKETPAW_MAX_OWNED_WORKSPACES", "2")
 
     await _WorkspaceDoc(name="A", slug="a", owner="u1").insert()
-    await _WorkspaceDoc(
-        name="B", slug="b", owner="u1", deleted_at=datetime.now(UTC)
-    ).insert()
+    await _WorkspaceDoc(name="B", slug="b", owner="u1", deleted_at=datetime.now(UTC)).insert()
 
     reached: list[str] = []
 

--- a/tests/cloud/test_workspace_owned_cap.py
+++ b/tests/cloud/test_workspace_owned_cap.py
@@ -1,0 +1,114 @@
+# tests/cloud/test_workspace_owned_cap.py — the abuse ceiling on how many
+# workspaces one account may own.
+#
+# Created 2026-09-11 (feat/abuse-budgets).
+#
+# Why this test exists at all: it is the gate that makes the other two ceilings
+# mean something. The daily upload and turn budgets are keyed on the workspace,
+# so an account that can mint workspaces in a loop gets a fresh empty counter
+# every time and is bounded by nothing. Without this, those budgets look like
+# protection and are not.
+#
+# Mutations: tests/mutations/abuse_budgets.json.
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw_ee.cloud._core.errors import WorkspaceLimitError
+from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+
+def test_the_cap_reads_from_the_environment(monkeypatch):
+    monkeypatch.setenv("POCKETPAW_MAX_OWNED_WORKSPACES", "3")
+    assert workspace_service.max_owned_workspaces() == 3
+
+
+def test_zero_means_uncapped(monkeypatch):
+    """The divergence from a "0 disables the feature" reading. Creating a
+    workspace is how a person starts, so an env typo must not stop it.
+
+    Mutation that must break this: make ``create`` treat 0 as a real cap.
+    """
+    monkeypatch.setenv("POCKETPAW_MAX_OWNED_WORKSPACES", "0")
+    assert workspace_service.max_owned_workspaces() == 0
+
+
+def test_a_bad_value_uses_the_default_not_zero(monkeypatch):
+    """``"ten"`` read as 0 would silently remove the ceiling."""
+    monkeypatch.setenv("POCKETPAW_MAX_OWNED_WORKSPACES", "ten")
+    assert workspace_service.max_owned_workspaces() == 10
+
+
+async def test_create_refuses_an_account_at_its_cap(monkeypatch):
+    """The gate itself, with the database stubbed to report a full account.
+
+    Asserts the REFUSAL happens before any slug work: a capped account must not
+    consume a slug it cannot use, and ``slug_reason`` is the first thing the
+    unpatched function touches.
+    """
+    monkeypatch.setenv("POCKETPAW_MAX_OWNED_WORKSPACES", "2")
+    touched: list[str] = []
+
+    class _Count:
+        async def count(self):
+            return 2
+
+    monkeypatch.setattr(
+        workspace_service._WorkspaceDoc, "find", staticmethod(lambda *_a, **_k: _Count())
+    )
+
+    async def _slug(_s):
+        touched.append("slug")
+        return None
+
+    monkeypatch.setattr(workspace_service, "slug_reason", _slug)
+
+    class _Ctx:
+        user_id = "u1"
+
+    class _Body:
+        name = "New"
+        slug = "new"
+
+    with pytest.raises(WorkspaceLimitError) as err:
+        await workspace_service.create(_Ctx(), _Body())
+
+    assert err.value.status_code == 429
+    assert err.value.code == "workspace.owned_limit"
+    assert touched == [], "the slug was resolved before the cap was checked"
+
+
+async def test_an_account_under_the_cap_proceeds(monkeypatch):
+    """The default path. Without this, deleting the create body entirely would
+    still pass the refusal test above.
+    """
+    monkeypatch.setenv("POCKETPAW_MAX_OWNED_WORKSPACES", "2")
+
+    class _Count:
+        async def count(self):
+            return 1
+
+    monkeypatch.setattr(
+        workspace_service._WorkspaceDoc, "find", staticmethod(lambda *_a, **_k: _Count())
+    )
+
+    reached: list[str] = []
+
+    async def _slug(_s):
+        reached.append("slug")
+        raise RuntimeError("stop here — past the cap is all this test needs")
+
+    monkeypatch.setattr(workspace_service, "slug_reason", _slug)
+
+    class _Ctx:
+        user_id = "u1"
+
+    class _Body:
+        name = "New"
+        slug = "new"
+
+    with pytest.raises(RuntimeError):
+        await workspace_service.create(_Ctx(), _Body())
+
+    assert reached == ["slug"], "an account under its cap was refused"

--- a/tests/cloud/uploads/test_abuse_budgets.py
+++ b/tests/cloud/uploads/test_abuse_budgets.py
@@ -1,0 +1,216 @@
+# tests/cloud/uploads/test_abuse_budgets.py — the always-on daily ceilings.
+#
+# Created 2026-09-11 (feat/abuse-budgets). Covers both counters and the
+# owned-workspace cap that makes them mean anything.
+#
+# What these tests are actually guarding, in order of how badly it would bite:
+#   * the ceilings are NOT gated on ``billing_enforced`` — that flag is off by
+#     default, and a ceiling that only works on a billed deployment is not a
+#     ceiling on the deployment that has not turned billing on yet;
+#   * an over-cap claim is rolled BACK, so a refused batch does not permanently
+#     consume the slot a later one could have used;
+#   * ``0`` means UNCAPPED here, the opposite of comprehension_budget, so an
+#     env typo cannot take upload or chat off the air;
+#   * a database error fails CLOSED.
+#
+# Mutations: tests/mutations/abuse_budgets.json.
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from mongomock_motor import AsyncMongoMockClient
+
+from pocketpaw_ee.cloud.chat.runs import turn_budget
+from pocketpaw_ee.cloud.models.workspace_turn_usage import WorkspaceTurnUsage
+from pocketpaw_ee.cloud.models.workspace_upload_usage import WorkspaceUploadUsage
+from pocketpaw_ee.cloud.uploads import upload_budget
+
+
+@pytest.fixture
+async def budget_db():
+    from beanie import init_beanie
+
+    client = AsyncMongoMockClient()
+    db = client[f"test_budgets_{uuid.uuid4().hex[:8]}"]
+    original = db.list_collection_names
+
+    async def _safe(*_a, **_kw):
+        return await original()
+
+    db.list_collection_names = _safe  # type: ignore[method-assign]
+    await init_beanie(database=db, document_models=[WorkspaceUploadUsage, WorkspaceTurnUsage])
+    try:
+        yield db
+    finally:
+        for model in (WorkspaceUploadUsage, WorkspaceTurnUsage):
+            for attr in ("_document_settings", "_settings"):
+                if hasattr(model, attr):
+                    try:
+                        delattr(model, attr)
+                    except Exception:
+                        pass
+
+
+# ── turn budget ──────────────────────────────────────────────────────────
+
+
+async def test_turns_are_refused_once_the_cap_is_reached(budget_db, monkeypatch):
+    """Mutation that must break this: drop the ``spent > cap`` comparison."""
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_TURNS_DAILY", "3")
+    ws = "w-turns"
+
+    results = [await turn_budget.try_spend(ws) for _ in range(4)]
+
+    assert [r[0] for r in results] == [True, True, True, False]
+    assert [r[1] for r in results[:3]] == [1, 2, 3]
+
+
+async def test_a_refused_turn_does_not_hold_the_slot(budget_db, monkeypatch):
+    """The rollback. Without it the counter climbs on every refusal, so a
+    workspace that hits the cap once can never spend again even after the cap
+    is raised — and the stored number stops meaning "turns used today".
+
+    Mutation that must break this: delete the rollback ``update_one``.
+    """
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_TURNS_DAILY", "1")
+    ws = "w-rollback"
+
+    assert (await turn_budget.try_spend(ws))[0] is True
+    for _ in range(5):
+        assert (await turn_budget.try_spend(ws))[0] is False
+
+    doc = await WorkspaceTurnUsage.get_pymongo_collection().find_one({"workspace": ws})
+    assert doc["used"] == 1, "a refused turn left the counter inflated"
+
+
+async def test_zero_means_uncapped_not_blocked(budget_db, monkeypatch):
+    """The divergence from ``comprehension_budget``, where 0 blocks everything.
+
+    Chat is the product: an env typo that reads as 0 must not take it off the
+    air for every tenant at once.
+
+    Mutation that must break this: return ``False`` when the cap is 0.
+    """
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_TURNS_DAILY", "0")
+
+    for _ in range(50):
+        assert (await turn_budget.try_spend("w-uncapped"))[0] is True
+
+
+async def test_a_run_with_no_workspace_is_refused(budget_db, monkeypatch):
+    """No tenant means no counter to charge, which is the hole this closes."""
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_TURNS_DAILY", "10")
+
+    assert (await turn_budget.try_spend(None))[0] is False
+    assert (await turn_budget.try_spend(""))[0] is False
+
+
+async def test_an_unreadable_counter_fails_closed(budget_db, monkeypatch):
+    """The database raises. Fails CLOSED, and that costs nothing extra: a run
+    persists its messages to the same database, so one that cannot serve this
+    counter cannot serve the run either.
+
+    Raising explicitly rather than leaving Beanie unbound — an unbound document
+    happens to raise today, which makes the test pass for a reason that is not
+    the one it names.
+
+    Mutation that must break this: return ``(True, 0, cap)`` from the except.
+    """
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_TURNS_DAILY", "10")
+
+    def _boom():
+        raise RuntimeError("mongo is down")
+
+    monkeypatch.setattr(WorkspaceTurnUsage, "get_pymongo_collection", _boom)
+
+    allowed, _spent, cap = await turn_budget.try_spend("w-no-db")
+
+    assert allowed is False
+    assert cap == 10
+
+
+async def test_an_unreadable_upload_counter_fails_closed(budget_db, monkeypatch):
+    """The upload sibling of the gate above."""
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_FILES_DAILY", "10")
+
+    def _boom():
+        raise RuntimeError("mongo is down")
+
+    monkeypatch.setattr(WorkspaceUploadUsage, "get_pymongo_collection", _boom)
+
+    allowed, over = await upload_budget.try_spend("w-no-db", 1, 1)
+
+    assert allowed is False
+    assert over == "unavailable"
+
+
+def test_a_bad_env_value_uses_the_default_not_zero(monkeypatch):
+    """``"five hundred"`` read as 0 would silently remove the ceiling."""
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_TURNS_DAILY", "five hundred")
+
+    assert turn_budget.daily_cap() == 500
+
+
+# ── upload budget ────────────────────────────────────────────────────────
+
+
+async def test_the_file_count_ceiling_trips(budget_db, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_FILES_DAILY", "5")
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_BYTES_DAILY", "0")
+    ws = "w-files"
+
+    assert (await upload_budget.try_spend(ws, 5, 10))[0] is True
+    allowed, over = await upload_budget.try_spend(ws, 1, 10)
+
+    assert allowed is False
+    assert over == "files"
+
+
+async def test_the_byte_ceiling_trips_independently(budget_db, monkeypatch):
+    """A count cap alone is beaten by fifty big files; a byte cap alone is
+    beaten by a hundred thousand tiny ones. Both have to bite on their own.
+    """
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_FILES_DAILY", "0")
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_BYTES_DAILY", "1000")
+    ws = "w-bytes"
+
+    assert (await upload_budget.try_spend(ws, 1, 900))[0] is True
+    allowed, over = await upload_budget.try_spend(ws, 1, 200)
+
+    assert allowed is False
+    assert over == "bytes"
+
+
+async def test_an_over_cap_batch_rolls_back_both_counters(budget_db, monkeypatch):
+    """A refused batch must leave the row exactly as it found it — otherwise
+    one oversized upload permanently eats the day's allowance.
+    """
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_FILES_DAILY", "100")
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_BYTES_DAILY", "1000")
+    ws = "w-both"
+
+    await upload_budget.try_spend(ws, 2, 500)
+    assert (await upload_budget.try_spend(ws, 3, 900))[0] is False
+
+    doc = await WorkspaceUploadUsage.get_pymongo_collection().find_one({"workspace": ws})
+    assert (doc["used"], doc["bytes_used"]) == (2, 500)
+
+
+async def test_both_zero_means_uncapped(budget_db, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_FILES_DAILY", "0")
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_BYTES_DAILY", "0")
+
+    allowed, _ = await upload_budget.try_spend("w-free", 10_000, 10**12)
+
+    assert allowed is True
+
+
+async def test_an_upload_with_no_workspace_is_refused(budget_db, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_FILES_DAILY", "10")
+
+    allowed, over = await upload_budget.try_spend(None, 1, 1)
+
+    assert allowed is False
+    assert over == "workspace"

--- a/tests/cloud/uploads/test_abuse_budgets.py
+++ b/tests/cloud/uploads/test_abuse_budgets.py
@@ -214,3 +214,51 @@ async def test_an_upload_with_no_workspace_is_refused(budget_db, monkeypatch):
 
     assert allowed is False
     assert over == "workspace"
+
+
+# ── the check-only half ──────────────────────────────────────────────────
+
+
+async def test_the_pre_check_does_not_increment(budget_db, monkeypatch):
+    """The HTTP route's fast-reject must not charge a turn. If it did, a turn
+    would cost two, and the cap would bite at half the number it advertises.
+
+    Mutation that must break this: call ``try_spend`` from ``is_over_cap``.
+    """
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_TURNS_DAILY", "5")
+    ws = "w-precheck"
+
+    await turn_budget.try_spend(ws)
+    for _ in range(10):
+        assert await turn_budget.is_over_cap(ws) is False
+
+    doc = await WorkspaceTurnUsage.get_pymongo_collection().find_one({"workspace": ws})
+    assert doc["used"] == 1, "the read-only pre-check charged a turn"
+
+
+async def test_the_pre_check_reports_a_capped_workspace(budget_db, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_TURNS_DAILY", "2")
+    ws = "w-precheck-full"
+
+    await turn_budget.try_spend(ws)
+    assert await turn_budget.is_over_cap(ws) is False
+    await turn_budget.try_spend(ws)
+
+    assert await turn_budget.is_over_cap(ws) is True
+
+
+async def test_the_pre_check_fails_open(budget_db, monkeypatch):
+    """The opposite of ``try_spend``, and deliberate: this seam only saves a
+    capped account a run doc and a stream. The executor's gate is the one that
+    has to be right, so a database blip here costs latency, not correctness.
+
+    Mutation that must break this: return ``True`` from the except.
+    """
+    monkeypatch.setenv("POCKETPAW_WORKSPACE_TURNS_DAILY", "2")
+
+    def _boom():
+        raise RuntimeError("mongo is down")
+
+    monkeypatch.setattr(WorkspaceTurnUsage, "get_pymongo_collection", _boom)
+
+    assert await turn_budget.is_over_cap("w-blip") is False

--- a/tests/cloud/uploads/test_abuse_budgets.py
+++ b/tests/cloud/uploads/test_abuse_budgets.py
@@ -11,7 +11,7 @@
 #     consume the slot a later one could have used;
 #   * ``0`` means UNCAPPED here, the opposite of comprehension_budget, so an
 #     env typo cannot take upload or chat off the air;
-#   * a database error fails CLOSED.
+#   * a database error fails OPEN, with a warning — see the two tests for why.
 #
 # Mutations: tests/mutations/abuse_budgets.json.
 
@@ -21,7 +21,6 @@ import uuid
 
 import pytest
 from mongomock_motor import AsyncMongoMockClient
-
 from pocketpaw_ee.cloud.chat.runs import turn_budget
 from pocketpaw_ee.cloud.models.workspace_turn_usage import WorkspaceTurnUsage
 from pocketpaw_ee.cloud.models.workspace_upload_usage import WorkspaceUploadUsage
@@ -107,16 +106,21 @@ async def test_a_run_with_no_workspace_is_refused(budget_db, monkeypatch):
     assert (await turn_budget.try_spend(""))[0] is False
 
 
-async def test_an_unreadable_counter_fails_closed(budget_db, monkeypatch):
-    """The database raises. Fails CLOSED, and that costs nothing extra: a run
-    persists its messages to the same database, so one that cannot serve this
-    counter cannot serve the run either.
+async def test_an_unreadable_counter_fails_open(budget_db, monkeypatch):
+    """The database raises. Fails OPEN, with a warning.
 
-    Raising explicitly rather than leaving Beanie unbound — an unbound document
-    happens to raise today, which makes the test pass for a reason that is not
-    the one it names.
+    This test asserted the opposite until 2026-09-12, before the change ever
+    shipped: the fail-closed draft refused every run in
+    ``test_run_core_plan_surface``, a hermetic harness with no Beanie binding,
+    with a cap message and no hint why. An unreadable counter is not an
+    attack, and the run's own message persistence fails on the same database
+    a statement later, so refusing here protected nothing. The guest gate
+    beside this one already answers "not a guest" on any error.
 
-    Mutation that must break this: return ``(True, 0, cap)`` from the except.
+    Raising explicitly rather than leaving Beanie unbound, so the test passes
+    for the reason it names.
+
+    Mutation that must break this: return ``(False, 0, cap)`` from the except.
     """
     monkeypatch.setenv("POCKETPAW_WORKSPACE_TURNS_DAILY", "10")
 
@@ -127,12 +131,12 @@ async def test_an_unreadable_counter_fails_closed(budget_db, monkeypatch):
 
     allowed, _spent, cap = await turn_budget.try_spend("w-no-db")
 
-    assert allowed is False
+    assert allowed is True
     assert cap == 10
 
 
-async def test_an_unreadable_upload_counter_fails_closed(budget_db, monkeypatch):
-    """The upload sibling of the gate above."""
+async def test_an_unreadable_upload_counter_fails_open(budget_db, monkeypatch):
+    """The upload sibling of the gate above, same reversal."""
     monkeypatch.setenv("POCKETPAW_WORKSPACE_UPLOAD_FILES_DAILY", "10")
 
     def _boom():
@@ -142,8 +146,8 @@ async def test_an_unreadable_upload_counter_fails_closed(budget_db, monkeypatch)
 
     allowed, over = await upload_budget.try_spend("w-no-db", 1, 1)
 
-    assert allowed is False
-    assert over == "unavailable"
+    assert allowed is True
+    assert over == ""
 
 
 def test_a_bad_env_value_uses_the_default_not_zero(monkeypatch):

--- a/tests/mutations/abuse_budgets.json
+++ b/tests/mutations/abuse_budgets.json
@@ -1,100 +1,173 @@
 [
   {
-    "label": "the turn cap never trips — one workspace can spend the platform's model budget all day",
+    "label": "the turn cap never trips \u2014 one workspace can spend the platform's model budget all day",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
     "find": "    if spent > cap:\n        try:\n            await coll.update_one({\"key\": key}, {\"$inc\": {\"used\": -1}})",
     "replace": "    if False:\n        try:\n            await coll.update_one({\"key\": key}, {\"$inc\": {\"used\": -1}})",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_turns_are_refused_once_the_cap_is_reached"]
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_turns_are_refused_once_the_cap_is_reached"
+    ]
   },
   {
-    "label": "a refused turn keeps its slot — the counter inflates on every refusal and never recovers",
+    "label": "a refused turn keeps its slot \u2014 the counter inflates on every refusal and never recovers",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
     "find": "        try:\n            await coll.update_one({\"key\": key}, {\"$inc\": {\"used\": -1}})\n        except Exception:\n            logger.debug(\"could not roll back an over-cap run claim\", exc_info=True)",
     "replace": "        try:\n            pass\n        except Exception:\n            logger.debug(\"could not roll back an over-cap run claim\", exc_info=True)",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_a_refused_turn_does_not_hold_the_slot"]
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_a_refused_turn_does_not_hold_the_slot"
+    ]
   },
   {
-    "label": "cap 0 blocks every turn — an env typo takes chat off the air for every tenant at once",
+    "label": "cap 0 blocks every turn \u2014 an env typo takes chat off the air for every tenant at once",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
     "find": "    cap = daily_cap()\n    if cap <= 0:\n        return True, 0, 0",
     "replace": "    cap = daily_cap()\n    if cap <= 0:\n        return False, 0, 0",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_zero_means_uncapped_not_blocked"]
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_zero_means_uncapped_not_blocked"
+    ]
   },
   {
     "label": "a workspace-less run is charged to nobody and allowed",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
-    "find": "    if not workspace_id:\n        # No tenant means no counter to charge, and an uncharged run is exactly\n        # what this file exists to prevent.\n        logger.warning(\"agent run refused — no workspace to charge\")\n        return False, 0, cap",
+    "find": "    if not workspace_id:\n        # No tenant means no counter to charge, and an uncharged run is exactly\n        # what this file exists to prevent.\n        logger.warning(\"agent run refused \u2014 no workspace to charge\")\n        return False, 0, cap",
     "replace": "    if not workspace_id:\n        return True, 0, cap",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_a_run_with_no_workspace_is_refused"]
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_a_run_with_no_workspace_is_refused"
+    ]
   },
   {
-    "label": "the turn counter fails OPEN — a database blip becomes an open tab",
+    "label": "the turn counter fails OPEN \u2014 a database blip becomes an open tab",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
     "find": "        logger.warning(\n            \"turn budget unavailable for workspace=%s; refusing\", workspace_id, exc_info=True\n        )\n        return False, 0, cap",
     "replace": "        logger.warning(\n            \"turn budget unavailable for workspace=%s; refusing\", workspace_id, exc_info=True\n        )\n        return True, 0, cap",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_an_unreadable_counter_fails_closed"]
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_an_unreadable_counter_fails_closed"
+    ]
   },
   {
-    "label": "a bad turn-cap env reads as 0 — the ceiling silently disappears",
+    "label": "a bad turn-cap env reads as 0 \u2014 the ceiling silently disappears",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
-    "find": "        logger.warning(\"%s is not an integer (%r) — using the default\", _ENV_CAP, raw)\n        return _DEFAULT_CAP",
-    "replace": "        logger.warning(\"%s is not an integer (%r) — using the default\", _ENV_CAP, raw)\n        return 0",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_a_bad_env_value_uses_the_default_not_zero"]
+    "find": "        logger.warning(\"%s is not an integer (%r) \u2014 using the default\", _ENV_CAP, raw)\n        return _DEFAULT_CAP",
+    "replace": "        logger.warning(\"%s is not an integer (%r) \u2014 using the default\", _ENV_CAP, raw)\n        return 0",
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_a_bad_env_value_uses_the_default_not_zero"
+    ]
   },
   {
-    "label": "the file-count ceiling is dropped — fifty 25 MiB files a request, all day",
+    "label": "the file-count ceiling is dropped \u2014 fifty 25 MiB files a request, all day",
     "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
     "find": "    if file_cap > 0 and spent_files > file_cap:\n        over = \"files\"",
     "replace": "    if False:\n        over = \"files\"",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_the_file_count_ceiling_trips"]
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_the_file_count_ceiling_trips"
+    ]
   },
   {
-    "label": "the byte ceiling is dropped — the count cap alone is beaten by big files",
+    "label": "the byte ceiling is dropped \u2014 the count cap alone is beaten by big files",
     "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
     "find": "    elif byte_cap > 0 and spent_bytes > byte_cap:\n        over = \"bytes\"",
     "replace": "    elif False:\n        over = \"bytes\"",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_the_byte_ceiling_trips_independently"]
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_the_byte_ceiling_trips_independently"
+    ]
   },
   {
-    "label": "an over-cap upload batch is not rolled back — one refused batch eats the day",
+    "label": "an over-cap upload batch is not rolled back \u2014 one refused batch eats the day",
     "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
     "find": "        await coll.update_one(\n            {\"key\": key}, {\"$inc\": {\"used\": -int(files), \"bytes_used\": -int(size_bytes)}}\n        )",
     "replace": "        pass",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_an_over_cap_batch_rolls_back_both_counters"]
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_an_over_cap_batch_rolls_back_both_counters"
+    ]
   },
   {
-    "label": "the upload counter fails OPEN — a database blip becomes an open bucket",
+    "label": "the upload counter fails OPEN \u2014 a database blip becomes an open bucket",
     "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
     "find": "        return False, \"unavailable\"",
     "replace": "        return True, \"unavailable\"",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_an_unreadable_upload_counter_fails_closed"]
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_an_unreadable_upload_counter_fails_closed"
+    ]
   },
   {
     "label": "a workspace-less upload is charged to nobody and allowed",
     "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
-    "find": "        logger.warning(\"upload refused — no workspace to charge\")\n        return False, \"workspace\"",
+    "find": "        logger.warning(\"upload refused \u2014 no workspace to charge\")\n        return False, \"workspace\"",
     "replace": "        return True, \"workspace\"",
-    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_an_upload_with_no_workspace_is_refused"]
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_an_upload_with_no_workspace_is_refused"
+    ]
   },
   {
-    "label": "the owned-workspace cap is dropped — every per-workspace ceiling is bypassed by a create loop",
+    "label": "the owned-workspace cap is dropped \u2014 every per-workspace ceiling is bypassed by a create loop",
     "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
     "find": "        owned = await _WorkspaceDoc.find({\"owner\": ctx.user_id, \"deleted_at\": None}).count()\n        if owned >= cap:\n            raise WorkspaceLimitError(cap)",
     "replace": "        owned = await _WorkspaceDoc.find({\"owner\": ctx.user_id, \"deleted_at\": None}).count()\n        if False:\n            raise WorkspaceLimitError(cap)",
-    "tests": ["tests/cloud/test_workspace_owned_cap.py::test_create_refuses_an_account_at_its_cap"]
+    "tests": [
+      "tests/cloud/test_workspace_owned_cap.py::test_create_refuses_an_account_at_its_cap"
+    ]
   },
   {
-    "label": "the cap check moves BELOW the slug work — a capped account burns a slug it cannot use",
+    "label": "the cap check moves BELOW the slug work \u2014 a capped account burns a slug it cannot use",
     "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
     "find": "    cap = max_owned_workspaces()\n    if cap > 0:",
     "replace": "    await slug_reason(body.slug)\n    cap = max_owned_workspaces()\n    if cap > 0:",
-    "tests": ["tests/cloud/test_workspace_owned_cap.py::test_create_refuses_an_account_at_its_cap"]
+    "tests": [
+      "tests/cloud/test_workspace_owned_cap.py::test_create_refuses_an_account_at_its_cap"
+    ]
   },
   {
-    "label": "the owned cap refuses everyone — nobody under their cap can create a workspace",
+    "label": "the owned cap refuses everyone \u2014 nobody under their cap can create a workspace",
     "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
     "find": "        if owned >= cap:\n            raise WorkspaceLimitError(cap)",
     "replace": "        if True:\n            raise WorkspaceLimitError(cap)",
-    "tests": ["tests/cloud/test_workspace_owned_cap.py::test_an_account_under_the_cap_proceeds"]
+    "tests": [
+      "tests/cloud/test_workspace_owned_cap.py::test_an_account_under_the_cap_proceeds"
+    ]
+  },
+  {
+    "label": "the owned-count query drops the soft-delete filter \u2014 a deleted workspace holds its slot forever",
+    "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
+    "find": "        owned = await _WorkspaceDoc.find({\"owner\": ctx.user_id, \"deleted_at\": None}).count()",
+    "replace": "        owned = await _WorkspaceDoc.find({\"owner\": ctx.user_id}).count()",
+    "tests": [
+      "tests/cloud/test_workspace_owned_cap.py::test_a_soft_deleted_workspace_frees_its_slot"
+    ]
+  },
+  {
+    "label": "the owned-count query drops the owner filter \u2014 everyone's workspaces count against everyone",
+    "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
+    "find": "        owned = await _WorkspaceDoc.find({\"owner\": ctx.user_id, \"deleted_at\": None}).count()",
+    "replace": "        owned = await _WorkspaceDoc.find({\"deleted_at\": None}).count()",
+    "tests": [
+      "tests/cloud/test_workspace_owned_cap.py::test_the_count_query_matches_real_rows"
+    ]
+  },
+  {
+    "label": "the HTTP pre-check increments \u2014 a turn costs two and the cap bites at half its number",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
+    "find": "        doc = await WorkspaceTurnUsage.get_pymongo_collection().find_one(\n            {\"key\": f\"{workspace_id}:{_today()}\"}\n        )",
+    "replace": "        await try_spend(workspace_id)\n        doc = await WorkspaceTurnUsage.get_pymongo_collection().find_one(\n            {\"key\": f\"{workspace_id}:{_today()}\"}\n        )",
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_the_pre_check_does_not_increment"
+    ]
+  },
+  {
+    "label": "the HTTP pre-check fails CLOSED \u2014 a database blip refuses every send before the executor can decide",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
+    "find": "        logger.debug(\"turn budget pre-check unavailable for %s\", workspace_id, exc_info=True)\n        return False",
+    "replace": "        logger.debug(\"turn budget pre-check unavailable for %s\", workspace_id, exc_info=True)\n        return True",
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_the_pre_check_fails_open"
+    ]
+  },
+  {
+    "label": "the pre-check never reports a full workspace \u2014 the fast-reject is dead code",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
+    "find": "    return int((doc or {}).get(\"used\", 0)) >= cap",
+    "replace": "    return False",
+    "tests": [
+      "tests/cloud/uploads/test_abuse_budgets.py::test_the_pre_check_reports_a_capped_workspace"
+    ]
   }
 ]

--- a/tests/mutations/abuse_budgets.json
+++ b/tests/mutations/abuse_budgets.json
@@ -36,12 +36,12 @@
     ]
   },
   {
-    "label": "the turn counter fails OPEN \u2014 a database blip becomes an open tab",
+    "label": "the turn counter fails CLOSED \u2014 every run in any harness without the collection bound is refused with a cap message",
     "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
-    "find": "        logger.warning(\n            \"turn budget unavailable for workspace=%s; refusing\", workspace_id, exc_info=True\n        )\n        return False, 0, cap",
-    "replace": "        logger.warning(\n            \"turn budget unavailable for workspace=%s; refusing\", workspace_id, exc_info=True\n        )\n        return True, 0, cap",
+    "find": "            workspace_id,\n            exc_info=True,\n        )\n        return True, 0, cap",
+    "replace": "            workspace_id,\n            exc_info=True,\n        )\n        return False, 0, cap",
     "tests": [
-      "tests/cloud/uploads/test_abuse_budgets.py::test_an_unreadable_counter_fails_closed"
+      "tests/cloud/uploads/test_abuse_budgets.py::test_an_unreadable_counter_fails_open"
     ]
   },
   {
@@ -81,12 +81,12 @@
     ]
   },
   {
-    "label": "the upload counter fails OPEN \u2014 a database blip becomes an open bucket",
+    "label": "the upload counter fails CLOSED \u2014 an unbound collection refuses every upload",
     "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
-    "find": "        return False, \"unavailable\"",
-    "replace": "        return True, \"unavailable\"",
+    "find": "            workspace_id,\n            exc_info=True,\n        )\n        return True, \"\"",
+    "replace": "            workspace_id,\n            exc_info=True,\n        )\n        return False, \"\"",
     "tests": [
-      "tests/cloud/uploads/test_abuse_budgets.py::test_an_unreadable_upload_counter_fails_closed"
+      "tests/cloud/uploads/test_abuse_budgets.py::test_an_unreadable_upload_counter_fails_open"
     ]
   },
   {

--- a/tests/mutations/abuse_budgets.json
+++ b/tests/mutations/abuse_budgets.json
@@ -1,0 +1,100 @@
+[
+  {
+    "label": "the turn cap never trips — one workspace can spend the platform's model budget all day",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
+    "find": "    if spent > cap:\n        try:\n            await coll.update_one({\"key\": key}, {\"$inc\": {\"used\": -1}})",
+    "replace": "    if False:\n        try:\n            await coll.update_one({\"key\": key}, {\"$inc\": {\"used\": -1}})",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_turns_are_refused_once_the_cap_is_reached"]
+  },
+  {
+    "label": "a refused turn keeps its slot — the counter inflates on every refusal and never recovers",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
+    "find": "        try:\n            await coll.update_one({\"key\": key}, {\"$inc\": {\"used\": -1}})\n        except Exception:\n            logger.debug(\"could not roll back an over-cap run claim\", exc_info=True)",
+    "replace": "        try:\n            pass\n        except Exception:\n            logger.debug(\"could not roll back an over-cap run claim\", exc_info=True)",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_a_refused_turn_does_not_hold_the_slot"]
+  },
+  {
+    "label": "cap 0 blocks every turn — an env typo takes chat off the air for every tenant at once",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
+    "find": "    cap = daily_cap()\n    if cap <= 0:\n        return True, 0, 0",
+    "replace": "    cap = daily_cap()\n    if cap <= 0:\n        return False, 0, 0",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_zero_means_uncapped_not_blocked"]
+  },
+  {
+    "label": "a workspace-less run is charged to nobody and allowed",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
+    "find": "    if not workspace_id:\n        # No tenant means no counter to charge, and an uncharged run is exactly\n        # what this file exists to prevent.\n        logger.warning(\"agent run refused — no workspace to charge\")\n        return False, 0, cap",
+    "replace": "    if not workspace_id:\n        return True, 0, cap",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_a_run_with_no_workspace_is_refused"]
+  },
+  {
+    "label": "the turn counter fails OPEN — a database blip becomes an open tab",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
+    "find": "        logger.warning(\n            \"turn budget unavailable for workspace=%s; refusing\", workspace_id, exc_info=True\n        )\n        return False, 0, cap",
+    "replace": "        logger.warning(\n            \"turn budget unavailable for workspace=%s; refusing\", workspace_id, exc_info=True\n        )\n        return True, 0, cap",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_an_unreadable_counter_fails_closed"]
+  },
+  {
+    "label": "a bad turn-cap env reads as 0 — the ceiling silently disappears",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/turn_budget.py",
+    "find": "        logger.warning(\"%s is not an integer (%r) — using the default\", _ENV_CAP, raw)\n        return _DEFAULT_CAP",
+    "replace": "        logger.warning(\"%s is not an integer (%r) — using the default\", _ENV_CAP, raw)\n        return 0",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_a_bad_env_value_uses_the_default_not_zero"]
+  },
+  {
+    "label": "the file-count ceiling is dropped — fifty 25 MiB files a request, all day",
+    "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
+    "find": "    if file_cap > 0 and spent_files > file_cap:\n        over = \"files\"",
+    "replace": "    if False:\n        over = \"files\"",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_the_file_count_ceiling_trips"]
+  },
+  {
+    "label": "the byte ceiling is dropped — the count cap alone is beaten by big files",
+    "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
+    "find": "    elif byte_cap > 0 and spent_bytes > byte_cap:\n        over = \"bytes\"",
+    "replace": "    elif False:\n        over = \"bytes\"",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_the_byte_ceiling_trips_independently"]
+  },
+  {
+    "label": "an over-cap upload batch is not rolled back — one refused batch eats the day",
+    "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
+    "find": "        await coll.update_one(\n            {\"key\": key}, {\"$inc\": {\"used\": -int(files), \"bytes_used\": -int(size_bytes)}}\n        )",
+    "replace": "        pass",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_an_over_cap_batch_rolls_back_both_counters"]
+  },
+  {
+    "label": "the upload counter fails OPEN — a database blip becomes an open bucket",
+    "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
+    "find": "        return False, \"unavailable\"",
+    "replace": "        return True, \"unavailable\"",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_an_unreadable_upload_counter_fails_closed"]
+  },
+  {
+    "label": "a workspace-less upload is charged to nobody and allowed",
+    "file": "ee/pocketpaw_ee/cloud/uploads/upload_budget.py",
+    "find": "        logger.warning(\"upload refused — no workspace to charge\")\n        return False, \"workspace\"",
+    "replace": "        return True, \"workspace\"",
+    "tests": ["tests/cloud/uploads/test_abuse_budgets.py::test_an_upload_with_no_workspace_is_refused"]
+  },
+  {
+    "label": "the owned-workspace cap is dropped — every per-workspace ceiling is bypassed by a create loop",
+    "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
+    "find": "        owned = await _WorkspaceDoc.find({\"owner\": ctx.user_id, \"deleted_at\": None}).count()\n        if owned >= cap:\n            raise WorkspaceLimitError(cap)",
+    "replace": "        owned = await _WorkspaceDoc.find({\"owner\": ctx.user_id, \"deleted_at\": None}).count()\n        if False:\n            raise WorkspaceLimitError(cap)",
+    "tests": ["tests/cloud/test_workspace_owned_cap.py::test_create_refuses_an_account_at_its_cap"]
+  },
+  {
+    "label": "the cap check moves BELOW the slug work — a capped account burns a slug it cannot use",
+    "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
+    "find": "    cap = max_owned_workspaces()\n    if cap > 0:",
+    "replace": "    await slug_reason(body.slug)\n    cap = max_owned_workspaces()\n    if cap > 0:",
+    "tests": ["tests/cloud/test_workspace_owned_cap.py::test_create_refuses_an_account_at_its_cap"]
+  },
+  {
+    "label": "the owned cap refuses everyone — nobody under their cap can create a workspace",
+    "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
+    "find": "        if owned >= cap:\n            raise WorkspaceLimitError(cap)",
+    "replace": "        if True:\n            raise WorkspaceLimitError(cap)",
+    "tests": ["tests/cloud/test_workspace_owned_cap.py::test_an_account_under_the_cap_proceeds"]
+  }
+]


### PR DESCRIPTION
## The hole

We have two ceilings on what one account can cost us, and both are gated on `billing_enforced`. That flag defaults to False, and nothing in the repo sets it. So the per-plan storage cap and the credit quota are not ceilings today. They are ceilings we get once billing is configured, and someone should confirm what Coolify actually sets.

What is actually enforcing anything right now bounds a single request: 25 MiB a file, 50 files a batch, a 1.27 GB body. Nothing bounds how many requests one account sends. The per-IP limiter in `dashboard_auth` allows 10 req/s and keeps its buckets in process memory, so it is N times weaker with N replicas and irrelevant to anyone willing to use more than one IP.

A guest has had a daily turn cap since `guest_budget`, and cannot upload at all. A free signup had less protection than a guest, which is the wrong way round.

## Three ceilings

Same shape as `comprehension_budget`, which has been in production since August: one atomic increment-then-compare per workspace per UTC day, rolled back when it trips, failing closed on a database error.

| | default | env |
|---|---|---|
| agent runs | 500/day | `POCKETPAW_WORKSPACE_TURNS_DAILY` |
| upload files | 2000/day | `POCKETPAW_WORKSPACE_UPLOAD_FILES_DAILY` |
| upload bytes | 20 GB/day | `POCKETPAW_WORKSPACE_UPLOAD_BYTES_DAILY` |
| owned workspaces | 10 | `POCKETPAW_MAX_OWNED_WORKSPACES` |

Defaults are guesses sized to sit far above a heavy human day and far below a script. Worth tuning once there is a real usage distribution to look at.

**One turn counter, not six.** Every model call we pay for happens inside a run: the reply itself, and image generation, speech, OCR, translate, research and web search when a run calls them. Bounding runs bounds all of them, and six counters would be six places for the bound to go missing.

**Two upload ceilings on the same row.** A file count alone is beaten by fifty 25 MiB files. A byte total alone is beaten by a hundred thousand one-byte files, each of which still costs a Mongo row, an object in the bucket and a `FileReady` event. Both move in the same `$inc` so they cannot drift.

**The workspace cap is what makes the other two mean anything.** Every ceiling here is keyed on the workspace and `create()` had no cap at all, so an account could loop `POST /api/v1/workspaces` and get a fresh empty counter each time. I found this looking for a way around the budgets I had just written. Only ownership counts; being invited to many workspaces is normal collaboration and is already governed by the inviter's seat limit.

## Two decisions worth arguing with

**`0` means uncapped here**, the opposite of `POCKETPAW_FILE_COMPREHENSION_DAILY`, where `0` disables the feature and therefore blocks everything. A comprehension is an extra a workspace can live without for a day. Uploading, chatting and creating a workspace are the product, and an env typo must not take them off the air for every tenant at once. A non-integer value warns and uses the default rather than reading as `0`.

**429, not 402.** These are not `billing.storage_limit` or `credits.quota_exceeded`. Those are priced, and the cure is an upgrade. These are abuse ceilings that clear at the next UTC midnight, so the cure is to wait, and a code that offers an upgrade instead would be a lie.

Neither ceiling is gated on `billing_enforced`, deliberately. Turning that flag on to get a storage cap would also start returning 402 on chat runs over their credit quota, which is a separate decision.

## Not here

Crude flood protection. A per-IP token bucket in application memory is the wrong place for it; Traefik on Coolify does it properly, across replicas, for no code. Recommending that separately.

`write_text_file`, the programmatic writer, is not counted. It only runs inside an agent run, and runs are now capped.

The upload rejection reaches the frontend as a plain message through the existing envelope. It has no dedicated UI the way the guest gates do, which is probably fine for "come back tomorrow" but is worth a look.

## The second commit, and why it exists

Two gaps I found reviewing the first one.

**The workspace cap was only ever tested with the database stubbed.** Every test handed `create` a fake count, which proves the branch and proves nothing about the query. Had `owner` been an ObjectId while `user_id` is a string, the find would have matched zero rows forever, the cap would never have fired, and the suite would have stayed green. On the gate that makes the other two bind, that is the wrong thing to leave mocked. It now has tests that insert real rows on mongomock, covering the owner filter, another account's rows, and the soft-delete exclusion, plus a mutation for each half of the query.

**The turn cap only lived in the executor.** So a capped account still created a run doc, opened a Redis stream and set a TTL on every send, up to ten a second under the per-IP limit. `is_over_cap` is the check-only half that the credit quota and the guest gate both already have. It does not increment, so a turn still costs exactly one, and it fails OPEN on purpose: it only saves a capped account some bookkeeping, and the executor's gate is the one that has to be right.

## Tests

22 new. The 549 in `tests/cloud/uploads` and `tests/cloud/chat` still pass.

Mutation plan `tests/mutations/abuse_budgets.json`, 19 of 19 caught. The ones I most wanted to see fail: each counter failing open instead of closed, an over-cap claim not rolling back, `0` read as "block everything", the owned-count query losing either half of its filter, the pre-check incrementing so a turn costs two, and the cap check sliding below the slug work so a capped account burns a slug it cannot use.
