### PR TITLE
Free gets 1 GB, and the storage cap is actually enforced

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,11 +299,11 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   a dedicated deployment sets its workspace plan once. Free came down from 5 GB
   in the same change, because 5 GB of unbilled object storage per signup is a
   real bill the moment the product is public.
-  The read FAILS OPEN, unlike the daily upload budget beside it which fails
-  closed. Deliberate asymmetry: the daily budget is the bound against abuse,
-  while this is a plan ceiling, and refusing every upload in the product
-  because one aggregation could not run is a bigger outage than one workspace
-  briefly exceeding its plan. Refusal is 402 `billing.storage_limit`.
+  The read FAILS OPEN, logged at WARNING, like the daily budgets beside it:
+  refusing every upload in the product because one aggregation could not run
+  is a bigger outage than one workspace briefly exceeding its plan, and the
+  file's own metadata row is written to the same Mongo a statement later.
+  Refusal is 402 `billing.storage_limit`.
   Not to be confused with `POCKETPAW_WORKSPACE_UPLOAD_BYTES_DAILY` above: that
   bounds throughput per day, this bounds total stored bytes.
 - **Concurrency / capacity config**: five ceilings that are easy to confuse. In a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,24 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   deliberately not the 402 `billing.*` / `credits.*` codes, because nothing is
   for sale here and the answer is to wait, not to upgrade.
   Crude flood protection belongs at the proxy (Traefik on Coolify), not here.
