### PR TITLE
Sites: AI tells that yield to the brief, and design sources the agent can actually use

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -773,6 +773,16 @@ _SITES_DESIGN_SKILLS: tuple[tuple[str, str, str], ...] = (
         "bleed-through, dead gutters, the mobile floor.",
     ),
     (
+        "sites-design-sources",
+        "both",
+        "When you are about to hand-write a BACKGROUND, texture, canvas shader, "
+        "CSS animation or text effect, when the brief NAMES an effect you want to "
+        "build well rather than by reflex, or when picking type and Inter is not "
+        "allowed. Real techniques filtered to what this surface can build: no npm "
+        "and no file downloads, so everything there is CSS, inline SVG or GLSL "
+        "you retype.",
+    ),
+    (
         "sites-interface-review",
         "refine",
         "When the user asks to review, critique or audit the page, or asks why it "

--- a/src/pocketpaw/atlas/data/atlas.json
+++ b/src/pocketpaw/atlas/data/atlas.json
@@ -2186,6 +2186,20 @@
     },
     {
       "gist": "",
+      "how": "a user invokes it as /sites-design-sources in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
+      "id": "skill:sites-design-sources",
+      "keywords": [
+        "sites-design-sources"
+      ],
+      "kind": "skill",
+      "name": "sites-design-sources",
+      "narrative": "Named reference sources for GROUNDS, EFFECTS, SHADERS, MOTION and TYPE on a Paw Site, filtered to what this surface can physically build. Invoke when you are about to hand-write a background, a texture, a canvas shader, a CSS animation or a text effect and want a real technique behind it instead of a default gradient, or when the brief NAMES an effect (marquee, halo, gradient headline, dither, grain) and you want to build it WELL rather than reach for the first shape that comes to mind. Also the way out of the overused-font trap in `pocketpaw-design-taste` 2.F. Everything listed here is TEXT you author into the source map: CSS, inline SVG, or a GLSL string. Nothing here is installed and nothing here is downloaded, because this surface has neither a package manager nor a filesystem.",
+      "requires": [],
+      "summary": "Named reference sources for GROUNDS, EFFECTS, SHADERS, MOTION and TYPE on a Paw Site, filtered to what this surface can physically build.",
+      "surface": ""
+    },
+    {
+      "gist": "",
       "how": "a user invokes it as /sites-interface-review in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
       "id": "skill:sites-interface-review",
       "keywords": [

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-design-taste/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-design-taste/SKILL.md
@@ -222,9 +222,9 @@ These pages render to HTML before any JS runs. Taste must never depend on JS to 
 
 ---
 
-## MODULE 5: AI TELLS - forbidden patterns (avoid unless the brief asks)
+## MODULE 5: AI TELLS - off by default, built well on request
 
-Shapes models reach for because other models reached for them, not because a page needed them. A brief overrides any of these; a reflex does not. Bans already stated where they are acted on (Inter and serif in 2.F, purple/neon/pure-black in 2.G, the centered hero and the three-card row in 3.B, card overuse in 3.C, decorative grounds in 2.B) are tells too and are not repeated here.
+Shapes models reach for because other models reached for them, not because a page needed them. Read every NO below as **never unprompted**, not as never: when the brief ASKS for a marquee, a gradient headline, a glow, a halo or an eyebrow chip, build it, and build it better than the default version - a named request is the spec (MODULE 0), and only a reflex is a tell. Two things no brief can ask you to break, because they are defects rather than defaults: the legibility floor (contrast, text that fits its container and is not occluded, headings in order) and asset honesty (never a fabricated `src`, never an invented fact). Bans already stated where they are acted on (Inter and serif in 2.F, purple/neon/pure-black in 2.G, the centered hero and the three-card row in 3.B, card overuse in 3.C, decorative grounds in 2.B) are tells too and are not repeated here.
 
 **Borders and edges.** NO accent stripe down one edge of a card (`border-left: 4px solid`): a coloured bar on one side is how an alert is drawn, so a plain card wearing one reads as a warning that never resolves. NO heavy coloured border on a rounded element, which fights the radius it sits on. NO hairline border AND a wide shadow defining the same edge; one treatment per edge. NO `border-top` + `border-bottom` on every row of a long list. NO radius past ~32px on a card, which squeezes the content into a blob. NO card nested inside a card (3.C.A is the one sanctioned nesting).
 

--- a/src/pocketpaw/bundled_skills/_bundled/skills/sites-design-sources/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/sites-design-sources/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: sites-design-sources
+description: |
+  Named reference sources for GROUNDS, EFFECTS, SHADERS, MOTION and TYPE on a Paw
+  Site, filtered to what this surface can physically build. Invoke when you are
+  about to hand-write a background, a texture, a canvas shader, a CSS animation or
+  a text effect and want a real technique behind it instead of a default gradient,
+  or when the brief NAMES an effect (marquee, halo, gradient headline, dither,
+  grain) and you want to build it WELL rather than reach for the first shape that
+  comes to mind. Also the way out of the overused-font trap in
+  `pocketpaw-design-taste` 2.F. Everything listed here is TEXT you author into the
+  source map: CSS, inline SVG, or a GLSL string. Nothing here is installed and
+  nothing here is downloaded, because this surface has neither a package manager
+  nor a filesystem.
+---
+
+# Design sources for a Paw Site
+
+## What this surface can actually take from a reference
+
+Three facts decide whether a source is usable here, and together they rule out
+most of the web's design catalogue:
+
+1.  **No package manager.** `package.json` is generator-owned and your source map
+    supplies FILES ONLY, so `npm i` is not a step you have. Every component
+    library, every animation runtime (`motion`, `gsap`, `lenis`), every icon
+    package and every shadcn registry entry is out, however good it is.
+2.  **No filesystem and no binary ingest.** Your belt is `create_*`, `edit_*`,
+    `read_site_source`, `list_site_assets`, `publish`, plus image and video
+    generation. There is no download tool and no upload-from-URL, so a WOFF2
+    file, an SVG pack, a texture PNG or a CC0 illustration set cannot be brought
+    into the project no matter how permissive its licence.
+3.  **What remains is technique.** A source is useful here when its value is
+    something you RETYPE as text: a CSS rule, an inline `<svg>`, a data URI, a
+    fragment-shader body, an easing curve, a font URL. Read the technique, author
+    the code yourself.
+
+So use these as reading, not as a dependency list. `WebFetch` is available on
+this surface and these pages are fetchable. Fetch one when you are about to build
+the thing it covers, never speculatively.
+
+## Grounds, patterns and texture (feeds 2.B)
+
+This section exists because "a tuned ground" has more answers than a gradient.
+All of these are authored as CSS or an inline SVG data URI.
+
+| Source | URL | Licence | What you retype |
+| --- | --- | --- | --- |
+| Pattern Craft | `patterncraft.fun` | MIT | Pure-CSS background patterns: grids, dots, rays, mesh. Copy the rule, retune the colours to your tokens. |
+| Hero Patterns | `heropatterns.com` | CC-BY | Tiling SVG patterns delivered as `background-image: url("data:image/svg+xml,...")`. Set the fill to your own ink before using it. |
+| Pattern Monster | `pattern.monster` | free | SVG pattern generator with stroke, scale and rotation controls. Take the emitted markup, not a file. |
+| fffuel | `fffuel.co` | free tools | SVG generators for grain, noise, soft gradients, blobs and dot fields. The output is markup you paste. |
+| Haikei | `haikei.app` | free tools | Layered waves, blobs and stacked shapes as SVG. |
+
+Grain over a flat ground is the highest-return one on this list: a noise SVG at
+very low opacity over a solid or two-stop gradient kills the plastic look a bare
+CSS gradient has, and it costs one element.
+
+**Licence discipline.** CC-BY means the author is credited somewhere real or you
+do not ship it. Where a source is a *generator*, the output is yours and there is
+nothing to attribute. Never paste something whose terms you did not read into a
+page a business will publish under its own name.
+
+## Canvas shaders (feeds 2.C)
+
+2.C allows a hand-written WebGL canvas: raw `getContext('webgl')`, a pass-through
+vertex shader, one fragment shader over a full-screen quad. This is where the
+fragment shader itself comes from.
+
+| Source | URL | Licence | Notes |
+| --- | --- | --- | --- |
+| Radiant Shaders | `radiant-shaders.com/gallery/all` | MIT | Self-contained fragment shaders. MIT means you can ship the maths. |
+| Codrops | `tympanus.net/codrops` | per-article | The best technique writing on the web for canvas, scroll and transition work. Read the article, write your own implementation. |
+| Grainient | `grainient.supply` | commercial tool | Grainy-gradient explorer. Use it to decide the LOOK, then reproduce it in your own shader or in CSS. Do not hotlink its output. |
+
+Everything in 2.C still applies: the canvas sits over a finished CSS fallback,
+the buffer is capped at 2x DPR, and the loop stops off-screen. A shader you
+copied without understanding is a shader you cannot cap.
+
+## Motion and effects (feeds 3.D)
+
+| Source | URL | Licence | What you retype |
+| --- | --- | --- | --- |
+| Animista | `animista.net` | BSD | Pure-CSS keyframe animations with the timing already worked out. Take the `@keyframes`, then slow it down: the defaults are demo-speed. |
+| Colorion Text Effects | `text-effects.colorion.co` | MIT | CSS-only text treatments. |
+| Theme Toggle Effect | `theme-toggle.rdsx.dev` | free | View-Transitions light/dark switching, which is a real interaction rather than an ornament. |
+
+## Type (feeds 2.F)
+
+**Only one font-loading path works on this surface: a URL in CSS.** A foundry's
+WOFF2 cannot be self-hosted here, because there is no way to get the file into
+the project. So:
+
+-   **Google Fonts** (`fonts.google.com`, OFL / Apache-2.0) is the practical
+    library, loaded with a single `@import` or one `<link>` in the document head.
+    It is far wider than its famous handful: Bricolage Grotesque, Instrument
+    Sans, Familjen Grotesk, Schibsted Grotesk, Gabarito, Funnel Display,
+    Geologica and Onest all live there, and none of them is Inter.
+-   **Fontpair** (`fontpair.co`) and **Free Faces** (`freefaces.gallery`) are for
+    CHOOSING. Pick a pairing there, then confirm the faces are servable from a
+    CDN you can reference before committing to them.
+-   **The independent OFL foundries** — Velvetyne (`velvetyne.fr`), Open Foundry
+    (`open-foundry.com`), Uncut (`uncut.wtf`), Collletttivo
+    (`collletttivo.it`), The League of Moveable Type — are where genuinely
+    distinctive free type lives. Treat them as a reference for what a display
+    face CAN look like, and as a real option only when the site owner supplies
+    the file through their own assets. Never write a `@font-face` pointing at a
+    foundry's own server: that is hotlinking someone else's bandwidth, and it
+    breaks the day they move the file.
+
+## Colour (feeds 2.G)
+
+`derive_palette` on your own belt comes first, because it is instant and returns
+values rather than a page to read. These cover what it does not:
+
+-   **OKLCH picker** (`oklch.com`, MIT) when a ramp needs perceptually even
+    steps. Lightness in OKLCH behaves the way the eye expects; HSL does not.
+-   **Colour Contrast Checker** (`colourcontrast.cc`, MIT) to confirm a pair
+    against the 4.5:1 body and 3:1 large/interface floors before shipping. You
+    have no browser on this surface, so contrast is the one number worth
+    confirming against a source rather than estimating.
+
+## The failure this skill exists to prevent
+
+A catalogue of hundreds of design resources is mostly a catalogue of things you
+cannot use, and reading one as a menu is how a page ends up padded with effects
+nobody asked for. `pocketpaw-design-taste` MODULE 0 still governs: the brief
+decides what gets built. Come here once you already know you are building a
+ground, a shader, an animation or a type system, and you want that ONE thing to
+be good.


### PR DESCRIPTION
Follow-up to #2163, which shipped MODULE 0 and the widened tells list.

## The tells fought the scope rule

MODULE 5 was forty absolutist `NO`s sitting under a one-line caveat. MODULE 0 says the request is the spec and wins wherever modules disagree, so a brief that literally asks for a scrolling logo marquee hit a wall of prohibitions instead of getting one built well.

The heading and intro now say it outright, and name the cases: marquee, gradient headline, glow, halo, eyebrow chip. Read every `NO` as *never unprompted*, not as never.

Two things stay hard, because they are defects rather than defaults:

- the legibility floor (contrast, text that fits and is not occluded, headings in order)
- asset honesty (never a fabricated `src`, never an invented fact)

That split is not invented here. It is the detector registry's own taxonomy: 32 `slop` rules against 27 `quality` ones. Slop is a default you should not reach for. Quality is a defect nobody can ask for.

## sites-design-sources

A named reference skill for grounds, patterns, canvas shaders, CSS motion and type. Named rather than embedded, so it costs nothing on the turns that never reach for a background or a font. Scoped `both`, so refine gets it too.

The shortlist was filtered against what this surface can physically build, and the binding constraint turned out not to be npm.

`SITE_MEDIA_TOOL_IDS` carries only `generate_site_image` and `generate_site_video`. The sites belt has no download tool and no upload-from-URL. So every *download-shaped* resource is unreachable whatever its licence: a foundry WOFF2, a CC0 illustration pack, a texture PNG, an SVG asset library. What survives is only what you retype as text.

That is why the skill lists CSS background patterns, MIT fragment shaders and CSS keyframes, and why it forbids pointing a `@font-face` at a foundry's own server. It also corrects the font path: a CSS URL is the only way a font loads here.

## Sizing

`pocketpaw-design-taste` is at 34,493 bytes, 507 under the ceiling. The reframe cost 474 bytes and the skill is out of line, being named.

## Verified

- 264 passed across `tests/cloud/surface`, the skill budget and the installer
- `atlas build --check` clean, artifact rebuilt for the new skill
- 1552 mutation anchors across 129 plans each resolve exactly once
- `sites.py` still 2,085 CRLF with zero bare LF, so no whole-file diff

Three pre-existing failures on `dev` are untouched and unrelated: `test_local_machine_tools_are_never_offered` (passes alone, fails in batch, so it is ordering), and two in `tests/cloud/test_surface_profile.py` that assert `"create-svelte-site" in profile.skill_names` when the set holds `pocketpaw-create-svelte-site`. That second pair is a real bug and wants its own issue.
