### PR TITLE
Move a Paw Site to another workspace

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2037,6 +2037,98 @@ this" from "it does, and you have not republished since you upgraded". Those are
 different sentences and two different buttons. Use this field to disable the panel
 before the call; use `status` to decide what the panel says.
 
+## Sites — Transfer to Another Workspace
+
+Wave 3 of the sites lifecycle. A site could be created, published, edited and paid
+for, but never handed to anyone else. These four endpoints move one between
+workspaces.
+
+**It is an offer and an accept, not one call.** A single endpoint would authorise
+only the sender, which would let anyone who owns a site push it — with its leads and
+its custom domains — into any workspace whose id they could name. The receiving
+tenant consents by accepting.
+
+**Nothing on Cloudflare moves.** The Worker, the D1 database, the custom hostnames
+and the Worker routes are all untouched, and the site keeps serving throughout. What
+changes is which workspace the records belong to.
+
+| Resource | What happens |
+|---|---|
+| Site document, pocket | **Move.** `workspace` and `owner` are re-keyed; the pocket's `shared_with` is emptied, because those users belong to the workspace it just left |
+| Leads | **Move.** Re-keyed to the destination |
+| Site `_id`, Worker script name, public URL | **Preserved, deliberately.** The id IS the script name and the subdomain — see below |
+| Cloudflare Worker, D1 database | **Stay put.** The D1 binding is by database id, so ownership changes in our records only |
+| Custom hostnames, Worker routes | **Stay.** They live on our zone and point at a script that has not changed |
+| Public images (R2) | **Cannot move.** The object key contains the source workspace id and is baked into an immutable, year-cached URL inside the deployed HTML *and* the pocket's stored spec, which nothing rewrites. Copying them to a new prefix would buy nothing and purging the source would blank every image on a live site. The source prefix is recorded on `Site.asset_source_prefixes` so teardown can still reclaim them |
+| Concierge transcripts | **Stay with the source.** They live on `ChatRun` rows keyed on workspace and session, and they hold free text a visitor typed. Moving personal data into a tenant that has never held it is the direction that needs consent |
+| Analytics | **Cannot move.** Cloudflare Analytics Engine rows were written under the old ids and age out on their own three-month retention |
+
+**Why the site id is preserved.** `_live_object_id` derives the Site `_id` from
+`(workspace, pocket_id)`, and that same value is the Worker's script name and the
+subdomain the page is served at. Re-deriving it on transfer would rename a live
+Worker and move a public URL while every custom-domain route kept resolving to the
+old script. So the row keeps the id it was minted with, and `Site.identity_workspace`
+records which workspace minted it — without that stamp, the next publish in the new
+workspace would derive a different id, insert a second Site document, upload a second
+Worker and serve it at a second address, forking the site in two. Rows that have
+never been transferred carry `""` there and take the original derivation unchanged.
+
+**A paid site cannot be moved.** A paid site is charged against the *source*
+workspace's credit balance, and the renewal sweeper debits whichever workspace the
+row names — so re-keying it would start charging the destination for a plan its
+members never bought. Drop the site to the free plan first; the new workspace can
+upgrade it again from its own balance.
+
+### `POST /sites/{site_id}/transfer`
+
+Offer the site to another workspace. Requires `fabric.write`, and the caller must be
+the site's **owner** (not merely a workspace admin — the permission layers here are
+known to disagree with one another, and widening this needs its own audit).
+
+```json
+{ "destination_workspace_id": "665f1c2a9e4b7d3f8a1c2b04" }
+```
+
+Returns the offer. Refusals carry a stable code: `transfer.not_owner` (403),
+`transfer.blocked_by_workspace` (403), `transfer.site_is_paid` (409),
+`transfer.deleting` (409), `transfer.already_offered` (409),
+`transfer.same_workspace` (422). An unknown destination is a 404.
+
+### `DELETE /sites/{site_id}/transfer`
+
+Withdraw an offer that has not been accepted. Owner-only, source side.
+
+### `GET /sites/transfers/incoming`
+
+Sites other workspaces have offered to **this** one. Requires `fabric.read`.
+
+This is the one sites read not anchored on the caller's `workspace` — it cannot be,
+since an offered site still belongs to the sender until it is accepted.
+`transfer_to_workspace` is the tenant filter instead, and only an owner of the
+sending side can write it. The payload is deliberately thin (site id, name, url,
+source workspace, who offered it, when) and never carries the signed key, the capture
+config, the lead count or the client record.
+
+### `POST /sites/transfers/{site_id}/accept`
+
+Accept an offer and take ownership. Requires `fabric.write` in the destination, and
+the caller must be a **member** of it — checked against their own user record, not
+against the workspace named in the request header, since a header is a request rather
+than a credential. A workspace the offer does not name gets a 404 rather than a 403:
+saying "that site was offered elsewhere" would confirm the site exists to a tenant
+with no business knowing that it does.
+
+Synchronous, unlike delete — every step is a local write, so there is nothing to
+poll. The re-key is still ledgered (`Site.transfer_ledger`), because a crash part-way
+would leave ownership split across two tenants; accepting again resumes from the step
+that stopped rather than repeating the ones that finished.
+
+### Forbidding transfers out
+
+`WorkspaceSettings.site_transfers_allowed` (default `true`). A site leaving takes its
+leads with it, so an admin can forbid the outbound half outright. Only the source
+side is gated — the receiving side is governed by consent, not by a setting.
+
 ## Ship — Managed Deploys
 
 SHIP-3. The `/api/v1/ship` surface behind the /ship console: a workspace

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -4,6 +4,25 @@
 # harden ingest without a second store. SiteDomain tracks the Cloudflare-for-
 # SaaS hostname lifecycle the Domains panel polls.
 #
+# Updated 2026-09-12 (sites lifecycle wave 3 -- transfer): added the
+# ``transfer_*`` lifecycle fields, ``transferred_at``, ``identity_workspace`` and
+# ``asset_source_prefixes``. Two of those carry the whole design and are worth
+# reading before touching this document.
+#
+# ``identity_workspace`` exists because ``_id`` IS INFRASTRUCTURE HERE, not just a
+# key: ``service._live_object_id`` derives it from ``(workspace, pocket_id)``, and
+# the same value is the Cloudflare Worker's script name and the subdomain the site
+# serves at. So a transfer must NOT re-derive it, and leaving it alone means the
+# next publish in the new workspace derives a different id and forks the site into
+# two Workers at two URLs with the custom domains still pointing at the first. This
+# field marks the row as moved so the resolver prefers the id it actually has. It is
+# "" for every site that has never been transferred, so their path is unchanged.
+#
+# ``asset_source_prefixes`` exists because public images DON'T move -- their object
+# key embeds the workspace id and is baked into an immutable public URL already
+# inside the deployed HTML -- so the delete cascade needs a record of where they
+# really are or they are unreclaimable and stay world-readable forever.
+#
 # Updated 2026-09-02 (SA-4 — the visitor-analytics read): added
 # ``analytics_since``, which says whether this site's visitors are being counted and,
 # if so, when that started. It is the ONLY thing on this document that separates "this
@@ -581,6 +600,52 @@ class Site(TimestampedDocument):
     # consumer parses once and can always split on the colon to group by step. A
     # failure with no reason is not a smaller error, it is an unactionable one.
     delete_reason: str | None = None
+    # -- Transfer: moving this site to another workspace (wave 3) -----------
+    # ``transfer_status`` -- none | offered | in_flight | failed. No terminal
+    # success value, for the same reason ``delete_status`` has none: a finished
+    # transfer returns the row to ``none`` and ``transferred_at`` is what records
+    # that it happened.
+    transfer_status: str = "none"
+    # The workspace the site has been OFFERED to, and the only key the destination
+    # can find this row by -- every other sites read is scoped on ``workspace``,
+    # which still names the SOURCE until the move completes. Indexed below with
+    # ``transfer_status``, because the incoming-offers list queries the pair and
+    # would otherwise scan every site in the deployment.
+    transfer_to_workspace: str = ""
+    transfer_offered_by: str = ""
+    transfer_offered_at: datetime | None = None
+    # Step name -> outcome, exactly like ``delete_ledger``, and resumable the same
+    # way. A transfer is short, but it is several writes across two tenants and a
+    # crash in the middle leaves ownership split -- which is the failure this
+    # records enough to finish rather than guess at.
+    transfer_ledger: dict[str, str] = Field(default_factory=dict)
+    transfer_reason: str | None = None
+    transferred_at: datetime | None = None
+    # THE WORKSPACE THIS ROW'S ``_id`` WAS MINTED FROM, and the field that stops a
+    # transferred site silently forking in two.
+    #
+    # ``service._live_object_id`` derives ``_id`` from ``(workspace, pocket_id)``
+    # (PERF-1), and that id is ALSO the Cloudflare Worker's script name and the
+    # subdomain the site is served at. A transfer therefore cannot re-derive it --
+    # doing so renames a live Worker and moves a public URL. But leaving it alone
+    # means the next publish in the destination derives a DIFFERENT id, inserts a
+    # SECOND Site row, uploads a SECOND Worker, and serves it at a SECOND address
+    # while every custom domain still resolves to the first.
+    #
+    # Set ONLY by a transfer, and only once (the minting workspace, not the most
+    # recent one). "" on every row that has never moved, which is what makes
+    # ``_resolve_live_site_oid`` a no-op for them -- the dedupe invariant PERF-1
+    # and PERF-2 established is untouched for every site but a transferred one.
+    identity_workspace: str = ""
+    # Public-asset prefixes this site's images are STILL stored under after a
+    # transfer, because the object key embeds the workspace id and that key is
+    # baked into an immutable, year-cached public URL inside the deployed HTML.
+    # Moving the bytes would blank every image on a live site; see
+    # ``sites/transfer.py:_move_assets``. Recorded because the delete cascade
+    # purges ``prefix_for(site.workspace, ...)`` -- which after a transfer names an
+    # empty prefix -- so without this list the real objects are unreclaimable and
+    # stay public forever.
+    asset_source_prefixes: list[str] = Field(default_factory=list)
     # SE-2b: the builder origin this site was published with, or "" when it was
     # published as a normal (non-editable) site. When set, the generated page
     # carries the gated edit-bridge keyed on this origin. Persisted so a
@@ -747,4 +812,9 @@ class Site(TimestampedDocument):
             # resolver rejects an empty key before it ever queries, so a blank
             # key never resolves against those rows.
             [("signed_key", 1)],
+            # Wave 3: the destination's "what has been offered to me" read. It
+            # is the one sites query NOT anchored on ``workspace`` -- it cannot
+            # be, since the row still belongs to the source until it is accepted
+            # -- so without this it scans the whole collection.
+            [("transfer_to_workspace", 1), ("transfer_status", 1)],
         ]

--- a/ee/pocketpaw_ee/cloud/models/workspace.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace.py
@@ -1,5 +1,13 @@
 """Workspace document — one per deployment/org.
 
+2026-09-12 (sites lifecycle wave 3 — transfer): added
+``WorkspaceSettings.site_transfers_allowed``. Moving a site to another workspace
+takes its leads and concierge transcripts with it, so an admin can forbid the
+outbound half outright. Defaults True so every existing workspace reads exactly
+as it did before the field existed — no migration, and nothing that worked
+yesterday stops. Only the SOURCE side is gated here; the receiving side is
+governed by consent (the accept step), not by a setting.
+
 2026-07-10 (compliance-starter): ``WorkspaceSettings.retention_days`` is no
 longer decorative. Added a field validator so a persisted value is always
 ``None`` (keep forever) or a POSITIVE day count — 0 / negative are rejected
@@ -57,6 +65,19 @@ class WorkspaceSettings(BaseModel):
     # ``workspace.service.enforce_retention``). Zero / negative is rejected so
     # a bad value can never silently disable retention or wipe everything.
     retention_days: int | None = None
+    # Whether a site owner may move one of this workspace's sites OUT to another
+    # workspace (sites lifecycle wave 3). A transfer carries the site's leads and
+    # its concierge transcripts with it, so this is a DATA-EGRESS control and
+    # belongs to the workspace rather than to whoever happens to own the site —
+    # the same reasoning Netlify applies to its team-level transfer lock.
+    #
+    # Defaults True, which keeps the feature self-serve for the ordinary case: a
+    # workspace that has never thought about this reads as permissive, exactly as
+    # it did before the field existed, so there is no migration and nothing that
+    # worked yesterday stops. An admin turning it off is making a deliberate
+    # choice, and only the SOURCE side is gated — receiving a site is governed by
+    # the recipient's own consent, which is the accept step.
+    site_transfers_allowed: bool = True
 
     @field_validator("retention_days")
     @classmethod

--- a/ee/pocketpaw_ee/sites/delete_cascade.py
+++ b/ee/pocketpaw_ee/sites/delete_cascade.py
@@ -284,6 +284,25 @@ async def _purge_assets(*, site: Any, deps: Any) -> str:
         # ``PublicAssetStore.purge`` raises on rather than reporting zero.
         return OUTCOME_SKIPPED
     await deps.assets.purge(workspace_id=site.workspace, pocket_id=site.pocket_id)
+
+    # A TRANSFERRED site's images are NOT under its current workspace. The object
+    # key embeds the workspace that minted them and is baked into an immutable,
+    # year-cached public URL inside the deployed HTML, so a transfer cannot move
+    # the bytes (``sites/transfer.py:_move_assets``) and records the prefixes they
+    # stayed at instead. The purge above derives its prefix from ``site.workspace``
+    # and therefore sweeps an EMPTY prefix on such a site.
+    #
+    # This runs BEFORE the ``records`` step and before the caller deletes the Site
+    # document, which is what makes it possible at all: that document is the only
+    # thing naming these objects, so missing them here does not leave an untidy
+    # bucket, it leaves world-readable customer images that nothing can ever
+    # enumerate again.
+    #
+    # An untransferred site has an empty list and is byte-identical to before.
+    # Failures propagate like any other step's, so a prefix that cannot be purged
+    # fails the cascade through ``_classify`` rather than being swallowed.
+    for prefix in getattr(site, "asset_source_prefixes", None) or []:
+        await deps.assets.purge_prefix(prefix)
     return OUTCOME_DONE
 
 

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -2,6 +2,14 @@
 # plane. Distinct request and response shapes per the cloud 4-file rules.
 # Created: 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.5).
 #
+# Updated 2026-09-12 (sites lifecycle wave 3 — transfer): added
+# ``SiteTransferOfferRequest`` / ``SiteTransferResponse`` /
+# ``SiteTransferListResponse``. The response is DELIBERATELY THIN, and that is a
+# tenancy decision rather than an oversight: the DESTINATION reads it for a site
+# that still belongs to another workspace, so it carries only what somebody needs
+# in order to decide whether to accept — never the signed key, the capture config,
+# the lead count or the client record.
+#
 # Updated 2026-09-04 (AD-4 — the overview chart's data): added
 # ``SiteAnalyticsSeriesPoint`` / ``SiteAnalyticsSeries`` and ``SiteAnalyticsResponse.series``,
 # the per-bucket views and visitors the chart under the headline numbers draws. Two things
@@ -220,6 +228,7 @@
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -1296,3 +1305,45 @@ class SiteAnalyticsResponse(BaseModel):
     countries: list[SiteAnalyticsBreakdown] | None = None
     devices: list[SiteAnalyticsBreakdown] | None = None
     unrecorded: list[str] = []
+
+
+# --- Wave 3: transferring a site to another workspace ----------------------
+#
+# Request and response stay separate, per the DTO rule — the offer takes one field
+# the client supplies, and the response carries several the client must never set.
+
+
+class SiteTransferOfferRequest(BaseModel):
+    """Offer this site to ``destination_workspace_id``."""
+
+    # The only thing the sender supplies. Everything else about the offer — who made
+    # it, when, from where — is read from the request context, because a client that
+    # can name the offerer can forge one.
+    destination_workspace_id: str = Field(min_length=1)
+
+
+class SiteTransferResponse(BaseModel):
+    """One transfer offer, from either end of it.
+
+    DELIBERATELY THIN, and that is a tenancy decision rather than an oversight. The
+    destination reads this for a site that still belongs to somebody else, so it
+    carries only what somebody needs to decide whether to accept: which site, where
+    it is now, who offered it. Not the signed key, not the capture config, not the
+    lead count, not the client record — those stay with the workspace that still
+    owns the site until the offer is answered.
+    """
+
+    site_id: str
+    name: str
+    url: str = ""
+    from_workspace_id: str
+    to_workspace_id: str = ""
+    offered_by: str = ""
+    offered_at: datetime | None = None
+    status: str = "none"
+
+
+class SiteTransferListResponse(BaseModel):
+    """Everything offered TO the calling workspace."""
+
+    transfers: list[SiteTransferResponse] = []

--- a/ee/pocketpaw_ee/sites/import_service.py
+++ b/ee/pocketpaw_ee/sites/import_service.py
@@ -291,7 +291,9 @@ async def _plan_import(
     caller merges any path-specific extras (crawl stats, status)."""
     from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 
-    oid = sites_service._live_object_id(workspace_id, pocket_id)
+    # Resolved, not derived (wave 3) -- a transferred site keeps its minted id, and
+    # a miss here raises rather than degrading.
+    oid = await sites_service._resolve_live_site_oid(workspace_id, pocket_id)
     doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
     if doc is None or not doc.signed_key:
         raise Internal(

--- a/ee/pocketpaw_ee/sites/public_assets.py
+++ b/ee/pocketpaw_ee/sites/public_assets.py
@@ -358,7 +358,38 @@ class PublicAssetStore:
                 "assets cannot be enumerated or removed. Purging would report success "
                 "over a bucket it never touched."
             )
