### PR TITLE
A signed-up kiosk turn brings its own key too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,21 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   Refusal is 402 `billing.storage_limit`.
   Not to be confused with `POCKETPAW_WORKSPACE_UPLOAD_BYTES_DAILY` above: that
   bounds throughput per day, this bounds total stored bytes.
+- **Kiosk BYOK gate (`POCKETPAW_OTHER_HAND_REQUIRE_BYOK`)**: default OFF. When
+  on, a SIGNED-UP user on the Otherhand surface must have their own provider
+  key and gets no platform fallback, refused with 402 `byok_key_required`.
+  Guests already have this rule unconditionally (`guest_key_required`,
+  feat/byok-guest-backend) and are untouched — two rules, two codes, because a
+  guest is told to create an account and an account is told to add a key.
+  Scoped to the SURFACE, never the workspace: the same deployment serves the
+  full Paw OS, where the platform fallback is the product, so a workspace-wide
+  gate would take chat off the air for every non-kiosk user the moment the
+  variable is set. The surface is read from the server-resolved
+  `ctx.surface_context`; the fast-reject in `agent_router` reads the
+  client-supplied hint and is therefore UX only, with the executor
+  (`run_core._requires_own_key`) as the enforcement. Exists for the window
+  between launching the kiosk and switching billing on; remove the variable to
+  revert.
 - **Concurrency / capacity config**: five ceilings that are easy to confuse. In a
   cloud deploy the first two are the ones that bound how much work executes at once.
   `POCKETPAW_ARQ_MAX_JOBS` (default `10`, arq's own) — the **chat lane's** ceiling:

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -195,6 +195,29 @@ class GuestUploadForbidden(CloudError):
         return base
 
 
+class ByokKeyRequired(CloudError):
+    """A signed-up kiosk turn found no usable BYOK key (402, ``byok_key_required``).
+
+    Added 2026-09-12 (feat/kiosk-require-byok). The account sibling of
+    ``GuestKeyRequired``, and deliberately a DIFFERENT code: a guest is told to
+    create an account, while someone who already has one must be told to add a
+    key. Reusing the guest code would show a logged-in user a "create an
+    account" prompt, which is the kind of dead end that reads as a broken
+    product rather than a missing setting.
+
+    Only ever raised on the Otherhand surface, and only while
+    ``other_hand_require_byok`` is on — the window between launching the kiosk
+    and switching billing on. Everywhere else the platform fallback stands.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            402,
+            "byok_key_required",
+            "Add your own API key in Settings to keep going.",
+        )
+
+
 class GuestKeyRequired(CloudError):
     """A guest turn found no usable BYOK key (402, ``guest_key_required``).
 
@@ -544,6 +567,7 @@ def with_cause(error: CloudError, cause: BaseException) -> CloudError:
 
 
 __all__ = [
+    "ByokKeyRequired",
     "GuestKeyRequired",
     "GuestLimitError",
     "GuestUploadForbidden",

--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -109,6 +109,41 @@ SITES_REFINE_HISTORY_TURNS = 2
 _SITES_REFINE_HISTORY_ROWS = 2 * SITES_REFINE_HISTORY_TURNS
 
 
+async def _assert_own_key_if_kiosk_requires_it(ctx: Any) -> None:
+    """Raise ``ByokKeyRequired`` when the kiosk needs a key this account lacks.
+
+    A CHECK, never a spend, and a convenience rather than a control: the
+    surface it reads was resolved from a client-supplied hint, so omitting the
+    hint skips it. ``run_core._requires_own_key`` is the gate that decides,
+    from the server-side context, and it runs on every path into the executor.
+
+    Guests are left alone here: ``assert_guest_turn_allowed`` above already
+    refused a keyless guest with their own code, and answering them twice with
+    two different codes would make the prompt flicker between "create an
+    account" and "add a key".
+    """
+    from pocketpaw.config import get_settings
+
+    if not get_settings().other_hand_require_byok:
+        return
+    sc = getattr(ctx, "surface_context", None)
+    if sc is None or sc.kind is not SurfaceKind.OTHER_HAND:
+        return
+
+    from pocketpaw_ee.cloud.auth import guest_budget
+
+    if await guest_budget.load_guest(ctx.user_id) is not None:
+        return
+
+    from pocketpaw_ee.cloud.byok import service as byok_service
+
+    status = await byok_service.get_status(ctx.workspace_id)
+    if not getattr(status, "configured", False):
+        from pocketpaw_ee.cloud._core.errors import ByokKeyRequired
+
+        raise ByokKeyRequired()
+
+
 def _is_sites_refine_surface(surface_context: SurfaceContext | None) -> bool:
     """True only for the /sites EDIT/REFINE chat surface.
 
@@ -249,6 +284,16 @@ async def post_agent_chat(
         user_id,
         {"surface": body.surface, "meta": body.surface_meta or {}},
     )
+
+    # Kiosk BYOK fast-reject (2026-09-12). UX ONLY — see the docstring.
+    #
+    # The browser gets a clean pre-stream 402 with the code the key prompt
+    # keys on, instead of a run doc whose first frame is an error. But the
+    # surface here comes from ``body.surface``, which the CLIENT sends, so a
+    # caller that simply omits it walks straight past this. The enforcement
+    # lives in the executor (``run_core._requires_own_key``), which reads the
+    # server-resolved context. Never move the gate here and delete that one.
+    await _assert_own_key_if_kiosk_requires_it(ctx)
 
     # Supersede any prior in-flight run for this scope. ``request_cancel``
     # writes the cancel flag in Redis so a worker in another process notices.

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1797,6 +1797,27 @@ async def _drive_agent_loop(
                     },
                 )
                 return
+            # Kiosk: an ACCOUNT must bring its own key too (2026-09-12).
+            #
+            # A sibling of the guest rule above, not a widening of it. The
+            # guest rule is unconditional and permanent; this one is
+            # flag-gated and scoped to ONE surface, for the window between
+            # launching the kiosk and switching billing on. Two rules, two
+            # codes: a guest is told to create an account, an account is told
+            # to add a key, and telling a logged-in user to sign up again is a
+            # dead end that reads as a broken product.
+            #
+            # The surface comes from ``ctx.surface_context``, resolved
+            # SERVER-side after scope resolution — not from the request body.
+            # A client-supplied surface would make a surface-scoped gate
+            # opt-out by omission. This is the enforcement seam; the router's
+            # fast-reject is UX only.
+            if _requires_own_key(ctx):
+                from pocketpaw_ee.cloud._core.errors import ByokKeyRequired
+
+                _exc = ByokKeyRequired()
+                yield ("error", {"code": _exc.code, "message": _exc.message})
+                return
         # --- Supervised native-resume wiring (feat/session-supervisor SS-5) -----
         # Flag-gated (default OFF). When ON, route this turn through the
         # SessionSupervisor: recover any prior native ``cli_session_id`` from the
@@ -2333,6 +2354,29 @@ async def _reject_if_over_daily_turns(spec: RunSpec, ctx: ScopeContext, transpor
     except Exception:
         logger.debug("turn-cap stream ttl set failed for %s", spec.run_id, exc_info=True)
     return True
+
+
+def _requires_own_key(ctx: ScopeContext) -> bool:
+    """Must THIS turn pay with the user's own key, having found none?
+
+    True only when every one of these holds, and the order is the cheap checks
+    first so an ordinary turn on any other surface pays one boolean:
+
+    * ``other_hand_require_byok`` is on (default OFF, so every existing deploy
+      and the whole of Paw OS are untouched until an operator sets it);
+    * the run resolved to the Otherhand surface, read from the SERVER-side
+      ``surface_context`` rather than anything the client sent.
+
+    Guests never reach here — the branch above already refused them, with
+    their own code. Callers reach this only after credential resolution came
+    back ``platform``.
+    """
+    from pocketpaw.config import get_settings
+
+    if not get_settings().other_hand_require_byok:
+        return False
+    sc = ctx.surface_context
+    return sc is not None and sc.kind is SurfaceKind.OTHER_HAND
 
 
 async def _reject_if_over_credit_quota(spec: RunSpec, ctx: ScopeContext, transport: Any) -> bool:

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1305,6 +1305,22 @@ class Settings(BaseSettings):
             "AgentRouter.create_isolated_backend."
         ),
     )
+    other_hand_require_byok: bool = Field(
+        default=False,
+        description=(
+            "Otherhand/kiosk only: a SIGNED-UP user must also bring their own "
+            "provider key, with no platform fallback. Guests are already "
+            "refused a keyless turn unconditionally (guest_key_required); this "
+            "extends the same rule to accounts on that ONE surface, for the "
+            "window between launching the kiosk and switching billing on. "
+            "Default False so every existing deploy is unchanged and the "
+            "rollout is one env var, reverted by removing it. Scoped to the "
+            "surface, never workspace-wide: the same deployment serves the full "
+            "Paw OS, where the platform fallback is the product. Refuses with "
+            "402 byok_key_required, a DISTINCT code from the guest one because "
+            "the fix is different — add a key, not create an account."
+        ),
+    )
     litellm_model: str = Field(
         default="",
         description=(

--- a/tests/cloud/runs/test_run_core_kiosk_requires_byok.py
+++ b/tests/cloud/runs/test_run_core_kiosk_requires_byok.py
@@ -1,0 +1,272 @@
+# tests/cloud/runs/test_run_core_kiosk_requires_byok.py — a signed-up kiosk
+# turn must bring its own key too, while the flag is on.
+#
+# Created 2026-09-12 (feat/kiosk-require-byok). The account sibling of the
+# guest no-keyless-turns rule, for the window between launching the kiosk and
+# switching billing on.
+#
+# Four things these pin, in the order they would hurt if they broke:
+#
+#   * flag OFF is byte-identical — the default, so every existing deploy and
+#     the whole of Paw OS are untouched until an operator sets one env var;
+#   * a NON-kiosk surface is never gated, even with the flag on — the same
+#     deployment serves the full Paw OS, where the platform fallback IS the
+#     product;
+#   * a guest still gets ``guest_key_required``, not the new code — two rules,
+#     two codes, because a guest is told to create an account and an account
+#     is told to add a key;
+#   * a resolved key proceeds normally.
+#
+# Harness cloned from test_run_core_byok_wiring.py.
+#
+# Mutations: tests/mutations/kiosk_require_byok.json.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.byok.service import TurnCredentials
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceKind, SurfaceMeta
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _fresh_settings():
+    """``get_settings`` is ``lru_cache``d, so a flag set after the first call in
+    the process is invisible. Without this the first test to run pins the value
+    for the rest of the file, and the others pass or fail on ordering rather
+    than on behaviour. Cleared on the way IN and OUT so neither this file nor
+    the next one inherits a stale Settings.
+    """
+    from pocketpaw.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+_PLAINTEXT = "sk-ant-api03-" + "kiosk" * 9
+
+
+class _Ev:
+    def __init__(self, type_: str, content: str = "") -> None:
+        self.type = type_
+        self.content = content
+        self.metadata: dict[str, Any] = {}
+
+
+class _CapturePool:
+    def __init__(self) -> None:
+        self.run_kwargs: dict[str, Any] | None = None
+        self.run_called = False
+
+    async def get(self, _agent_id):
+        return SimpleNamespace(config={"backend": "claude_agent_sdk", "model": ""}, agent_name="A")
+
+    def run(self, agent_id, content, session_key, **kwargs):
+        self.run_called = True
+        self.run_kwargs = kwargs
+
+        async def _gen():
+            yield _Ev("text", "ok")
+            yield _Ev("done")
+
+        return _gen()
+
+
+def _ctx(*, surface: SurfaceKind | None, user_id: str = "u1") -> ScopeContext:
+    ctx = ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id=user_id,
+        members=[user_id],
+        target_agent_id="a1",
+    )
+    # The REAL SurfaceContext, not a namespace double: the turn path reads
+    # ``preamble`` and ``preamble_cache_key`` off it long before the gate, so a
+    # partial double fails for a reason that has nothing to do with the gate.
+    ctx.surface_context = (
+        None
+        if surface is None
+        else SurfaceContext(
+            workspace_id="w1",
+            user_id=user_id,
+            kind=surface,
+            meta=SurfaceMeta(),
+            preamble="",
+            preamble_cache_key=None,
+        )
+    )
+    return ctx
+
+
+async def _not_guest(_user_id):
+    return None
+
+
+async def _is_guest(_user_id):
+    return SimpleNamespace(id="g1", active_workspace="w1")
+
+
+async def _never_cancelled():
+    return False
+
+
+async def _drive(
+    monkeypatch,
+    ctx: ScopeContext,
+    *,
+    creds: TurnCredentials,
+    guest_loader=_not_guest,
+) -> tuple[_CapturePool, list[tuple[str, dict]]]:
+    monkeypatch.delenv("POCKETPAW_SESSION_SUPERVISOR", raising=False)
+
+    pool = _CapturePool()
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: pool, raising=False)
+
+    from pocketpaw_ee.cloud.auth import guest_budget
+    from pocketpaw_ee.cloud.byok import service as byok_service
+
+    async def _resolve(_ws):
+        return creds
+
+    monkeypatch.setattr(byok_service, "resolve_turn_credentials", _resolve)
+    monkeypatch.setattr(guest_budget, "load_guest", guest_loader)
+
+    out: list[tuple[str, dict]] = []
+    gen = run_core._drive_agent_loop(
+        ctx,
+        user_content="hi",
+        attachments_in=None,
+        mentions_in=None,
+        history=[],
+        is_cancelled=_never_cancelled,
+        emit_stream_start=False,
+    )
+    async for ev in gen:
+        out.append(ev)
+    return pool, out
+
+
+def _codes(events) -> list[str]:
+    return [e[1].get("code") for e in events if e[0] == "error"]
+
+
+# ── the flag ─────────────────────────────────────────────────────────────
+
+
+async def test_flag_off_keeps_the_platform_fallback(monkeypatch):
+    """The DEFAULT, and the one that must not regress: with the flag unset a
+    signed-up kiosk turn runs on platform credentials exactly as before.
+
+    Mutation that must break this: invert the flag check.
+    """
+    monkeypatch.delenv("POCKETPAW_OTHER_HAND_REQUIRE_BYOK", raising=False)
+
+    pool, events = await _drive(
+        monkeypatch,
+        _ctx(surface=SurfaceKind.OTHER_HAND),
+        creds=TurnCredentials(source="platform"),
+    )
+
+    assert pool.run_called, "the turn was refused with the flag off"
+    assert "byok_key_required" not in _codes(events)
+
+
+async def test_flag_on_refuses_a_keyless_account_on_the_kiosk(monkeypatch):
+    """The rule itself.
+
+    Mutation that must break this: return False from ``_requires_own_key``.
+    """
+    monkeypatch.setenv("POCKETPAW_OTHER_HAND_REQUIRE_BYOK", "1")
+
+    pool, events = await _drive(
+        monkeypatch,
+        _ctx(surface=SurfaceKind.OTHER_HAND),
+        creds=TurnCredentials(source="platform"),
+    )
+
+    assert _codes(events) == ["byok_key_required"]
+    assert not pool.run_called, "a keyless turn reached the model anyway"
+
+
+# ── scope ────────────────────────────────────────────────────────────────
+
+
+async def test_another_surface_is_never_gated(monkeypatch):
+    """The same deployment serves the full Paw OS, where the platform fallback
+    is the product. A workspace-wide gate here would take chat off the air for
+    every non-kiosk user the moment the env var is set.
+
+    Mutation that must break this: drop the surface check.
+    """
+    monkeypatch.setenv("POCKETPAW_OTHER_HAND_REQUIRE_BYOK", "1")
+
+    pool, events = await _drive(
+        monkeypatch,
+        _ctx(surface=SurfaceKind.GENERIC),
+        creds=TurnCredentials(source="platform"),
+    )
+
+    assert pool.run_called
+    assert "byok_key_required" not in _codes(events)
+
+
+async def test_a_run_with_no_surface_is_never_gated(monkeypatch):
+    """A legacy client that sends no surface hint resolves to no context. It
+    is not on the kiosk, so it keeps the fallback.
+    """
+    monkeypatch.setenv("POCKETPAW_OTHER_HAND_REQUIRE_BYOK", "1")
+
+    pool, _events = await _drive(
+        monkeypatch,
+        _ctx(surface=None),
+        creds=TurnCredentials(source="platform"),
+    )
+
+    assert pool.run_called
+
+
+# ── the two rules stay two rules ─────────────────────────────────────────
+
+
+async def test_a_guest_still_gets_the_guest_code(monkeypatch):
+    """Answering a guest with ``byok_key_required`` would show them "add a key
+    in Settings" when what they need is an account. The guest branch runs
+    first and returns, so this one never sees them.
+
+    Mutation that must break this: move the account gate above the guest one.
+    """
+    monkeypatch.setenv("POCKETPAW_OTHER_HAND_REQUIRE_BYOK", "1")
+
+    _pool, events = await _drive(
+        monkeypatch,
+        _ctx(surface=SurfaceKind.OTHER_HAND),
+        creds=TurnCredentials(source="platform"),
+        guest_loader=_is_guest,
+    )
+
+    assert _codes(events) == ["guest_key_required"]
+
+
+async def test_an_account_with_a_key_proceeds(monkeypatch):
+    """The happy path. Without it, refusing every kiosk turn would pass every
+    test above.
+    """
+    monkeypatch.setenv("POCKETPAW_OTHER_HAND_REQUIRE_BYOK", "1")
+
+    pool, events = await _drive(
+        monkeypatch,
+        _ctx(surface=SurfaceKind.OTHER_HAND),
+        creds=TurnCredentials(source="byok", api_key=_PLAINTEXT, provider="anthropic"),
+    )
+
+    assert pool.run_called
+    assert pool.run_kwargs is not None
+    assert pool.run_kwargs.get("byok_api_key") == _PLAINTEXT
+    assert _codes(events) == []

--- a/tests/cloud/runs/test_run_core_kiosk_requires_byok.py
+++ b/tests/cloud/runs/test_run_core_kiosk_requires_byok.py
@@ -49,6 +49,7 @@ def _fresh_settings():
     yield
     get_settings.cache_clear()
 
+
 _PLAINTEXT = "sk-ant-api03-" + "kiosk" * 9
 
 

--- a/tests/mutations/kiosk_require_byok.json
+++ b/tests/mutations/kiosk_require_byok.json
@@ -1,0 +1,37 @@
+[
+  {
+    "label": "the flag is ignored — every signed-up kiosk turn is refused the moment the code ships, with no rollout step",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "    if not get_settings().other_hand_require_byok:\n        return False",
+    "replace": "    if False:\n        return False",
+    "tests": ["tests/cloud/runs/test_run_core_kiosk_requires_byok.py::test_flag_off_keeps_the_platform_fallback"]
+  },
+  {
+    "label": "the gate never fires — the switch reads On and the platform keeps paying",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "    sc = ctx.surface_context\n    return sc is not None and sc.kind is SurfaceKind.OTHER_HAND",
+    "replace": "    sc = ctx.surface_context\n    return False and sc is not None",
+    "tests": ["tests/cloud/runs/test_run_core_kiosk_requires_byok.py::test_flag_on_refuses_a_keyless_account_on_the_kiosk"]
+  },
+  {
+    "label": "the surface check is dropped — the gate goes workspace-wide and takes the whole Paw OS off the air",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "    sc = ctx.surface_context\n    return sc is not None and sc.kind is SurfaceKind.OTHER_HAND",
+    "replace": "    sc = ctx.surface_context\n    return True or sc is not None",
+    "tests": ["tests/cloud/runs/test_run_core_kiosk_requires_byok.py::test_another_surface_is_never_gated"]
+  },
+  {
+    "label": "the account gate runs BEFORE the guest one — a guest is told to add a key in Settings they cannot reach",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "            if _guest is not None:\n                yield (\n                    \"error\",\n                    {\n                        \"code\": \"guest_key_required\",",
+    "replace": "            if _guest is not None and not _requires_own_key(ctx):\n                yield (\n                    \"error\",\n                    {\n                        \"code\": \"guest_key_required\",",
+    "tests": ["tests/cloud/runs/test_run_core_kiosk_requires_byok.py::test_a_guest_still_gets_the_guest_code"]
+  },
+  {
+    "label": "a resolved key is refused too — the gate fires on every kiosk turn, key or not",
+    "file": "ee/pocketpaw_ee/cloud/chat/runs/run_core.py",
+    "find": "        if byok_creds.source == \"byok\" and byok_creds.api_key:",
+    "replace": "        if False and byok_creds.api_key:",
+    "tests": ["tests/cloud/runs/test_run_core_kiosk_requires_byok.py::test_an_account_with_a_key_proceeds"]
+  }
+]


### PR DESCRIPTION
## The gap

Guests cannot take a keyless turn on the kiosk. No platform fallback, by design, since the guest BYOK work. An account on the same surface could. So the kiosk can launch, someone signs up, and every turn they take is billed to us.

That is fine once billing is on. Until then it is an open tab with a signup form in front of it.

## The gate

`POCKETPAW_OTHER_HAND_REQUIRE_BYOK=1` and a signed-up Otherhand turn with no usable key is refused with 402 `byok_key_required`.

Off by default, so no deploy changes behaviour until someone sets it, and removing the variable is the rollback. That is deliberate: this is a window, not a policy.

**Scoped to the surface, never the workspace.** The same container serves the full Paw OS, where the platform fallback is the product. A workspace-wide gate would take chat off the air for every non-kiosk user the moment the variable is set.

**A sibling of the guest rule, not a widening of it.** Two rules, two codes. A guest is told to create an account. An account is told to add a key. Reusing `guest_key_required` would show a signed-in reader a "Create account" button that does nothing for them, which is the kind of dead end that reads as a broken product rather than a missing setting.

**Two seams, one of which decides.** The executor reads `ctx.surface_context`, resolved server-side after scope resolution. The router also fast-rejects so the browser gets a clean pre-stream 402 instead of a run document whose first frame is an error, but the router reads a client-supplied surface hint and is bypassable by omitting it. Its docstring says so. Do not move the gate there and delete the other one.

## Worth knowing before you turn it on

**The key entry point exists on the kiosk.** The Settings sheet in the user menu carries the provider key, so a signed-up reader can fix this without leaving the surface. The frontend half of this change adds an "Add your key" button on the refusal banner that opens the same sheet.

**Model choice and key provider have to agree.** With BYOK required, a composer model only works if the reader's key serves it. That path already exists: a key whose provider does not offer the chosen model gets a clear `byok.model_provider_mismatch` rather than an upstream 401. Nothing new here, but it becomes the common case rather than the rare one once every kiosk turn is BYOK.

**The setting is read through a cached `get_settings`.** Changing the variable needs a restart, not just an env edit.

## Tests

6 new, and the rest of `tests/cloud/runs` is unchanged. The suite has 6 pre-existing failures on this branch's base that have nothing to do with this change.

Mutation plan `tests/mutations/kiosk_require_byok.json`, 5 of 5 caught. The two that matter: the surface check being dropped so the gate goes workspace-wide, and the account rule jumping ahead of the guest rule so a guest is told to add a key in a Settings sheet they have no account for.

## Frontend

Separate PR in paw-enterprise: the new code maps to its own gate, with copy and a button that opens the key sheet rather than the signup form.
