### PR TITLE
A site could be deleted from the UI but not from the backend

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2128,6 +2128,89 @@ that stopped rather than repeating the ones that finished.
 `WorkspaceSettings.site_transfers_allowed` (default `true`). A site leaving takes its
 leads with it, so an admin can forbid the outbound half outright. Only the source
 side is gated — the receiving side is governed by consent, not by a setting.
+## Deleting a site
+
+Wave 1 of the sites lifecycle. Deleting a site is **irreversible**, **owner-only**, and
+**not one request** — it is a durable job over an ordered cascade (stop the billing,
+revoke the signed key, pull the routes / hostnames / Worker, then the D1, the bucket
+prefix and the dependent rows, and the Site document last). Source:
+`ee/pocketpaw_ee/sites/router.py`, `ee/pocketpaw_ee/sites/delete_job.py`.
+
+**A data export is forced first.** Before anything destructive runs, the job captures the
+site's D1 tables and captured leads to a `SiteExport` row in private storage. An export
+that cannot be vouched for is a hard stop: the cascade never starts, the site is left
+exactly as it was, and the row settles at `export:<cause>`. That export is the entire
+recovery story, which is why it is a precondition rather than a courtesy — see
+[the export endpoint](#post-sitessite_idexport) for the standalone version of the same
+capture.
+
+**Visitor analytics are not purged and cannot be.** They live in Cloudflare Analytics
+Engine on a three-month retention this product does not control. The delete says so
+rather than implying a completeness it cannot deliver.
+
+### `DELETE /sites/{site_id}`
+
+Auth: `fabric.write`, plus **owner-only** on top of it — a workspace member who may edit
+a site may not destroy it. A non-owner inside the workspace gets `403`
+(`site.not_owner`); a site in another workspace gets `404`, because confirming a
+stranger's site exists is itself a leak.
+
+Response **`202`** — deliberately not `204`. The site is **still serving** when this
+returns:
+
+```json
+{
+  "site_id": "68b6f2c1a4d3e50012ab34cd",
+  "status": "queued",
+  "job_id": "site-delete-68b6f2c1a4d3e50012ab34cd-9f2c..."
+}
+```
+
+A second delete of a site whose teardown is already running does not conflict: it answers
+`202` reporting the in-flight attempt, because the site is already being deleted, which
+is what the caller asked for. A delete that previously **failed** can be started again —
+the cascade resumes from its ledger and skips every step the earlier attempt finished.
+
+### `GET /sites/{site_id}/delete-status`
+
+Auth: `fabric.read`, owner-only for the same reason (`delete_reason` names which teardown
+step stopped).
+
+Response `200` while the delete is running or stopped:
+
+```json
+{
+  "site_id": "68b6f2c1a4d3e50012ab34cd",
+  "delete_status": "tearing_down",
+  "delete_reason": null,
+  "delete_ledger": { "billing": "done", "revoke": "done" },
+  "delete_export_id": "68b7a1...",
+  "delete_job_id": "site-delete-..."
+}
+```
+
+**This endpoint `404`s when the delete SUCCEEDS, and that 404 is the success signal.**
+There is no terminal `"deleted"` status by construction: the cascade's last step removes
+the Site document, and `delete_status` is a field on that document, so a completed delete
+has nothing left to report a status on. A client that reads this `404` as an error
+reports every successful delete as a broken one.
+
+`delete_status` is one of `none`, `queued`, `exporting`, `tearing_down`, `failed`. Treat
+an **unrecognised** value as still running rather than terminal — a client that stops
+polling on a status it has not heard of abandons a live teardown and leaves the user
+looking at a half-destroyed site that claims it finished.
+
+`delete_reason` is a two-part `"<step>:<cause>"` string reusing `build_reason`'s exact
+format. Render the **step** half; the cause half is a fixed machine token written for a
+log, never raw provider text. `export` is the step worth its own sentence — it is the one
+failure where nothing was destroyed and the user's site is untouched.
+
+### Deleting the pocket instead
+
+You cannot. `DELETE /pockets/{id}` **refuses** with `409 pocket.has_site` while a site is
+published from it, rather than cascading — a cascade from there would bypass the forced
+export, so the one path that can destroy a site stays the one path that preserves its
+data first. Delete the site, then the pocket.
 
 ## Ship — Managed Deploys
 

--- a/ee/pocketpaw_ee/sites/build_worker.py
+++ b/ee/pocketpaw_ee/sites/build_worker.py
@@ -30,12 +30,25 @@
 # await on a remote exec. So these four slots cost the worker container almost nothing,
 # and the number is about how many sandboxes the account should be paying for at once
 # rather than about memory. Raise it with the Daytona quota, not with the memory limit.
-"""The site-build lane's arq WorkerSettings (backend-perf C1)."""
+# Updated 2026-09-12 (sites lifecycle wave 1, feat/sites-delete-endpoint): the lane
+# grew a THIRD job — ``run_site_delete``, the forced export plus the teardown cascade.
+# It rides this queue rather than opening a fourth one: this is already the consumer
+# of site work, and a third ``build:`` service cannot be added to the Coolify compose
+# file anyway (paw-workspace #193/#194).
+#
+# THERE IS EXACTLY ONE ``functions = [...]`` ASSIGNMENT IN THIS CLASS, and it must stay
+# that way. A second one silently wins over the first — ``chat/runs/worker.py`` carries
+# a comment about the merge that produced two there and would have registered NEITHER
+# ship job. Adding a lane means editing the existing list, never appending a new
+# assignment.
+"""The site lane's arq WorkerSettings (backend-perf C1): builds, previews, deletes."""
 
 from __future__ import annotations
 
 import logging
 import os
+
+from arq import func
 
 from pocketpaw_ee.cloud.chat.runs.worker import (
     arq_health_check_interval_seconds,
@@ -46,6 +59,11 @@ from pocketpaw_ee.cloud.chat.runs.worker import (
     worker_startup,
 )
 from pocketpaw_ee.sites.build_job import SITE_BUILD_QUEUE_NAME, site_build_job_timeout_seconds
+from pocketpaw_ee.sites.delete_job import (
+    SITE_DELETE_FUNCTION_NAME,
+    run_site_delete,
+    site_delete_job_timeout_seconds,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +104,24 @@ def _sites_max_jobs() -> int:
     return val
 
 
+# The DELETE job rides this same lane, wrapped like the build jobs and for the same
+# reasons: its OWN timeout (a cascade walks Cloudflare, D1 and R2 serially and must not be
+# clipped by a budget sized for a sandbox build), and ``max_tries=1``.
+#
+# ``max_tries=1`` is load-bearing here rather than conventional. ``run_cascade`` is
+# resumable from its ledger, but the resume belongs to a PERSON: a cascade that stopped
+# because Cloudflare was returning 500s would be re-entered by an automatic retry seconds
+# later, into the same outage, spending the one cheap resume on a failure that has not
+# cleared. The row settles at ``failed`` naming the step, and the owner pressing delete
+# again is what re-claims it — ``failed`` is deliberately not an in-flight status.
+_site_delete_fn = func(
+    run_site_delete,
+    name=SITE_DELETE_FUNCTION_NAME,
+    timeout=site_delete_job_timeout_seconds(),
+    max_tries=1,
+)
+
+
 class WorkerSettings:
     """arq worker configuration for the site-build queue."""
 
@@ -94,7 +130,7 @@ class WorkerSettings:
     # carries its own timeout and ``max_tries=1``; re-wrapping them here would fork the
     # build timeout, and a build that arq cancels before its in-sandbox timeout fires is
     # recorded as lost infrastructure rather than as the slow-but-healthy build it was.
-    functions = [site_build_fn, site_preview_build_fn]
+    functions = [site_build_fn, site_preview_build_fn, _site_delete_fn]
     on_startup = worker_startup
     on_shutdown = worker_shutdown
     # No auto-retry, matching every other lane: a build is billed per attempt in a

--- a/ee/pocketpaw_ee/sites/delete_job.py
+++ b/ee/pocketpaw_ee/sites/delete_job.py
@@ -1,0 +1,433 @@
+# ee/pocketpaw_ee/sites/delete_job.py — the site-delete lane's WORKER SIDE: the arq job
+# that carries ONE site from "the owner pressed delete" to "there is no Site document",
+# plus the enqueue helper that starts one.
+#
+# Created 2026-09-12 (sites lifecycle wave 1, feat/sites-delete-endpoint). The two halves
+# of this lane already existed and had no way to meet: ``delete_cascade.run_cascade``
+# could tear a site down in a survivable order and nothing called it, and
+# ``service.create_site_export`` could capture the customer's data and nothing required
+# it. This module is what joins them, and it is the FIRST caller either has ever had.
+#
+# THE FORCED EXPORT IS STEP ZERO OF THIS JOB, AND NOT A PRECONDITION ON THE ENDPOINT.
+# That is the load-bearing decision in this file, so the reasoning is here rather than in
+# a commit message:
+#
+#   * The shipped client has an ``exporting`` status (``delete-types.ts``,
+#     ``SiteDeleteStatus``) and a failure sentence keyed on the ``export`` STEP
+#     (``deleteFailureMessage``'s ``STEP_MESSAGES``). Both are read from the POLL, off
+#     ``Site.delete_status`` / ``Site.delete_reason``. A synchronous export inside the
+#     DELETE request could never produce either: the status would never be observable,
+#     and an export failure would arrive as a 4xx on the delete call instead of as the
+#     ``export:<cause>`` reason the client is written to render.
+#   * An export PAGES a D1 500 rows at a time and walks every captured lead. On a busy
+#     dynamic site that is minutes of work. Holding an HTTP request open for it is the
+#     exact thing the 202 contract exists to avoid, and it would die at the proxy long
+#     before it died honestly.
+#   * What the cascade's header actually demands is that the export resolve "before the
+#     cascade is ever enqueued" — i.e. before the first DESTRUCTIVE step runs, because an
+#     export taken between steps could fail after something irreversible had already
+#     happened. This job satisfies that guarantee exactly: the export completes and is
+#     recorded on the row BEFORE ``run_cascade`` is entered. Nothing destructive runs
+#     ahead of it.
+#
+# A STALE EXPORT IS NOT REUSED. If the owner took an export last week, the leads captured
+# since then are not in it, and a delete that pointed at it would satisfy the gate while
+# destroying data nobody kept. A fresh one is taken on every attempt — EXCEPT on a resume,
+# where ``delete_export_id`` already names a ``ready`` row taken by this same delete. That
+# is the export's equivalent of the cascade's ledger skip, and it is the only case where
+# the existing bytes are provably a copy of the site as this delete found it.
+#
+# ``max_tries = 1``, LIKE EVERY OTHER LANE IN THIS TREE — and here it is not just house
+# style. ``run_cascade`` is resumable from its ledger, but the resume decision belongs to
+# a PERSON, not to arq. A cascade that stopped at ``script`` because Cloudflare was
+# returning 500s would be re-entered by an automatic retry seconds later, into the same
+# outage, spending the ledger's one cheap resume on a failure that has not cleared. The
+# row settles at ``failed`` with the step that stopped it, the owner presses delete again,
+# and ``claim_delete_queued`` lets them — ``failed`` is deliberately not an in-flight
+# status — at which point the cascade skips everything the first attempt finished.
+#
+# IT RIDES THE SITE-BUILD QUEUE rather than opening a third one. The sites lane
+# (``build_worker.WorkerSettings``) is already the consumer of site work, and a third
+# arq service cannot be added to the Coolify compose file anyway — a third ``build:``
+# blew the SSH argv limit and broke every deploy (paw-workspace #193/#194). A delete is
+# bounded work that shares the lane's four slots with builds, which is the right trade:
+# the alternative is a queue with no consumer, which is worse than no split at all.
+
+"""The delete job: force the export, run the cascade, remove the row."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import uuid
+from typing import Any
+
+from arq import create_pool
+from arq.connections import ArqRedis, RedisSettings
+
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.build_job import SITE_BUILD_QUEUE_NAME
+
+# ``_classify`` is imported ACROSS the underscore on purpose. ``delete_reason`` has one
+# vocabulary of causes, owned by the cascade, and the export step's cause has to be drawn
+# from it or an operator grouping failures by cause is grouping two different alphabets.
+# Re-implementing the same rule here is how the two would drift.
+from pocketpaw_ee.sites.delete_cascade import CascadeStepFailed, _classify, run_cascade
+
+logger = logging.getLogger(__name__)
+
+#: The arq-registered name of the delete job. Pinned explicitly rather than left to
+#: ``__qualname__`` so the enqueue and the registration cannot drift apart the way a
+#: rename would silently let them.
+SITE_DELETE_FUNCTION_NAME = "run_site_delete"
+
+#: The step name a forced-export failure is reported under. It is NOT a member of
+#: ``delete_cascade.CASCADE_STEPS`` — the export is not a cascade step, it is the
+#: precondition the cascade is gated on — but it shares the ``"<step>:<cause>"`` shape so
+#: one consumer parses every ``delete_reason``, and the shipped client keys its most
+#: reassuring sentence ("nothing was deleted, your site is untouched") on exactly this
+#: token.
+STEP_EXPORT = "export"
+
+_DEFAULT_DELETE_TIMEOUT_SECONDS = 900
+_TIMEOUT_ENV = "POCKETPAW_SITES_DELETE_TIMEOUT_SEC"
+
+
+def site_delete_job_timeout_seconds() -> int:
+    """The arq ``job_timeout`` for :func:`run_site_delete`, and the window the claim
+    measures staleness against.
+
+    Fifteen minutes, well past the design's targets (under a minute for a static site,
+    under five for a dynamic one with data) and past the client's own six-minute poll
+    ceiling. Sized long deliberately: the budget's job is to release a slot held by a
+    genuinely dead worker, and a delete that arq cancels mid-cascade is strictly worse
+    than one that takes longer than expected — the ledger records completed steps, but
+    the row is left mid-teardown with a live cancellation nobody logged a reason for.
+
+    Same fail-soft contract as the other lanes: an unparseable or non-positive value
+    falls back to the default rather than reaching arq, where ``0`` means "no timeout at
+    all" and a negative one is nonsense.
+    """
+    raw = os.environ.get(_TIMEOUT_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_DELETE_TIMEOUT_SECONDS
+    try:
+        val = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an int; using default %ds",
+            _TIMEOUT_ENV,
+            raw,
+            _DEFAULT_DELETE_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_DELETE_TIMEOUT_SECONDS
+    if val <= 0:
+        logger.warning(
+            "%s=%d is not positive; using default %ds",
+            _TIMEOUT_ENV,
+            val,
+            _DEFAULT_DELETE_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_DELETE_TIMEOUT_SECONDS
+    return val
+
+
+class CloudflareUnavailable(Exception):
+    """A cascade step needed Cloudflare and this deployment has no client for it.
+
+    Raised rather than skipped. "There is no Cloudflare here" and "there was nothing to
+    remove" are different facts, and recording the second for the first is how a cascade
+    reports a completed teardown over a Worker that is still serving — the same mistake
+    ``_delete_script`` avoids by reading ``deploy_target`` instead of the configured mode.
+    """
+
+
+class _NoCloudflare:
+    """Stands in for the client on a deployment that has none, and refuses honestly."""
+
+    def __getattr__(self, name: str) -> Any:
+        async def _refuse(*_args: Any, **_kwargs: Any) -> None:
+            raise CloudflareUnavailable(name)
+
+        return _refuse
+
+
+class _DeleteDeps:
+    """The side effects ``run_cascade`` calls, resolved once per job.
+
+    Assembled here rather than inside the cascade so the ordering and the ledger stay
+    testable without Cloudflare, a bucket, or a database — which is the whole reason
+    ``run_cascade`` takes ``deps`` at all.
+    """
+
+    def __init__(self, *, cloudflare: Any, assets: Any) -> None:
+        self.cloudflare = cloudflare
+        self.assets = assets
+
+    async def purge_records(self, *, workspace_id: str, site_id: str) -> None:
+        await sites_service.purge_site_records(workspace_id=workspace_id, site_id=site_id)
+
+
+def _build_deps() -> _DeleteDeps:
+    from pocketpaw_ee.sites.public_assets import public_asset_store
+
+    cloudflare: Any
+    if sites_service._local_mode():
+        cloudflare = _NoCloudflare()
+    else:
+        try:
+            cloudflare = sites_service._cf_client()
+        except Exception as exc:  # noqa: BLE001 - an unconfigured deployment, not a bug
+            logger.warning("sites.delete: no Cloudflare client available (%s)", exc)
+            cloudflare = _NoCloudflare()
+    # ``None`` is what the cascade's R2 step reads as "no public rail on this
+    # deployment", which is a deployment fact and a legitimate skip. Distinct from an
+    # adapter that exists and cannot list, which ``PublicAssetStore.purge`` raises on.
+    return _DeleteDeps(cloudflare=cloudflare, assets=public_asset_store())
+
+
+def _cause_of(exc: Exception) -> str:
+    """A short machine token for ``delete_reason``, never raw provider text.
+
+    A ``CloudError`` already carries a curated machine code (``sites.export_unavailable``)
+    and that is strictly more useful to an operator than the exception's class name, so it
+    is preferred and flattened into the same alphabet. Everything else falls through to
+    the cascade's own classifier, which is what keeps one vocabulary across both halves.
+    """
+    if isinstance(exc, CloudError):
+        code = getattr(exc, "code", "") or ""
+        flattened = "".join(c.lower() if c.isalnum() else "_" for c in code).strip("_")
+        if flattened:
+            return flattened
+    return _classify(exc)
+
+
+async def _force_export(site: Any) -> str:
+    """Capture the customer's data, and return the export id. Raises if it cannot.
+
+    Resumes rather than repeats: an export already named by ``delete_export_id`` and
+    still ``ready`` was taken by THIS delete, before anything was destroyed, so it is a
+    faithful copy of the site as the delete found it and re-taking it would only cost a
+    second full read of a database that is about to be deleted anyway.
+
+    Every other case takes a fresh one — see the module header on why a pre-existing
+    export from last week is not reusable.
+    """
+    existing_id = (getattr(site, "delete_export_id", "") or "").strip()
+    if existing_id and await sites_service.site_export_is_ready(
+        workspace_id=site.workspace, export_id=existing_id
+    ):
+        logger.info(
+            "sites.delete: reusing this attempt's export %s for site %s", existing_id, site.id
+        )
+        return existing_id
+
+    export = await sites_service.create_site_export(
+        workspace_id=site.workspace, user_id=site.owner, site_id=str(site.id)
+    )
+    if export.status != "ready":
+        # ``create_site_export`` raises on a failure it detected, so reaching here means
+        # a row came back in some other state. Treated as a hard stop: an export that is
+        # not ``ready`` has no bytes, and the whole point of the gate is that "we kept a
+        # copy" is never assumed.
+        raise CascadeStepFailed(STEP_EXPORT, "export_not_ready")
+    return export.id
+
+
+async def run_site_delete(
+    ctx: dict[str, Any],
+    workspace_id: str,
+    site_id: str,
+    *,
+    _deps: Any = None,
+) -> None:
+    """arq job: export the site's data, tear it down in order, then delete the row.
+
+    ``ctx`` is the arq worker context and is unused — everything the job needs is in the
+    payload, and the workspace rides along so the row can be read back under the tenancy
+    it belongs to rather than by id alone.
+
+    A MISSING SITE IS A SUCCESS, NOT AN ERROR. The last thing a completed delete does is
+    remove this row, so a job that wakes to find nothing has found its own earlier
+    attempt's success — or a row that was already gone. Either way there is nothing left
+    to tear down and nothing to record it on.
+
+    Nothing here raises on an operational failure. The row settles at ``failed`` carrying
+    the step that stopped it, which is what the client polls for; raising as well would
+    only add an arq-level error beside a row that already says what happened.
+    """
+    site = await sites_service.load_build_site(workspace_id, site_id)
+    if site is None:
+        # ``load_build_site`` is named for the lane that introduced it; the read it
+        # performs — workspace-scoped, ``None`` for a deleted or malformed id — is
+        # exactly what this job needs, so it is reused rather than duplicated.
+        logger.info("sites.delete: site %s is already gone; nothing to do", site_id)
+        return
+
+    # ── The forced export: step zero, before anything destructive ────────────
+    await sites_service.mark_delete_stage(site, status="exporting")
+    try:
+        export_id = await _force_export(site)
+    except Exception as exc:  # noqa: BLE001 - classified into the row, never re-raised
+        reason = (
+            exc.reason if isinstance(exc, CascadeStepFailed) else f"{STEP_EXPORT}:{_cause_of(exc)}"
+        )
+        logger.warning(
+            "sites.delete: export failed for site %s (%s); NOTHING was deleted",
+            site_id,
+            reason,
+            exc_info=True,
+        )
+        await sites_service.record_delete_failure(site, reason=reason)
+        return
+
+    await site.set({"delete_export_id": export_id})
+    site.delete_export_id = export_id
+
+    # ── The cascade: everything from here is destructive ─────────────────────
+    await sites_service.mark_delete_stage(site, status="tearing_down")
+    deps = _deps if _deps is not None else _build_deps()
+    try:
+        await run_cascade(site=site, deps=deps, save=sites_service.record_delete_progress)
+    except CascadeStepFailed as exc:
+        logger.warning("sites.delete: cascade stopped for site %s at %s", site_id, exc.reason)
+        await sites_service.record_delete_failure(site, reason=exc.reason)
+        return
+    except Exception as exc:  # noqa: BLE001 - an unclassified stop is still a stop
+        # The cascade classifies its own step failures, so reaching here means something
+        # outside a step raised — the ledger write itself, most likely. Recorded rather
+        # than swallowed: a row left in ``tearing_down`` with no reason makes the client
+        # poll a delete nobody is running until its deadline lapses.
+        logger.exception("sites.delete: unexpected failure tearing down site %s", site_id)
+        await sites_service.record_delete_failure(site, reason=f"cascade:{_cause_of(exc)}")
+        return
+
+    # ── The row, last ────────────────────────────────────────────────────────
+    # Deleting this is the success signal: the status endpoint 404s from here, which is
+    # what the client reads as "it finished". See ``service.delete_site_document``.
+    await sites_service.delete_site_document(site)
+    logger.info("sites.delete: site %s deleted (export %s)", site_id, export_id)
+
+
+# ---------------------------------------------------------------------------
+# The enqueue
+# ---------------------------------------------------------------------------
+
+_pool: ArqRedis | None = None
+_pool_lock = asyncio.Lock()
+
+
+async def _get_pool() -> ArqRedis:
+    """The process's arq pool — the same lazy double-checked pattern the build lane
+    uses, for the same reason: one pool per process, and concurrent first-enqueues must
+    not leak two."""
+    global _pool
+    if _pool is None:
+        async with _pool_lock:
+            if _pool is None:
+                url = os.environ.get("POCKETPAW_REDIS_URL", "").strip()
+                if not url:
+                    raise RuntimeError(
+                        "POCKETPAW_REDIS_URL is not set — the site-delete lane needs Redis."
+                    )
+                _pool = await create_pool(RedisSettings.from_dsn(url))
+    return _pool
+
+
+def _reset_for_tests() -> None:
+    global _pool
+    _pool = None
+
+
+def _mint_job_id(site_id: str) -> str:
+    """A unique arq job id, minted BEFORE the enqueue so it can be persisted with the
+    queued stamp in one write.
+
+    Uuid-tailed rather than deterministic, for the reason the build lane documents: arq
+    refuses an enqueue whose id already holds a job OR a RESULT, and results outlive the
+    job by ``keep_result``. A stable ``site-delete-<id>`` would therefore refuse the
+    RETRY of a failed delete for an hour after it failed — a single-flight guard nobody
+    asked for, enforced in the wrong layer, and invisible because arq's refusal is a
+    ``None`` return rather than an error. The real single-flight guard is the conditional
+    claim below.
+    """
+    return f"site-delete-{site_id}-{uuid.uuid4().hex}"
+
+
+async def enqueue_site_delete(site: Any, *, _pool_override: Any = None) -> str | None:
+    """Queue the delete of ``site``; return the job id, or ``None`` when one is in flight.
+
+    The workspace and site id are read OFF THE DOC rather than taken as parameters, which
+    is a tenancy decision and not a convenience: a caller that could pass a workspace
+    alongside a doc could pass a mismatched pair, and the job would then destroy a site
+    under the workspace it was told rather than the one the row belongs to.
+
+    Order, and why:
+
+      1. CLAIM the slot — stamp ``queued`` + the clock + the job id in ONE CONDITIONAL
+         write, BEFORE the enqueue. Conditional because a read-then-write gate loses the
+         race the build lane measured at 8 sandboxes for 8 concurrent publishes; here the
+         same race is two workers running two cascades over one site, which is worse than
+         a wasted sandbox. Before the enqueue, because a worker that picked the job up
+         first would write a real status and then have this stamp land on top of it,
+         pinning a finished delete in ``queued`` forever.
+      2. ENQUEUE. On ANY failure — dead Redis, or arq refusing the id — settle the row at
+         ``failed`` and re-raise. Skipping that rollback is what pins a row in ``queued``
+         behind a job that never existed, and the claim would then refuse every delete of
+         this site until the staleness window lapsed.
+
+    ``None`` is not an error. It means another attempt owns the slot, and the caller
+    reports that attempt rather than starting a second teardown of one site.
+    """
+    workspace_id = site.workspace
+    site_id = str(site.id)
+    timeout = site_delete_job_timeout_seconds()
+
+    job_id = _mint_job_id(site_id)
+    claimed = await sites_service.claim_delete_queued(site, job_id=job_id, timeout_seconds=timeout)
+    if not claimed:
+        logger.info(
+            "sites.delete: site %s already has a delete in flight (%s) — not enqueueing",
+            site_id,
+            getattr(site, "delete_status", None),
+        )
+        return None
+
+    try:
+        pool = _pool_override or await _get_pool()
+        job = await pool.enqueue_job(
+            SITE_DELETE_FUNCTION_NAME,
+            workspace_id,
+            site_id,
+            _job_id=job_id,
+            _queue_name=SITE_BUILD_QUEUE_NAME,
+        )
+        if job is None:
+            # arq answers None when the id already exists. With a uuid tail that should be
+            # impossible, so it is a failed enqueue rather than evidence a delete is
+            # coming — a row left in ``queued`` for a job nobody will run is exactly what
+            # the rollback below exists to prevent.
+            raise RuntimeError(f"arq refused job id {job_id!r} — a job with that id exists")
+    except Exception:
+        logger.exception("sites.delete: enqueue failed for site %s", site_id)
+        # Best-effort and separately suppressed: the raise below is what the caller acts
+        # on, and a failed rollback must not replace it with a second, less useful error.
+        with contextlib.suppress(Exception):
+            await sites_service.record_delete_failure(site, reason="enqueue:pool_or_enqueue_raised")
+        raise
+
+    logger.info("sites.delete: queued delete %s for site %s (%ds budget)", job_id, site_id, timeout)
+    return job_id
+
+
+__all__ = [
+    "SITE_DELETE_FUNCTION_NAME",
+    "STEP_EXPORT",
+    "CloudflareUnavailable",
+    "enqueue_site_delete",
+    "run_site_delete",
+    "site_delete_job_timeout_seconds",
+]

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -9,6 +9,13 @@
 # that still belongs to another workspace, so it carries only what somebody needs
 # in order to decide whether to accept — never the signed key, the capture config,
 # the lead count or the client record.
+# Updated 2026-09-12 (sites lifecycle wave 1, feat/sites-delete-endpoint): added
+# ``SiteDeleteQueuedResponse`` and ``SiteDeleteStatusResponse``, the two wire
+# shapes of the site-delete lane. Both carry status as a plain ``str`` rather than
+# a literal, and the poll has NO terminal success value — the cascade's last step
+# deletes the document the status field lives on, so success is the 404. Read the
+# class docstrings before tightening either, because both looseness calls are
+# load-bearing against the shipped client.
 #
 # Updated 2026-09-04 (AD-4 — the overview chart's data): added
 # ``SiteAnalyticsSeriesPoint`` / ``SiteAnalyticsSeries`` and ``SiteAnalyticsResponse.series``,
@@ -477,6 +484,61 @@ class SiteExportResponse(BaseModel):
     # When the sweeper will purge these bytes. Surfaced so the UI can say how long
     # the owner has to download it rather than implying it is kept forever.
     expires_at: str | None = None
+
+
+class SiteDeleteQueuedResponse(BaseModel):
+    """Answer of ``DELETE /sites/{site_id}`` — 202, with the job handle.
+
+    202 AND NOT 204. The site is still serving when this returns: the teardown is a
+    durable job over an ordered cascade, and a 204 would be a simpler contract and a
+    lie. The client polls ``GET /sites/{site_id}/delete-status`` from here.
+
+    ``status`` is typed ``str`` rather than a literal for the same reason the poll's
+    is — see :class:`SiteDeleteStatusResponse`.
+    """
+
+    site_id: str
+    #: ``"queued"`` on the happy path. A request that arrives while an earlier attempt
+    #: still holds the slot reports THAT attempt's status instead, because the site is
+    #: already being deleted and a conflict the caller cannot act on would be noise.
+    status: str = "queued"
+    #: Mirrors ``Site.delete_job_id``. Persisted rather than transient because a queued
+    #: destructive job is exactly when someone reloads the page.
+    job_id: str | None = None
+
+
+class SiteDeleteStatusResponse(BaseModel):
+    """Answer of ``GET /sites/{site_id}/delete-status``.
+
+    THIS ENDPOINT 404s ON SUCCESS, and that is the contract rather than an edge case.
+    The cascade's last step deletes the Site document, and ``delete_status`` is a field
+    on that document — so a completed delete has nothing left to report a status on.
+    There is deliberately no terminal ``"deleted"`` value here; adding one would mean
+    keeping the row the delete exists to remove, and the shipped client reads the 404
+    as its success signal.
+
+    ``delete_status`` is a plain ``str`` on purpose. The client treats any value it
+    does not recognise as STILL RUNNING, which only works if an unknown value can
+    reach it — a stricter type here would push a future status through validation and
+    turn "we added a phase" into "the poll stops on a live teardown".
+    """
+
+    site_id: str
+    #: none | queued | exporting | tearing_down | failed. Read via the client's
+    #: helpers, never by comparing the string at a call site.
+    delete_status: str = "none"
+    #: WHY a delete stopped, as ``"<step>:<cause>"`` — the same two-part shape
+    #: ``build_reason`` uses, so a consumer parses it once. The cause half is a fixed
+    #: machine token from ``delete_cascade._classify``, never raw provider text.
+    delete_reason: str | None = None
+    #: Step name -> outcome: the resume ledger. A re-entered job skips every step
+    #: recorded here, which is what makes a retry a resume rather than a repeat.
+    delete_ledger: dict[str, str] = Field(default_factory=dict)
+    #: The ``SiteExport`` holding the customer's data, captured before anything was
+    #: destroyed. An ID and not a URL: the export outlives the site precisely because
+    #: it is NOT stored on the document the cascade deletes.
+    delete_export_id: str = ""
+    delete_job_id: str | None = None
 
 
 class SiteMetadataUpdate(BaseModel):

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -16,6 +16,15 @@
 # its custom domains -- into any workspace whose id they can name. The receiving
 # tenant consents by accepting, and the service re-checks membership against the
 # accepting user's OWN record rather than trusting the workspace header.
+# Updated 2026-09-12 (sites lifecycle wave 1, feat/sites-delete-endpoint): the two
+# routes that make deleting a site real — DELETE ``/sites/{site_id}`` and GET
+# ``/sites/{site_id}/delete-status``. The delete UI shipped against this contract
+# before the backend existed, so the shapes are FIXED by the client and not ours to
+# re-pick: the delete answers 202 (the site is still serving when it returns, because
+# the teardown is a durable job) and the poll 404s ON SUCCESS (the cascade's last step
+# deletes the document the status field lives on). Both are OWNER-ONLY on top of the
+# usual fabric gate — a member who may edit a site may not destroy it — and the owner
+# check itself lives in the service, where the non-HTTP callers cannot walk past it.
 #
 # Updated 2026-09-02 (SA-4 — the visitor-analytics read): GET
 # ``/sites/{site_id}/analytics``, the read half of the counter SA-1/SA-2 deploy.
@@ -291,6 +300,8 @@ from pocketpaw_ee.sites.dto import (
     SiteClientUpdate,
     SiteDataRowsResponse,
     SiteDataTablesResponse,
+    SiteDeleteQueuedResponse,
+    SiteDeleteStatusResponse,
     SiteEntitlementsResponse,
     SiteExportResponse,
     SiteInvoiceCreate,
@@ -1106,6 +1117,59 @@ async def download_site_export(
         chunks,
         media_type="application/json",
         headers={"Content-Disposition": 'attachment; filename="' + filename + '"'},
+    )
+
+
+@router.delete("/sites/{site_id}", response_model=SiteDeleteQueuedResponse, status_code=202)
+async def delete_site(
+    site_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SiteDeleteQueuedResponse:
+    """Destroy a site and everything it owns. OWNER ONLY, and IRREVERSIBLE.
+
+    202 AND NOT 204, which is the whole shape of this endpoint. The teardown is a
+    durable job over an ordered cascade — cancel the billing, revoke the key, pull the
+    routes, hostnames and Worker, then the D1, the bucket prefix and the dependent
+    rows — and the site is STILL SERVING when this call returns. A 204 would be a
+    simpler contract and a lie. Poll ``/delete-status`` from here.
+
+    A DATA EXPORT IS FORCED FIRST, inside the job, before anything destructive runs.
+    That is the entire recovery story for an action with no undo, and it is a hard
+    stop rather than a best effort: an export that cannot be vouched for leaves the
+    site completely untouched and settles the row at ``export:<cause>``.
+
+    ``fabric.write`` like every sibling write, and then OWNER-ONLY on top of it in the
+    service — a workspace member who may edit a site may not destroy it. The owner
+    check is in the service rather than here because jobs, bus handlers and MCP tools
+    reach services directly; see ``sites_service.start_site_delete``.
+    """
+    return await sites_service.start_site_delete(
+        workspace_id=ctx.workspace_id, user_id=ctx.user_id, site_id=site_id
+    )
+
+
+@router.get("/sites/{site_id}/delete-status", response_model=SiteDeleteStatusResponse)
+async def site_delete_status(
+    site_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> SiteDeleteStatusResponse:
+    """How far a delete has got. 404 ONCE IT FINISHES — and that 404 is the success.
+
+    There is no terminal "deleted" status to return, by construction: the cascade's
+    last step removes the Site document, and ``delete_status`` is a field on that
+    document. A client that treats this 404 as an error reports every successful
+    delete as a broken one, so the shipped client reads it as completion instead.
+
+    Owner-only like the delete itself. ``delete_reason`` names which step of a
+    teardown stopped, which is operational detail about a site the reader may be able
+    to see but not administer. A site in ANOTHER workspace is a 404 from the service's
+    tenant-scoped load, which is a different answer from the 403 a non-owner inside
+    the workspace gets, on purpose.
+    """
+    return await sites_service.site_delete_status(
+        workspace_id=ctx.workspace_id, user_id=ctx.user_id, site_id=site_id
     )
 
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,25 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-09-12 (sites lifecycle wave 1, feat/sites-delete-endpoint): the
+# DELETE lifecycle — ``start_site_delete`` / ``site_delete_status`` (the two
+# owner-only seams the REST routes call) plus the writes the delete job drives the
+# row through: ``claim_delete_queued``, ``mark_delete_stage``,
+# ``record_delete_failure``, ``record_delete_progress``, ``purge_site_records`` and
+# ``delete_site_document``. The cascade and the export already existed and had no
+# caller; this is the half that gives them one.
+#
+# THE OWNER CHECK LIVES HERE, not in the router, for the reason
+# ``pockets.service.delete`` records against the same decision: jobs, bus handlers
+# and MCP tools reach services directly, so a guard in the router is one they walk
+# past. A non-owner inside the workspace is 403 and a site outside it is 404 — two
+# different answers, because confirming a stranger's site exists is itself a leak.
+#
+# ``record_delete_progress`` PERSISTS MORE THAN THE LEDGER, and the tuple it reads
+# is load-bearing: the cascade stops billing by clearing ``subscription_status`` in
+# memory, so a ledger-only save would leave a failed teardown whose ledger says
+# billing is done and whose row still bills. See ``_CASCADE_MUTATED_FIELDS``.
+#
 # Updated 2026-09-11 (SC-1, feat/sites-svelte-edit-create): ``edit_svelte_component``
 # gained ``create`` and now returns ``(site_doc, unreferenced)`` rather than the doc
 # alone. Three things came with it. It reads the pocket UNCONDITIONALLY now (the create
@@ -1077,7 +1096,8 @@ from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 from pocketpaw_ee.cloud.models.site import SiteDomain as _SiteDomainDoc
 from pocketpaw_ee.cloud.models.site import SiteInvoice as _SiteInvoiceDoc
 from pocketpaw_ee.cloud.models.site_export import SiteExport as _SiteExportDoc
-from pocketpaw_ee.sites.build_state import claim_precondition
+from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter as _SiteRateCounterDoc
+from pocketpaw_ee.sites.build_state import claim_precondition, stale_after
 from pocketpaw_ee.sites.domain import HostnameStatus
 from pocketpaw_ee.sites.dto import (
     ANALYTICS_STATUS_NEVER_COUNTED,
@@ -1097,6 +1117,8 @@ from pocketpaw_ee.sites.dto import (
     SiteDataRowsResponse,
     SiteDataTableInfo,
     SiteDataTablesResponse,
+    SiteDeleteQueuedResponse,
+    SiteDeleteStatusResponse,
     SiteEntitlementsResponse,
     SiteExportResponse,
     SiteInvoiceCreate,
@@ -9739,7 +9761,13 @@ def _export_response(doc: _SiteExportDoc) -> SiteExportResponse:
         size_bytes=doc.size_bytes,
         table_counts=dict(doc.table_counts or {}),
         lead_count=doc.lead_count,
-        created_at=doc.created_at.isoformat() if doc.created_at else None,
+        # ``createdAt``, not ``created_at``. ``TimestampedDocument`` declares the
+        # camelCase field and nothing aliases it, so the snake_case spelling this
+        # line carried since the export shipped raised ``AttributeError`` on EVERY
+        # call — which meant ``POST /sites/{id}/export`` answered 500 after doing all
+        # its work, and the delete lane's forced export could never satisfy its own
+        # gate. Nothing caught it because no test had ever built an export response.
+        created_at=doc.createdAt.isoformat() if doc.createdAt else None,
         expires_at=doc.expires_at.isoformat() if doc.expires_at else None,
     )
 
@@ -9880,6 +9908,25 @@ async def _fail_export(export: _SiteExportDoc, exc: Exception, site_id: str) -> 
     )
     await export.save()
     logger.warning("sites.export failed for site=%s: %s", site_id, exc, exc_info=True)
+
+
+async def site_export_is_ready(*, workspace_id: str, export_id: str) -> bool:
+    """Whether ONE export holds bytes, tenant-scoped. The delete lane's resume check.
+
+    A direct read rather than a scan of ``list_site_exports``: the question is about one
+    row, and answering it by listing a workspace's whole export history — then mapping
+    every row through a response DTO — does strictly more work and fails on strictly
+    more things than the question needs.
+    """
+    try:
+        oid = ObjectId(export_id)
+    except (InvalidId, TypeError):
+        return False
+    doc = await _SiteExportDoc.find_one({"_id": oid, "workspace": workspace_id})
+    # ``ready`` and nothing else. A ``pending`` or ``failed`` row records an ATTEMPT,
+    # not a copy of anyone's data, and treating either as satisfying the gate is how a
+    # delete proceeds over data nobody kept.
+    return doc is not None and doc.status == "ready" and bool(doc.storage_key)
 
 
 async def list_site_exports(*, workspace_id: str, site_id: str = "") -> list[SiteExportResponse]:
@@ -10348,6 +10395,278 @@ class _TransferDeps:
             {"$set": {"workspace": destination_workspace_id}}
         )
         return bool(getattr(result, "modified_count", 0) or 0)
+# The delete lifecycle (sites lifecycle wave 1)
+# ---------------------------------------------------------------------------
+#
+# These are the seams ``sites/delete_job.py`` writes a delete through. They live here
+# rather than in the job for the reason every other Site write does: the job is not
+# the only caller this will ever have, and a guard a second caller can walk past is
+# not a guard.
+#
+# EVERY WRITE BELOW IS FIELD-SCOPED. Not a style preference — a delete runs for
+# minutes against a document a BUILD also writes to, and a ``save()`` here would push
+# a stale whole-document snapshot back and silently roll ``build_status`` backwards.
+# ``update_site_metadata`` documents the same rule for a human-paced edit; it binds
+# harder for a job that holds its in-memory doc across a multi-minute cascade.
+
+#: The delete statuses that CLAIM an attempt is running. ``failed`` is deliberately
+#: not among them: the cascade is resumable from its ledger, so a stopped delete must
+#: be re-claimable or a site that failed once could never be deleted again. ``none``
+#: is the never-asked row.
+DELETE_IN_FLIGHT_STATUSES = frozenset({"queued", "exporting", "tearing_down"})
+
+
+def delete_claim_precondition(
+    timeout_seconds: int, *, now: datetime | None = None
+) -> dict[str, Any]:
+    """The Mongo filter that lets a caller CLAIM the delete slot, as a query fragment.
+
+    The same shape — and the same asymmetry — as ``build_state.claim_precondition``,
+    and for the same reason: the decision has to live INSIDE the write, or two
+    concurrent deletes of one site both read a claimable row and both enqueue.
+
+    A MISSING OR UNREADABLE STAMP READS AS CLAIMABLE. That is the safe direction here
+    exactly as it is for builds, and the cost of getting it wrong is not symmetric: a
+    redundant claim costs one idempotent pass over a ledger that skips every finished
+    step, while a stuck guard leaves a site that can never be deleted — still serving,
+    still ingesting leads, and (on a paid tier) still charging.
+    """
+    reference = now or datetime.now(UTC)
+    if reference.tzinfo is None:  # pragma: no cover - defensive
+        reference = reference.replace(tzinfo=UTC)
+    return {
+        "$or": [
+            {"delete_status": {"$nin": sorted(DELETE_IN_FLIGHT_STATUSES)}},
+            {"delete_started_at": {"$not": {"$type": "date"}}},
+            {"delete_started_at": {"$lt": reference - stale_after(timeout_seconds)}},
+        ]
+    }
+
+
+async def claim_delete_queued(
+    site: _SiteDoc,
+    *,
+    job_id: str,
+    timeout_seconds: int,
+    now: datetime | None = None,
+) -> bool:
+    """CLAIM the delete slot for ``site`` and stamp it ``queued``. False means lost.
+
+    One conditional write, mirroring ``claim_build_queued`` — see that function and
+    :func:`delete_claim_precondition` for why the gate cannot be a read followed by a
+    write.
+
+    ``delete_reason`` is cleared so a retry never shows the previous attempt's step,
+    and ``delete_ledger`` is deliberately LEFT ALONE: it is what makes the retry a
+    resume rather than a repeat, and clearing it here would re-run every destructive
+    step the last attempt already completed.
+    """
+    stamp = now or datetime.now(UTC)
+    values: dict[str, Any] = {
+        "delete_status": "queued",
+        "delete_started_at": stamp,
+        "delete_job_id": job_id,
+        "delete_reason": None,
+    }
+    collection = type(site).get_pymongo_collection()
+    won = await collection.find_one_and_update(
+        {"_id": site.id, **delete_claim_precondition(timeout_seconds, now=stamp)},
+        {"$set": values},
+    )
+    if won is None:
+        return False
+    # The DB is now ahead of the in-memory doc, and every later step of the enqueue
+    # reads this object. A caller that won the claim but still saw the pre-claim row
+    # would log — and roll back to — the wrong status.
+    for field, value in values.items():
+        setattr(site, field, value)
+    return True
+
+
+async def mark_delete_stage(site: _SiteDoc, *, status: str) -> None:
+    """Advance a claimed delete to its next phase and RE-STAMP the clock.
+
+    Re-stamping matches ``mark_build_running``: ``delete_started_at`` means "when the
+    current phase began", so a job that waited behind the lane's concurrency ceiling
+    does not spend its staleness window on queue wait and get declared stale while it
+    is actively tearing a site down.
+    """
+    stamp = datetime.now(UTC)
+    await site.set({"delete_status": status, "delete_started_at": stamp})
+    site.delete_status = status
+    site.delete_started_at = stamp
+
+
+async def record_delete_failure(site: _SiteDoc, *, reason: str) -> None:
+    """Stop the delete at ``failed`` and say WHERE, as ``"<step>:<cause>"``.
+
+    ``delete_job_id`` is left in place, like ``record_build_outcome`` leaves
+    ``build_job_id``: a client polling with that handle must still find the row it was
+    watching. ``delete_ledger`` is left in place too — it is the resume.
+    """
+    await site.set({"delete_status": "failed", "delete_reason": reason})
+    site.delete_status = "failed"
+    site.delete_reason = reason
+
+
+#: The fields the cascade mutates ON THE DOC, written back alongside the ledger.
+#:
+#: THIS TUPLE IS NOT COSMETIC, and a ledger-only save would be a live bug rather than
+#: an incomplete one. ``delete_cascade._stop_billing`` stops the money by clearing
+#: ``subscription_status`` IN MEMORY — that local write IS the mechanism on the
+#: credits rail, because ``renewal_sweeper`` selects the rows it charges on exactly
+#: that field. ``_revoke_key`` closes the public lead-ingest surface the same way. If
+#: this callback persisted only ``delete_ledger``, a cascade that failed at a later
+#: step would leave a row whose ledger says billing is done and whose
+#: ``subscription_status`` still says ``active``; the resume would SKIP the billing
+#: step on the strength of that ledger, and the customer would keep being charged for
+#: a half-destroyed site. That is precisely the failure putting billing first exists
+#: to prevent, re-introduced by the persistence layer.
+_CASCADE_MUTATED_FIELDS = (
+    "delete_ledger",
+    "subscription_status",
+    "renewal_date",
+    "signed_key",
+    "revoked",
+)
+
+
+async def record_delete_progress(site: _SiteDoc) -> None:
+    """Persist one cascade step's effects: the ledger PLUS what that step changed.
+
+    This is the ``save`` callback ``delete_cascade.run_cascade`` invokes after EVERY
+    step, and it is field-scoped for the reason at the top of this section. See
+    :data:`_CASCADE_MUTATED_FIELDS` for why it is not ledger-only.
+    """
+    await site.set({field: getattr(site, field) for field in _CASCADE_MUTATED_FIELDS})
+
+
+async def purge_site_records(*, workspace_id: str, site_id: str) -> int:
+    """Delete the dependent rows a destroyed site leaves behind. Returns the count.
+
+    Scoped on ``(workspace, site_id)`` — the compound index ``Lead`` already declares —
+    so this can never reach another site's submissions. The tenancy is IN the query
+    rather than checked after it, because a purge that filtered in Python would still
+    have read the other tenant's rows.
+
+    WHAT THIS DOES NOT PURGE, said here rather than discovered later:
+
+      * VISITOR ANALYTICS. They live in Cloudflare Analytics Engine on a three-month
+        retention this product does not control. The confirm dialog says so out loud
+        and the export bundle repeats it — implying a full wipe would be a
+        completeness we cannot deliver.
+      * CONCIERGE TRANSCRIPTS. They are ``ChatRun`` rows keyed on the POCKET and owned
+        by the Paw Bar surface; reaching into another subsystem's collection from here
+        would put a second writer on rows only that surface knows the shape of.
+        Tracked as follow-up. The site's signed key is revoked in cascade step 2, so
+        no NEW transcript can be written once a delete starts.
+      * SITE DESIGN BRIEFS. They carry no ``site_id`` at all — a brief belongs to an
+        import, not to the site an import eventually became — so there is no query
+        that could select this site's.
+    """
+    removed = 0
+    leads = await _LeadDoc.find({"workspace": workspace_id, "site_id": site_id}).delete()
+    removed += getattr(leads, "deleted_count", 0) or 0
+    # The per-minute capture counters. They carry a 120s TTL and would expire on their
+    # own, but a site being destroyed should not leave rows behind that name it.
+    # ``scope_id`` is the site id for the overall scope and ``"{site_id}:{rate_key}"``
+    # for the per-IP one, so one anchored prefix selects both and nothing else — an
+    # unanchored match would also select a different site whose id merely contains
+    # this one.
+    counters = await _SiteRateCounterDoc.find(
+        {"scope_id": {"$regex": f"^{re.escape(site_id)}(:|$)"}}
+    ).delete()
+    removed += getattr(counters, "deleted_count", 0) or 0
+    return removed
+
+
+async def delete_site_document(site: _SiteDoc) -> None:
+    """Remove the Site row — the LAST thing a delete does, and the success signal.
+
+    There is no terminal ``delete_status`` because this row is where that field lives.
+    A reader that finds no Site has found a completed delete, which is why
+    ``GET /sites/{id}/delete-status`` answering 404 is what the client treats as
+    success rather than as an error.
+    """
+    # no-event: there is no ``SiteDeleted`` event type, and this is not the place to
+    # mint one. ``SitePublished`` exists because a publish has downstream consumers
+    # (knowledge sync, the screenshot capture); a delete has none today, and an event
+    # emitted for nobody is a contract to keep for no reason. If a consumer appears —
+    # a workspace activity feed is the likely one — add the type WITH it, so the
+    # payload is shaped by a real reader rather than guessed at here.
+    await site.delete()
+
+
+async def start_site_delete(
+    *, workspace_id: str, user_id: str, site_id: str
+) -> SiteDeleteQueuedResponse:
+    """Queue the destruction of one site. OWNER ONLY. Answers before it is done.
+
+    The owner check is HERE and not in the router, following the reasoning
+    ``pockets.service.delete`` records: the router is not the only caller (jobs, bus
+    handlers and MCP tools reach services directly), so a guard in the router is one
+    those callers walk past.
+
+    A non-owner in the SAME workspace gets 403 — they can see the site, they simply
+    may not destroy it — while a site in another workspace is a 404 from ``_load``,
+    because confirming a stranger's site exists is itself a leak. Two different
+    answers, on purpose.
+    """
+    from pocketpaw_ee.sites.delete_job import enqueue_site_delete
+
+    site = await _load(workspace_id, site_id)
+    if site.owner != user_id:
+        from pocketpaw_ee.guards.audit import log_denial
+
+        log_denial(
+            actor=user_id,
+            action="site.delete",
+            code="site.not_owner",
+            resource_id=str(site.id),
+        )
+        raise Forbidden("site.not_owner", "Only the site's owner can delete it.")
+
+    job_id = await enqueue_site_delete(site)
+    if job_id is None:
+        # Another attempt holds the slot. NOT an error: the site is already being
+        # deleted, which is what this caller asked for, so report the in-flight
+        # attempt rather than a conflict they cannot act on.
+        return SiteDeleteQueuedResponse(
+            site_id=site_id,
+            status=site.delete_status or "queued",
+            job_id=site.delete_job_id,
+        )
+    # no-event: queuing a delete mutates only this row's own lifecycle fields, and the
+    # client learns the outcome by polling rather than through the realtime bus. The
+    # destroy itself is covered by ``delete_site_document``'s note above.
+    return SiteDeleteQueuedResponse(site_id=site_id, status="queued", job_id=job_id)
+
+
+async def site_delete_status(
+    *, workspace_id: str, user_id: str, site_id: str
+) -> SiteDeleteStatusResponse:
+    """Where a delete has got to. OWNER ONLY, and a 404 once it FINISHED.
+
+    The 404 is not an edge case, it is the contract: the cascade's last step deletes
+    the document this read lives on, so ``_load`` raising ``NotFound`` is how a client
+    learns the delete succeeded. There is deliberately no terminal status to return
+    instead — inventing one would mean keeping the row the delete exists to remove.
+
+    Owner-only for the same reason the delete is: ``delete_reason`` names which step of
+    a teardown failed, which is operational detail about a site the reader may not
+    administer.
+    """
+    site = await _load(workspace_id, site_id)
+    if site.owner != user_id:
+        raise Forbidden("site.not_owner", "Only the site's owner can delete it.")
+    return SiteDeleteStatusResponse(
+        site_id=site_id,
+        delete_status=site.delete_status or "none",
+        delete_reason=site.delete_reason,
+        delete_ledger=dict(site.delete_ledger or {}),
+        delete_export_id=site.delete_export_id or "",
+        delete_job_id=site.delete_job_id,
+    )
 
 
 __all__ = [
@@ -10377,10 +10696,19 @@ __all__ = [
     "update_site_metadata",
     "create_site_export",
     "list_site_exports",
+    "site_export_is_ready",
     "open_site_export",
     "sweep_expired_site_exports",
     "offer_site_transfer",
     "accept_site_transfer",
     "cancel_site_transfer",
     "list_incoming_site_transfers",
+    "start_site_delete",
+    "site_delete_status",
+    "claim_delete_queued",
+    "mark_delete_stage",
+    "record_delete_failure",
+    "record_delete_progress",
+    "purge_site_records",
+    "delete_site_document",
 ]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -10395,6 +10395,8 @@ class _TransferDeps:
             {"$set": {"workspace": destination_workspace_id}}
         )
         return bool(getattr(result, "modified_count", 0) or 0)
+
+
 # The delete lifecycle (sites lifecycle wave 1)
 # ---------------------------------------------------------------------------
 #

--- a/tests/cloud/runs/test_worker_lanes.py
+++ b/tests/cloud/runs/test_worker_lanes.py
@@ -90,16 +90,47 @@ async def test_the_default_ceilings_leave_room_for_chat():
 async def test_the_sites_lane_registers_the_chat_lanes_own_wrapped_functions():
     """Identity, not equality.
 
-    Each site function is wrapped with its own timeout because a build's budget (1020s at
-    today's defaults) is wider than the workspace-jobs timeout it used to share. A second
-    wrapping here would fork that number, and an arq cancellation that lands before the
-    in-sandbox timeout fires destroys the sentinel the lane classifies from — a slow but
-    healthy build gets recorded as lost infrastructure.
+    Each BUILD function is wrapped with its own timeout because a build's budget (1020s
+    at today's defaults) is wider than the workspace-jobs timeout it used to share. A
+    second wrapping here would fork that number, and an arq cancellation that lands
+    before the in-sandbox timeout fires destroys the sentinel the lane classifies from —
+    a slow but healthy build gets recorded as lost infrastructure.
+
+    Asserted by IDENTITY rather than as an exact list, because the lane is allowed to own
+    functions of its own — the delete job below is one. What must never happen is a
+    re-wrapped COPY of a build function appearing here, and identity is what catches that;
+    an equality check on the whole list would also fail for the harmless case of a new
+    lane-owned job, which is how a list assertion turns into a rename tax.
     """
-    assert sites_worker.WorkerSettings.functions == [
-        chat_worker.site_build_fn,
-        chat_worker.site_preview_build_fn,
+    registered = sites_worker.WorkerSettings.functions
+
+    assert chat_worker.site_build_fn in registered
+    assert chat_worker.site_preview_build_fn in registered
+
+
+async def test_the_sites_lane_owns_the_delete_job_rather_than_borrowing_it():
+    """The delete job is this lane's own, and its budget is not a build's.
+
+    A delete walks Cloudflare, D1 and R2 serially; a build waits on a remote sandbox
+    compile. Wrapping the delete with the build timeout would be the same forking mistake
+    the test above exists to prevent, pointed the other way.
+
+    ``max_tries=1`` is asserted because it is load-bearing rather than stylistic: the
+    cascade resumes from its ledger, and an arq retry would re-enter it seconds after a
+    failure, spending that one cheap resume on an outage that has not cleared.
+    """
+    from pocketpaw_ee.sites.delete_job import SITE_DELETE_FUNCTION_NAME
+
+    delete_fns = [
+        f
+        for f in sites_worker.WorkerSettings.functions
+        if getattr(f, "name", None) == SITE_DELETE_FUNCTION_NAME
     ]
+
+    assert len(delete_fns) == 1, "the delete job must be registered exactly once"
+    assert delete_fns[0].max_tries == 1
+    # Its own budget, not the build lane's.
+    assert delete_fns[0].timeout_s != sites_worker.site_build_job_timeout_seconds()
 
 
 async def test_the_chat_lane_still_claims_site_jobs_left_on_the_default_queue():

--- a/tests/ee/sites/test_delete_endpoint.py
+++ b/tests/ee/sites/test_delete_endpoint.py
@@ -1,0 +1,368 @@
+# tests/ee/sites/test_delete_endpoint.py — the HTTP contract of the site-delete lane
+# (sites lifecycle wave 1, feat/sites-delete-endpoint).
+#
+# WHAT IS UNDER TEST IS A CONTRACT SOMEONE ELSE ALREADY SHIPPED AGAINST. The delete UI
+# (paw-enterprise #895) went out before this backend existed, reading
+# ``core/sites/delete-api.ts`` and ``delete-types.ts``. So these tests pin the wire, not
+# the implementation: the 202 and its body, the 403-vs-404 split, and — the one that
+# looks like a bug if you do not know the design — that the poll 404s ON SUCCESS.
+#
+# The 404-on-success case gets its own test because it is the single assumption most
+# likely to be "fixed" by a future reader into a terminal ``deleted`` status. It cannot
+# be: step 8 of the cascade deletes the Site document, and ``delete_status`` is a field
+# ON that document. A terminal status would require keeping the row the delete exists to
+# remove, and the shipped client reads the 404 as completion (``isDeleteFinished``).
+#
+# Auth wiring mirrors test_router.py — see the long note in ``_build_app`` there about
+# why this module does NOT patch ``get_workspace_plan`` itself.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites import delete_job as delete_job_mod
+from pocketpaw_ee.sites import service as sites_service
+
+WORKSPACE = "ws_owner"
+OWNER = "user-test-1"
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "member") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, workspace_id: str, user_id: str = OWNER) -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id)]
+
+
+def _build_app(workspace_id: str, user_id: str = OWNER) -> FastAPI:
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.sites.router import router as sites_router
+
+    fake_user = _FakeUser(workspace_id, user_id)
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(sites_router, prefix="/api/v1")
+
+    async def _ctx() -> RequestContext:
+        return RequestContext(
+            user_id=str(fake_user.id),
+            workspace_id=workspace_id,
+            request_id="test",
+            scope=ScopeKind.WORKSPACE,
+            started_at=datetime.now(UTC),
+        )
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[current_active_user] = lambda: fake_user
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _seed(**kw: Any) -> Site:
+    """A Site row with only what a delete needs. Inserted directly rather than
+    published, because these tests are about the delete gate and ``publish`` would drag
+    a generator, a bundle reader and a Cloudflare double in with it."""
+    doc = Site(
+        workspace=kw.pop("workspace", WORKSPACE),
+        pocket_id=kw.pop("pocket_id", "pk1"),
+        owner=kw.pop("owner", OWNER),
+        name=kw.pop("name", "Owner Site"),
+        **kw,
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest_asyncio.fixture
+async def _no_real_enqueue(monkeypatch) -> list[Any]:
+    """Record enqueues instead of reaching Redis, and still perform the CLAIM.
+
+    The claim is left real on purpose: it is the conditional write that decides whether
+    a second delete of one site is refused, and a double that skipped it would make the
+    in-flight test pass for the wrong reason.
+    """
+    calls: list[Any] = []
+
+    async def _fake(site: Any, **_kw: Any) -> str | None:
+        claimed = await sites_service.claim_delete_queued(site, job_id="job-1", timeout_seconds=900)
+        if not claimed:
+            return None
+        calls.append(str(site.id))
+        return "job-1"
+
+    monkeypatch.setattr(delete_job_mod, "enqueue_site_delete", _fake)
+    return calls
+
+
+# ── DELETE /sites/{site_id} ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_answers_202_with_the_job_handle(beanie_test_db, _no_real_enqueue):
+    """202, not 204. The site is still serving when this returns — the teardown is a
+    job — and the body carries what the client needs to start polling."""
+    site = await _seed()
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        res = await c.delete(f"/api/v1/sites/{site.id}")
+
+    assert res.status_code == 202
+    body = res.json()
+    assert body["site_id"] == str(site.id)
+    assert body["status"] == "queued"
+    assert body["job_id"] == "job-1"
+    assert _no_real_enqueue == [str(site.id)]
+
+
+@pytest.mark.asyncio
+async def test_delete_stamps_the_row_so_a_reload_can_find_the_attempt(
+    beanie_test_db, _no_real_enqueue
+):
+    """``delete_job_id`` is PERSISTED, not transient. A queued destructive job is
+    exactly when someone reloads the page, and a handle that lived only in the response
+    would be gone at the moment the wait is longest."""
+    site = await _seed()
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        await c.delete(f"/api/v1/sites/{site.id}")
+
+    row = await Site.get(site.id)
+    assert row.delete_status == "queued"
+    assert row.delete_job_id == "job-1"
+    assert row.delete_started_at is not None
+
+
+@pytest.mark.asyncio
+async def test_a_non_owner_in_the_workspace_gets_403_and_not_404(beanie_test_db, _no_real_enqueue):
+    """403 and 404 are two different answers on purpose.
+
+    A member who can SEE the site but may not destroy it must be told the rule, not
+    told the site does not exist — the client renders a permission sentence off exactly
+    this status. Nothing may be enqueued.
+    """
+    site = await _seed(owner="somebody-else")
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        res = await c.delete(f"/api/v1/sites/{site.id}")
+
+    assert res.status_code == 403
+    assert res.json()["error"]["code"] == "site.not_owner"
+    assert _no_real_enqueue == []
+    row = await Site.get(site.id)
+    assert row.delete_status == "none"
+
+
+@pytest.mark.asyncio
+async def test_a_site_in_another_workspace_is_404_not_403(beanie_test_db, _no_real_enqueue):
+    """Cross-tenant is a 404 even though the caller is not the owner either. Confirming
+    a stranger's site exists is itself the leak, so the tenancy answer wins over the
+    ownership one."""
+    site = await _seed(workspace="ws_other", owner="someone-there")
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        res = await c.delete(f"/api/v1/sites/{site.id}")
+
+    assert res.status_code == 404
+    assert _no_real_enqueue == []
+
+
+@pytest.mark.asyncio
+async def test_a_second_delete_reports_the_attempt_already_running(
+    beanie_test_db, _no_real_enqueue
+):
+    """Two deletes of one site must not become two cascades. The loser reports the
+    in-flight attempt rather than a conflict the user cannot act on — the site IS being
+    deleted, which is what they asked for."""
+    site = await _seed()
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        first = await c.delete(f"/api/v1/sites/{site.id}")
+        second = await c.delete(f"/api/v1/sites/{site.id}")
+
+    assert first.status_code == 202
+    assert second.status_code == 202
+    assert second.json()["status"] == "queued"
+    # One claim won, so exactly one job was ever queued.
+    assert _no_real_enqueue == [str(site.id)]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_delete_can_be_started_again(beanie_test_db, _no_real_enqueue):
+    """``failed`` is deliberately NOT an in-flight status. The cascade resumes from its
+    ledger, so a site whose teardown stopped must be re-deletable — otherwise one bad
+    afternoon at Cloudflare leaves a site nobody can ever remove."""
+    site = await _seed(delete_status="failed", delete_reason="script:runtime_error")
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        res = await c.delete(f"/api/v1/sites/{site.id}")
+
+    assert res.status_code == 202
+    assert _no_real_enqueue == [str(site.id)]
+    row = await Site.get(site.id)
+    # The reason is cleared so a retry never shows the previous attempt's step...
+    assert row.delete_reason is None
+
+
+@pytest.mark.asyncio
+async def test_retrying_a_failed_delete_keeps_the_ledger(beanie_test_db, _no_real_enqueue):
+    """...and the LEDGER survives, because it is what makes the retry a resume.
+
+    Clearing it alongside the reason would re-run every destructive step the first
+    attempt finished: re-cancel the billing, re-purge the bucket.
+    """
+    site = await _seed(
+        delete_status="failed",
+        delete_reason="script:runtime_error",
+        delete_ledger={"billing": "done", "revoke": "done"},
+    )
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        await c.delete(f"/api/v1/sites/{site.id}")
+
+    row = await Site.get(site.id)
+    assert row.delete_ledger == {"billing": "done", "revoke": "done"}
+
+
+# ── GET /sites/{site_id}/delete-status ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_poll_reports_the_phase_and_the_reason(beanie_test_db):
+    site = await _seed(
+        delete_status="tearing_down",
+        delete_reason=None,
+        delete_ledger={"billing": "done"},
+        delete_export_id="exp-1",
+        delete_job_id="job-9",
+    )
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        res = await c.get(f"/api/v1/sites/{site.id}/delete-status")
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["site_id"] == str(site.id)
+    assert body["delete_status"] == "tearing_down"
+    assert body["delete_reason"] is None
+    assert body["delete_ledger"] == {"billing": "done"}
+    assert body["delete_export_id"] == "exp-1"
+    assert body["delete_job_id"] == "job-9"
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_delete_reports_the_step_that_stopped_it(beanie_test_db):
+    """``delete_reason`` is the raw ``"<step>:<cause>"``. The client splits on the colon
+    and renders the STEP, so the step half has to survive the wire verbatim."""
+    site = await _seed(delete_status="failed", delete_reason="export:export_unavailable")
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        res = await c.get(f"/api/v1/sites/{site.id}/delete-status")
+
+    assert res.json()["delete_reason"] == "export:export_unavailable"
+    assert res.json()["delete_reason"].split(":")[0] == "export"
+
+
+@pytest.mark.asyncio
+async def test_the_poll_404s_once_the_delete_has_FINISHED(beanie_test_db):
+    """THE 404 IS THE SUCCESS SIGNAL, not an error.
+
+    The cascade's last step deletes the Site document, and ``delete_status`` lives on
+    that document — so a finished delete has nothing left to report a status on. The
+    shipped client's ``isDeleteFinished`` reads exactly this 404 as completion. A
+    terminal ``deleted`` status added here would mean keeping the row the delete exists
+    to remove.
+    """
+    site = await _seed(delete_status="tearing_down")
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        before = await c.get(f"/api/v1/sites/{site.id}/delete-status")
+        assert before.status_code == 200
+
+        # What the cascade's final step does.
+        await sites_service.delete_site_document(site)
+
+        after = await c.get(f"/api/v1/sites/{site.id}/delete-status")
+
+    assert after.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_no_delete_status_is_ever_terminal_success(beanie_test_db):
+    """A guard against the most likely future 'fix'. If someone adds a terminal status,
+    the poll stops 404-ing on success and every completed delete reads as a failure to
+    the shipped client."""
+    from pocketpaw_ee.sites.dto import SiteDeleteStatusResponse
+
+    assert SiteDeleteStatusResponse.model_fields["delete_status"].default == "none"
+    # The in-flight set is the whole running vocabulary; nothing in it means "done".
+    assert sites_service.DELETE_IN_FLIGHT_STATUSES == frozenset(
+        {"queued", "exporting", "tearing_down"}
+    )
+    assert "deleted" not in sites_service.DELETE_IN_FLIGHT_STATUSES
+
+
+@pytest.mark.asyncio
+async def test_the_poll_is_owner_only_too(beanie_test_db):
+    """``delete_reason`` names which step of a teardown failed — operational detail
+    about a site the reader may see but not administer."""
+    site = await _seed(owner="somebody-else", delete_status="tearing_down")
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        res = await c.get(f"/api/v1/sites/{site.id}/delete-status")
+
+    assert res.status_code == 403
+    assert res.json()["error"]["code"] == "site.not_owner"
+
+
+@pytest.mark.asyncio
+async def test_the_poll_is_tenant_scoped(beanie_test_db):
+    site = await _seed(workspace="ws_other", owner="someone-there")
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        res = await c.get(f"/api/v1/sites/{site.id}/delete-status")
+
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_site_id_is_404_and_not_a_500(beanie_test_db, _no_real_enqueue):
+    """A caller-supplied id that is not an ObjectId means "no such site", not an
+    unhandled ``InvalidId`` — the same guard ``_load`` already applies everywhere else."""
+    app = _build_app(WORKSPACE)
+
+    async with _client(app) as c:
+        assert (await c.delete("/api/v1/sites/not-an-objectid")).status_code == 404
+        assert (await c.get("/api/v1/sites/not-an-objectid/delete-status")).status_code == 404

--- a/tests/ee/sites/test_delete_job.py
+++ b/tests/ee/sites/test_delete_job.py
@@ -1,0 +1,583 @@
+# tests/ee/sites/test_delete_job.py — the delete job: the forced export, the cascade,
+# and the row (sites lifecycle wave 1, feat/sites-delete-endpoint).
+#
+# THE CENTRAL ASSERTION OF THIS FILE is that nothing destructive runs before an export
+# exists. The captain's requirement, the cascade's header and the shipped client's
+# ``export:`` failure sentence all say the same thing from three directions, and none of
+# them was enforced anywhere until this job. So the ordering tests here are not
+# belt-and-braces: they are the only thing standing between "we took a copy first" and a
+# sentence in a doc.
+#
+# The second thing under test is quieter and was a live bug during this build: the
+# cascade stops billing by clearing ``subscription_status`` IN MEMORY, so a save callback
+# that persisted only ``delete_ledger`` would leave a half-torn-down site whose ledger
+# says billing is done and whose row still bills. See ``_CASCADE_MUTATED_FIELDS``.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.models.lead import Lead, LeadSource
+from pocketpaw_ee.cloud.models.site import Site, SiteDomain
+from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
+from pocketpaw_ee.sites import delete_job as delete_job_mod
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.delete_cascade import CASCADE_STEPS, CascadeStepFailed
+from pocketpaw_ee.sites.export import ExportUnavailable
+
+WORKSPACE = "ws_owner"
+OWNER = "u-owner"
+
+
+class _CF:
+    """Records the Cloudflare calls the cascade makes, and can refuse one."""
+
+    def __init__(self, fail_on: str | None = None) -> None:
+        self.calls: list[str] = []
+        self.fail_on = fail_on
+
+    def __getattr__(self, name: str) -> Any:
+        async def _call(*_a: Any, **_kw: Any) -> None:
+            if self.fail_on == name:
+                raise RuntimeError("cloudflare said no")
+            self.calls.append(name)
+
+        return _call
+
+
+class _Assets:
+    def __init__(self) -> None:
+        self.purged: list[tuple[str, str]] = []
+
+    async def purge(self, *, workspace_id: str, pocket_id: str) -> int:
+        self.purged.append((workspace_id, pocket_id))
+        return 0
+
+
+class _Deps:
+    def __init__(self, cf: _CF | None = None) -> None:
+        self.cloudflare = cf or _CF()
+        self.assets = _Assets()
+        self.purged_records: list[tuple[str, str]] = []
+
+    async def purge_records(self, *, workspace_id: str, site_id: str) -> None:
+        self.purged_records.append((workspace_id, site_id))
+
+
+async def _seed(**kw: Any) -> Site:
+    doc = Site(
+        workspace=kw.pop("workspace", WORKSPACE),
+        pocket_id=kw.pop("pocket_id", "pk1"),
+        owner=kw.pop("owner", OWNER),
+        name=kw.pop("name", "Owner Site"),
+        # A site with something to tear down in every step, so an ordering test is not
+        # quietly passing because every step returned "nothing to do".
+        script_name=kw.pop("script_name", "paw-site-x"),
+        deploy_target=kw.pop("deploy_target", "wfp"),
+        d1_database_id=kw.pop("d1_database_id", "db-1"),
+        signed_key=kw.pop("signed_key", "key-abc"),
+        subscription_status=kw.pop("subscription_status", "active"),
+        billing_rail=kw.pop("billing_rail", "credits"),
+        domains=kw.pop(
+            "domains",
+            [SiteDomain(hostname="www.x.com", cf_hostname_id="ch_1", cf_route_id="rt_1")],
+        ),
+        **kw,
+    )
+    await doc.insert()
+    return doc
+
+
+class _ExportStub:
+    """Stands in for ``create_site_export``, recording when it ran."""
+
+    def __init__(
+        self, *, order: list[str], export_id: str = "exp-1", raises: Exception | None = None
+    ):
+        self.order = order
+        self.export_id = export_id
+        self.raises = raises
+        self.calls = 0
+
+    async def __call__(self, *, workspace_id: str, user_id: str, site_id: str) -> Any:
+        self.calls += 1
+        self.order.append("export")
+        if self.raises is not None:
+            raise self.raises
+
+        class _Row:
+            id = self.export_id
+            status = "ready"
+
+        return _Row()
+
+
+@pytest.fixture
+def _order() -> list[str]:
+    return []
+
+
+# ── The forced export comes first, and gates everything ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_export_runs_before_any_destructive_step(beanie_test_db, monkeypatch, _order):
+    """The whole precondition, in one assertion: 'export' is the FIRST thing that
+    happened, ahead of every cascade step."""
+    site = await _seed()
+    monkeypatch.setattr(sites_service, "create_site_export", _ExportStub(order=_order))
+
+    deps = _Deps()
+    original = sites_service.record_delete_progress
+
+    async def _tracking(doc: Any) -> None:
+        _order.extend(k for k in doc.delete_ledger if k not in _order)
+        await original(doc)
+
+    monkeypatch.setattr(sites_service, "record_delete_progress", _tracking)
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=deps)
+
+    assert _order[0] == "export"
+    assert _order[1:] == list(CASCADE_STEPS)
+
+
+@pytest.mark.asyncio
+async def test_an_unusable_export_stops_the_delete_before_anything_is_destroyed(
+    beanie_test_db, monkeypatch, _order
+):
+    """THE SAFETY NET. An export that cannot be vouched for must leave the site exactly
+    as it was — not 'mostly there', not 'billing already cancelled'. The client's
+    sentence for this case promises the user their site is untouched, and this is what
+    makes that sentence true."""
+    site = await _seed()
+    monkeypatch.setattr(
+        sites_service,
+        "create_site_export",
+        _ExportStub(
+            order=_order,
+            raises=ValidationError(
+                "sites.export_unavailable", "This site's live data cannot be read."
+            ),
+        ),
+    )
+    deps = _Deps()
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=deps)
+
+    row = await Site.get(site.id)
+    assert row is not None, "the site must survive an export that failed"
+    assert row.delete_status == "failed"
+    assert row.delete_reason == "export:sites_export_unavailable"
+    assert row.delete_reason.split(":")[0] == "export"
+    # Nothing was torn down.
+    assert row.delete_ledger == {}
+    assert deps.cloudflare.calls == []
+    assert deps.assets.purged == []
+    assert deps.purged_records == []
+    # And the site is still billing, because we never got as far as stopping it.
+    assert row.subscription_status == "active"
+
+
+@pytest.mark.asyncio
+async def test_a_bare_ExportUnavailable_is_still_reported_as_the_export_step(
+    beanie_test_db, monkeypatch, _order
+):
+    """``ExportUnavailable`` is a plain ``Exception``, not a ``CloudError`` — the exact
+    shape that escaped a CloudError-only handler as a bare 500 once before (#2135). Here
+    it must still land as an ``export:`` reason rather than an unclassified stop."""
+    site = await _seed()
+    monkeypatch.setattr(
+        sites_service,
+        "create_site_export",
+        _ExportStub(order=_order, raises=ExportUnavailable("no D1 here")),
+    )
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=_Deps())
+
+    row = await Site.get(site.id)
+    assert row.delete_status == "failed"
+    assert row.delete_reason == "export:exportunavailable"
+
+
+@pytest.mark.asyncio
+async def test_an_export_that_is_not_ready_is_refused(beanie_test_db, monkeypatch, _order):
+    """A row that came back in any state but ``ready`` has no bytes. 'We kept a copy' is
+    never assumed from the existence of a row."""
+    site = await _seed()
+
+    class _NotReady(_ExportStub):
+        async def __call__(self, **_kw: Any) -> Any:
+            self.order.append("export")
+
+            class _Row:
+                id = "exp-1"
+                status = "pending"
+
+            return _Row()
+
+    monkeypatch.setattr(sites_service, "create_site_export", _NotReady(order=_order))
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=_Deps())
+
+    row = await Site.get(site.id)
+    assert row.delete_status == "failed"
+    assert row.delete_reason == "export:export_not_ready"
+    assert row.delete_ledger == {}
+
+
+@pytest.mark.asyncio
+async def test_the_export_id_is_recorded_before_the_cascade_runs(
+    beanie_test_db, monkeypatch, _order
+):
+    """The export outlives the site, so the pointer to it has to be written while there
+    is still a row to write it on."""
+    site = await _seed()
+    monkeypatch.setattr(
+        sites_service, "create_site_export", _ExportStub(order=_order, export_id="exp-42")
+    )
+    seen: list[str] = []
+
+    class _WatchingCF(_CF):
+        def __getattr__(self, name: str) -> Any:
+            inner = super().__getattr__(name)
+
+            async def _call(*a: Any, **kw: Any) -> None:
+                row = await Site.get(site.id)
+                seen.append(row.delete_export_id)
+                await inner(*a, **kw)
+
+            return _call
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=_Deps(cf=_WatchingCF()))
+
+    assert seen, "the cascade never reached Cloudflare"
+    assert all(v == "exp-42" for v in seen)
+
+
+@pytest.mark.asyncio
+async def test_a_resume_reuses_this_attempts_export_rather_than_retaking_it(
+    beanie_test_db, monkeypatch, _order
+):
+    """A ``ready`` export already named on the row was taken by THIS delete, before
+    anything was destroyed, so it is a faithful copy and re-taking it would only cost a
+    second full read of a database about to be deleted."""
+    from pocketpaw_ee.cloud.models.site_export import SiteExport
+
+    export = SiteExport(
+        workspace=WORKSPACE, owner=OWNER, site_id="", status="ready", storage_key="k"
+    )
+    site = await _seed()
+    export.site_id = str(site.id)
+    await export.insert()
+    await site.set({"delete_export_id": str(export.id)})
+    site.delete_export_id = str(export.id)
+
+    stub = _ExportStub(order=_order)
+    monkeypatch.setattr(sites_service, "create_site_export", stub)
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=_Deps())
+
+    assert stub.calls == 0, "a ready export from this attempt should not be retaken"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_export_on_the_row_is_not_reused(beanie_test_db, monkeypatch, _order):
+    """Only ``ready`` satisfies the gate. A failed export row is the record of an
+    attempt, not a copy of anyone's data."""
+    from pocketpaw_ee.cloud.models.site_export import SiteExport
+
+    site = await _seed()
+    export = SiteExport(
+        workspace=WORKSPACE, owner=OWNER, site_id=str(site.id), status="failed", error="nope"
+    )
+    await export.insert()
+    await site.set({"delete_export_id": str(export.id)})
+    site.delete_export_id = str(export.id)
+
+    stub = _ExportStub(order=_order, export_id="exp-fresh")
+    monkeypatch.setattr(sites_service, "create_site_export", stub)
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=_Deps())
+
+    assert stub.calls == 1
+
+
+# ── The cascade's own effects have to reach the database ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_cascade_persists_the_billing_stop_it_already_made(
+    beanie_test_db, monkeypatch, _order
+):
+    """THE LEDGER IS NOT THE ONLY THING A STEP CHANGES.
+
+    ``_stop_billing`` ends the charging by clearing ``subscription_status`` in memory —
+    on the credits rail that local write IS the mechanism, because the renewal sweeper
+    selects on exactly that field. If the save callback wrote only ``delete_ledger``, a
+    cascade that stopped later would leave a row whose ledger says billing is done and
+    whose status still says ``active``; the resume would then SKIP the billing step on
+    the strength of that ledger and the customer would keep paying for a site that no
+    longer serves.
+    """
+    site = await _seed()
+    monkeypatch.setattr(sites_service, "create_site_export", _ExportStub(order=_order))
+
+    # Stop the cascade at the Worker delete — after billing and the key revoke.
+    deps = _Deps(cf=_CF(fail_on="delete_worker"))
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=deps)
+
+    row = await Site.get(site.id)
+    assert row is not None
+    assert row.delete_status == "failed"
+    assert row.delete_reason == "script:runtimeerror"
+    # The ledger recorded the two steps that ran...
+    assert row.delete_ledger.get("billing") == "done"
+    assert row.delete_ledger.get("revoke") == "done"
+    # ...and so did the FIELDS those steps changed.
+    assert row.subscription_status == "none", "the billing stop never reached the database"
+    assert row.renewal_date is None
+    assert row.signed_key == "", "the public ingest key was not actually revoked"
+    assert row.revoked is True
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_cascade_leaves_the_site_and_its_ledger(
+    beanie_test_db, monkeypatch, _order
+):
+    """The row survives a failure on purpose: it carries the ledger, which is the only
+    thing that knows which steps finished."""
+    site = await _seed()
+    monkeypatch.setattr(sites_service, "create_site_export", _ExportStub(order=_order))
+
+    await delete_job_mod.run_site_delete(
+        {}, WORKSPACE, str(site.id), _deps=_Deps(cf=_CF(fail_on="delete_database"))
+    )
+
+    row = await Site.get(site.id)
+    assert row is not None
+    assert row.delete_status == "failed"
+    assert row.delete_reason.startswith("d1:")
+    assert "script" in row.delete_ledger
+
+
+@pytest.mark.asyncio
+async def test_a_cascade_failure_never_raises_out_of_the_job(beanie_test_db, monkeypatch, _order):
+    """The row settles at ``failed`` carrying the step. Raising as well would add an
+    arq-level error beside a row that already says what happened — and with
+    ``max_tries=1`` nothing would act on it anyway."""
+    site = await _seed()
+    monkeypatch.setattr(sites_service, "create_site_export", _ExportStub(order=_order))
+
+    # No exception expected.
+    await delete_job_mod.run_site_delete(
+        {}, WORKSPACE, str(site.id), _deps=_Deps(cf=_CF(fail_on="delete_worker_route"))
+    )
+    assert (await Site.get(site.id)).delete_status == "failed"
+
+
+# ── Completion ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_completed_delete_removes_the_site_document(beanie_test_db, monkeypatch, _order):
+    """The row going away IS the success signal — there is no terminal status, because
+    this is the document the status would live on."""
+    site = await _seed()
+    monkeypatch.setattr(sites_service, "create_site_export", _ExportStub(order=_order))
+    deps = _Deps()
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=deps)
+
+    assert await Site.get(site.id) is None
+    assert deps.purged_records == [(WORKSPACE, str(site.id))]
+
+
+@pytest.mark.asyncio
+async def test_the_job_walks_the_row_through_the_phases_the_client_renders(
+    beanie_test_db, monkeypatch, _order
+):
+    """``exporting`` then ``tearing_down``. The client turns these into the only
+    question a site's owner actually has — has my data been saved yet — so a job that
+    skipped straight to tearing down would answer it wrongly."""
+    site = await _seed()
+    phases: list[str] = []
+
+    async def _record_phase(**kw: Any) -> Any:
+        row = await Site.get(site.id)
+        phases.append(row.delete_status)
+
+        class _Row:
+            id = "exp-1"
+            status = "ready"
+
+        return _Row()
+
+    monkeypatch.setattr(sites_service, "create_site_export", _record_phase)
+
+    class _PhaseCF(_CF):
+        def __getattr__(self, name: str) -> Any:
+            inner = super().__getattr__(name)
+
+            async def _call(*a: Any, **kw: Any) -> None:
+                row = await Site.get(site.id)
+                if row.delete_status not in phases:
+                    phases.append(row.delete_status)
+                await inner(*a, **kw)
+
+            return _call
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=_Deps(cf=_PhaseCF()))
+
+    assert phases == ["exporting", "tearing_down"]
+
+
+@pytest.mark.asyncio
+async def test_a_site_that_is_already_gone_is_a_no_op(beanie_test_db, monkeypatch, _order):
+    """A job that wakes to find no row has found its own earlier attempt's success."""
+    stub = _ExportStub(order=_order)
+    monkeypatch.setattr(sites_service, "create_site_export", stub)
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, "68bf0000000000000000dead", _deps=_Deps())
+
+    assert stub.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_the_job_cannot_delete_a_site_from_another_workspace(
+    beanie_test_db, monkeypatch, _order
+):
+    """The workspace rides in the payload and the read is scoped to it, so a bad payload
+    cannot reach another tenant's row."""
+    site = await _seed(workspace="ws_other")
+    stub = _ExportStub(order=_order)
+    monkeypatch.setattr(sites_service, "create_site_export", stub)
+
+    await delete_job_mod.run_site_delete({}, WORKSPACE, str(site.id), _deps=_Deps())
+
+    assert stub.calls == 0
+    assert await Site.get(site.id) is not None
+
+
+# ── The dependent rows ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_purging_records_takes_this_sites_rows_and_only_this_sites(beanie_test_db):
+    """Tenancy and site scope are both IN the query. A purge that filtered afterwards
+    would already have read the other site's submissions."""
+    mine, theirs = "site-a", "site-b"
+    for site_id, workspace in ((mine, WORKSPACE), (theirs, WORKSPACE), (mine, "ws_other")):
+        await Lead(
+            workspace=workspace,
+            site_id=site_id,
+            form_type="contact",
+            properties={},
+            source=LeadSource(form_type="contact", site_id=site_id),
+        ).insert()
+
+    removed = await sites_service.purge_site_records(workspace_id=WORKSPACE, site_id=mine)
+
+    assert removed == 1
+    left = [(d.workspace, d.site_id) for d in await Lead.find_all().to_list()]
+    assert sorted(left) == sorted([(WORKSPACE, theirs), ("ws_other", mine)])
+
+
+@pytest.mark.asyncio
+async def test_purging_records_takes_both_rate_counter_scopes(beanie_test_db):
+    """``scope_id`` is the site id for the overall scope and ``"{site_id}:{rate_key}"``
+    for the per-IP one — one anchored prefix has to catch both, and nothing else."""
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC)
+    for scope, scope_id in (
+        ("site", "site-a"),
+        ("ip", "site-a:1.2.3.4"),
+        ("site", "site-abc"),  # a DIFFERENT site whose id merely starts the same way
+        ("site", "site-b"),
+    ):
+        await SiteRateCounter(scope=scope, scope_id=scope_id, bucket=now, hits=1).insert()
+
+    await sites_service.purge_site_records(workspace_id=WORKSPACE, site_id="site-a")
+
+    left = sorted(d.scope_id for d in await SiteRateCounter.find_all().to_list())
+    assert left == ["site-abc", "site-b"]
+
+
+# ── The enqueue ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_failed_enqueue_does_not_pin_the_row_in_queued(beanie_test_db):
+    """A row left in ``queued`` behind a job that never existed would refuse every
+    future delete of this site until the staleness window lapsed."""
+
+    class _DeadPool:
+        async def enqueue_job(self, *_a: Any, **_kw: Any) -> None:
+            raise RuntimeError("redis is gone")
+
+    site = await _seed()
+
+    with pytest.raises(RuntimeError):
+        await delete_job_mod.enqueue_site_delete(site, _pool_override=_DeadPool())
+
+    row = await Site.get(site.id)
+    assert row.delete_status == "failed"
+    assert row.delete_reason == "enqueue:pool_or_enqueue_raised"
+
+
+@pytest.mark.asyncio
+async def test_arq_refusing_the_id_is_treated_as_a_failed_enqueue(beanie_test_db):
+    """arq answers ``None`` for a duplicate id. Reading that as 'a job is coming' is how
+    a row sits in ``queued`` forever."""
+
+    class _RefusingPool:
+        async def enqueue_job(self, *_a: Any, **_kw: Any) -> None:
+            return None
+
+    site = await _seed()
+
+    with pytest.raises(RuntimeError):
+        await delete_job_mod.enqueue_site_delete(site, _pool_override=_RefusingPool())
+
+    assert (await Site.get(site.id)).delete_status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_the_job_id_is_not_deterministic(beanie_test_db):
+    """A stable id would make arq refuse the RETRY of a failed delete for as long as its
+    result lived in Redis — a single-flight guard nobody asked for, in the wrong layer,
+    and invisible because the refusal is a ``None`` return."""
+    a = delete_job_mod._mint_job_id("s1")
+    b = delete_job_mod._mint_job_id("s1")
+    assert a != b
+    assert a.startswith("site-delete-s1-")
+
+
+@pytest.mark.asyncio
+async def test_the_delete_is_registered_on_the_lane_that_consumes_the_queue(monkeypatch):
+    """A job enqueued to a queue no worker reads is a job that never runs. This asserts
+    the registration is on the WINNING ``functions`` list — a second assignment in that
+    class would silently override the first."""
+    monkeypatch.setenv("POCKETPAW_REDIS_URL", "redis://localhost:6379")
+    import importlib
+
+    from pocketpaw_ee.sites import build_worker
+
+    importlib.reload(build_worker)
+    names = [getattr(f, "name", None) for f in build_worker.WorkerSettings.functions]
+    assert delete_job_mod.SITE_DELETE_FUNCTION_NAME in names
+    assert build_worker.WorkerSettings.queue_name == delete_job_mod.SITE_BUILD_QUEUE_NAME
+    assert build_worker.WorkerSettings.max_tries == 1
+
+
+@pytest.mark.asyncio
+async def test_a_cascade_step_failure_carries_the_step_in_the_reason() -> None:
+    """The client splits ``delete_reason`` on the colon and renders the STEP half, so
+    the shape is a wire contract rather than a log convention."""
+    err = CascadeStepFailed("hostnames", "timeout_error")
+    assert err.reason == "hostnames:timeout_error"
+    assert err.reason.split(":")[0] == "hostnames"