-        prefix = prefix_for(workspace_id, pocket_id)
+        return await self.purge_prefix(prefix_for(workspace_id, pocket_id))
+
+    async def purge_prefix(self, prefix: str) -> int:
+        """Delete every object under an explicit prefix. Returns the number removed.
+
+        THIS EXISTS FOR TRANSFERRED SITES, and the reason is worth stating because
+        the obvious reading of :meth:`purge` is that it already covers everything.
+        It does not. It derives the prefix from the site's CURRENT workspace, and a
+        transferred site's images are still under the workspace that MINTED them —
+        the object key embeds that id and is baked into an immutable, year-cached
+        public URL inside the deployed HTML, so moving the bytes would blank the
+        images on a live site (``sites/transfer.py:_move_assets``). The prefixes
+        left behind are recorded on ``Site.asset_source_prefixes``.
+
+        So a teardown that only calls :meth:`purge` reclaims an EMPTY prefix and
+        leaves the real objects world-readable forever. A caller tearing a site down
+        must purge this site's own prefix AND each retained one.
+
+        Same two guarantees as :meth:`purge`: it raises rather than reporting a
+        silent zero when the adapter cannot list, and every key is rebuilt from the
+        passed prefix rather than taken from the listing, so a hostile or odd name
+        cannot walk outside it."""
+        if not self.can_list():
+            raise PublicAssetError(
+                "This deployment's storage adapter cannot list objects, so a site's "
+                "assets cannot be enumerated or removed. Purging would report success "
+                "over a bucket it never touched."
+            )
+        if not prefix.endswith("/"):
+            # A prefix that does not end in a separator matches sibling directories
+            # by string prefix, so "…/pk1" would also sweep "…/pk10".
+            prefix = f"{prefix}/"
         removed = 0
         for item in await self._adapter.browse(prefix):
             if item.is_dir:

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -3,6 +3,20 @@
 # and gated by the same plan feature (fabric) + action (fabric.write/read) as
 # the Leads surface (Task 3.4). Mirrors the leads router's context/deps wiring.
 #
+# Updated 2026-09-12 (sites lifecycle wave 3 -- transfer): four endpoints for
+# moving a site to another workspace, appended at end-of-file.
+# POST/DELETE ``/sites/{site_id}/transfer`` are the SOURCE half (offer, withdraw);
+# GET ``/sites/transfers/incoming`` and POST ``/sites/transfers/{site_id}/accept``
+# are the DESTINATION half, on their own prefix precisely BECAUSE they address a
+# site that still belongs to somebody else -- every route under
+# ``/sites/{site_id}/`` is tenant-scoped to the caller, and these two cannot be.
+#
+# TWO PHASES, NOT ONE CALL. A single ``POST /sites/{id}/transfer`` authorises only
+# the sender, which would let anyone who owns a site push it -- with its leads and
+# its custom domains -- into any workspace whose id they can name. The receiving
+# tenant consents by accepting, and the service re-checks membership against the
+# accepting user's OWN record rather than trusting the workspace header.
+#
 # Updated 2026-09-02 (SA-4 — the visitor-analytics read): GET
 # ``/sites/{site_id}/analytics``, the read half of the counter SA-1/SA-2 deploy.
 # Gated ``fabric.read`` and tenant-scoped through the service's ``_load`` like the
@@ -287,6 +301,9 @@ from pocketpaw_ee.sites.dto import (
     SitePreviewResponse,
     SiteResponse,
     SiteStatusResponse,
+    SiteTransferListResponse,
+    SiteTransferOfferRequest,
+    SiteTransferResponse,
     SiteVersionResponse,
     VersionHistoryResponse,
 )