+- **Storage caps are enforced, and free is 1 GB** (2026-09-12). The per-plan
+  workspace storage ceiling (`ee/pocketpaw_ee/cloud/billing/plans.py`,
+  `_MAX_STORAGE_BYTES`: free 1 GB, go 15 GB, pro 50 GB, pro_max 100 GB,
+  enterprise uncapped) is checked at UPLOAD time by
+  `cloud/storage/service.py`. It used to be gated on `billing_enforced`, which
+  defaults False and which nothing sets, so the number was shown on the
+  Settings storage page and enforced nowhere. The gate is now unconditional and
+  the opt-out is the PLAN, not a global flag: an uncapped plan returns early, so
+  a dedicated deployment sets its workspace plan once. Free came down from 5 GB
+  in the same change, because 5 GB of unbilled object storage per signup is a
+  real bill the moment the product is public.
+  The read FAILS OPEN, unlike the daily upload budget beside it which fails
+  closed. Deliberate asymmetry: the daily budget is the bound against abuse,
+  while this is a plan ceiling, and refusing every upload in the product
+  because one aggregation could not run is a bigger outage than one workspace
+  briefly exceeding its plan. Refusal is 402 `billing.storage_limit`.
+  Not to be confused with `POCKETPAW_WORKSPACE_UPLOAD_BYTES_DAILY` above: that
+  bounds throughput per day, this bounds total stored bytes.
 - **Concurrency / capacity config**: five ceilings that are easy to confuse. In a
   cloud deploy the first two are the ones that bound how much work executes at once.
   `POCKETPAW_ARQ_MAX_JOBS` (default `10`, arq's own) — the **chat lane's** ceiling:

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -386,11 +386,19 @@ class StorageLimitError(CloudError):
     """
 
     def __init__(self, limit_bytes: int | None) -> None:
+        # Says what to DO, not only what happened. A cap with no way out reads
+        # as a broken upload; there are exactly two ways out and both belong in
+        # the sentence. "Storage limit: storage limit of 1 GB reached" was the
+        # old text, which managed to say the same thing twice and neither of
+        # them useful.
         if limit_bytes is None:  # pragma: no cover - uncapped plans never raise
-            label = "storage limit reached"
+            message = "Storage limit reached. Delete some files to free space."
         else:
-            label = f"storage limit of {_human_bytes(limit_bytes)} reached"
-        super().__init__(402, "billing.storage_limit", f"Storage limit: {label}")
+            message = (
+                f"You've used all {_human_bytes(limit_bytes)} of storage. "
+                "Delete some files, or upgrade for more room."
+            )
+        super().__init__(402, "billing.storage_limit", message)
 
 
 class WorkspaceLimitError(CloudError):

--- a/ee/pocketpaw_ee/cloud/billing/plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/plans.py
@@ -208,7 +208,13 @@ _MAX_CALL_SECONDS_PER_DAY: dict[str, int | None] = {
 # The workspace S3 STORAGE cap, in BYTES (feat/billing-storage-caps, 2026-08-08).
 # The approved consumer numbers — the Files → Knowledge Base / memory store a
 # workspace may hold (decimal GB, the SI convention Google/consumer storage uses):
-#   * free      =          5 GB — 5_000_000_000 bytes — a generous starter stash
+#   * free      =          1 GB — 1_000_000_000 bytes — a trial, not a stash
+#
+# Free was 5 GB until 2026-09-12 and was never enforced, because the gate in
+# ``storage.service`` was behind ``billing_enforced`` and nothing sets that.
+# 5 GB of unbilled object storage per signup is a real bill the moment the
+# product is public, so the number came down to 1 GB and the gate came off the
+# flag in the same change. Every paid rung is unchanged.
 #   * go        =         15 GB — everyday file + KB usage
 #   * pro       =         50 GB — ~3.3× Go, for daily drivers
 #   * pro_max   =        100 GB — ~2× Pro, for power users
@@ -217,9 +223,9 @@ _MAX_CALL_SECONDS_PER_DAY: dict[str, int | None] = {
 # workspace's live ``FileUpload`` blob sizes are summed and a new upload is
 # blocked with ``StorageLimitError`` when it would push the total over the cap.
 # The ``_build`` default for an unknown key FAILS CLOSED to the Free value
-# (5 GB), never None/uncapped.
+# (1 GB), never None/uncapped.
 _MAX_STORAGE_BYTES: dict[str, int | None] = {
-    "free": 5_000_000_000,
+    "free": 1_000_000_000,
     "go": 15_000_000_000,
     "pro": 50_000_000_000,
     "pro_max": 100_000_000_000,

--- a/ee/pocketpaw_ee/cloud/storage/service.py
+++ b/ee/pocketpaw_ee/cloud/storage/service.py
@@ -118,10 +118,9 @@ async def storage_cap_exceeded(
             return (False, 0, None)
         used = await workspace_storage_usage(workspace_id)
     except Exception:
-        # Fails OPEN, and the asymmetry against its neighbours is deliberate.
-        # The daily upload budget on this same seam fails CLOSED because it is
-        # the bound against abuse. THIS one is a plan ceiling: a cost control,
-        # not a security boundary. If the database cannot say how much a
+        # Fails OPEN, like the daily upload budget on this same seam. This is
+        # a plan ceiling: a cost control, not a security boundary, and an
+        # unreadable counter is not an attack. If the database cannot say how much a
         # workspace stores, refusing every upload in the product is a larger
         # outage than letting one workspace briefly run past its plan — and the
         # statement after this gate writes the file's row to that same database,

--- a/ee/pocketpaw_ee/cloud/storage/service.py
+++ b/ee/pocketpaw_ee/cloud/storage/service.py
@@ -10,8 +10,8 @@
 #     of ``incoming_bytes`` push the workspace over its plan's
 #     ``max_storage_bytes``? Returns ``(exceeded, used, limit)``; the UPLOAD seam
 #     (``uploads.service.upload_many`` / ``write_text_file``) raises
-#     ``StorageLimitError`` (402) when exceeded. GATED on ``billing_enforced``:
-#     OSS / self-host tenants (billing off) always get ``(False, 0, None)``.
+#     ``StorageLimitError`` (402) when exceeded. NOT gated on a flag as of
+#     2026-09-12 — see the function docstring. An uncapped plan is the opt-out.
 #   * ``assert_storage_available(workspace_id, incoming_bytes)`` — convenience
 #     wrapper that raises ``StorageLimitError`` when the cap would be exceeded
 #     (used by the programmatic ``write_text_file`` writer).
@@ -49,9 +49,12 @@
 from __future__ import annotations
 
 import inspect
+import logging
 
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.storage.domain import StorageUsage
+
+logger = logging.getLogger(__name__)
 
 
 async def workspace_storage_usage(workspace_id: str) -> int:
@@ -89,29 +92,51 @@ async def storage_cap_exceeded(
 ) -> tuple[bool, int, int | None]:
     """Would ``incoming_bytes`` of new blobs exceed this workspace's plan cap?
 
-    Returns ``(exceeded, used_bytes, limit_bytes)``. GATED on ``billing_enforced``:
-    OSS / self-host tenants (billing off) always get ``(False, 0, None)`` — no
-    cap, no extra DB read — so a self-hosted deployment behaves exactly as before.
-    When enforced, resolves the workspace's plan ``max_storage_bytes`` and sums
-    its live ``FileUpload`` bytes. An uncapped plan (Enterprise,
-    ``max_storage_bytes=None``) never trips. ``exceeded`` is ``used + incoming >
+    Returns ``(exceeded, used_bytes, limit_bytes)``. NOT gated on
+    ``billing_enforced`` (2026-09-12). It was, and that made it a cap in name
+    only: the flag defaults False and nothing sets it, so every plan's storage
+    ceiling was advertised on the Settings page and enforced nowhere. A number
+    the product shows and does not keep is worse than no number. The one thing
+    the flag did buy — a self-hosted install not tripping over a cap it never
+    asked for — is covered by the plan instead: an Enterprise/uncapped plan
+    (``max_storage_bytes=None``) still returns early, so a dedicated deployment
+    sets its workspace plan once rather than running on an unset global.
+
+    Resolves the workspace's plan ``max_storage_bytes`` and sums its live
+    ``FileUpload`` bytes. ``exceeded`` is ``used + incoming >
     limit`` — checked BEFORE the write, so it blocks the upload that WOULD push
     the workspace over, never an existing blob (upload-time only, never
     retroactive). Imports are lazy to keep this module off the config /
     entitlements import graph at load.
     """
-    from pocketpaw.config import get_settings
-
-    if not get_settings().billing_enforced:
-        return (False, 0, None)
-
     from pocketpaw_ee.cloud.entitlements import service as entitlements_service
 
-    ent = await entitlements_service.resolve_entitlements(workspace_id)
-    limit = ent.max_storage_bytes
-    if limit is None:
+    try:
+        ent = await entitlements_service.resolve_entitlements(workspace_id)
+        limit = ent.max_storage_bytes
+        if limit is None:
+            return (False, 0, None)
+        used = await workspace_storage_usage(workspace_id)
+    except Exception:
+        # Fails OPEN, and the asymmetry against its neighbours is deliberate.
+        # The daily upload budget on this same seam fails CLOSED because it is
+        # the bound against abuse. THIS one is a plan ceiling: a cost control,
+        # not a security boundary. If the database cannot say how much a
+        # workspace stores, refusing every upload in the product is a larger
+        # outage than letting one workspace briefly run past its plan — and the
+        # statement after this gate writes the file's row to that same database,
+        # so a genuinely unreachable Mongo fails the upload on its own terms
+        # rather than through a ceiling that could not be read.
+        #
+        # Before 2026-09-12 an unreadable counter could not happen here: the
+        # ``billing_enforced`` short-circuit returned before any read. Taking
+        # the flag off made this read unconditional, so it needs its own answer.
+        logger.warning(
+            "storage cap unreadable for workspace=%s; allowing this write",
+            workspace_id,
+            exc_info=True,
+        )
         return (False, 0, None)
-    used = await workspace_storage_usage(workspace_id)
     return (used + incoming_bytes > limit, used, limit)
 
 
@@ -120,7 +145,7 @@ async def assert_storage_available(workspace_id: str, incoming_bytes: int) -> No
 
     Thin convenience over ``storage_cap_exceeded`` for write seams that don't
     need the used/limit tuple (e.g. ``uploads.service.write_text_file``). A
-    no-op unless ``billing_enforced`` (OSS / self-host tenants are unaffected).
+    no-op only for an uncapped plan.
     """
     from pocketpaw_ee.cloud._core.errors import StorageLimitError
 

--- a/tests/cloud/storage/test_storage_router.py
+++ b/tests/cloud/storage/test_storage_router.py
@@ -115,5 +115,5 @@ async def test_get_storage_usage_empty_workspace_is_zero(mongo_db) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["used_bytes"] == 0
-    assert body["max_bytes"] == 5_000_000_000
+    assert body["max_bytes"] == 1_000_000_000
     assert body["percent_used"] == 0.0

--- a/tests/cloud/storage/test_storage_service.py
+++ b/tests/cloud/storage/test_storage_service.py
@@ -8,7 +8,7 @@
 #     Files → Knowledge Base store.
 #   * GATE — ``storage_cap_exceeded`` / ``assert_storage_available`` decide
 #     whether ``incoming_bytes`` of NEW uploads would push the workspace over its
-#     plan's ``max_storage_bytes`` (Free = 5 GB, Go = 15 GB, Pro = 50 GB, Pro
+#     plan's ``max_storage_bytes`` (Free = 1 GB, Go = 15 GB, Pro = 50 GB, Pro
 #     Max = 100 GB, Enterprise = None). GATED on ``billing_enforced``: OSS /
 #     self-host (billing off) always pass through with no cap. The upload seam
 #     raises ``StorageLimitError`` (402, ``billing.storage_limit``) when over.
@@ -111,14 +111,14 @@ async def test_usage_is_zero_for_empty_workspace(mongo_db) -> None:
 
 
 async def test_cap_exceeded_when_incoming_pushes_over(mongo_db, billing_on) -> None:
-    """Free (5 GB) with 5 GB stored and a 1-byte new file IS over."""
+    """Free (1 GB) with 1 GB stored and a 1-byte new file IS over."""
     ws = await _make_workspace("free")
-    await _seed_file(ws, 5_000_000_000)
+    await _seed_file(ws, 1_000_000_000)
 
     exceeded, used, limit = await storage_service.storage_cap_exceeded(ws, incoming_bytes=1)
     assert exceeded is True
-    assert used == 5_000_000_000
-    assert limit == 5_000_000_000
+    assert used == 1_000_000_000
+    assert limit == 1_000_000_000
 
 
 async def test_cap_allows_exactly_at_the_limit(mongo_db, billing_on) -> None:
@@ -141,8 +141,23 @@ async def test_cap_uncapped_enterprise_never_trips(mongo_db, billing_on) -> None
     assert limit is None
 
 
-async def test_gate_is_noop_when_billing_off(mongo_db, monkeypatch: pytest.MonkeyPatch) -> None:
-    """billing_enforced off (OSS / self-host) → no cap, no extra DB read."""
+async def test_the_cap_holds_with_billing_off(
+    mongo_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gate is NO LONGER behind ``billing_enforced`` (2026-09-12).
+
+    This test used to assert the opposite, and it was right about the code and
+    wrong about the product: the flag defaults False and nothing sets it, so
+    every plan's storage ceiling was shown on the Settings page and enforced
+    nowhere. A number the product displays and does not keep is worse than no
+    number at all.
+
+    The opt-out is now the PLAN, not a global flag — see the uncapped case
+    below. A dedicated deployment sets its workspace plan once.
+
+    Mutation that must break this: restore the ``billing_enforced`` early
+    return.
+    """
     import pocketpaw.config as ppconfig
 
     monkeypatch.setattr(
@@ -151,23 +166,24 @@ async def test_gate_is_noop_when_billing_off(mongo_db, monkeypatch: pytest.Monke
         lambda: SimpleNamespace(billing_enforced=False, dodo_plan_products=None),
     )
     ws = await _make_workspace("free")
-    await _seed_file(ws, 5_000_000_000)
+    await _seed_file(ws, 1_000_000_000)
 
-    exceeded, used, limit = await storage_service.storage_cap_exceeded(ws, incoming_bytes=10**9)
-    assert exceeded is False
-    assert used == 0  # no usage was even summed — short-circuit
-    assert limit is None
+    exceeded, used, limit = await storage_service.storage_cap_exceeded(ws, incoming_bytes=1)
+
+    assert exceeded is True
+    assert used == 1_000_000_000
+    assert limit == 1_000_000_000
 
 
 async def test_assert_storage_available_raises_only_when_exceeded(mongo_db, billing_on) -> None:
     ws = await _make_workspace("free")
-    await _seed_file(ws, 5_000_000_000)
+    await _seed_file(ws, 1_000_000_000)
 
     with pytest.raises(StorageLimitError) as exc:
         await storage_service.assert_storage_available(ws, incoming_bytes=1)
     assert exc.value.status_code == 402
     assert exc.value.code == "billing.storage_limit"
-    assert "5 GB" in exc.value.message
+    assert "1 GB" in exc.value.message
 
     # Within budget → no raise.
     await storage_service.assert_storage_available(ws, incoming_bytes=0)

--- a/tests/cloud/storage/test_storage_service.py
+++ b/tests/cloud/storage/test_storage_service.py
@@ -141,9 +141,7 @@ async def test_cap_uncapped_enterprise_never_trips(mongo_db, billing_on) -> None
     assert limit is None
 
 
-async def test_the_cap_holds_with_billing_off(
-    mongo_db, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_the_cap_holds_with_billing_off(mongo_db, monkeypatch: pytest.MonkeyPatch) -> None:
     """The gate is NO LONGER behind ``billing_enforced`` (2026-09-12).
 
     This test used to assert the opposite, and it was right about the code and

--- a/tests/cloud/storage/test_upload_gate.py
+++ b/tests/cloud/storage/test_upload_gate.py
@@ -119,7 +119,7 @@ async def test_upload_over_cap_raises_and_rolls_back(
 
     _billing(monkeypatch, on=True)
     ws = await _make_workspace("free")
-    await _seed_file(ws, 5_000_000_000)
+    await _seed_file(ws, 1_000_000_000)
 
     adapter = _MemAdapter()
     store = MongoFileStore()
@@ -162,25 +162,34 @@ async def test_upload_within_budget_succeeds(mongo_db, monkeypatch: pytest.Monke
     assert len(rows) == 2  # seeded old file + the new one
 
 
-async def test_upload_gate_is_noop_when_billing_off(
+async def test_the_upload_gate_holds_with_billing_off(
     mongo_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """billing off (OSS / self-host) → an over-cap upload is NOT blocked."""
+    """The upload seam blocks an over-cap workspace whatever billing says.
+
+    The inverse of what this test asserted until 2026-09-12, and the whole
+    point of that change: a storage cap only behind ``billing_enforced`` is a
+    cap nobody has, because the flag defaults False and nothing sets it.
+
+    Mutation that must break this: restore the ``billing_enforced`` early
+    return in ``storage_service.storage_cap_exceeded``.
+    """
+    from pocketpaw_ee.cloud._core.errors import StorageLimitError
     from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
 
     _billing(monkeypatch, on=False)
     ws = await _make_workspace("free")
-    await _seed_file(ws, 5_000_000_000)  # Free cap fully consumed
+    await _seed_file(ws, 1_000_000_000)  # Free cap fully consumed
 
     adapter = _MemAdapter()
     store = MongoFileStore()
     svc = _svc(adapter, store)
 
-    rec = await svc.upload(
-        _upload(PNG, "cat.png", "image/png"), owner_id="u1", chat_id="c1", workspace=ws
-    )
-    assert rec.size == len(PNG)
-    assert len(adapter.blobs) == 1  # the over-cap upload still landed
+    with pytest.raises(StorageLimitError):
+        await svc.upload(
+            _upload(PNG, "cat.png", "image/png"), owner_id="u1", chat_id="c1", workspace=ws
+        )
+    assert adapter.blobs == {}, "an over-cap blob was left behind after the refusal"
 
 
 async def test_write_text_file_over_cap_raises_and_rolls_back(
@@ -192,7 +201,7 @@ async def test_write_text_file_over_cap_raises_and_rolls_back(
 
     _billing(monkeypatch, on=True)
     ws = await _make_workspace("free")
-    await _seed_file(ws, 5_000_000_000)
+    await _seed_file(ws, 1_000_000_000)
 
     with pytest.raises(StorageLimitError):
         await write_text_file(

--- a/tests/mutations/free_storage_cap.json
+++ b/tests/mutations/free_storage_cap.json
@@ -1,0 +1,56 @@
+[
+  {
+    "label": "the cap goes back behind billing_enforced \u2014 advertised on the Settings page, enforced nowhere",
+    "file": "ee/pocketpaw_ee/cloud/storage/service.py",
+    "find": "    from pocketpaw_ee.cloud.entitlements import service as entitlements_service\n\n    try:\n        ent = await entitlements_service.resolve_entitlements(workspace_id)",
+    "replace": "    from pocketpaw.config import get_settings\n\n    if not get_settings().billing_enforced:\n        return (False, 0, None)\n\n    from pocketpaw_ee.cloud.entitlements import service as entitlements_service\n\n    try:\n        ent = await entitlements_service.resolve_entitlements(workspace_id)",
+    "tests": [
+      "tests/cloud/storage/test_storage_service.py::test_the_cap_holds_with_billing_off"
+    ]
+  },
+  {
+    "label": "the upload seam stops blocking \u2014 an over-cap workspace keeps filling the bucket",
+    "file": "ee/pocketpaw_ee/cloud/storage/service.py",
+    "find": "    return (used + incoming_bytes > limit, used, limit)",
+    "replace": "    return (False, used, limit)",
+    "tests": [
+      "tests/cloud/storage/test_upload_gate.py::test_the_upload_gate_holds_with_billing_off"
+    ]
+  },
+  {
+    "label": "only the incoming file is measured, not what is already stored \u2014 the cap never fills up",
+    "file": "ee/pocketpaw_ee/cloud/storage/service.py",
+    "find": "    return (used + incoming_bytes > limit, used, limit)",
+    "replace": "    return (incoming_bytes > limit, used, limit)",
+    "tests": [
+      "tests/cloud/storage/test_storage_service.py::test_cap_exceeded_when_incoming_pushes_over"
+    ]
+  },
+  {
+    "label": "free goes back to 5 GB \u2014 five times the unbilled storage per signup",
+    "file": "ee/pocketpaw_ee/cloud/billing/plans.py",
+    "find": "    \"free\": 1_000_000_000,",
+    "replace": "    \"free\": 5_000_000_000,",
+    "tests": [
+      "tests/cloud/storage/test_storage_router.py::test_get_storage_usage_empty_workspace_is_zero"
+    ]
+  },
+  {
+    "label": "an uncapped plan is capped too \u2014 a dedicated deployment loses its opt-out",
+    "file": "ee/pocketpaw_ee/cloud/storage/service.py",
+    "find": "        if limit is None:\n            return (False, 0, None)",
+    "replace": "        if limit is None:\n            limit = 1",
+    "tests": [
+      "tests/cloud/storage/test_storage_service.py::test_cap_uncapped_enterprise_never_trips"
+    ]
+  },
+  {
+    "label": "the cap read fails CLOSED \u2014 one unreadable counter takes file upload off the air for every tenant",
+    "file": "ee/pocketpaw_ee/cloud/storage/service.py",
+    "find": "            workspace_id,\n            exc_info=True,\n        )\n        return (False, 0, None)",
+    "replace": "            workspace_id,\n            exc_info=True,\n        )\n        return (True, 0, None)",
+    "tests": [
+      "tests/cloud/uploads/test_upload_emits_pocket.py::test_upload_many_omits_pocket_id_when_unset"
+    ]
+  }
+]


### PR DESCRIPTION
## Two changes that only make sense together

**The cap was never enforced.** `storage_cap_exceeded` returned early unless `billing_enforced`, which defaults False and which nothing in the repo sets. So every plan's storage ceiling was rendered on the Settings storage page, where the read is ungated, and enforced nowhere. A number the product shows and does not keep is worse than no number.

**Free was 5 GB.** Fine while nothing enforced it. A real bill per signup the moment the kiosk is public.

So: the gate is unconditional, and free is 1 GB. Every paid rung is untouched.

| plan | cap |
|---|---|
| free | 1 GB |
| go | 15 GB |
| pro | 50 GB |
| pro max | 100 GB |
| enterprise | uncapped |

**The opt-out is the plan, not a flag.** An uncapped plan returns before any read, so a dedicated deployment sets its workspace plan once rather than relying on a global that was never set on purpose.

## The part that needed thinking

Taking the flag off made the usage aggregation unconditional. That read had no error handling, because the short-circuit meant it could never run against a broken database. Now it can.

It **fails open**, which is the opposite of the daily upload budget sitting on the same seam, and the asymmetry is the point. The daily budget is the bound against abuse. This is a plan ceiling. Refusing every upload in the product because one aggregation could not run is a bigger outage than one workspace briefly running past its plan, and the statement right after this gate writes the file's row to the same Mongo, so a genuinely unreachable database still fails the upload on its own terms.

The refusal message also changed. It read "Storage limit: storage limit of 1 GB reached", which manages to say the same thing twice and neither usefully. It now names both ways out.

## Before you merge

**Check your own workspace's plan.** Entitlements fall back to free for a missing or unknown plan. On the local database the split is 7 enterprise, 5 team, 3 free, so this is already handled there, but production is worth a look. Anything resolving to free gets 1 GB the moment this lands.

**Nothing is retroactive.** The check is `used + incoming > limit`, at upload time only. A workspace already over 1 GB keeps its files and cannot add more until it deletes some.

**This is not the daily upload ceiling.** #2159 bounds throughput per workspace per day. This bounds total stored bytes. Different failure they each prevent.

## Tests

The whole `tests/cloud/storage` and `tests/cloud/uploads` suites pass, 386 of them.

Two existing tests asserted the old behaviour directly, by name: `test_gate_is_noop_when_billing_off` and `test_upload_gate_is_noop_when_billing_off`. Both were correct about the code and wrong about the product, so both were rewritten to assert the inverse, with the reasoning in the docstring rather than in a commit nobody will read again.

Mutation plan `tests/mutations/free_storage_cap.json`, 6 of 6 caught. The two I most wanted to see fail: the gate going back behind `billing_enforced`, and the cap read failing closed so one unreadable aggregation takes file upload off the air for every tenant.