--- a/tests/ee/sites/test_site_export_service.py
+++ b/tests/ee/sites/test_site_export_service.py
@@ -5,6 +5,12 @@
 # builder's own honesty is covered in test_site_export.py; what is tested here is
 # that the SERVICE routes a static site to the legitimate empty and a dynamic site
 # with no reachable D1 to a failure, rather than collapsing both into "no tables".
+#
+# Updated 2026-09-12 (feat/sites-delete-endpoint): added the response-mapping test at
+# the bottom. Every test above it exercises a PURE helper and none had ever built a
+# document, which is exactly how ``_export_response`` shipped reading a ``created_at``
+# field no document declares — an ``AttributeError`` on every call, so the whole export
+# surface answered 500 and the delete lane's forced export could never pass its gate.
 
 from __future__ import annotations
 
@@ -88,3 +94,35 @@ def test_a_static_site_is_recognised_by_its_error_code_not_by_guessing() -> None
     starts reporting its export as failed — so the contract is pinned here."""
     exc = ValidationError("sites.not_dynamic", "not a dynamic site")
     assert exc.code == "sites.not_dynamic"
+
+
+@pytest.mark.asyncio
+async def test_an_export_can_actually_be_rendered_as_a_response(beanie_test_db) -> None:
+    """The export response maps ``createdAt``, and nothing had ever built one.
+
+    ``_export_response`` read ``doc.created_at`` — a snake_case spelling that
+    ``TimestampedDocument`` does not declare and nothing aliases — so it raised
+    ``AttributeError`` on EVERY call from the day the export shipped. The whole feature
+    was unreachable behind it: ``POST /sites/{id}/export`` did all of its work and then
+    answered 500, ``GET /sites/exports`` could not list, and the delete lane's forced
+    export could never satisfy its own gate.
+
+    It survived review because every existing test in this file exercises the PURE
+    helpers (``retention_days``, ``export_key``, ``export_filename``, ``store_export``)
+    and none of them builds a document. This one does, which is the only reason it
+    catches it.
+    """
+    from pocketpaw_ee.cloud.models.site_export import SiteExport
+    from pocketpaw_ee.sites.service import _export_response
+
+    doc = SiteExport(
+        workspace="w1", owner="u1", site_id="s1", status="ready", storage_key="k", size_bytes=12
+    )
+    await doc.insert()
+
+    out = _export_response(doc)
+
+    assert out.id == str(doc.id)
+    assert out.status == "ready"
+    assert out.created_at is not None, "createdAt must reach the wire"
+    assert out.created_at == doc.createdAt.isoformat()

--- a/tests/mutations/queue_lanes.json
+++ b/tests/mutations/queue_lanes.json
@@ -84,8 +84,8 @@
   {
     "label": "the sites lane stops registering the preview function, so preview jobs enqueued onto the sites queue have no worker willing to claim them and arq says nothing",
     "file": "ee/pocketpaw_ee/sites/build_worker.py",
-    "find": "    functions = [site_build_fn, site_preview_build_fn]",
-    "replace": "    functions = [site_build_fn]",
+    "find": "    functions = [site_build_fn, site_preview_build_fn, _site_delete_fn]",
+    "replace": "    functions = [site_build_fn, _site_delete_fn]",
     "tests": [
       "tests/cloud/runs/test_worker_lanes.py"
     ]

--- a/tests/mutations/sites_burst_harness.json
+++ b/tests/mutations/sites_burst_harness.json
@@ -56,8 +56,8 @@
   {
     "label": "D5/atomic: the claim ignores the write's outcome and always reports a win, so every loser of the race enqueues anyway and the precondition becomes decoration",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    if won is None:\n        return False",
-    "replace": "    if won is None:\n        pass",
+    "find": ", **claim_precondition(timeout_seconds, now=stamp)},\n        {\"$set\": values},\n    )\n    if won is None:\n        return False",
+    "replace": ", **claim_precondition(timeout_seconds, now=stamp)},\n        {\"$set\": values},\n    )\n    if won is None:\n        pass",
     "tests": [
       "tests/ee/sites/test_burst_harness.py::TestSingleFlightUnderContention"
     ]
@@ -83,8 +83,8 @@
   {
     "label": "D5/atomic: the claim tests the window against a different clock than it stamps with, so the row is judged against a window it was not written with",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "claim_precondition(timeout_seconds, now=stamp)",
-    "replace": "claim_precondition(timeout_seconds)",
+    "find": "**claim_precondition(timeout_seconds, now=stamp)",
+    "replace": "**claim_precondition(timeout_seconds)",
     "tests": [
       "tests/ee/sites/test_burst_harness.py::TestTheClaimPreconditionMatchesTheGuard"
     ]

--- a/tests/mutations/sites_delete_endpoint.json
+++ b/tests/mutations/sites_delete_endpoint.json
@@ -167,7 +167,8 @@
     "find": "    functions = [site_build_fn, site_preview_build_fn, _site_delete_fn]",
     "replace": "    functions = [site_build_fn, site_preview_build_fn]",
     "tests": [
-      "tests/ee/sites/test_delete_job.py"
+      "tests/ee/sites/test_delete_job.py",
+      "tests/cloud/runs/test_worker_lanes.py"
     ]
   },
   {
@@ -186,6 +187,24 @@
     "replace": "        created_at=doc.created_at.isoformat() if doc.created_at else None,",
     "tests": [
       "tests/ee/sites/test_site_export_service.py"
+    ]
+  },
+  {
+    "label": "the delete job is wrapped with the BUILD timeout, forking a budget sized for a remote sandbox compile onto a cascade that walks Cloudflare, D1 and R2 serially",
+    "file": "ee/pocketpaw_ee/sites/build_worker.py",
+    "find": "    timeout=site_delete_job_timeout_seconds(),\n    max_tries=1,\n)",
+    "replace": "    timeout=site_build_job_timeout_seconds(),\n    max_tries=1,\n)",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
+    ]
+  },
+  {
+    "label": "the delete job gains arq-level retries, so a cascade stopped by an outage is re-entered seconds later into the same outage and spends its one cheap ledger resume",
+    "file": "ee/pocketpaw_ee/sites/build_worker.py",
+    "find": "    timeout=site_delete_job_timeout_seconds(),\n    max_tries=1,\n)",
+    "replace": "    timeout=site_delete_job_timeout_seconds(),\n    max_tries=3,\n)",
+    "tests": [
+      "tests/cloud/runs/test_worker_lanes.py"
     ]
   }
 ]

--- a/tests/mutations/sites_delete_endpoint.json
+++ b/tests/mutations/sites_delete_endpoint.json
@@ -1,0 +1,191 @@
+[
+  {
+    "label": "the delete endpoint stops checking ownership, so any workspace member can destroy a site they did not create",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    site = await _load(workspace_id, site_id)\n    if site.owner != user_id:\n        from pocketpaw_ee.guards.audit import log_denial",
+    "replace": "    site = await _load(workspace_id, site_id)\n    if False:\n        from pocketpaw_ee.guards.audit import log_denial",
+    "tests": [
+      "tests/ee/sites/test_delete_endpoint.py"
+    ]
+  },
+  {
+    "label": "the delete-status poll stops checking ownership, so any member can read which teardown step failed on a site they do not administer",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    site = await _load(workspace_id, site_id)\n    if site.owner != user_id:\n        raise Forbidden(\"site.not_owner\", \"Only the site's owner can delete it.\")\n    return SiteDeleteStatusResponse(",
+    "replace": "    site = await _load(workspace_id, site_id)\n    if False:\n        raise Forbidden(\"site.not_owner\", \"Only the site's owner can delete it.\")\n    return SiteDeleteStatusResponse(",
+    "tests": [
+      "tests/ee/sites/test_delete_endpoint.py"
+    ]
+  },
+  {
+    "label": "a non-owner is refused with 404 instead of 403, so the client renders 'this site is gone' at someone whose site is very much alive",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        raise Forbidden(\"site.not_owner\", \"Only the site's owner can delete it.\")\n\n    job_id = await enqueue_site_delete(site)",
+    "replace": "        raise NotFound(\"site\", site_id)\n\n    job_id = await enqueue_site_delete(site)",
+    "tests": [
+      "tests/ee/sites/test_delete_endpoint.py"
+    ]
+  },
+  {
+    "label": "the delete answers 200 instead of 202, so a client reading the status code concludes the site is already gone while it is still serving",
+    "file": "ee/pocketpaw_ee/sites/router.py",
+    "find": "@router.delete(\"/sites/{site_id}\", response_model=SiteDeleteQueuedResponse, status_code=202)",
+    "replace": "@router.delete(\"/sites/{site_id}\", response_model=SiteDeleteQueuedResponse, status_code=200)",
+    "tests": [
+      "tests/ee/sites/test_delete_endpoint.py"
+    ]
+  },
+  {
+    "label": "THE FORCED EXPORT IS SKIPPED ENTIRELY, so a site is destroyed with no copy of the customer's data kept anywhere",
+    "file": "ee/pocketpaw_ee/sites/delete_job.py",
+    "find": "    await sites_service.mark_delete_stage(site, status=\"exporting\")\n    try:\n        export_id = await _force_export(site)",
+    "replace": "    await sites_service.mark_delete_stage(site, status=\"exporting\")\n    try:\n        export_id = \"\"",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "a failed export no longer stops the job, so the cascade runs on and destroys the data the export could not read",
+    "file": "ee/pocketpaw_ee/sites/delete_job.py",
+    "find": "        await sites_service.record_delete_failure(site, reason=reason)\n        return\n\n    await site.set({\"delete_export_id\": export_id})",
+    "replace": "        await sites_service.record_delete_failure(site, reason=reason)\n        export_id = \"\"\n\n    await site.set({\"delete_export_id\": export_id})",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "an export that is not ready satisfies the gate, so a pending row with no bytes is accepted as the customer's saved copy",
+    "file": "ee/pocketpaw_ee/sites/delete_job.py",
+    "find": "    if export.status != \"ready\":",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "a FAILED export already on the row is reused as this delete's copy, so the gate is satisfied by the record of an attempt rather than by data",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return doc is not None and doc.status == \"ready\" and bool(doc.storage_key)",
+    "replace": "    return doc is not None",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "the export id is never written to the row, so the one surviving copy of the data is orphaned the moment the site document goes",
+    "file": "ee/pocketpaw_ee/sites/delete_job.py",
+    "find": "    await site.set({\"delete_export_id\": export_id})\n    site.delete_export_id = export_id",
+    "replace": "    site.delete_export_id = export_id",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "the cascade's save callback persists ONLY the ledger, so a stopped teardown leaves a row whose ledger says billing is done and whose subscription is still active and still charging",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "_CASCADE_MUTATED_FIELDS = (\n    \"delete_ledger\",\n    \"subscription_status\",\n    \"renewal_date\",\n    \"signed_key\",\n    \"revoked\",\n)",
+    "replace": "_CASCADE_MUTATED_FIELDS = (\"delete_ledger\",)",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "the claim precondition stops refusing an in-flight delete, so two workers run two cascades over one site at the same time",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            {\"delete_status\": {\"$nin\": sorted(DELETE_IN_FLIGHT_STATUSES)}},",
+    "replace": "            {\"delete_status\": {\"$nin\": []}},",
+    "tests": [
+      "tests/ee/sites/test_delete_endpoint.py"
+    ]
+  },
+  {
+    "label": "a failed delete counts as in flight, so one bad afternoon at Cloudflare leaves a site nobody can ever delete again",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "DELETE_IN_FLIGHT_STATUSES = frozenset({\"queued\", \"exporting\", \"tearing_down\"})",
+    "replace": "DELETE_IN_FLIGHT_STATUSES = frozenset({\"queued\", \"exporting\", \"tearing_down\", \"failed\"})",
+    "tests": [
+      "tests/ee/sites/test_delete_endpoint.py"
+    ]
+  },
+  {
+    "label": "the claim wipes the ledger, so a retry re-runs every destructive step the first attempt already finished",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        \"delete_job_id\": job_id,\n        \"delete_reason\": None,\n    }\n    collection = type(site).get_pymongo_collection()",
+    "replace": "        \"delete_job_id\": job_id,\n        \"delete_reason\": None,\n        \"delete_ledger\": {},\n    }\n    collection = type(site).get_pymongo_collection()",
+    "tests": [
+      "tests/ee/sites/test_delete_endpoint.py"
+    ]
+  },
+  {
+    "label": "the Site document is never removed, so a completed delete leaves a row and the poll never 404s — the client watches a finished delete until its deadline lapses",
+    "file": "ee/pocketpaw_ee/sites/delete_job.py",
+    "find": "    await sites_service.delete_site_document(site)\n    logger.info(\"sites.delete: site %s deleted (export %s)\", site_id, export_id)",
+    "replace": "    logger.info(\"sites.delete: site %s deleted (export %s)\", site_id, export_id)",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "the lead purge drops its site_id filter, so deleting one site destroys every other site's captured leads in the workspace",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    leads = await _LeadDoc.find({\"workspace\": workspace_id, \"site_id\": site_id}).delete()",
+    "replace": "    leads = await _LeadDoc.find({\"workspace\": workspace_id}).delete()",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "the rate-counter purge is unanchored, so deleting site-a also purges site-abc's counters",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        {\"scope_id\": {\"$regex\": f\"^{re.escape(site_id)}(:|$)\"}}",
+    "replace": "        {\"scope_id\": {\"$regex\": re.escape(site_id)}}",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "a failed enqueue no longer rolls the row back, so it sits in queued behind a job nobody will ever run and refuses every future delete of that site",
+    "file": "ee/pocketpaw_ee/sites/delete_job.py",
+    "find": "            await sites_service.record_delete_failure(site, reason=\"enqueue:pool_or_enqueue_raised\")",
+    "replace": "            pass",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "arq refusing the job id is read as a queued job, so the row waits forever on a delete that was never accepted",
+    "file": "ee/pocketpaw_ee/sites/delete_job.py",
+    "find": "            raise RuntimeError(f\"arq refused job id {job_id!r} — a job with that id exists\")",
+    "replace": "            pass",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "the delete job is not registered on the lane that consumes its queue, so every delete is enqueued to a queue no worker reads",
+    "file": "ee/pocketpaw_ee/sites/build_worker.py",
+    "find": "    functions = [site_build_fn, site_preview_build_fn, _site_delete_fn]",
+    "replace": "    functions = [site_build_fn, site_preview_build_fn]",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "the job id goes back to being deterministic, so arq silently refuses the RETRY of a failed delete for as long as its result lives in Redis",
+    "file": "ee/pocketpaw_ee/sites/delete_job.py",
+    "find": "    return f\"site-delete-{site_id}-{uuid.uuid4().hex}\"",
+    "replace": "    return f\"site-delete-{site_id}\"",
+    "tests": [
+      "tests/ee/sites/test_delete_job.py"
+    ]
+  },
+  {
+    "label": "the export response reads created_at again — the snake_case field no document declares — so every export call raises AttributeError and the whole export surface 500s",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        created_at=doc.createdAt.isoformat() if doc.createdAt else None,",
+    "replace": "        created_at=doc.created_at.isoformat() if doc.created_at else None,",
+    "tests": [
+      "tests/ee/sites/test_site_export_service.py"
+    ]
+  }
+]


### PR DESCRIPTION
The delete UI shipped in paw-enterprise #895 against two endpoints that were never built. Pressing delete on a site 404s today. The teardown cascade (#2134) and the data export both merged earlier and neither had a caller. This is the half that gives them one.

## What this adds

| | | |
|---|---|---|
| `DELETE` | `/sites/{site_id}` | `fabric.write` + owner-only → **202** `{site_id, status, job_id}` |
| `GET` | `/sites/{site_id}/delete-status` | `fabric.read` + owner-only → the poll, **404 on success** |

Plus `ee/pocketpaw_ee/sites/delete_job.py`, the arq job that runs the thing, registered on the sites lane that already consumes the sites queue.

**202 and not 204.** The site is still serving when the call returns. **The poll 404s when the delete succeeds** — the cascade's last step deletes the Site document and `delete_status` is a field on that document, so a completed delete has nothing left to report a status on. There is no terminal `deleted` status and there cannot be one; the shipped client reads the 404 as completion. Both shapes were fixed by `core/sites/delete-api.ts` before I got here, so they were not mine to re-pick.

**403 and 404 are different answers on purpose.** A member who can see a site but does not own it gets 403 and a sentence about the rule. A site in another workspace gets 404, because confirming a stranger's site exists is itself the leak. The owner check lives in the service rather than the router, following the reasoning `pockets.service.delete` already records against the same decision: jobs, bus handlers and MCP tools reach services directly, so a router guard is one they walk past.

## Where the forced export went, and why

**Step zero of the job, not a precondition on the endpoint.** Three reasons, in order of how much they decided it:

1. The shipped client has an `exporting` status and a failure sentence keyed on the `export` step. Both are read from the **poll**, off `delete_status` / `delete_reason`. A synchronous export inside the DELETE request cannot produce either — the status would never be observable, and an export failure would arrive as a 4xx on the delete call instead of as the `export:<cause>` reason the client is written to render.
2. An export pages a D1 500 rows at a time and walks every captured lead. On a busy dynamic site that is minutes. Holding an HTTP request open for it is exactly what the 202 contract exists to avoid, and it would die at the proxy before it died honestly.
3. What `delete_cascade`'s header actually demands is that the export resolve before the first **destructive** step, because an export taken between steps could fail after something irreversible had already run. The job satisfies that exactly: the export completes and is recorded on the row before `run_cascade` is entered.

A failed export leaves the site **completely** untouched — nothing enqueued, nothing cancelled, no ledger entries. That is what makes the client's "your site is untouched" sentence true rather than optimistic. `ExportUnavailable` is a plain `Exception`, not a `CloudError`, and is caught explicitly; #2135 fixed that same escape once already.

A stale export is not reused. One already named on the row and still `ready` was taken by *this* delete before anything was destroyed, so it is a faithful copy and re-taking it only costs a second full read of a database that is about to go. Anything else gets a fresh one.

## Two bugs found on the way

**`POST /sites/{id}/export` 500s on `dev` today.** `_export_response` reads `doc.created_at` — a snake_case field `TimestampedDocument` does not declare and nothing aliases — so it raises `AttributeError` on every call. The endpoint does all of its work and then fails at the last line. It survived because every existing test in `test_site_export_service.py` exercises a pure helper and none had ever built a document. Fixed here because it had to be: the forced export could never have passed its own gate otherwise. There is now a test that builds one.

**A ledger-only save would have kept billing a deleted site.** The cascade stops the money by clearing `subscription_status` *in memory* — on the credits rail that local write is the whole mechanism, because `renewal_sweeper` selects the rows it charges on exactly that field. Had the save callback persisted only `delete_ledger`, a cascade that stopped at a later step would leave a row whose ledger says billing is done and whose status still says `active`, and the resume would skip the billing step on the strength of that ledger. The callback now writes the fields the cascade actually touches. Still field-scoped, so a concurrent build-status write cannot be rolled back.

## Decisions worth arguing with

**`max_tries = 1`.** `run_cascade` is resumable, but the resume belongs to a person. A cascade that stopped because Cloudflare was returning 500s would be re-entered by an automatic retry seconds later, into the same outage, spending the ledger's one cheap resume on a failure that has not cleared. Instead the row settles at `failed` naming the step, and `failed` is deliberately **not** an in-flight status, so the owner pressing delete again re-claims the row and the cascade skips everything the first attempt finished.

**It rides the existing sites queue** rather than opening a new one. That lane already consumes site work, and a third `build:` service cannot go in the Coolify compose file anyway (paw-workspace #193/#194).

**The pocket is not orphaned.** Nothing changed there: `pockets.service.delete` still refuses with `409 pocket.has_site` while a site is published, rather than cascading. Deleting the site clears that guard. A cascade from the pocket side would bypass the forced export, which is the point of the refusal.

## What I did not do

`purge_site_records` clears leads and rate counters. It does **not** purge concierge transcripts — those are `ChatRun` rows keyed on the pocket and owned by the Paw Bar surface, and reaching into another subsystem's collection from here would put a second writer on rows only that surface knows the shape of. Worth a follow-up. The site's signed key is revoked in cascade step 2, so no new transcript can be written once a delete starts. Visitor analytics are not purged and cannot be — three-month Cloudflare retention we do not control, which the dialog and the export bundle both already say out loud.

## Testing

37 new tests across the endpoint contract and the job. 23 mutations in `tests/mutations/sites_delete_endpoint.json`, all caught — including the two above, so neither can come back quietly.

This change rotted two anchors in other plans (`queue_lanes.json`, `sites_burst_harness.json`) because `claim_delete_queued` mirrors `claim_build_queued` closely enough to make two previously-unique anchors ambiguous. Both are repointed at the same harm, both plans re-run clean, and `mutate.py --validate` is green repo-wide at 1530 anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