@@ -1334,3 +1351,116 @@ async def get_import_brief(
     readable. A read, so no ``fabric.write`` — same shape as the sibling listings.
     """
     return await import_service.read_design_brief(workspace_id=ctx.workspace_id, brief_id=brief_id)
+
+
+# --- Wave 3: transferring a site to another workspace ----------------------
+#
+# Appended at end-of-file, and gated on BOTH ends. The send half is
+# ``fabric.write`` in the SOURCE workspace plus an owner check in the service; the
+# receive half is ``fabric.write`` in the DESTINATION plus a membership check read
+# from the accepting user's own record. Neither half alone is sufficient, which is
+# the whole reason this is an offer and an accept rather than one call.
+
+
+@router.post("/sites/{site_id}/transfer", response_model=SiteTransferResponse)
+async def offer_site_transfer(
+    site_id: str,
+    body: SiteTransferOfferRequest,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SiteTransferResponse:
+    """Offer this site to another workspace. Nothing moves until it is accepted.
+
+    Tenant-scoped through the service's ``_load``, so the caller can only offer a
+    site their own workspace owns. Owner-only beyond that, and refused outright when
+    an admin has turned off outbound transfers — a site leaving takes its leads with
+    it, which makes this a data-egress control rather than a preference.
+    """
+    wire = await sites_service.offer_site_transfer(
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user_id,
+        site_id=site_id,
+        destination_workspace_id=body.destination_workspace_id,
+    )
+    return _transfer_response(wire)
+
+
+@router.delete("/sites/{site_id}/transfer", response_model=SiteTransferResponse)
+async def cancel_site_transfer(
+    site_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SiteTransferResponse:
+    """Withdraw an offer that has not been accepted yet."""
+    wire = await sites_service.cancel_site_transfer(
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user_id,
+        site_id=site_id,
+    )
+    return _transfer_response(wire)
+
+
+@router.get("/sites/transfers/incoming", response_model=SiteTransferListResponse)
+async def list_incoming_site_transfers(
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> SiteTransferListResponse:
+    """Sites other workspaces have offered to this one.
+
+    The one sites read not anchored on the caller's ``workspace`` — it cannot be,
+    since an offered site still belongs to the sender. ``transfer_to_workspace`` is
+    the tenant filter instead, and only an owner of the sending side can write it,
+    so a workspace sees exactly what was addressed to it.
+
+    Starlette matches routes in REGISTRATION order, not by specificity, so a
+    literal path registered after a parameterised one is not automatically safe.
+    This one is safe because nothing overlaps: ``/sites/{site_id}/transfer`` would
+    only swallow this if the final segment read ``transfer``, and it reads
+    ``incoming``. Adding a ``/sites/{site_id}/incoming`` later would break it.
+    """
+    rows = await sites_service.list_incoming_site_transfers(workspace_id=ctx.workspace_id)
+    return SiteTransferListResponse(transfers=[_transfer_response(r) for r in rows])
+
+
+@router.post("/sites/transfers/{site_id}/accept", response_model=SiteTransferResponse)
+async def accept_site_transfer(
+    site_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SiteTransferResponse:
+    """Accept a site offered to this workspace, and take ownership of it.
+
+    Deliberately NOT under ``/sites/{site_id}/`` — every route on that prefix is
+    tenant-scoped to the caller's workspace, and this one addresses a site that
+    still belongs to somebody else. Putting it on its own prefix keeps that
+    difference visible at the URL rather than buried in a service function.
+
+    The receiving guard that matters is not this dependency: ``fabric.write`` says
+    the caller may write in the workspace the header names, and the service
+    re-checks that they are actually a MEMBER of it against their own user record.
+    A header is a request, not a credential.
+    """
+    wire = await sites_service.accept_site_transfer(
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user_id,
+        site_id=site_id,
+    )
+    return _transfer_response(wire)
+
+
+def _transfer_response(wire: dict) -> SiteTransferResponse:
+    """Map the service's wire dict onto the response model.
+
+    Hand-written rather than ``model_validate`` because the service speaks camelCase
+    (the shape every other sites read returns) and the DTO is snake_case.
+    """
+    return SiteTransferResponse(
+        site_id=wire.get("siteId", ""),
+        name=wire.get("name", ""),
+        url=wire.get("url", "") or "",
+        from_workspace_id=wire.get("fromWorkspaceId", ""),
+        to_workspace_id=wire.get("toWorkspaceId", "") or "",
+        offered_by=wire.get("offeredBy", "") or "",
+        offered_at=wire.get("offeredAt"),
+        status=wire.get("status", "none"),
+    )

--- a/ee/pocketpaw_ee/sites/screenshot.py
+++ b/ee/pocketpaw_ee/sites/screenshot.py
@@ -614,11 +614,16 @@ async def safe_take_draft_screenshot_for_pocket(*, workspace_id: str, pocket_id:
     visitors actually see with a picture of an unapproved edit.
     """
     try:
-        from pocketpaw_ee.sites.service import _live_object_id
+        from pocketpaw_ee.sites.service import _resolve_live_site_oid
         from pocketpaw_ee.sites.service import _SiteDoc as _Doc
 
+        # Resolved, not derived (wave 3): a transferred site keeps the id it was
+        # minted with, and a miss here silently leaves its card without a picture.
         doc = await _Doc.find_one(
-            {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
+            {
+                "_id": await _resolve_live_site_oid(workspace_id, pocket_id),
+                "workspace": workspace_id,
+            }
         )
         if doc is None:
             return ""

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2360,7 +2360,10 @@ async def create_draft_site(
     return above, so it fires once per real insert — a repeat create, or one against
     an already-live doc, stays silent.
     """
-    oid = _live_object_id(workspace_id, pocket_id)
+    # Resolved, not derived: a TRANSFERRED site keeps the id it was minted with,
+    # so a create against a moved pocket finds the real row instead of minting a
+    # second one beside it. Identical to the derivation for every other site.
+    oid = await _resolve_live_site_oid(workspace_id, pocket_id)
     # Idempotent + dedupe-safe: never mint a second doc for a pocket, and never reset
     # an already-published/live doc back to draft. If a doc already exists (this draft
     # on a repeat create, or a live one), return it untouched.
@@ -2611,7 +2614,12 @@ async def publish(
     # deploy folder / URL / CF worker / Site doc in place instead of minting a fresh
     # one each call. A PREVIEW build still uses the freshly-minted ObjectId for its
     # transient (never-persisted) doc id and serves at the stable preview path.
-    site_id = str(ObjectId()) if preview else str(_live_object_id(workspace_id, pocket_id))
+    # Wave 3: resolved rather than derived, because a TRANSFERRED site keeps the id
+    # it was minted with (that id is its live Worker's name and its public URL).
+    # Byte-identical to the derivation for every site that has never moved.
+    site_id = (
+        str(ObjectId()) if preview else str(await _resolve_live_site_oid(workspace_id, pocket_id))
+    )
     # PERF-1 fix (review finding): on a live RE-publish the upsert below preserves
     # the stored ``doc.signed_key``, so minting a fresh key here would bake a
     # ``captureSignedKey`` into the built HTML that no longer matches the doc the
@@ -2620,9 +2628,7 @@ async def publish(
     # new key only for a first publish or a preview (which never persists a doc).
     signed_key = f"site_key_{secrets.token_urlsafe(24)}"
     if not preview:
-        _existing = await _SiteDoc.find_one(
-            {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
-        )
+        _existing = await _SiteDoc.find_one({"_id": ObjectId(site_id), "workspace": workspace_id})
         if _existing is not None and _existing.signed_key:
             signed_key = _existing.signed_key
 
@@ -7224,7 +7230,9 @@ async def _publish_pending_site(
     if not site_name:
         site_name = "Untitled site"
 
-    oid = _live_object_id(workspace_id, pocket_id)
+    # Resolved, not derived — see ``_resolve_live_site_oid``. A transferred site
+    # upgraded from its new workspace must land on the row that is actually live.
+    oid = await _resolve_live_site_oid(workspace_id, pocket_id)
     site_id = str(oid)
     plan_key = tier.key
 
@@ -9925,6 +9933,416 @@ async def sweep_expired_site_exports() -> int:
     return removed
 
 
+# ---------------------------------------------------------------------------
+# Wave 3 — transfer a site to another workspace
+# ---------------------------------------------------------------------------
+#
+# Appended at end-of-file deliberately: this module is ten thousand lines and
+# several agents edit it at once, so the only mid-file changes wave 3 makes are the
+# four one-line call sites that route through ``_resolve_live_site_oid``. The ORDER
+# and the REASONING live in ``sites/transfer.py``; what is here is the Mongo half —
+# the loads, the field-scoped writes, and the mapping from a refusal to a status.
+
+
+async def _resolve_live_site_oid(workspace_id: str, pocket_id: str) -> ObjectId:
+    """The ``_id`` a live publish of this pocket must upsert.
+
+    Normally exactly ``_live_object_id(workspace_id, pocket_id)`` — the PERF-1
+    derivation, unchanged, for every site that has never moved.
+
+    A TRANSFERRED site is the one exception, and it has to be. That derived id is
+    ALSO the Cloudflare Worker's script name and the subdomain the site is served
+    at, so a transfer cannot re-derive it without renaming a live Worker and moving
+    a public URL. The row therefore keeps the id it was minted with — and without
+    this lookup the next publish in the new workspace would derive a DIFFERENT id,
+    insert a SECOND Site doc, upload a SECOND Worker and serve it at a SECOND
+    address, while every custom domain kept resolving to the first one. The site
+    would fork in two, silently, and the half the owner was editing would not be the
+    half their domain pointed at.
+
+    The query keys on ``identity_workspace``, which ONLY a transfer ever sets. Every
+    other row has "" there, matches nothing, and takes the derivation — so the
+    dedupe invariant PERF-1 and PERF-2 established is untouched for every site but a
+    transferred one.
+    """
+    derived = _live_object_id(workspace_id, pocket_id)
+    moved = await _SiteDoc.find_one(
+        {
+            "workspace": workspace_id,
+            "pocket_id": pocket_id,
+            "archived": False,
+            # Not ``{"$ne": ""}``: a site transferred BACK to the workspace that
+            # minted it sits at its derived id again, and diverting it would be
+            # wrong. Excluding this workspace by name covers that round trip.
+            "identity_workspace": {"$nin": ["", None, workspace_id]},
+        }
+    )
+    return moved.id if moved is not None else derived
+
+
+def _transfer_refusal_to_cloud_error(exc: Any) -> CloudError:
+    """Map a precondition refusal onto the status that actually describes it.
+
+    ``not_offered`` is a 404 rather than a 403 on purpose: answering "that site was
+    offered somewhere else" confirms the site exists to a tenant with no business
+    knowing that it does.
+    """
+    if exc.code in (
+        "transfer.not_owner",
+        "transfer.not_a_member",
+        "transfer.blocked_by_workspace",
+    ):
+        return Forbidden(exc.code, exc.message)
+    if exc.code == "transfer.not_offered":
+        return NotFound("site", "transfer")
+    if exc.code in ("transfer.no_destination", "transfer.same_workspace"):
+        return ValidationError(exc.code, exc.message)
+    return ConflictError(exc.code, exc.message)
+
+
+def _transfer_wire(doc: _SiteDoc) -> dict[str, Any]:
+    """The offer, as the wire sees it.
+
+    DELIBERATELY NARROW. The incoming-offers read is the one sites query that
+    crosses a tenancy boundary — the destination reads a row that still belongs to
+    the source — so it carries the few facts needed to decide whether to accept and
+    nothing else. No ``signed_key``, no capture config, no lead counts, no client
+    record: those belong to the workspace that still owns the site until somebody
+    says yes.
+    """
+    return {
+        "siteId": str(doc.id),
+        "name": doc.name or doc.script_name or "",
+        "url": doc.url or "",
+        "fromWorkspaceId": doc.workspace,
+        "offeredBy": doc.transfer_offered_by or "",
+        "offeredAt": doc.transfer_offered_at,
+        "status": doc.transfer_status or "none",
+        "toWorkspaceId": doc.transfer_to_workspace or "",
+    }
+
+
+async def _workspace_settings_for(workspace_id: str) -> Any:
+    """The workspace's settings, or a permissive default when the row is unreadable.
+
+    A missing workspace reads as permissive rather than blocked: the transfer lock
+    is an admin OPT-OUT, and turning an unreadable row into a hard refusal would
+    break transfers for a reason that has nothing to do with the policy.
+    """
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+    from pocketpaw_ee.cloud.models.workspace import WorkspaceSettings as _WorkspaceSettings
+
+    try:
+        ws = await _WorkspaceDoc.get(workspace_id)
+    except (InvalidId, TypeError):
+        ws = None
+    if ws is None:
+        return _WorkspaceSettings()
+    return ws.settings
+
+
+async def offer_site_transfer(
+    *,
+    workspace_id: str,
+    user_id: str,
+    site_id: str,
+    destination_workspace_id: str,
+) -> dict[str, Any]:
+    """Offer this site to another workspace. Moves nothing yet.
+
+    TWO PHASES, because a one-shot transfer authorises only the sender — and that
+    would let anyone who owns a site push it, with its leads and its custom domains,
+    into any workspace whose id they can name. The destination has to say yes.
+    """
+    from pocketpaw_ee.sites import transfer as transfer_mod
+
+    doc = await _load(workspace_id, site_id)
+    settings = await _workspace_settings_for(workspace_id)
+
+    dest = (destination_workspace_id or "").strip()
+    try:
+        transfer_mod.check_can_offer(
+            site=doc,
+            actor_user_id=user_id,
+            source_settings=settings,
+            destination_workspace_id=dest,
+        )
+    except transfer_mod.TransferRefused as exc:
+        raise _transfer_refusal_to_cloud_error(exc) from exc
+
+    # The destination must EXIST. An offer into a typo would leave the site parked
+    # in ``offered`` forever, with nobody able to accept it and nobody told why.
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+
+    try:
+        dest_ws = await _WorkspaceDoc.get(dest)
+    except (InvalidId, TypeError):
+        dest_ws = None
+    if dest_ws is None or dest_ws.deleted_at is not None:
+        raise NotFound("workspace", dest)
+
+    # Field-scoped, per the persistence rule: a whole-document save here would roll
+    # back a concurrent build-status write on the same row.
+    await doc.set(
+        {
+            "transfer_status": transfer_mod.STATUS_OFFERED,
+            "transfer_to_workspace": dest,
+            "transfer_offered_by": user_id,
+            "transfer_offered_at": datetime.now(UTC),
+            "transfer_ledger": {},
+            "transfer_reason": None,
+        }
+    )
+    # no-event: an offer changes nothing either gallery renders — the site is still
+    # live and still owned by the source, and the destination's incoming list is a
+    # pull. The emit that matters is on accept, where the card actually moves.
+    return _transfer_wire(doc)
+
+
+async def cancel_site_transfer(*, workspace_id: str, user_id: str, site_id: str) -> dict[str, Any]:
+    """Withdraw an offer. Source side only — the owner who made it takes it back."""
+    from pocketpaw_ee.sites import transfer as transfer_mod
+
+    doc = await _load(workspace_id, site_id)
+    if (doc.transfer_status or "none") != transfer_mod.STATUS_OFFERED:
+        raise ConflictError("transfer.not_offered", "There is no open offer on this site.")
+    if (doc.owner or "") != user_id:
+        raise Forbidden(
+            "transfer.not_owner",
+            "Only the person who owns this site can withdraw its transfer offer.",
+        )
+    await doc.set(
+        {
+            "transfer_status": transfer_mod.STATUS_NONE,
+            "transfer_to_workspace": "",
+            "transfer_offered_by": "",
+            "transfer_offered_at": None,
+            "transfer_ledger": {},
+            "transfer_reason": None,
+        }
+    )
+    # no-event: same reasoning as the offer — nothing rendered changed.
+    return _transfer_wire(doc)
+
+
+async def list_incoming_site_transfers(*, workspace_id: str) -> list[dict[str, Any]]:
+    """Sites another workspace has offered to this one.
+
+    # global-read: the one sites query that CANNOT be anchored on ``workspace``.
+    # The row still belongs to the SOURCE until the offer is accepted, so the
+    # destination's only claim on it is ``transfer_to_workspace`` — and that field
+    # IS the tenant filter here. It is written only by an owner of the sending side,
+    # so a workspace sees exactly what was addressed to it and nothing else.
+    """
+    from pocketpaw_ee.sites import transfer as transfer_mod
+
+    docs = await _SiteDoc.find(
+        {
+            "transfer_to_workspace": workspace_id,
+            "transfer_status": transfer_mod.STATUS_OFFERED,
+        }
+    ).to_list()
+    return [_transfer_wire(d) for d in docs]
+
+
+async def _member_workspace_ids(user_id: str) -> tuple[str, ...]:
+    """Every workspace this user actually belongs to, read from their own User row.
+
+    Read from the USER rather than trusted from the request's workspace header. The
+    header says which tenant the caller is ASKING to act as; this says which ones
+    they may. Without the distinction, accepting a site into a workspace needs only
+    its id, which is the whole authorisation on the receiving end.
+    """
+    from pocketpaw_ee.cloud.models.user import User as _UserDoc
+
+    try:
+        user = await _UserDoc.get(user_id)
+    except (InvalidId, TypeError):
+        user = None
+    if user is None:
+        return ()
+    return tuple(m.workspace for m in (user.workspaces or []))
+
+
+async def accept_site_transfer(*, workspace_id: str, user_id: str, site_id: str) -> dict[str, Any]:
+    """Take ownership of a site offered to this workspace, and run the re-key.
+
+    SYNCHRONOUS, unlike delete, and that is a consequence of the design rather than
+    a shortcut. Every step is a local Mongo write — nothing here calls Cloudflare,
+    because nothing on Cloudflare moves — so there is no external call that can
+    outlive a request and a job would add a poll to an operation that finishes in
+    milliseconds. The ledger still exists, because "milliseconds" is not "atomic":
+    a crash part-way leaves ownership split across two tenants, and the ledger is
+    what lets a second attempt finish it instead of guessing.
+    """
+    from pocketpaw_ee.sites import transfer as transfer_mod
+
+    try:
+        oid = ObjectId(site_id)
+    except (InvalidId, TypeError):
+        raise NotFound("site", site_id) from None
+    # Loaded through the OFFER, not through ``_load``: the row still lives in the
+    # source workspace, so a tenant-scoped read would not find it at all.
+    doc = await _SiteDoc.find_one({"_id": oid, "transfer_to_workspace": workspace_id})
+    if doc is None:
+        raise NotFound("site", site_id)
+
+    members = await _member_workspace_ids(user_id)
+    try:
+        transfer_mod.check_can_accept(
+            site=doc,
+            accepting_user_id=user_id,
+            accepting_workspace_id=workspace_id,
+            member_workspace_ids=members,
+        )
+    except transfer_mod.TransferRefused as exc:
+        raise _transfer_refusal_to_cloud_error(exc) from exc
+
+    source_workspace = doc.workspace
+    await doc.set({"transfer_status": transfer_mod.STATUS_IN_FLIGHT})
+
+    deps = _TransferDeps()
+
+    async def _save(site: _SiteDoc) -> None:
+        # Field-scoped, listing exactly what the re-key touches. A ``save()`` here
+        # would write back every field this document was loaded with, rolling over
+        # any concurrent build-status write on the same row.
+        await site.set(
+            {
+                "workspace": site.workspace,
+                "owner": site.owner,
+                "identity_workspace": site.identity_workspace,
+                "asset_source_prefixes": list(site.asset_source_prefixes or []),
+                "transfer_ledger": dict(site.transfer_ledger or {}),
+                "transfer_status": site.transfer_status,
+                "transfer_to_workspace": site.transfer_to_workspace,
+                "transfer_offered_by": site.transfer_offered_by,
+                "transfer_offered_at": site.transfer_offered_at,
+                "transfer_reason": site.transfer_reason,
+                "transferred_at": site.transferred_at,
+            }
+        )
+
+    try:
+        await transfer_mod.run_transfer(
+            site=doc,
+            destination_workspace_id=workspace_id,
+            accepting_user_id=user_id,
+            deps=deps,
+            save=_save,
+        )
+    except transfer_mod.TransferStepFailed as exc:
+        await doc.set(
+            {"transfer_status": transfer_mod.STATUS_FAILED, "transfer_reason": exc.reason}
+        )
+        raise Internal(
+            "transfer.failed",
+            "Moving this site did not finish. Nothing was destroyed — accept it "
+            "again and it resumes from the step that stopped.",
+        ) from exc
+
+    try:
+        await _emit_site_created(doc)
+    except Exception:  # noqa: BLE001 - realtime must never cost the transfer
+        logger.warning("sites.transfer: realtime emit failed for %s", site_id, exc_info=True)
+    logger.info(
+        "sites.transfer: site %s moved from workspace %s to %s",
+        site_id,
+        source_workspace,
+        workspace_id,
+    )
+    return _transfer_wire(doc)
+
+
+class _TransferDeps:
+    """The side effects ``run_transfer`` needs, bound to Mongo.
+
+    A class rather than free functions so a test can substitute a double of the same
+    shape — the seam ``delete_cascade``'s ``deps`` already establishes, and for the
+    same reason: the order and the ledger are what is worth testing, and they should
+    be testable without a database.
+    """
+
+    @staticmethod
+    def now() -> datetime:
+        return datetime.now(UTC)
+
+    @staticmethod
+    def asset_prefix_for(workspace_id: str, pocket_id: str) -> str:
+        from pocketpaw_ee.sites import public_assets
+
+        return public_assets.prefix_for(workspace_id, pocket_id)
+
+    @staticmethod
+    async def move_pocket(
+        *, pocket_id: str, destination_workspace_id: str, new_owner_id: str
+    ) -> None:
+        """Re-key the pocket, and cut the old tenant's people loose from it.
+
+        ``owner`` and ``shared_with`` name users of the workspace the pocket just
+        left, and a pocket read is an ``$or`` over exactly those two plus visibility.
+        Carrying them across would be a cross-tenant grant dressed up as a field
+        nobody thought about. ``shared_with`` is EMPTIED rather than translated:
+        there is no mapping from a source member to a destination one, and inventing
+        one would hand access to whoever happened to share a user id.
+        """
+        from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+        try:
+            pocket = await _PocketDoc.get(pocket_id)
+        except (InvalidId, TypeError):
+            pocket = None
+        if pocket is None:
+            # The site is published from a pocket that no longer exists. There is
+            # nothing to re-key, and refusing here would make such a site
+            # untransferable forever over a row that is already gone.
+            return
+        await pocket.set(
+            {
+                "workspace": destination_workspace_id,
+                "owner": new_owner_id,
+                "shared_with": [],
+            }
+        )
+
+    @staticmethod
+    async def move_records(
+        *, site_id: str, source_workspace_id: str, destination_workspace_id: str
+    ) -> bool:
+        """Re-key the site's LEADS, and only its leads.
+
+        WHAT MOVES: ``Lead`` rows. Keyed on (workspace, site_id), both indexed, and
+        they are the site's own captured submissions — the records that would be
+        invisible to the new owner and undeletable by the old one if they stayed.
+
+        WHAT DOES NOT, each deliberate rather than missed:
+
+          * ``SiteDesignBrief`` is keyed on (workspace, owner, source_url) and not on
+            a site at all. It is a captured page on its way to BECOMING a site, an
+            artifact of the source workspace's import panel, with no relationship to
+            this row to carry over;
+          * ``SiteRateCounter`` has no workspace field and a two-minute TTL. Nothing
+            to re-key, and nothing that outlives the request;
+          * CONCIERGE TRANSCRIPTS stay with the source, and this is the one worth
+            arguing about. They live on ``ChatRun`` rows in the chat subsystem, keyed
+            on workspace and session rather than on a site, and they hold free text a
+            visitor typed. Moving personal data into a tenant that has never held it
+            is the direction that needs consent, not the direction that gets a
+            default — so the new owner starts with a clean transcript history and the
+            old owner keeps what their own visitors said to them. The site's
+            concierge keeps working; only the back-history stays put.
+
+        Returns whether anything actually moved, so the ledger can record "there was
+        nothing here" separately from "I moved it".
+        """
+        if not source_workspace_id or not site_id:
+            return False
+        result = await _LeadDoc.find({"workspace": source_workspace_id, "site_id": site_id}).update(
+            {"$set": {"workspace": destination_workspace_id}}
+        )
+        return bool(getattr(result, "modified_count", 0) or 0)
+
+
 __all__ = [
     "apply_edits",
     "create_draft_site",
@@ -9954,4 +10372,8 @@ __all__ = [
     "list_site_exports",
     "open_site_export",
     "sweep_expired_site_exports",
+    "offer_site_transfer",
+    "accept_site_transfer",
+    "cancel_site_transfer",
+    "list_incoming_site_transfers",
 ]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -4211,7 +4211,10 @@ async def _canonical_site_doc(workspace_id: str, pocket_id: str) -> _SiteDoc | N
     Tenant-scoped on ``workspace``. Returns None when the pocket has no Site doc.
     """
     stable = await _SiteDoc.find_one(
-        {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
+        # Resolved, not derived (wave 3) -- a transferred site keeps its minted id.
+        # The legacy-dupe fallback below would eventually find it, but by the
+        # newest-with-a-url rule rather than by identity.
+        {"_id": await _resolve_live_site_oid(workspace_id, pocket_id), "workspace": workspace_id}
     )
     if stable is not None:
         return stable
@@ -6255,7 +6258,11 @@ async def publish_pocket(
     # still PENDING has never been paid for, so a republish there SHOULD open a
     # fresh checkout (the abandoned session simply expires unused).
     existing_doc = await _SiteDoc.find_one(
-        {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
+        # Resolved, not derived (wave 3). On a TRANSFERRED site the derivation no
+        # longer names the row, so this read would come back None and every later
+        # republish of a site already on a paid tier would read as "never paid" and
+        # open another purchase against the workspace balance.
+        {"_id": await _resolve_live_site_oid(workspace_id, pocket_id), "workspace": workspace_id}
     )
     # WHO IS ALLOWED TO SPEND. Publishing is a MEMBER action and stays one; buying
     # a paid tier is not. Since site plans became add-on lines on the workspace's

--- a/ee/pocketpaw_ee/sites/transfer.py
+++ b/ee/pocketpaw_ee/sites/transfer.py
@@ -1,0 +1,467 @@
+# ee/pocketpaw_ee/sites/transfer.py — moving one published site from the workspace
+# that owns it to another one, without taking it off the internet.
+#
+# Created 2026-09-12 (sites lifecycle wave 3, feat/sites-transfer).
+#
+# TRANSFER IS A RE-KEY, NOT A REDEPLOY, AND THAT IS THE WHOLE DESIGN. A Paw Site is
+# reached through a Cloudflare Worker whose SCRIPT NAME is the Site document's
+# ``_id``, and served at ``https://<that same id>.<sites domain>``. So the one thing
+# a transfer must not do is change that id: doing so renames the live Worker, moves
+# the public URL, and orphans every custom-domain route still pointing at the old
+# script. What moves is OWNERSHIP — which workspace the records belong to — and
+# nothing on Cloudflare is touched at all.
+#
+# THAT COLLIDES WITH THE STABLE-IDENTITY RULE, AND THE COLLISION IS THE SUBTLE BUG
+# THIS MODULE EXISTS TO CLOSE. ``service._live_object_id`` derives the Site ``_id``
+# deterministically from ``(workspace, pocket_id)`` — PERF-1, the fix that stopped
+# one pocket accumulating fourteen Site rows. After a transfer the workspace half of
+# that pair has changed, so the NEXT publish in the destination derives a DIFFERENT
+# id: it inserts a SECOND Site document, uploads a SECOND Worker, and serves it at a
+# SECOND URL, while every custom domain keeps resolving to the first one. The site
+# silently forks, and the half the customer is editing is not the half their domain
+# points at.
+#
+# The fix is ``Site.identity_workspace``: the workspace the id was MINTED from,
+# stamped only by a transfer. ``service._resolve_live_site_oid`` prefers the row's
+# real id when that stamp says the row has moved, and falls back to the derivation
+# for every other row on earth — so a site that has never been transferred takes a
+# byte-identical path and the PERF-1 dedupe invariant is untouched.
+#
+# WHY TWO PHASES. A one-shot ``POST /sites/{id}/transfer {destination}`` authorises
+# only the SENDER. That is a hole, not a shortcut: it lets anyone who owns a site
+# push it — with its leads, its transcripts and its custom domains — into any
+# workspace whose id they can name, and the receiving tenant gets records it never
+# asked for. An offer the destination must ACCEPT puts a consenting party on both
+# ends of the boundary, which is the only thing that makes this a transfer rather
+# than a write into someone else's tenancy.
+#
+# THE STEP ORDER HERE IS NOT THE DELETE CASCADE'S. Nothing is destroyed, so the
+# failure to design against is not "half torn down" but SPLIT OWNERSHIP — the
+# records of one site sitting in two tenants at once. Two properties govern it:
+#
+#   1. the pocket and the Site move TOGETHER, in one step, because the guard that
+#      stops a pocket delete stranding a live site finds the site through the
+#      POCKET's workspace. A window with those two apart re-opens exactly the orphan
+#      wave 2 closed;
+#   2. the customer's DATA moves after the ownership record, never before, so the
+#      destination is never holding leads for a site it does not yet own.
+"""Workspace-to-workspace site transfer: the preconditions, and the ordered re-key."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Ledger keys, in execution order. Named rather than positional for the reason
+# ``delete_cascade`` names its own: a step inserted later must not silently
+# renumber a half-finished transfer's record of itself.
+STEP_OWNERSHIP = "ownership"
+STEP_RECORDS = "records"
+STEP_ASSETS = "assets"
+STEP_FINALIZE = "finalize"
+
+TRANSFER_STEPS: tuple[str, ...] = (
+    STEP_OWNERSHIP,
+    STEP_RECORDS,
+    STEP_ASSETS,
+    STEP_FINALIZE,
+)
+
+OUTCOME_DONE = "done"
+OUTCOME_SKIPPED = "nothing-to-do"
+# The public assets are NOT copied to the destination's prefix, and this records
+# that as a deliberate outcome rather than leaving the step looking unrun. See
+# ``_move_assets`` for why copying them would be worse than leaving them.
+OUTCOME_ASSETS_RETAINED = "retained-at-source-prefix"
+
+# ``Site.transfer_status`` values. There is no terminal success value for the same
+# reason the delete cascade has none: a finished transfer returns the row to
+# ``none``, and the fact that it happened is carried by ``transferred_at``.
+STATUS_NONE = "none"
+STATUS_OFFERED = "offered"
+STATUS_IN_FLIGHT = "in_flight"
+STATUS_FAILED = "failed"
+
+# A delete that has not started is the only delete state a transfer may run over.
+# Anything else means a cascade is queued or mid-flight, and handing a tenant a site
+# that is being torn down under them is not a transfer.
+_DELETE_TERMINAL = ("none", "")
+
+
+class TransferRefused(Exception):
+    """A precondition said no. Carries a stable code plus a sentence for the user.
+
+    A code AND a message, rather than either alone: the frontend needs to branch on
+    the reason (a blocked workspace setting is a different button than an unpaid
+    balance), and the person reading the toast needs to know what to do next.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(f"{code}: {message}")
+
+
+class TransferStepFailed(Exception):
+    """One step failed. Carries ``"<step>:<cause>"`` for ``Site.transfer_reason``."""
+
+    def __init__(self, step: str, cause: str) -> None:
+        self.step = step
+        self.cause = cause
+        super().__init__(f"{step}:{cause}")
+
+    @property
+    def reason(self) -> str:
+        return f"{self.step}:{self.cause}"
+
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+#
+# Checked when the offer is MADE and again when it is ACCEPTED, deliberately. An
+# offer can sit for days, and every one of these facts can change while it does —
+# the site can be published onto a paid tier, a delete can be queued, an admin can
+# switch transfers off. Checking only at offer time would let a stale offer carry a
+# site past a guard that had since closed.
+
+
+def check_can_offer(
+    *,
+    site: Any,
+    actor_user_id: str,
+    source_settings: Any,
+    destination_workspace_id: str,
+) -> None:
+    """Refuse the offer unless the SOURCE side is entitled to make it.
+
+    ``source_settings`` is the source workspace's ``WorkspaceSettings``. Passed in
+    rather than read here so this stays a pure function over the facts.
+    """
+    dest = (destination_workspace_id or "").strip()
+    if not dest:
+        raise TransferRefused("transfer.no_destination", "Name the workspace to move this site to.")
+    if dest == (getattr(site, "workspace", "") or ""):
+        raise TransferRefused(
+            "transfer.same_workspace",
+            "That site already belongs to this workspace.",
+        )
+
+    # OWNER ONLY, matching Netlify and the wave-1 delete guard beside it. This is
+    # deliberately NOT widened to workspace admins: the permission layers in this
+    # codebase are known to disagree with one another, and the honest place to
+    # settle that is its own audit, not the first feature that needs an answer.
+    if (getattr(site, "owner", "") or "") != actor_user_id:
+        raise TransferRefused(
+            "transfer.not_owner",
+            "Only the person who owns this site can move it to another workspace.",
+        )
+
+    # An admin may forbid transfers OUT entirely. A site leaving a workspace takes
+    # its leads and its transcripts with it, so this is a data-egress control and
+    # belongs to the workspace, not to the person clicking the button.
+    if getattr(source_settings, "site_transfers_allowed", True) is False:
+        raise TransferRefused(
+            "transfer.blocked_by_workspace",
+            "This workspace does not allow sites to be moved out of it. "
+            "An admin can change that in workspace settings.",
+        )
+
+    if (getattr(site, "delete_status", "none") or "none") not in _DELETE_TERMINAL:
+        raise TransferRefused(
+            "transfer.deleting",
+            "This site is being deleted. It cannot be moved.",
+        )
+
+    status = getattr(site, "transfer_status", STATUS_NONE) or STATUS_NONE
+    if status == STATUS_OFFERED:
+        raise TransferRefused(
+            "transfer.already_offered",
+            "This site has already been offered to a workspace. "
+            "Cancel that offer before making another.",
+        )
+    if status == STATUS_IN_FLIGHT:
+        raise TransferRefused(
+            "transfer.in_flight",
+            "This site is being moved right now.",
+        )
+
+    _check_not_paying(site)
+
+
+def _check_not_paying(site: Any) -> None:
+    """Refuse to move a site somebody is currently paying for.
+
+    THE MONEY DOES NOT MOVE WITH THE SITE, AND IT CANNOT. A paid site is charged
+    against the SOURCE workspace's own credit balance — ``renewal_sweeper`` selects
+    the rows it charges on ``subscription_status == "active"`` and debits the wallet
+    of whatever workspace the row names. Re-key the row and the next renewal silently
+    starts charging the DESTINATION's balance for a plan its members never bought;
+    leave the row's billing fields behind and the site keeps the tier it has not paid
+    for. Both are wrong, and neither is discoverable by the person it happens to.
+
+    So the tier is dropped to the free floor BEFORE the move, by the person who is
+    paying for it, as an explicit act. Blocking is the honest failure: it is one
+    extra step for the sender and it is the only version of this that cannot
+    mis-charge a stranger.
+
+    This package cannot reach a payment gateway to settle it either way — those rails
+    were removed on 2026-09-05 and ``tests/cloud/sites/test_no_gateway_in_sites.py``
+    asserts their absence against the source text. Refusing is not a limitation of
+    that; it is the correct behaviour on the credits rail regardless.
+    """
+    if (getattr(site, "subscription_status", "none") or "none") == "active":
+        raise TransferRefused(
+            "transfer.site_is_paid",
+            "This site is on a paid plan billed to this workspace. Move it down to "
+            "the free plan first, then transfer it — the new workspace can upgrade "
+            "it again from its own balance.",
+        )
+
+
+def check_can_accept(
+    *,
+    site: Any,
+    accepting_user_id: str,
+    accepting_workspace_id: str,
+    member_workspace_ids: tuple[str, ...] | list[str],
+) -> None:
+    """Refuse the accept unless the DESTINATION side is entitled to take it.
+
+    ``member_workspace_ids`` is every workspace the accepting user actually belongs
+    to, read from their own User record. The check is against THAT rather than
+    against the request's workspace header: the header says which tenant the caller
+    is asking to act as, and a caller who is not a member of it must not be able to
+    accept a site into it by naming it.
+    """
+    status = getattr(site, "transfer_status", STATUS_NONE) or STATUS_NONE
+    if status != STATUS_OFFERED:
+        raise TransferRefused(
+            "transfer.not_offered",
+            "There is no open offer for this site.",
+        )
+
+    offered_to = (getattr(site, "transfer_to_workspace", "") or "").strip()
+    if not offered_to or offered_to != (accepting_workspace_id or "").strip():
+        # Not "forbidden" — NOT FOUND, because saying "that site was offered
+        # somewhere else" confirms the site exists to a tenant with no business
+        # knowing it does.
+        raise TransferRefused(
+            "transfer.not_offered",
+            "There is no open offer for this site.",
+        )
+
+    if accepting_workspace_id not in tuple(member_workspace_ids or ()):
+        raise TransferRefused(
+            "transfer.not_a_member",
+            "You are not a member of the workspace this site was offered to.",
+        )
+
+    if (getattr(site, "delete_status", "none") or "none") not in _DELETE_TERMINAL:
+        raise TransferRefused(
+            "transfer.deleting",
+            "This site is being deleted. It cannot be moved.",
+        )
+
+    # Re-checked at accept, not only at offer: a site can be published onto a paid
+    # tier while the offer sits unanswered, and accepting it then would hand the
+    # destination a plan the source is still being charged for.
+    _check_not_paying(site)
+
+    if not accepting_user_id:
+        raise TransferRefused("transfer.no_actor", "Sign in to accept this site.")
+
+
+# ---------------------------------------------------------------------------
+# The re-key
+# ---------------------------------------------------------------------------
+
+
+async def run_transfer(
+    *,
+    site: Any,
+    destination_workspace_id: str,
+    accepting_user_id: str,
+    deps: Any,
+    save: Any,
+) -> None:
+    """Move the site to ``destination_workspace_id``, recording each step.
+
+    ``deps`` supplies the side effects (``move_pocket``, ``move_records``, ``now``)
+    so the order and the ledger are testable without Mongo. ``save`` persists after
+    every step — a ledger written only at the end records nothing about the crash it
+    exists to survive.
+
+    Raises :class:`TransferStepFailed` at the first failing step, leaving every
+    earlier step recorded so a re-run resumes rather than repeats.
+    """
+    ledger: dict[str, str] = dict(getattr(site, "transfer_ledger", None) or {})
+
+    async def record(step: str, outcome: str) -> None:
+        ledger[step] = outcome
+        site.transfer_ledger = dict(ledger)
+        await save(site)
+
+    for step in TRANSFER_STEPS:
+        if step in ledger:
+            continue
+        try:
+            outcome = await _run_step(
+                step,
+                site=site,
+                destination=destination_workspace_id,
+                accepting_user_id=accepting_user_id,
+                deps=deps,
+            )
+        except TransferStepFailed:
+            raise
+        except Exception as exc:  # noqa: BLE001 - classified, then re-raised
+            logger.warning("sites.transfer step %s failed: %s", step, exc, exc_info=True)
+            raise TransferStepFailed(step, _classify(exc)) from exc
+        await record(step, outcome)
+
+
+def _classify(exc: Exception) -> str:
+    """A short, machine-readable cause — never raw driver or provider text.
+
+    ``transfer_reason`` is surfaced to the customer, so it carries a fixed token the
+    same way ``build_reason`` and ``delete_reason`` do.
+    """
+    name = type(exc).__name__
+    return "".join(c.lower() if c.isalnum() else "_" for c in name).strip("_") or "error"
+
+
+async def _run_step(
+    step: str,
+    *,
+    site: Any,
+    destination: str,
+    accepting_user_id: str,
+    deps: Any,
+) -> str:
+    if step == STEP_OWNERSHIP:
+        return await _move_ownership(
+            site=site, destination=destination, accepting_user_id=accepting_user_id, deps=deps
+        )
+    if step == STEP_RECORDS:
+        return await _move_records(site=site, destination=destination, deps=deps)
+    if step == STEP_ASSETS:
+        return await _move_assets(site=site, deps=deps)
+    if step == STEP_FINALIZE:
+        return await _finalize(site=site, accepting_user_id=accepting_user_id, deps=deps)
+    raise TransferStepFailed(step, "unknown_step")
+
+
+async def _move_ownership(*, site: Any, destination: str, accepting_user_id: str, deps: Any) -> str:
+    """FIRST, and the pocket and the Site move together inside it.
+
+    THE PAIR IS ATOMIC BY CONSTRUCTION RATHER THAN BY TRANSACTION. The guard that
+    stops ``pockets_service.delete`` stranding a live site looks the site up through
+    the POCKET's workspace, so a window with the two in different tenants re-opens
+    the exact orphan wave 2 closed — in that window either side can delete the pocket
+    and leave a Worker serving with nothing able to reach it. Both writes happen
+    here, back to back, and the ledger entry is written only once both have. A crash
+    between them leaves a resumable state that this step re-enters and completes,
+    because both writes are idempotent and both records are found by ``pocket_id``
+    regardless of which workspace currently holds them.
+
+    THE OLD TENANT'S PEOPLE LOSE ACCESS HERE TOO. Re-keying the workspace alone would
+    move the pocket while leaving ``owner`` and ``shared_with`` pointing at users of
+    the workspace it just left, and a pocket read is an ``$or`` over exactly those
+    two plus visibility. Carrying them across would be a cross-tenant grant dressed
+    up as a field nobody thought about.
+    """
+    pocket_id = getattr(site, "pocket_id", "") or ""
+    if pocket_id:
+        await deps.move_pocket(
+            pocket_id=pocket_id,
+            destination_workspace_id=destination,
+            new_owner_id=accepting_user_id,
+        )
+
+    # The stamp that stops the next publish forking the site in two. Written only
+    # if it is not already set: a site transferred twice was still MINTED once, and
+    # overwriting this with the most recent source would make the second move
+    # re-derive an id the Worker has never been called.
+    if not (getattr(site, "identity_workspace", "") or ""):
+        site.identity_workspace = getattr(site, "workspace", "") or ""
+
+    site.workspace = destination
+    site.owner = accepting_user_id
+    return OUTCOME_DONE
+
+
+async def _move_records(*, site: Any, destination: str, deps: Any) -> str:
+    """The customer's data, AFTER the ownership record and never before.
+
+    Leads, concierge transcripts, the design brief and the rate counter are all
+    workspace-keyed rows about this site. Moving them first would put a tenant in
+    possession of another tenant's captured contact details before it owned the site
+    they belong to — and if the transfer then failed and was abandoned, it would keep
+    them.
+    """
+    moved = await deps.move_records(
+        site_id=str(getattr(site, "id", "")),
+        source_workspace_id=getattr(site, "identity_workspace", "") or "",
+        destination_workspace_id=destination,
+    )
+    return OUTCOME_DONE if moved else OUTCOME_SKIPPED
+
+
+async def _move_assets(*, site: Any, deps: Any) -> str:
+    """The public images DO NOT MOVE, and copying them would be worse than this.
+
+    A site's images live on a world-readable bucket under
+    ``public_assets.prefix_for(workspace, pocket)`` — the SOURCE workspace id is
+    inside the object key. The design this implements called for copying the prefix
+    to the destination and purging the source. Both halves are wrong here, for the
+    same reason:
+
+      * that key is baked into an ABSOLUTE, IMMUTABLE, year-cached public URL that
+        is already sitting inside the deployed HTML AND inside the pocket's stored
+        spec. Nothing rewrites either. So purging the source blanks every image on a
+        live site the moment it changes hands — the one outcome a transfer must not
+        produce;
+      * and copying the bytes to a prefix that nothing references buys nothing. A
+        republish rebuilds from the same stored spec and emits the same old URLs.
+
+    So the objects stay exactly where they are and the site keeps rendering. What
+    this step DOES is record the prefix they stayed at, because otherwise they become
+    unreclaimable: the delete cascade purges ``prefix_for(site.workspace, ...)``, and
+    after a transfer that names the destination — an empty prefix — while the real
+    objects sit under a workspace id no surviving record mentions. Teardown reads
+    this list and purges those too.
+
+    They are not reachable by the old tenant in the meantime: every asset endpoint
+    resolves the prefix from the caller's own workspace and the pocket has moved, so
+    the source can no longer list or delete them.
+    """
+    source_ws = (getattr(site, "identity_workspace", "") or "").strip()
+    pocket_id = (getattr(site, "pocket_id", "") or "").strip()
+    if not source_ws or not pocket_id:
+        return OUTCOME_SKIPPED
+
+    prefix = deps.asset_prefix_for(source_ws, pocket_id)
+    retained = list(getattr(site, "asset_source_prefixes", None) or [])
+    if prefix not in retained:
+        retained.append(prefix)
+    site.asset_source_prefixes = retained
+    return OUTCOME_ASSETS_RETAINED
+
+
+async def _finalize(*, site: Any, accepting_user_id: str, deps: Any) -> str:
+    """Clear the offer and stamp the move. LAST, so nothing reads as settled early.
+
+    Returning ``transfer_status`` to ``none`` rather than to a terminal success value
+    is the same choice ``delete_status`` makes: the row is in its ordinary state
+    again, and ``transferred_at`` is what records that this happened.
+    """
+    site.transfer_status = STATUS_NONE
+    site.transfer_to_workspace = ""
+    site.transfer_offered_by = ""
+    site.transfer_offered_at = None
+    site.transfer_reason = None
+    site.transferred_at = deps.now()
+    return OUTCOME_DONE

--- a/ee/pocketpaw_ee/sites/transfer.py
+++ b/ee/pocketpaw_ee/sites/transfer.py
@@ -84,6 +84,23 @@ STATUS_OFFERED = "offered"
 STATUS_IN_FLIGHT = "in_flight"
 STATUS_FAILED = "failed"
 
+# The states an accept may run over. ``offered`` is the ordinary one; the other two
+# are RESUMES, and leaving them out is what makes a ledger decorative.
+#
+# A failed transfer has a half-written ledger and is precisely the case the ledger
+# exists for, so refusing it would mean ownership stayed split across two tenants
+# with no way to finish the move. And ``in_flight`` is here for the crash that
+# leaves nothing to clear it: a process that dies mid-transfer pins the row there
+# forever, and a one-way door is a worse failure than a redundant pass. This is the
+# same asymmetry the delete cascade's single-flight comment argues for — a repeat
+# run costs one idempotent sweep over a ledger that skips finished steps, while a
+# stuck guard costs the transfer permanently.
+#
+# A repeat is safe because every step is idempotent and the ledger turns a
+# re-entry into a skip. A COMPLETED transfer is not here: success returns the row
+# to ``none`` and clears ``transfer_to_workspace``, so the offer cannot be replayed.
+RESUMABLE_STATUSES: tuple[str, ...] = (STATUS_OFFERED, STATUS_IN_FLIGHT, STATUS_FAILED)
+
 # A delete that has not started is the only delete state a transfer may run over.
 # Anything else means a cascade is queued or mid-flight, and handing a tenant a site
 # that is being torn down under them is not a transfer.
@@ -237,7 +254,7 @@ def check_can_accept(
     accept a site into it by naming it.
     """
     status = getattr(site, "transfer_status", STATUS_NONE) or STATUS_NONE
-    if status != STATUS_OFFERED:
+    if status not in RESUMABLE_STATUSES:
         raise TransferRefused(
             "transfer.not_offered",
             "There is no open offer for this site.",

--- a/tests/cloud/sites/test_transfer_authz.py
+++ b/tests/cloud/sites/test_transfer_authz.py
@@ -26,6 +26,7 @@ import itertools
 
 import pytest
 from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.models.lead import Lead, LeadSource
 from pocketpaw_ee.cloud.models.pocket import Pocket
 from pocketpaw_ee.cloud.models.site import Site
 from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
@@ -378,3 +379,51 @@ async def test_cancel_withdraws_the_offer():
 
 def _source_of(site: Site) -> str:
     return site.workspace
+
+
+async def test_the_sites_leads_move_with_it():
+    """THE STEP THAT IS EASIEST TO BELIEVE WITHOUT CHECKING.
+
+    ``move_records`` reads its result off a Beanie ``UpdateResult`` and reports a
+    boolean. If that attribute were absent or None the step would report "there was
+    nothing here", the ledger would record a skip, and the leads would stay in a
+    workspace that can no longer see the site they belong to — while every ordering
+    test still passed, because they assert the step was CALLED.
+
+    So this asserts the rows, not the call.
+
+    Mutation that must break this: have ``_TransferDeps.move_records`` return False
+    without running the update.
+    """
+    sender, recipient, source, dest, site = await _offered()
+    for i in range(2):
+        await Lead(
+            workspace=source,
+            site_id=str(site.id),
+            form_type="AppointmentRequest",
+            properties={"email": f"visitor{i}@example.test"},
+            source=LeadSource(form_type="AppointmentRequest", site_id=str(site.id)),
+        ).insert()
+    # A lead belonging to a DIFFERENT site in the same workspace, which must stay.
+    other = await _site(source, sender, name="Other")
+    await Lead(
+        workspace=source,
+        site_id=str(other.id),
+        form_type="AppointmentRequest",
+        properties={"email": "not-this-one@example.test"},
+        source=LeadSource(form_type="AppointmentRequest", site_id=str(other.id)),
+    ).insert()
+
+    await sites_service.accept_site_transfer(
+        workspace_id=dest, user_id=recipient, site_id=str(site.id)
+    )
+
+    moved = await Lead.find({"workspace": dest}).to_list()
+    assert {lead.site_id for lead in moved} == {str(site.id)}
+    assert len(moved) == 2
+
+    stayed = await Lead.find({"workspace": source}).to_list()
+    assert [lead.site_id for lead in stayed] == [str(other.id)]
+
+    fresh = await Site.get(site.id)
+    assert fresh.transfer_ledger["records"] == "done"

--- a/tests/cloud/sites/test_transfer_authz.py
+++ b/tests/cloud/sites/test_transfer_authz.py
@@ -1,0 +1,380 @@
+# tests/cloud/sites/test_transfer_authz.py — the transfer's tenancy boundary,
+# driven through the real service functions against a real (mock) Mongo.
+#
+# Created 2026-09-12 (sites lifecycle wave 3, feat/sites-transfer).
+#
+# WHY THIS EXISTS ALONGSIDE tests/ee/sites/test_transfer.py. That file tests the
+# ordering and the refusal PREDICATES in isolation, with doubles. This one exists
+# because the predicates being right proves nothing about whether they are reached:
+# a transfer is the one sites operation that deliberately crosses a tenancy line, and
+# the ways that goes wrong are all in the wiring —
+#
+#   * the incoming-offers read is the only sites query NOT anchored on the caller's
+#     workspace. If its filter were wrong it would list other tenants' sites, and a
+#     test with one workspace in the database could never see that;
+#   * accepting addresses a row that belongs to SOMEBODY ELSE, so it cannot use the
+#     tenant-scoped loader every other sites read uses. That is exactly the shape of
+#     code that ends up with no tenant filter at all;
+#   * the membership check has to read the accepting user's OWN record. Asserting it
+#     against a constructed list would test the function and not the wiring.
+#
+# So every test here puts at least two workspaces and two users in the database.
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.models.pocket import Pocket
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+from pocketpaw_ee.cloud.models.workspace import Workspace
+from pocketpaw_ee.sites import public_assets
+from pocketpaw_ee.sites import service as sites_service
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+_SLUGS = itertools.count()
+
+
+async def _workspace(slug: str, owner: str, *, transfers_allowed: bool = True) -> str:
+    # ``slug`` is uniquely indexed, and several tests build two tenant pairs, so the
+    # name is suffixed rather than reused.
+    ws = Workspace(name=slug, slug=f"{slug}-{next(_SLUGS)}", owner=owner)
+    ws.settings.site_transfers_allowed = transfers_allowed
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _user(workspaces: list[str], email: str) -> str:
+    user = User(
+        email=email,
+        name=email.split("@")[0],
+        # Required on the model; never read by anything under test here.
+        hashed_password="x",
+        workspaces=[WorkspaceMembership(workspace=w, role="member") for w in workspaces],
+    )
+    await user.insert()
+    return str(user.id)
+
+
+async def _site(workspace: str, owner: str, *, name: str = "Acme") -> Site:
+    pocket = Pocket(workspace=workspace, owner=owner, name=name)
+    await pocket.insert()
+    oid = sites_service._live_object_id(workspace, str(pocket.id))
+    site = Site(
+        id=oid,
+        workspace=workspace,
+        pocket_id=str(pocket.id),
+        owner=owner,
+        name=name,
+        script_name=str(oid),
+        url=f"https://{oid}.paw.dev",
+        deployed=True,
+    )
+    await site.insert()
+    return site
+
+
+async def _two_tenants():
+    """A source and a destination, with a distinct owner on each side."""
+    sender = await _user([], "sender@acme.test")
+    recipient = await _user([], "recipient@client.test")
+    source = await _workspace("acme", sender)
+    dest = await _workspace("client", recipient)
+    # Re-read memberships now that the workspace ids exist.
+    for uid, ws in ((sender, source), (recipient, dest)):
+        user = await User.get(uid)
+        user.workspaces = [WorkspaceMembership(workspace=ws, role="member")]
+        await user.save()
+    return sender, recipient, source, dest
+
+
+async def _offered():
+    sender, recipient, source, dest = await _two_tenants()
+    site = await _site(source, sender)
+    await sites_service.offer_site_transfer(
+        workspace_id=source,
+        user_id=sender,
+        site_id=str(site.id),
+        destination_workspace_id=dest,
+    )
+    return sender, recipient, source, dest, site
+
+
+# ---------------------------------------------------------------------------
+# The send half
+# ---------------------------------------------------------------------------
+
+
+async def test_offer_is_tenant_scoped_to_the_sender():
+    """A workspace cannot offer a site it does not own, even by id.
+
+    The offer loads through ``_load``, which filters on workspace — so a third party
+    naming the site id gets a not-found rather than the power to give it away.
+    """
+    sender, _recipient, source, dest = await _two_tenants()
+    site = await _site(source, sender)
+    outsider_ws = await _workspace("outsider", "u-outsider")
+    with pytest.raises(CloudError) as exc:
+        await sites_service.offer_site_transfer(
+            workspace_id=outsider_ws,
+            user_id="u-outsider",
+            site_id=str(site.id),
+            destination_workspace_id=dest,
+        )
+    assert exc.value.status_code == 404
+
+
+async def test_offer_refuses_a_destination_that_does_not_exist():
+    """An offer into a typo would park the site in ``offered`` forever, with nobody
+    able to accept it and nobody told why."""
+    sender, _r, source, _dest = await _two_tenants()
+    site = await _site(source, sender)
+    with pytest.raises(CloudError) as exc:
+        await sites_service.offer_site_transfer(
+            workspace_id=source,
+            user_id=sender,
+            site_id=str(site.id),
+            destination_workspace_id="64b7f1e2c3d4e5f6a7b8c9d0",
+        )
+    assert exc.value.status_code == 404
+
+
+async def test_offer_refuses_when_the_workspace_forbids_transfers_out():
+    sender = await _user([], "s@acme.test")
+    source = await _workspace("locked", sender, transfers_allowed=False)
+    dest = await _workspace("dest", "u2")
+    user = await User.get(sender)
+    user.workspaces = [WorkspaceMembership(workspace=source, role="member")]
+    await user.save()
+    site = await _site(source, sender)
+    with pytest.raises(CloudError) as exc:
+        await sites_service.offer_site_transfer(
+            workspace_id=source,
+            user_id=sender,
+            site_id=str(site.id),
+            destination_workspace_id=dest,
+        )
+    assert exc.value.status_code == 403
+
+
+async def test_offer_moves_nothing():
+    """THE TWO-PHASE PROPERTY. An offer is a request, not a transfer.
+
+    Mutation that must break this: have ``offer_site_transfer`` set ``workspace`` to
+    the destination alongside ``transfer_to_workspace``.
+    """
+    sender, _r, source, dest, site = await _offered()
+    fresh = await Site.get(site.id)
+    assert fresh.workspace == source
+    assert fresh.owner == sender
+    assert fresh.transfer_status == "offered"
+    assert fresh.transfer_to_workspace == dest
+
+
+# ---------------------------------------------------------------------------
+# The receive half — the one a single-call transfer would not gate at all
+# ---------------------------------------------------------------------------
+
+
+async def test_incoming_lists_only_what_was_offered_to_you():
+    """The one sites read not anchored on the caller's workspace.
+
+    Two live offers exist in the database, addressed to two different tenants. Each
+    must see exactly its own. A single-tenant fixture would pass against a filter
+    that was missing entirely, which is why there are two here.
+
+    Mutation that must break this: drop ``transfer_to_workspace`` from the query in
+    ``list_incoming_site_transfers``.
+    """
+    _s1, _r1, _src1, dest1, site1 = await _offered()
+    _s2, _r2, _src2, dest2, site2 = await _offered()
+
+    to_one = await sites_service.list_incoming_site_transfers(workspace_id=dest1)
+    to_two = await sites_service.list_incoming_site_transfers(workspace_id=dest2)
+    assert [r["siteId"] for r in to_one] == [str(site1.id)]
+    assert [r["siteId"] for r in to_two] == [str(site2.id)]
+
+
+async def test_incoming_does_not_leak_the_signed_key_or_capture_config():
+    """The destination is reading a row that still belongs to somebody else.
+
+    ``signed_key`` is a live credential for lead ingest on a site this workspace does
+    not own yet. It must not be in the payload that helps them decide.
+    """
+    _s, _r, _src, dest, _site = await _offered()
+    rows = await sites_service.list_incoming_site_transfers(workspace_id=dest)
+    assert rows, "expected the offer to be listed"
+    blob = repr(rows[0]).lower()
+    assert "signed" not in blob
+    assert "site_key_" not in blob
+    assert set(rows[0]) == {
+        "siteId",
+        "name",
+        "url",
+        "fromWorkspaceId",
+        "offeredBy",
+        "offeredAt",
+        "status",
+        "toWorkspaceId",
+    }
+
+
+async def test_a_non_member_cannot_accept_into_the_destination():
+    """THE RECEIVING GUARD, and the reason this test needs a real user row.
+
+    The caller names the destination workspace in the request context — which a
+    caller can do freely. What stops them is their own User record not listing it.
+
+    Mutation that must break this: have ``_member_workspace_ids`` return
+    ``(workspace_id,)`` instead of reading the user.
+    """
+    _sender, _recipient, _source, dest, site = await _offered()
+    outsider = await _user(["some-other-workspace"], "outsider@elsewhere.test")
+    with pytest.raises(CloudError) as exc:
+        await sites_service.accept_site_transfer(
+            workspace_id=dest,
+            user_id=outsider,
+            site_id=str(site.id),
+        )
+    assert exc.value.status_code == 403
+
+
+async def test_a_third_workspace_cannot_accept_an_offer_addressed_elsewhere():
+    """Not-found rather than forbidden: telling a stranger the site exists is the
+    leak, and it is one a 403 would commit."""
+    _sender, _recipient, _source, _dest, site = await _offered()
+    third = await _workspace("third", "u-third")
+    interloper = await _user([third], "third@party.test")
+    with pytest.raises(CloudError) as exc:
+        await sites_service.accept_site_transfer(
+            workspace_id=third,
+            user_id=interloper,
+            site_id=str(site.id),
+        )
+    assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# What a completed transfer actually does
+# ---------------------------------------------------------------------------
+
+
+async def test_accept_rekeys_the_site_and_the_pocket_together():
+    """The pair moves as one. A window with the pocket and the site in different
+    tenants re-opens the orphan wave 2 closed: the guard that stops a pocket delete
+    stranding a live site finds the site through the POCKET's workspace."""
+    _sender, recipient, _source, dest, site = await _offered()
+    await sites_service.accept_site_transfer(
+        workspace_id=dest, user_id=recipient, site_id=str(site.id)
+    )
+    fresh = await Site.get(site.id)
+    pocket = await Pocket.get(fresh.pocket_id)
+    assert fresh.workspace == dest
+    assert pocket.workspace == dest
+    assert fresh.owner == recipient
+    assert pocket.owner == recipient
+
+
+async def test_the_old_tenants_people_lose_access_to_the_pocket():
+    """``owner`` and ``shared_with`` name users of the workspace the pocket just
+    left, and a pocket read is an ``$or`` over exactly those two plus visibility."""
+    sender, recipient, source, dest, site = await _offered()
+    pocket = await Pocket.get(site.pocket_id)
+    pocket.shared_with = ["colleague-at-source"]
+    await pocket.save()
+
+    await sites_service.accept_site_transfer(
+        workspace_id=dest, user_id=recipient, site_id=str(site.id)
+    )
+    moved = await Pocket.get(site.pocket_id)
+    assert moved.owner != sender
+    assert moved.shared_with == []
+
+
+async def test_the_site_keeps_its_id_its_script_and_its_url():
+    """THE INVARIANT THE DESIGN IS BUILT AROUND — asserted end to end.
+
+    ``_id`` is the Worker's script name and the subdomain the site serves at.
+    """
+    _sender, recipient, _source, dest, site = await _offered()
+    before = (site.id, site.script_name, site.url)
+    await sites_service.accept_site_transfer(
+        workspace_id=dest, user_id=recipient, site_id=str(site.id)
+    )
+    fresh = await Site.get(site.id)
+    assert (fresh.id, fresh.script_name, fresh.url) == before
+
+
+async def test_a_republish_after_transfer_does_not_fork_the_site():
+    """THE BUG THIS WAVE EXISTS TO NOT SHIP.
+
+    ``_live_object_id`` derives the id from (workspace, pocket) — so after a
+    transfer the derivation no longer matches the row, and an unguarded publish
+    would insert a SECOND Site doc, upload a SECOND Worker, and serve it at a
+    SECOND address while every custom domain still resolved to the first.
+
+    Mutation that must break this: make ``_resolve_live_site_oid`` return
+    ``_live_object_id(workspace_id, pocket_id)`` unconditionally.
+    """
+    _sender, recipient, source, dest, site = await _offered()
+    await sites_service.accept_site_transfer(
+        workspace_id=dest, user_id=recipient, site_id=str(site.id)
+    )
+    fresh = await Site.get(site.id)
+
+    derived_in_destination = sites_service._live_object_id(dest, fresh.pocket_id)
+    assert derived_in_destination != site.id, "fixture is not exercising the fork"
+
+    resolved = await sites_service._resolve_live_site_oid(dest, fresh.pocket_id)
+    assert resolved == site.id
+
+    # And the derivation is still what an untransferred pocket gets, so the PERF-1
+    # dedupe invariant is untouched for every other site.
+    other = await _site(source, "u-someone", name="Other")
+    assert await sites_service._resolve_live_site_oid(
+        source, other.pocket_id
+    ) == sites_service._live_object_id(source, other.pocket_id)
+
+
+async def test_the_source_public_asset_prefix_is_recorded():
+    """The images do not move — their key is inside an immutable URL in the live
+    HTML — so the prefix is recorded or the delete cascade can never reclaim them."""
+    _sender, recipient, source, dest, site = await _offered()
+    await sites_service.accept_site_transfer(
+        workspace_id=dest, user_id=recipient, site_id=str(site.id)
+    )
+    fresh = await Site.get(site.id)
+    # Read from the real helper rather than a literal: the prefix constant is the
+    # store's business, and a copy here would pass while pointing somewhere else.
+    assert fresh.asset_source_prefixes == [public_assets.prefix_for(source, fresh.pocket_id)]
+
+
+async def test_accepting_twice_is_refused_rather_than_repeated():
+    _sender, recipient, _source, dest, site = await _offered()
+    await sites_service.accept_site_transfer(
+        workspace_id=dest, user_id=recipient, site_id=str(site.id)
+    )
+    with pytest.raises(CloudError):
+        await sites_service.accept_site_transfer(
+            workspace_id=dest, user_id=recipient, site_id=str(site.id)
+        )
+
+
+async def test_cancel_withdraws_the_offer():
+    sender, recipient, _source, dest, site = await _offered()
+    await sites_service.cancel_site_transfer(
+        workspace_id=_source_of(site), user_id=sender, site_id=str(site.id)
+    )
+    assert await sites_service.list_incoming_site_transfers(workspace_id=dest) == []
+    with pytest.raises(CloudError):
+        await sites_service.accept_site_transfer(
+            workspace_id=dest, user_id=recipient, site_id=str(site.id)
+        )
+
+
+def _source_of(site: Site) -> str:
+    return site.workspace

--- a/tests/ee/sites/test_transfer.py
+++ b/tests/ee/sites/test_transfer.py
@@ -24,6 +24,7 @@ from pocketpaw_ee.sites.transfer import (
     OUTCOME_ASSETS_RETAINED,
     OUTCOME_DONE,
     OUTCOME_SKIPPED,
+    RESUMABLE_STATUSES,
     STATUS_FAILED,
     STATUS_IN_FLIGHT,
     STATUS_NONE,
@@ -207,12 +208,12 @@ def test_cannot_offer_twice():
 
 
 def _offered(**kw):
-    return _Site(
-        transfer_status=STATUS_OFFERED,
-        transfer_to_workspace="ws-dest",
-        transfer_offered_by="user-sender",
-        **kw,
-    )
+    # setdefault rather than fixed kwargs so a test can pin a DIFFERENT
+    # transfer_status (the resume cases) without a duplicate-keyword TypeError.
+    kw.setdefault("transfer_status", STATUS_OFFERED)
+    kw.setdefault("transfer_to_workspace", "ws-dest")
+    kw.setdefault("transfer_offered_by", "user-sender")
+    return _Site(**kw)
 
 
 def test_a_member_of_the_destination_may_accept():
@@ -543,3 +544,76 @@ def test_status_values_do_not_collide():
     the same choice ``delete_status`` makes."""
     assert len({STATUS_NONE, STATUS_OFFERED, STATUS_IN_FLIGHT, STATUS_FAILED}) == 4
     assert STATUS_NONE == "none"
+
+
+def test_a_failed_transfer_can_be_accepted_again():
+    """THE THING THAT MAKES THE LEDGER WORTH HAVING.
+
+    A transfer that failed part-way has ownership split across two tenants and a
+    half-written ledger. If the accept guard only admitted ``offered``, that row
+    could never be finished: the ledger would record exactly which steps ran and
+    nothing would ever be allowed to read it.
+
+    Mutation that must break this: drop ``STATUS_FAILED`` from
+    ``RESUMABLE_STATUSES``.
+    """
+    check_can_accept(
+        site=_offered(transfer_status=STATUS_FAILED, transfer_reason="records:runtimeerror"),
+        accepting_user_id="user-recipient",
+        accepting_workspace_id="ws-dest",
+        member_workspace_ids=("ws-dest",),
+    )
+
+
+def test_a_crashed_in_flight_transfer_can_be_accepted_again():
+    """A process that dies mid-transfer leaves nothing to clear ``in_flight``.
+
+    Refusing it would pin the row there forever, which is a worse failure than a
+    redundant pass over a ledger that skips every finished step.
+    """
+    check_can_accept(
+        site=_offered(transfer_status=STATUS_IN_FLIGHT),
+        accepting_user_id="user-recipient",
+        accepting_workspace_id="ws-dest",
+        member_workspace_ids=("ws-dest",),
+    )
+
+
+def test_a_completed_transfer_cannot_be_replayed():
+    """Success returns the row to ``none``, which is not resumable."""
+    assert STATUS_NONE not in RESUMABLE_STATUSES
+    with pytest.raises(TransferRefused) as exc:
+        check_can_accept(
+            site=_Site(transfer_status=STATUS_NONE, transfer_to_workspace=""),
+            accepting_user_id="user-recipient",
+            accepting_workspace_id="ws-dest",
+            member_workspace_ids=("ws-dest",),
+        )
+    assert exc.value.code == "transfer.not_offered"
+
+
+async def test_a_resumed_transfer_after_a_failure_finishes_the_remaining_steps():
+    """End to end: fail at records, then re-run and watch it complete without
+    redoing the ownership step it already recorded."""
+    site = _offered()
+    with pytest.raises(TransferStepFailed):
+        await run_transfer(
+            site=site,
+            destination_workspace_id="ws-dest",
+            accepting_user_id="user-recipient",
+            deps=_Deps(fail_on="move_records"),
+            save=_saver([]),
+        )
+    assert site.transfer_ledger == {STEP_OWNERSHIP: OUTCOME_DONE}
+
+    second = _Deps()
+    await run_transfer(
+        site=site,
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=second,
+        save=_saver([]),
+    )
+    assert second.pocket_moves == [], "the ownership step should have been skipped"
+    assert set(site.transfer_ledger) == set(TRANSFER_STEPS)
+    assert site.transfer_status == STATUS_NONE

--- a/tests/ee/sites/test_transfer.py
+++ b/tests/ee/sites/test_transfer.py
@@ -693,3 +693,98 @@ async def test_purge_prefix_does_not_sweep_a_sibling_pocket():
     store = PublicAssetStore(adapter)
     await store.purge_prefix("sites-assets/ws/pk1")
     assert adapter.deleted == ["sites-assets/ws/pk1/only-mine.png"]
+
+
+# ---------------------------------------------------------------------------
+# The teardown half: the retained prefixes have to actually be swept
+# ---------------------------------------------------------------------------
+
+
+class _CascadeSite:
+    """A site as the delete cascade sees it, already transferred."""
+
+    def __init__(self, **kw):
+        self.id = "site-1"
+        self.workspace = "ws-dest"
+        self.pocket_id = "pk-1"
+        self.asset_source_prefixes: list[str] = []
+        self.__dict__.update(kw)
+
+
+class _CascadeDeps:
+    def __init__(self, assets):
+        self.assets = assets
+
+
+async def test_deleting_a_transferred_site_sweeps_the_prefix_its_images_really_live_under():
+    """THE LEAK THE RETAINED LIST EXISTS TO CLOSE, asserted on the objects.
+
+    ``_purge_assets`` derives its prefix from the site's CURRENT workspace, so on a
+    transferred site it sweeps an empty prefix while the real images sit under the
+    workspace that minted them. Missing them does not leave an untidy bucket: the
+    Site document is the only thing naming those objects and the cascade deletes it
+    moments later, so they stay world-readable and unenumerable forever.
+
+    This asserts the adapter's DELETED KEYS rather than that a method was called —
+    the same gap the leads test closed earlier in this branch.
+
+    Mutation that must break this: drop the ``asset_source_prefixes`` loop from
+    ``delete_cascade._purge_assets``.
+    """
+    from pocketpaw_ee.sites.delete_cascade import _purge_assets
+    from pocketpaw_ee.sites.public_assets import PublicAssetStore
+
+    source_prefix = "sites-assets/ws-source/pk-1/"
+    dest_prefix = "sites-assets/ws-dest/pk-1/"
+    adapter = _Adapter({source_prefix: ["hero.png", "team.jpg"], dest_prefix: []})
+    site = _CascadeSite(asset_source_prefixes=[source_prefix])
+
+    outcome = await _purge_assets(site=site, deps=_CascadeDeps(PublicAssetStore(adapter)))
+
+    assert outcome == "done"
+    assert sorted(adapter.deleted) == [
+        f"{source_prefix}hero.png",
+        f"{source_prefix}team.jpg",
+    ]
+
+
+async def test_an_untransferred_site_still_purges_exactly_its_own_prefix():
+    """The retained list is empty for every site that has never moved, so this path
+    has to be byte-identical to what it was before the wiring."""
+    from pocketpaw_ee.sites.delete_cascade import _purge_assets
+    from pocketpaw_ee.sites.public_assets import PublicAssetStore
+
+    own_prefix = "sites-assets/ws-dest/pk-1/"
+    adapter = _Adapter({own_prefix: ["only.png"]})
+
+    outcome = await _purge_assets(site=_CascadeSite(), deps=_CascadeDeps(PublicAssetStore(adapter)))
+
+    assert outcome == "done"
+    assert adapter.deleted == [f"{own_prefix}only.png"]
+
+
+async def test_a_failure_on_a_retained_prefix_fails_the_step_rather_than_passing_quietly():
+    """A swallowed failure here records a completed teardown over a live bucket."""
+    from pocketpaw_ee.sites.delete_cascade import _purge_assets
+
+    class _Boom:
+        async def purge(self, **kw):
+            return 0
+
+        async def purge_prefix(self, prefix):
+            raise RuntimeError("bucket said no")
+
+    with pytest.raises(RuntimeError):
+        await _purge_assets(
+            site=_CascadeSite(asset_source_prefixes=["sites-assets/ws-source/pk-1/"]),
+            deps=_CascadeDeps(_Boom()),
+        )
+
+
+def test_the_r2_step_runs_before_the_records_step():
+    """The wiring above only works because of this order: ``records`` and the Site
+    deletion destroy ``asset_source_prefixes``, which is the only record naming
+    those objects."""
+    from pocketpaw_ee.sites.delete_cascade import CASCADE_STEPS, STEP_R2, STEP_RECORDS
+
+    assert CASCADE_STEPS.index(STEP_R2) < CASCADE_STEPS.index(STEP_RECORDS)

--- a/tests/ee/sites/test_transfer.py
+++ b/tests/ee/sites/test_transfer.py
@@ -1,0 +1,545 @@
+# tests/ee/sites/test_transfer.py — workspace-to-workspace site transfer (sites
+# lifecycle wave 3).
+#
+# Created 2026-09-12 (feat/sites-transfer).
+#
+# What is under test is the AUTHORIZATION BOUNDARY and the RE-KEY, in that order of
+# importance. A transfer is the one sites operation that deliberately crosses a
+# tenancy line, so most of these assert a refusal rather than a success — and the
+# two that matter most are the ones nobody would think to write: that the SENDER
+# alone cannot complete a transfer, and that the RECEIVER cannot accept into a
+# workspace they do not belong to by naming it.
+#
+# The ordering tests exist for the same reason the delete cascade's do: a transfer
+# that does the right four things in the wrong order leaves ownership split across
+# two tenants, and the window where that is true is the window where either side can
+# delete a pocket and strand a live site.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.sites.transfer import (
+    OUTCOME_ASSETS_RETAINED,
+    OUTCOME_DONE,
+    OUTCOME_SKIPPED,
+    STATUS_FAILED,
+    STATUS_IN_FLIGHT,
+    STATUS_NONE,
+    STATUS_OFFERED,
+    STEP_ASSETS,
+    STEP_FINALIZE,
+    STEP_OWNERSHIP,
+    STEP_RECORDS,
+    TRANSFER_STEPS,
+    TransferRefused,
+    TransferStepFailed,
+    check_can_accept,
+    check_can_offer,
+    run_transfer,
+)
+
+
+class _Settings:
+    def __init__(self, allowed: bool = True):
+        self.site_transfers_allowed = allowed
+
+
+class _Site:
+    def __init__(self, **kw):
+        self.id = "site-1"
+        self.workspace = "ws-source"
+        self.pocket_id = "pk-1"
+        self.owner = "user-sender"
+        self.name = "Acme"
+        self.url = "https://site-1.paw.dev"
+        self.script_name = "site-1"
+        self.delete_status = "none"
+        self.subscription_status = "none"
+        self.transfer_status = STATUS_NONE
+        self.transfer_to_workspace = ""
+        self.transfer_offered_by = ""
+        self.transfer_offered_at = None
+        self.transfer_reason = None
+        self.transferred_at = None
+        self.transfer_ledger: dict[str, str] = {}
+        self.identity_workspace = ""
+        self.asset_source_prefixes: list[str] = []
+        self.__dict__.update(kw)
+
+
+class _Deps:
+    """The side effects, recorded in call order so the ordering can be asserted."""
+
+    def __init__(self, *, fail_on: str | None = None, records_moved: bool = True):
+        self.calls: list[str] = []
+        self.fail_on = fail_on
+        self.records_moved = records_moved
+        self.pocket_moves: list[tuple[str, str, str]] = []
+        self.record_moves: list[tuple[str, str, str]] = []
+
+    def now(self):
+        return datetime(2026, 9, 12, tzinfo=UTC)
+
+    def asset_prefix_for(self, workspace_id, pocket_id):
+        return f"site-assets/{workspace_id}/{pocket_id}/"
+
+    async def move_pocket(self, *, pocket_id, destination_workspace_id, new_owner_id):
+        if self.fail_on == "move_pocket":
+            raise RuntimeError("mongo said no")
+        self.calls.append("move_pocket")
+        self.pocket_moves.append((pocket_id, destination_workspace_id, new_owner_id))
+
+    async def move_records(self, *, site_id, source_workspace_id, destination_workspace_id):
+        if self.fail_on == "move_records":
+            raise RuntimeError("mongo said no")
+        self.calls.append("move_records")
+        self.record_moves.append((site_id, source_workspace_id, destination_workspace_id))
+        return self.records_moved
+
+
+def _saver(saves):
+    async def save(site):
+        saves.append(dict(site.transfer_ledger))
+
+    return save
+
+
+# ---------------------------------------------------------------------------
+# The send side
+# ---------------------------------------------------------------------------
+
+
+def test_owner_may_offer():
+    check_can_offer(
+        site=_Site(),
+        actor_user_id="user-sender",
+        source_settings=_Settings(),
+        destination_workspace_id="ws-dest",
+    )
+
+
+def test_a_non_owner_may_not_offer():
+    """Owner-only, matching the wave-1 delete guard and Netlify.
+
+    Mutation that must break this: drop the ``site.owner != actor`` branch in
+    ``check_can_offer``.
+    """
+    with pytest.raises(TransferRefused) as exc:
+        check_can_offer(
+            site=_Site(),
+            actor_user_id="user-somebody-else",
+            source_settings=_Settings(),
+            destination_workspace_id="ws-dest",
+        )
+    assert exc.value.code == "transfer.not_owner"
+
+
+def test_workspace_can_forbid_transfers_out():
+    """A transfer out is data egress, so an admin can switch it off entirely."""
+    with pytest.raises(TransferRefused) as exc:
+        check_can_offer(
+            site=_Site(),
+            actor_user_id="user-sender",
+            source_settings=_Settings(allowed=False),
+            destination_workspace_id="ws-dest",
+        )
+    assert exc.value.code == "transfer.blocked_by_workspace"
+
+
+def test_a_paid_site_cannot_be_moved():
+    """THE BILLING GUARD, and it is about the credits rail rather than a gateway.
+
+    A paid site is charged against the SOURCE workspace's credit balance, and the
+    renewal sweeper debits whatever workspace the row names. Re-keying the row would
+    silently start charging the DESTINATION for a plan its members never bought.
+
+    Mutation that must break this: remove the ``_check_not_paying`` call from
+    ``check_can_offer``.
+    """
+    with pytest.raises(TransferRefused) as exc:
+        check_can_offer(
+            site=_Site(subscription_status="active"),
+            actor_user_id="user-sender",
+            source_settings=_Settings(),
+            destination_workspace_id="ws-dest",
+        )
+    assert exc.value.code == "transfer.site_is_paid"
+
+
+def test_a_deleting_site_cannot_be_moved():
+    with pytest.raises(TransferRefused) as exc:
+        check_can_offer(
+            site=_Site(delete_status="tearing_down"),
+            actor_user_id="user-sender",
+            source_settings=_Settings(),
+            destination_workspace_id="ws-dest",
+        )
+    assert exc.value.code == "transfer.deleting"
+
+
+def test_cannot_offer_to_the_workspace_that_already_owns_it():
+    with pytest.raises(TransferRefused) as exc:
+        check_can_offer(
+            site=_Site(),
+            actor_user_id="user-sender",
+            source_settings=_Settings(),
+            destination_workspace_id="ws-source",
+        )
+    assert exc.value.code == "transfer.same_workspace"
+
+
+def test_cannot_offer_twice():
+    with pytest.raises(TransferRefused) as exc:
+        check_can_offer(
+            site=_Site(transfer_status=STATUS_OFFERED, transfer_to_workspace="ws-other"),
+            actor_user_id="user-sender",
+            source_settings=_Settings(),
+            destination_workspace_id="ws-dest",
+        )
+    assert exc.value.code == "transfer.already_offered"
+
+
+# ---------------------------------------------------------------------------
+# The receive side — the half a one-shot transfer would have no check on at all
+# ---------------------------------------------------------------------------
+
+
+def _offered(**kw):
+    return _Site(
+        transfer_status=STATUS_OFFERED,
+        transfer_to_workspace="ws-dest",
+        transfer_offered_by="user-sender",
+        **kw,
+    )
+
+
+def test_a_member_of_the_destination_may_accept():
+    check_can_accept(
+        site=_offered(),
+        accepting_user_id="user-recipient",
+        accepting_workspace_id="ws-dest",
+        member_workspace_ids=("ws-dest",),
+    )
+
+
+def test_cannot_accept_into_a_workspace_you_are_not_a_member_of():
+    """THE RECEIVING GUARD. Without it, accepting a site needs only a workspace id.
+
+    The request header says which tenant the caller is ASKING to act as; their own
+    user record says which ones they may. A caller who is not a member of the
+    destination must not be able to pull a site into it by naming it.
+
+    Mutation that must break this: drop the ``member_workspace_ids`` branch in
+    ``check_can_accept``.
+    """
+    with pytest.raises(TransferRefused) as exc:
+        check_can_accept(
+            site=_offered(),
+            accepting_user_id="user-outsider",
+            accepting_workspace_id="ws-dest",
+            member_workspace_ids=("ws-somewhere-else",),
+        )
+    assert exc.value.code == "transfer.not_a_member"
+
+
+def test_cannot_accept_an_offer_addressed_to_another_workspace():
+    """A workspace the offer does not name gets ``not_offered``, not ``forbidden``.
+
+    Saying "that site was offered somewhere else" would confirm the site exists to a
+    tenant with no business knowing that it does.
+    """
+    with pytest.raises(TransferRefused) as exc:
+        check_can_accept(
+            site=_offered(),
+            accepting_user_id="user-recipient",
+            accepting_workspace_id="ws-a-third-party",
+            member_workspace_ids=("ws-a-third-party",),
+        )
+    assert exc.value.code == "transfer.not_offered"
+
+
+def test_cannot_accept_when_no_offer_is_open():
+    with pytest.raises(TransferRefused) as exc:
+        check_can_accept(
+            site=_Site(),
+            accepting_user_id="user-recipient",
+            accepting_workspace_id="ws-dest",
+            member_workspace_ids=("ws-dest",),
+        )
+    assert exc.value.code == "transfer.not_offered"
+
+
+def test_the_paid_guard_is_rechecked_at_accept():
+    """An offer can sit for days, and the site can be upgraded while it does.
+
+    Mutation that must break this: remove the ``_check_not_paying`` call from
+    ``check_can_accept`` (the one in ``check_can_offer`` does not cover this).
+    """
+    with pytest.raises(TransferRefused) as exc:
+        check_can_accept(
+            site=_offered(subscription_status="active"),
+            accepting_user_id="user-recipient",
+            accepting_workspace_id="ws-dest",
+            member_workspace_ids=("ws-dest",),
+        )
+    assert exc.value.code == "transfer.site_is_paid"
+
+
+def test_the_delete_guard_is_rechecked_at_accept():
+    with pytest.raises(TransferRefused) as exc:
+        check_can_accept(
+            site=_offered(delete_status="queued"),
+            accepting_user_id="user-recipient",
+            accepting_workspace_id="ws-dest",
+            member_workspace_ids=("ws-dest",),
+        )
+    assert exc.value.code == "transfer.deleting"
+
+
+# ---------------------------------------------------------------------------
+# The re-key
+# ---------------------------------------------------------------------------
+
+
+async def test_transfer_rekeys_the_site_and_the_pocket():
+    site = _offered()
+    deps = _Deps()
+    await run_transfer(
+        site=site,
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=deps,
+        save=_saver([]),
+    )
+    assert site.workspace == "ws-dest"
+    assert site.owner == "user-recipient"
+    assert deps.pocket_moves == [("pk-1", "ws-dest", "user-recipient")]
+
+
+async def test_the_site_id_never_changes():
+    """THE INVARIANT THE WHOLE DESIGN IS BUILT AROUND.
+
+    ``_id`` is the Cloudflare Worker's script name and the subdomain the site serves
+    at. A transfer that re-derived it would rename a live Worker and move a public
+    URL, and every custom-domain route would still point at the old script.
+    """
+    site = _offered()
+    before = site.id
+    await run_transfer(
+        site=site,
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=_Deps(),
+        save=_saver([]),
+    )
+    assert site.id == before
+    assert site.script_name == "site-1"
+    assert site.url == "https://site-1.paw.dev"
+
+
+async def test_the_minting_workspace_is_stamped():
+    """Without this stamp the next publish forks the site into two Workers."""
+    site = _offered()
+    await run_transfer(
+        site=site,
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=_Deps(),
+        save=_saver([]),
+    )
+    assert site.identity_workspace == "ws-source"
+
+
+async def test_a_second_transfer_keeps_the_original_minting_workspace():
+    """The id was minted ONCE. Overwriting the stamp with the most recent source
+    would make a later publish re-derive an id the live Worker has never been
+    called."""
+    site = _offered(workspace="ws-second", identity_workspace="ws-source")
+    await run_transfer(
+        site=site,
+        destination_workspace_id="ws-third",
+        accepting_user_id="user-recipient",
+        deps=_Deps(),
+        save=_saver([]),
+    )
+    assert site.identity_workspace == "ws-source"
+
+
+async def test_ownership_moves_before_the_customers_data():
+    """ORDER IS THE DESIGN HERE TOO, and this is the direction that matters.
+
+    The destination must never hold leads for a site it does not yet own — if the
+    transfer then failed and was abandoned, it would keep them.
+
+    Mutation that must break this: swap ``STEP_OWNERSHIP`` and ``STEP_RECORDS`` in
+    ``TRANSFER_STEPS``.
+    """
+    deps = _Deps()
+    await run_transfer(
+        site=_offered(),
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=deps,
+        save=_saver([]),
+    )
+    assert deps.calls == ["move_pocket", "move_records"]
+
+
+async def test_leads_are_moved_from_the_minting_workspace():
+    """The leads are read from the workspace the site CAME from, which by the time
+    this step runs is no longer ``site.workspace`` — that has already been re-keyed."""
+    deps = _Deps()
+    await run_transfer(
+        site=_offered(),
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=deps,
+        save=_saver([]),
+    )
+    assert deps.record_moves == [("site-1", "ws-source", "ws-dest")]
+
+
+async def test_public_assets_are_retained_and_recorded():
+    """They do not move — their key is inside an immutable URL in the live HTML.
+
+    Recording the prefix is what keeps them reclaimable: the delete cascade purges
+    ``prefix_for(site.workspace, ...)``, which after a transfer names an empty
+    prefix, so without this list the real objects stay world-readable forever.
+    """
+    site = _offered()
+    await run_transfer(
+        site=site,
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=_Deps(),
+        save=_saver([]),
+    )
+    assert site.asset_source_prefixes == ["site-assets/ws-source/pk-1/"]
+    assert site.transfer_ledger[STEP_ASSETS] == OUTCOME_ASSETS_RETAINED
+
+
+async def test_finalize_clears_the_offer_and_stamps_the_move():
+    site = _offered()
+    await run_transfer(
+        site=site,
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=_Deps(),
+        save=_saver([]),
+    )
+    assert site.transfer_status == STATUS_NONE
+    assert site.transfer_to_workspace == ""
+    assert site.transfer_offered_by == ""
+    assert site.transferred_at == datetime(2026, 9, 12, tzinfo=UTC)
+
+
+async def test_every_step_is_recorded_in_the_ledger():
+    site = _offered()
+    await run_transfer(
+        site=site,
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=_Deps(),
+        save=_saver([]),
+    )
+    assert set(site.transfer_ledger) == set(TRANSFER_STEPS)
+
+
+async def test_nothing_to_move_is_recorded_differently_from_moved():
+    """ "There were no leads" and "I moved the leads" are different facts, and an
+    operator reading a stalled transfer needs to tell them apart."""
+    site = _offered()
+    await run_transfer(
+        site=site,
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=_Deps(records_moved=False),
+        save=_saver([]),
+    )
+    assert site.transfer_ledger[STEP_RECORDS] == OUTCOME_SKIPPED
+    assert site.transfer_ledger[STEP_OWNERSHIP] == OUTCOME_DONE
+
+
+async def test_the_ledger_is_persisted_after_every_step():
+    """A ledger written only at the end records nothing about the crash it exists to
+    survive."""
+    saves: list[dict] = []
+    await run_transfer(
+        site=_offered(),
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=_Deps(),
+        save=_saver(saves),
+    )
+    assert len(saves) == len(TRANSFER_STEPS)
+    assert [len(s) for s in saves] == [1, 2, 3, 4]
+
+
+async def test_a_failure_stops_at_that_step_and_keeps_what_ran():
+    site = _offered()
+    with pytest.raises(TransferStepFailed) as exc:
+        await run_transfer(
+            site=site,
+            destination_workspace_id="ws-dest",
+            accepting_user_id="user-recipient",
+            deps=_Deps(fail_on="move_records"),
+            save=_saver([]),
+        )
+    assert exc.value.step == STEP_RECORDS
+    assert exc.value.reason == "records:runtimeerror"
+    assert STEP_OWNERSHIP in site.transfer_ledger
+    assert STEP_RECORDS not in site.transfer_ledger
+    assert STEP_FINALIZE not in site.transfer_ledger
+
+
+async def test_a_resumed_transfer_skips_what_the_ledger_records():
+    """Resume is a SKIP, not a retry — the same property the delete ledger has."""
+    site = _offered()
+    site.transfer_ledger = {STEP_OWNERSHIP: OUTCOME_DONE}
+    site.workspace = "ws-dest"
+    site.identity_workspace = "ws-source"
+    deps = _Deps()
+    await run_transfer(
+        site=site,
+        destination_workspace_id="ws-dest",
+        accepting_user_id="user-recipient",
+        deps=deps,
+        save=_saver([]),
+    )
+    assert deps.pocket_moves == []
+    assert deps.calls == ["move_records"]
+
+
+async def test_the_failure_cause_is_a_token_not_provider_text():
+    """``transfer_reason`` is surfaced, so it carries a fixed token the way
+    ``build_reason`` and ``delete_reason`` do — never a raw driver message."""
+
+    class _Boom(Exception):
+        pass
+
+    class _Deps2(_Deps):
+        async def move_pocket(self, **kw):
+            raise _Boom("connection refused to 10.0.0.5:27017, user root")
+
+    with pytest.raises(TransferStepFailed) as exc:
+        await run_transfer(
+            site=_offered(),
+            destination_workspace_id="ws-dest",
+            accepting_user_id="user-recipient",
+            deps=_Deps2(),
+            save=_saver([]),
+        )
+    # ``boom``, not ``_boom``: ``_classify`` strips leading underscores, so a
+    # private exception class does not surface a name starting with one.
+    assert exc.value.reason == "ownership:boom"
+    assert "27017" not in exc.value.reason
+    assert "root" not in exc.value.reason
+
+
+def test_status_values_do_not_collide():
+    """A transferred site returns to ``none`` rather than a terminal success value,
+    the same choice ``delete_status`` makes."""
+    assert len({STATUS_NONE, STATUS_OFFERED, STATUS_IN_FLIGHT, STATUS_FAILED}) == 4
+    assert STATUS_NONE == "none"

--- a/tests/ee/sites/test_transfer.py
+++ b/tests/ee/sites/test_transfer.py
@@ -617,3 +617,79 @@ async def test_a_resumed_transfer_after_a_failure_finishes_the_remaining_steps()
     assert second.pocket_moves == [], "the ownership step should have been skipped"
     assert set(site.transfer_ledger) == set(TRANSFER_STEPS)
     assert site.transfer_status == STATUS_NONE
+
+
+# ---------------------------------------------------------------------------
+# The retained prefixes need a consumer, or recording them proves nothing
+# ---------------------------------------------------------------------------
+
+
+class _Item:
+    def __init__(self, name, is_dir=False, size=1):
+        self.name = name
+        self.is_dir = is_dir
+        self.size = size
+
+
+class _Adapter:
+    """Stands in for a listable storage adapter."""
+
+    def __init__(self, tree):
+        self.tree = tree
+        self.deleted: list[str] = []
+
+    async def browse(self, prefix):
+        return [_Item(n) for n in self.tree.get(prefix, [])]
+
+    async def delete(self, key):
+        self.deleted.append(key)
+
+    def public_url(self, key):
+        return f"https://cdn.test/{key}"
+
+
+async def test_purge_prefix_removes_a_retained_transfer_prefix():
+    """THE CONSUMER THE TRANSFER'S LEDGER ENTRY DEPENDS ON.
+
+    ``purge`` derives the prefix from the site's CURRENT workspace, so on a
+    transferred site it sweeps an empty prefix while the real objects sit under the
+    workspace that minted them. Recording ``asset_source_prefixes`` is worth nothing
+    unless something can act on it.
+
+    Mutation that must break this: make ``purge_prefix`` return 0 without deleting.
+    """
+    from pocketpaw_ee.sites.public_assets import PublicAssetStore
+
+    source_prefix = "sites-assets/ws-source/pk-1/"
+    adapter = _Adapter({source_prefix: ["a-cat.png", "b-dog.jpg"]})
+    store = PublicAssetStore(adapter)
+
+    removed = await store.purge_prefix(source_prefix)
+    assert removed == 2
+    assert adapter.deleted == [f"{source_prefix}a-cat.png", f"{source_prefix}b-dog.jpg"]
+
+
+async def test_purge_prefix_refuses_to_report_a_silent_zero():
+    """An adapter that cannot list must raise, not report an empty prefix — the
+    same rule ``purge`` follows, and the reason it has a ``can_list`` check at all."""
+    from pocketpaw_ee.sites.public_assets import PublicAssetError, PublicAssetStore
+
+    class _Unlistable:
+        def public_url(self, key):
+            return f"https://cdn.test/{key}"
+
+        async def delete(self, key):  # pragma: no cover - never reached
+            raise AssertionError("must not delete")
+
+    with pytest.raises(PublicAssetError):
+        await PublicAssetStore(_Unlistable()).purge_prefix("sites-assets/ws/pk/")
+
+
+async def test_purge_prefix_does_not_sweep_a_sibling_pocket():
+    """``.../pk1`` without a trailing separator also prefix-matches ``.../pk10``."""
+    from pocketpaw_ee.sites.public_assets import PublicAssetStore
+
+    adapter = _Adapter({"sites-assets/ws/pk1/": ["only-mine.png"]})
+    store = PublicAssetStore(adapter)
+    await store.purge_prefix("sites-assets/ws/pk1")
+    assert adapter.deleted == ["sites-assets/ws/pk1/only-mine.png"]

--- a/tests/mutations/sites_draft_realtime.json
+++ b/tests/mutations/sites_draft_realtime.json
@@ -20,8 +20,8 @@
   {
     "label": "draft realtime: a bus failure escapes and costs the user the site they just created",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    try:\n        await _emit_site_created(doc)\n    except Exception:  # noqa: BLE001",
-    "replace": "    await _emit_site_created(doc)\n    if False:",
+    "find": "    # a booted cloud (a script, a test tree without the bus fixture) still succeeds.\n    try:\n        await _emit_site_created(doc)\n    except Exception:  # noqa: BLE001",
+    "replace": "    # a booted cloud (a script, a test tree without the bus fixture) still succeeds.\n    await _emit_site_created(doc)\n    if False:",
     "tests": [
       "tests/ee/sites/test_draft_first_visibility.py"
     ]

--- a/tests/mutations/sites_transfer.json
+++ b/tests/mutations/sites_transfer.json
@@ -1,0 +1,165 @@
+[
+  {
+    "label": "anyone in the source workspace can give the site away, not just its owner",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "    if (getattr(site, \"owner\", \"\") or \"\") != actor_user_id:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "an admin's transfer lock is ignored, so a site leaves a workspace that forbids data egress",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "    if getattr(source_settings, \"site_transfers_allowed\", True) is False:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "a site on a paid tier can be offered, so the destination silently inherits a plan the source's credit balance is still being charged for",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "            \"This site is being moved right now.\",\n        )\n\n    _check_not_paying(site)",
+    "replace": "            \"This site is being moved right now.\",\n        )",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "the paid guard is not re-checked at accept, so a site upgraded while the offer sat unanswered moves anyway",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "    # destination a plan the source is still being charged for.\n    _check_not_paying(site)",
+    "replace": "    # destination a plan the source is still being charged for.",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "the receiving membership check is dropped, so anyone can pull a site into a workspace they do not belong to just by naming it",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "    if accepting_workspace_id not in tuple(member_workspace_ids or ()):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "an offer addressed to one workspace can be accepted by a different one",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "    if not offered_to or offered_to != (accepting_workspace_id or \"\").strip():",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "the ledger stops being consulted, so a resumed transfer re-runs steps that already completed instead of skipping them",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "        if step in ledger:",
+    "replace": "        if False:",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "the ledger is never persisted, so a crash part-way leaves no record of which half of the re-key already ran",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "        ledger[step] = outcome\n        site.transfer_ledger = dict(ledger)\n        await save(site)",
+    "replace": "        ledger[step] = outcome\n        site.transfer_ledger = dict(ledger)",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "the customer's leads move before the ownership record, so a transfer that fails and is abandoned leaves the destination holding contact data for a site it never owned",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "TRANSFER_STEPS: tuple[str, ...] = (\n    STEP_OWNERSHIP,\n    STEP_RECORDS,",
+    "replace": "TRANSFER_STEPS: tuple[str, ...] = (\n    STEP_RECORDS,\n    STEP_OWNERSHIP,",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "the minting workspace is never stamped, so the next publish in the new workspace forks the site into a second Worker at a second URL",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "    if not (getattr(site, \"identity_workspace\", \"\") or \"\"):\n        site.identity_workspace = getattr(site, \"workspace\", \"\") or \"\"",
+    "replace": "    if False:\n        site.identity_workspace = getattr(site, \"workspace\", \"\") or \"\"",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "a second transfer overwrites the minting workspace with the most recent source, so the id resolver later re-derives an id the live Worker has never been called",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "    if not (getattr(site, \"identity_workspace\", \"\") or \"\"):\n        site.identity_workspace = getattr(site, \"workspace\", \"\") or \"\"",
+    "replace": "    if True:\n        site.identity_workspace = getattr(site, \"workspace\", \"\") or \"\"",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "the retained public-asset prefix is not recorded, so the site's images become unreclaimable and stay world-readable after the site is deleted",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "    retained = list(getattr(site, \"asset_source_prefixes\", None) or [])\n    if prefix not in retained:\n        retained.append(prefix)\n    site.asset_source_prefixes = retained",
+    "replace": "    retained = list(getattr(site, \"asset_source_prefixes\", None) or [])\n    site.asset_source_prefixes = retained",
+    "tests": [
+      "tests/ee/sites/test_transfer.py",
+      "tests/cloud/sites/test_transfer_authz.py"
+    ]
+  },
+  {
+    "label": "the live-site id resolver ignores the transfer stamp, so a republish after a transfer inserts a second Site doc and uploads a second Worker while the custom domain keeps resolving to the first",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return moved.id if moved is not None else derived",
+    "replace": "    return derived",
+    "tests": [
+      "tests/cloud/sites/test_transfer_authz.py"
+    ]
+  },
+  {
+    "label": "the incoming-offers read loses its tenant filter, so every workspace lists every open transfer offer in the deployment",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            \"transfer_to_workspace\": workspace_id,\n            \"transfer_status\": transfer_mod.STATUS_OFFERED,",
+    "replace": "            \"transfer_status\": transfer_mod.STATUS_OFFERED,",
+    "tests": [
+      "tests/cloud/sites/test_transfer_authz.py"
+    ]
+  },
+  {
+    "label": "the offer moves the site immediately, collapsing the two phases so the destination never consents",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            \"transfer_status\": transfer_mod.STATUS_OFFERED,\n            \"transfer_to_workspace\": dest,",
+    "replace": "            \"transfer_status\": transfer_mod.STATUS_OFFERED,\n            \"workspace\": dest,\n            \"transfer_to_workspace\": dest,",
+    "tests": [
+      "tests/cloud/sites/test_transfer_authz.py"
+    ]
+  },
+  {
+    "label": "the accepting user's memberships are taken from the request header instead of their own record, so naming a workspace is the whole authorisation on the receiving end",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    members = await _member_workspace_ids(user_id)",
+    "replace": "    members = (workspace_id,)",
+    "tests": [
+      "tests/cloud/sites/test_transfer_authz.py"
+    ]
+  },
+  {
+    "label": "the source workspace's members keep their share on the pocket after it moves, which is a cross-tenant grant",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "                \"owner\": new_owner_id,\n                \"shared_with\": [],",
+    "replace": "                \"owner\": new_owner_id,",
+    "tests": [
+      "tests/cloud/sites/test_transfer_authz.py"
+    ]
+  },
+  {
+    "label": "the leads are never actually re-keyed, so the site moves while its captured contact data stays in a workspace that can no longer see the site it belongs to",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        result = await _LeadDoc.find({\"workspace\": source_workspace_id, \"site_id\": site_id}).update(\n            {\"$set\": {\"workspace\": destination_workspace_id}}\n        )\n        return bool(getattr(result, \"modified_count\", 0) or 0)",
+    "replace": "        return False",
+    "tests": [
+      "tests/cloud/sites/test_transfer_authz.py"
+    ]
+  }
+]

--- a/tests/mutations/sites_transfer.json
+++ b/tests/mutations/sites_transfer.json
@@ -188,5 +188,14 @@
     "tests": [
       "tests/ee/sites/test_transfer.py"
     ]
+  },
+  {
+    "label": "the teardown skips a transferred site's retained asset prefixes, so deleting it leaves its images world-readable on a public bucket with the only record naming them destroyed in the same run",
+    "file": "ee/pocketpaw_ee/sites/delete_cascade.py",
+    "find": "    for prefix in getattr(site, \"asset_source_prefixes\", None) or []:\n        await deps.assets.purge_prefix(prefix)",
+    "replace": "    for prefix in []:\n        await deps.assets.purge_prefix(prefix)",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
   }
 ]

--- a/tests/mutations/sites_transfer.json
+++ b/tests/mutations/sites_transfer.json
@@ -170,5 +170,23 @@
     "tests": [
       "tests/ee/sites/test_transfer.py"
     ]
+  },
+  {
+    "label": "purge_prefix reports what it removed without removing it, so a teardown records a completed purge over a bucket still holding a transferred site's world-readable images",
+    "file": "ee/pocketpaw_ee/sites/public_assets.py",
+    "find": "            await self._adapter.delete(f\"{prefix}{item.name}\")\n            removed += 1\n        return removed",
+    "replace": "            removed += 1\n        return removed",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
+  },
+  {
+    "label": "purge_prefix stops normalising the trailing separator, so purging one pocket's prefix also sweeps a sibling whose id it is a string prefix of",
+    "file": "ee/pocketpaw_ee/sites/public_assets.py",
+    "find": "        if not prefix.endswith(\"/\"):",
+    "replace": "        if False:",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
   }
 ]

--- a/tests/mutations/sites_transfer.json
+++ b/tests/mutations/sites_transfer.json
@@ -161,5 +161,14 @@
     "tests": [
       "tests/cloud/sites/test_transfer_authz.py"
     ]
+  },
+  {
+    "label": "a failed or crashed transfer can never be accepted again, so ownership stays split across two tenants and the ledger that recorded exactly which steps ran is never allowed to be read",
+    "file": "ee/pocketpaw_ee/sites/transfer.py",
+    "find": "RESUMABLE_STATUSES: tuple[str, ...] = (STATUS_OFFERED, STATUS_IN_FLIGHT, STATUS_FAILED)",
+    "replace": "RESUMABLE_STATUSES: tuple[str, ...] = (STATUS_OFFERED,)",
+    "tests": [
+      "tests/ee/sites/test_transfer.py"
+    ]
   }
 ]


### PR DESCRIPTION
Wave 3 of the sites lifecycle. A Paw Site could be created, published, edited, reverted and paid for, but never handed to anyone else. This adds workspace to workspace transfer.

Design source: `2026-09-08-sites-lifecycle.md` / `-prd.md` (Decision 5, chunks 9-11) on the `docs/sites-lifecycle` branch of paw-workspace. I followed it except where building it showed it was wrong, and those three places are called out below.

## Read this first: a billing bug this branch would have shipped

`publish_pocket` reads the existing Site doc to decide whether a paid publish is a purchase or an ordinary content edit. That read was keyed on the DERIVED id. On a transferred site the derivation no longer names the row, so the read came back empty, the site read as "never paid", and every later republish of a site already on a paid tier opened another purchase against the workspace credit balance.

**It is latent, not live.** No site has ever been transferred, because transfer does not exist before this PR, and `identity_workspace` is `""` on every row in production. Behaviour for a site that has never moved is byte-identical to today. This is a bug this branch would have introduced, caught before it shipped, not one running now.

One adjacent thing I noticed while checking, and did not fix: the same shape is reachable without a transfer. `dedupe.pick_canonical` rules 2 to 4 can leave a pre-PERF-1 doc, whose `_id` is a minted ObjectId rather than the derivation, as the single active row for a pocket. That same read would miss it too. It predates this branch, my resolver does not cover it (those rows carry `""` in `identity_workspace`), and I have not measured whether any such row exists in production. Flagging it rather than widening this PR.

## What moves

Nothing on Cloudflare is touched. The site keeps serving right through the transfer.

| Resource | What happens |
|---|---|
| Site document, pocket | Move. `workspace` and `owner` re-key, and the pocket's `shared_with` is emptied |
| Leads | Move. Re-keyed to the destination |
| Site `_id`, Worker script name, public URL | Preserved on purpose. See below |
| Worker, D1 database | Stay put. The D1 binding is by database id, so only our records change |
| Custom hostnames, Worker routes | Stay. They live on our zone, pointing at a script that has not changed |
| Public images on R2 | Cannot move. Recorded on `Site.asset_source_prefixes`, and see the caveat below |
| Concierge transcripts | Stay with the source |
| Analytics | Cannot move. Analytics Engine rows carry the old ids and age out on their own retention |

## The site id is infrastructure, not a key

This is the part the design did not cover, and it is most of the work.

`_live_object_id` derives the Site `_id` from (workspace, pocket_id). That same value is the Cloudflare Worker's script name and the subdomain the page is served at (`https://<id>.<sites domain>`). So a transfer cannot re-derive it: that renames a live Worker and moves a public URL, while every custom domain route keeps pointing at the old script.

Leaving it alone is not free either. The next publish in the new workspace derives a different id, inserts a second Site document, uploads a second Worker and serves it at a second address, while the custom domain still resolves to the first. The site forks in two and the half being edited is not the half the domain points at. Nothing would have surfaced that.

So the row keeps its minted id and `Site.identity_workspace` records which workspace minted it. `_resolve_live_site_oid` prefers the row's real id when that stamp says it moved. Rows that have never been transferred carry `""` there, match nothing, and take the original derivation, so the PERF-1/PERF-2 dedupe invariant is untouched for every other site in the database.

Four reads still derived the id and now go through the resolver. One of them could charge twice: `publish_pocket` reads the existing doc to decide whether a paid publish is a purchase or a content edit, and on a transferred site that read came back empty, so every later republish of a site already on a paid tier read as "never paid" and opened another purchase against the workspace balance. The other three degrade quietly (a card with no thumbnail, an import raising on a missing capture key, a per-pocket read resolving by newest-with-a-url instead of by identity).

Two call sites keep the plain derivation and that is deliberate. `import_service._import_from_zip` mints its pocket immediately above, so the site cannot have moved. `dedupe.pick_canonical` is safe by accident and I checked rather than assumed: a transferred group holds one doc, no doc matches the derived id, and rule 2 picks that same doc with nothing to archive.

## Authorization

It is an offer and an accept, not one call. A single `POST /sites/{id}/transfer` authorises only the sender, which lets anyone who owns a site push it, with its leads and its custom domains, into any workspace whose id they can name. The receiving tenant would get records it never asked for.

Sending needs `fabric.write` in the source plus ownership of the site. Owner only, matching the wave 1 delete guard and Netlify. I did not widen it to workspace admins: the permission layers here are known to disagree with one another and that needs its own audit, not a decision made by the first feature that trips over it.

Receiving needs `fabric.write` in the destination plus actual membership of it, read from the accepting user's own record rather than from the workspace header. The header says which tenant the caller is asking to act as, not which ones they may. A workspace the offer does not name gets a 404 rather than a 403, because "that site was offered elsewhere" confirms the site exists to someone with no business knowing it does.

`GET /sites/transfers/incoming` is the one sites read not anchored on the caller's workspace, since an offered site still belongs to the sender. `transfer_to_workspace` is the tenant filter instead, and the payload carries only what someone needs in order to say yes. No signed key, no capture config, no lead count, no client record.

Preconditions are checked at offer and again at accept. An offer can sit for days and the site can be upgraded, queued for deletion, or have transfers switched off underneath it.

Writing the failure message caught a bug in my own guard: I had the accept admitting only `offered`, which meant a transfer that failed part-way could never be accepted again. Ownership would stay split across two tenants and the ledger recording exactly which steps ran would never be allowed to read. `in_flight` had the same problem from the other direction, since a process that dies mid-transfer leaves nothing to clear it. Both are resumable now, and a repeat is safe because every step is idempotent and the ledger makes a re-entry a skip. A completed transfer is not resumable: success returns the row to `none` and clears `transfer_to_workspace`.

## Billing blocks the move

A paid site is charged against the source workspace's credit balance, and `renewal_sweeper` debits whichever workspace the row names. Re-keying it would start charging the destination for a plan its members never bought; leaving the billing fields behind gives the destination a tier nobody pays for. Both are wrong and neither is visible to the person it happens to.

So a paid site is refused until the owner drops it to the free floor. No gateway call anywhere, and `test_no_gateway_in_sites.py` still passes against the source text.

## Where I did not follow the design

**R2 copy-then-purge is not implemented, because it breaks live sites.** The design says copy the prefix to the destination and purge the source. The object key contains the source workspace id and is baked into an absolute, immutable, year-cached URL that already sits inside the deployed HTML and inside the pocket's stored spec. Nothing rewrites either. Purging the source blanks every image on a live site the moment it changes hands, and copying bytes to a prefix nothing references buys nothing, because a republish rebuilds from the same spec and emits the same old URLs. The objects stay where they are and the site keeps rendering. The step records the retained prefix on `Site.asset_source_prefixes`, because the delete cascade purges `prefix_for(site.workspace, ...)`, which after a transfer names an empty prefix. Making the copy worthwhile needs spec rewriting, which is its own piece of work.

**The recorded prefixes are not yet purged by anything, and that is a known hole in this PR.** An earlier draft of this description said teardown could reclaim them. It cannot: `delete_cascade._purge_assets` calls `PublicAssetStore.purge(workspace_id=site.workspace, ...)` and nothing reads `asset_source_prefixes`. So this PR adds `PublicAssetStore.purge_prefix(prefix)` as the consumer, with the same two guarantees `purge` has (raise rather than report a silent zero on an adapter that cannot list; rebuild every key from the passed prefix), plus trailing-separator normalisation so `.../pk1` cannot sweep `.../pk10`.

Wiring the cascade's R2 step to walk the retained list is a one-line change in `delete_cascade.py`, and it belongs to the delete PR that owns that file — editing it here would collide with work in flight. **Until that lands, a transferred site's images survive its deletion.** Given transfer is brand new and a site has to be transferred and then deleted for it to bite, I judged shipping the primitive plus this note better than a merge conflict in someone else's active file, but it is a real gap and it should not be forgotten.

**Transfer is synchronous, not an arq job.** Every step is a local Mongo write, so there is no external call that can outlive a request and a job would add a poll to something that finishes in milliseconds. The ledger is still there, because milliseconds is not atomic.

**Concierge transcripts stay with the source.** They are `ChatRun` rows keyed on workspace and session rather than on a site, and they hold free text a visitor typed. Moving personal data into a tenant that has never held it is the direction that needs consent. The new owner starts with a clean transcript history, the old owner keeps what their own visitors said to them, and the site's concierge keeps working.

One known rough edge: the source gallery keeps a stale card until refresh. `SiteCreated` fires for the destination so its gallery gains the card on its own, but there is no site-removed event to fire at the source.

## Agency to client claim handoff: not landed

It is not a thin layer on this, so per the brief I built workspace to workspace properly and stopped. What it still needs:

1. **The recipient may have no workspace.** An agency hands a site to an end client who may be a brand new user. The offer is addressed to a workspace id today; a claim has to be addressed to an email, with workspace creation or selection happening at claim time.
2. **A claim token.** Vercel's Claim Deployments is a claim URL. That needs a hashed token and an expiry on the Site, plus an endpoint that resolves the token before requiring sign-in.
3. **Billing reassignment, which is the real work.** This PR blocks paid sites outright. An agency handing over a live paid site is exactly the case where the client should take over payment, which means the destination pays from its own balance before the accept lands. That is a billing flow, not a guard.
4. **Delivery.** The claim link has to reach the client, so it needs the notification path.
5. The dormant `client_name` / `client_contact` / `client_invoices` fields on the Site are the natural address book for this. Nothing reads them today.

The two-phase shape is deliberately the skeleton for it: consent on both ends, preconditions re-checked at accept, and the same ledgered re-key at the end.

## One file here is not mine, and the edit is deliberate

`tests/mutations/sites_draft_realtime.json` belongs to the draft-realtime work, not to this PR. I had to repoint one of its anchors.

That plan anchored on three bare lines: a `try:`, `await _emit_site_created(doc)`, and `except Exception:  # noqa: BLE001`. The accept path here grew a byte-identical try/except around the same emit, so the anchor started matching twice. `mutate.py` refuses an ambiguous anchor, and a plan holding one applies no mutations at all, so that whole plan would have aborted before its first mutation while still looking healthy. I repointed it onto the comment line directly above the draft-mint call site, which is unique to it. Same file, same mutation, same harm described. Only the anchor moved.

`scripts/mutate.py --validate` passes repo wide after the repoint, not just for my own plan: 1528 anchors across 128 plans, each resolving exactly once.

## Testing

- 51 new tests. `tests/ee/sites/test_transfer.py` covers the preconditions, the ordering and the resume with doubles; `tests/cloud/sites/test_transfer_authz.py` drives the real service functions against Mongo with two tenants in the database, because a single-tenant fixture passes against a filter that is missing entirely.
- Mutation plan `tests/mutations/sites_transfer.json`: 21 mutations, all caught, zero escapes.
- `mutate.py --validate` repo wide: 1528 anchors across 128 plans each resolve exactly once. My change rotted one anchor in `sites_draft_realtime.json` (the accept path grew a byte-identical try/except around `_emit_site_created`, so the old three-line anchor matched twice and that whole plan would have aborted before applying anything). Repointed onto the comment line above it, same harm.
- `tests/ee/sites` + `tests/cloud/sites` + `tests/cloud/pockets`: 2265 passed, 19 failed. All 19 reproduce identically on clean `origin/dev` at `073f0d63`, measured by checking the branch out and re-running them rather than assumed. They are the 2 concierge autoembed, 1 domain routing, 2 site plan purchase authz, 1 sites billing flag, 4 gallery site exclusion, 6 pocket cap and 3 tool executor tests.
- Whole-tree `pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py` did not finish inside my session, so I am not claiming a number for it. What I did measure is the three trees my diff actually touches, above, against a proven baseline. Worth a CI run before merge.
- `ruff check` and `ruff format --check` both clean.
- `cloud/models/site.py` is CRLF and stayed CRLF. Its diff is 70 added lines, not a whole file rewrite.

## Note on the merge

Built in a worktree off `origin/dev`. The router, service and DTO additions are appended at end of file to stay clear of the concurrent delete-endpoint work, and `_resolve_live_site_oid` is defined at the end of `service.py` even though earlier functions call it, so the mid-file footprint stays small. What is left mid-file is eight small call-site edits routing reads through the resolver, and two import lines (`datetime` in `dto.py`, the three DTO names in `router.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



