### PR TITLE
Paw Sites: put the install floor on the build path that actually runs

### DIFF
--- a/ee/pocketpaw_ee/sites/bun_supply_chain.py
+++ b/ee/pocketpaw_ee/sites/bun_supply_chain.py
@@ -1,0 +1,86 @@
+# bun_supply_chain.py — the ONE place the site-build install-time supply-chain
+# floor lives.
+#
+# Created: 2026-09-12 (fix/sites-install-supply-chain-floor) — extracted from
+# ``daytona_runner.py``, which owned ``SANDBOX_BUNFIG`` / ``SANDBOX_BUNFIG_REL``
+# because the sandbox was the only build host that wrote one. It was not the only
+# build host that INSTALLS. ``generator_client._SubprocessRunner.install`` runs
+# ``bun install`` too — on the path ``dev_server``, ``draft_markup``, ``service``
+# and the deployed Coolify image all use — and it wrote no bunfig at all, so that
+# path resolved from the open registry with lifecycle scripts enabled. A second
+# installer with no copy of the floor is how a floor stops being a floor, so the
+# constant moved HERE and both runners call it. ``daytona_runner`` re-exports both
+# names unchanged (the same re-export pattern ``sites_create`` uses for
+# ``react_paths``), so nothing that imported them from there had to change.
+"""Install-time supply-chain floor for generated Paw Site builds.
+
+WHY THIS FILE HAS TO EXIST AT ALL. This workspace's protections live in a
+DEVELOPER'S HOME DIR (``~/.npmrc``, ``~/.bunfig.toml``) and are in no repo, so
+neither a fresh Daytona container nor the Coolify runtime image inherits any of
+them: no release-age floor, no ``ignoreScripts``. A build host that resolves from
+the open registry with lifecycle scripts enabled is strictly weaker than the
+runtime image beside it.
+
+``minimumReleaseAge`` is the same 7-day floor the dev machines enforce, expressed
+in SECONDS because that is bun's unit — 604800. It is the control that would catch
+a compromised fresh publish of an already-vetted package, which the allowlist
+cannot: the allowlist pins WHICH packages, and a caret pin still floats the
+VERSION.
+
+``ignoreScripts`` matters more on a build host than on a laptop. A postinstall
+script here runs with the host's network and filesystem, next to the artifact we
+are about to deploy — and on the Coolify path, as the backend user in the
+container holding the app's secrets. Nothing in the vetted set needs one.
+
+DELIBERATELY WRITTEN AT THE BUILD BOUNDARY, NOT TEMPLATED INTO THE GENERATED
+PROJECT. Two reasons: it is a property of the BUILD HOST, not of the customer's
+site, so it has no business in their source tree; and applying it at this boundary
+means a template change cannot silently drop it. It lands in the project dir
+because that is where bun looks.
+
+DISPLACES rather than merges. A project-emitted ``bunfig.toml`` is overwritten, not
+respected and not merged, so a future template change cannot lower the floor by
+shipping its own. No generated project emits one today; this is a guard against
+the change that would.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Where bun looks, relative to the project root it installs in.
+BUILD_BUNFIG_REL = "bunfig.toml"
+
+#: The floor itself. Read the module docstring before changing either value.
+BUILD_BUNFIG = """# Written by pocketpaw's build lane — NOT part of your site's source.
+# Install-time supply-chain floor for this build. See bun_supply_chain.BUILD_BUNFIG.
+[install]
+# 7 days, in seconds. Matches the floor the dev machines enforce via ~/.bunfig.toml.
+minimumReleaseAge = 604800
+# No lifecycle scripts. Nothing in the vetted dependency set needs one, and a
+# postinstall here would run beside the artifact we are about to deploy.
+ignoreScripts = true
+"""
+
+
+def write_build_bunfig(project_dir: str | Path) -> None:
+    """Write the floor into ``project_dir``, displacing any bunfig already there.
+
+    Call this IMMEDIATELY BEFORE spawning ``bun install``. Written after the install
+    has started, it is not a floor — it is a file.
+
+    Logs when it displaces one, because a generated project that started emitting a
+    bunfig is a template change someone should hear about rather than a condition to
+    swallow silently.
+    """
+    target = Path(project_dir, BUILD_BUNFIG_REL)
+    if target.is_file():
+        logger.warning(
+            "sites.build.bunfig_displaced dir=%s — a project-supplied bunfig.toml was "
+            "overwritten by the build lane's supply-chain floor",
+            project_dir,
+        )
+    target.write_text(BUILD_BUNFIG, encoding="utf-8")

--- a/ee/pocketpaw_ee/sites/daytona_runner.py
+++ b/ee/pocketpaw_ee/sites/daytona_runner.py
@@ -126,6 +126,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from pocketpaw_ee.sites.bun_supply_chain import BUILD_BUNFIG, BUILD_BUNFIG_REL
 from pocketpaw_ee.sites.daytona_build import (
     BUILD_RESULT_FILENAME,
     BuildClassification,
@@ -153,36 +154,21 @@ SANDBOX_ARTIFACT_PATH = "/tmp/paw-artifact.tgz"
 
 #: SL-3 — the install-time supply-chain floor, uploaded INTO the sandbox project.
 #:
-#: WHY THIS FILE HAS TO EXIST HERE AT ALL. This workspace's protections live in the
-#: DEVELOPER'S HOME DIR (``~/.npmrc``, ``~/.bunfig.toml``) and are not in any repo, so a
-#: fresh container inherits NONE of them: no release-age floor, no ``ignore-scripts``. A
-#: build box that resolves from the open registry with lifecycle scripts enabled is
-#: strictly weaker than the runtime image beside it, and once Daytona is the ONLY build
-#: host that inversion is the whole exposure rather than a note.
+#: MOVED 2026-09-12 to ``bun_supply_chain`` and re-exported here under the original
+#: names, so nothing that imported ``dr.SANDBOX_BUNFIG`` had to change. The sandbox
+#: was never the only host that runs ``bun install``, and the other one had no copy
+#: of this floor. One constant with two call sites cannot drift; two constants that
+#: agree today can. Read ``bun_supply_chain``'s module docstring for why each control
+#: is here, and why the file is written at the build boundary rather than templated
+#: into the generated project.
 #:
-#: ``minimumReleaseAge`` is the same 7-day floor the dev machines enforce, expressed in
-#: SECONDS because that is bun's unit — 604800. It is the control that would have caught
-#: a compromised fresh publish of an already-vetted package, which the allowlist cannot:
-#: the allowlist pins WHICH packages and a caret pin still floats the VERSION.
-#:
-#: ``ignore-scripts`` matters more here than on a laptop. A postinstall script in a build
-#: container runs with the sandbox's network and its filesystem, next to the artifact we
-#: are about to deploy. Nothing in the vetted set needs one.
-#:
-#: DELIBERATELY UPLOADED, NOT TEMPLATED INTO THE GENERATED PROJECT. Two reasons: it is a
-#: property of the BUILD HOST, not of the customer's site, so it has no business in their
-#: source tree; and injecting it at this boundary means a template change cannot silently
-#: drop it. It lands in the project dir because that is where bun looks.
-SANDBOX_BUNFIG_REL = "bunfig.toml"
-SANDBOX_BUNFIG = """# Written by pocketpaw's build lane — NOT part of your site's source.
-# Install-time supply-chain floor for this sandbox. See daytona_runner.SANDBOX_BUNFIG.
-[install]
-# 7 days, in seconds. Matches the floor the dev machines enforce via ~/.bunfig.toml.
-minimumReleaseAge = 604800
-# No lifecycle scripts. Nothing in the vetted dependency set needs one, and a
-# postinstall here would run beside the artifact we are about to deploy.
-ignoreScripts = true
-"""
+#: Deliberately NOT naming that other runner here: this module is the Daytona lane,
+#: and ``test_fault_ladder_build`` text-scans it to keep a local build fallback from
+#: being reintroduced. Sharing a supply-chain constant is not a build fallback, but
+#: the guard reads source text, and a guard that has to reason about intent is worth
+#: less than one that does not.
+SANDBOX_BUNFIG_REL = BUILD_BUNFIG_REL
+SANDBOX_BUNFIG = BUILD_BUNFIG
 
 #: Seconds added to the in-sandbox timeout for our own ``execute_command`` budget.
 #: The inner ``timeout(1)`` should always fire first, because that path still runs the

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -308,6 +308,7 @@ from pathlib import Path
 from typing import Any, Protocol
 from urllib.parse import unquote
 
+from pocketpaw_ee.sites.bun_supply_chain import BUILD_BUNFIG_REL, write_build_bunfig
 from pocketpaw_ee.sites.engines import (
     candidate_static_output_rels,
     is_source_engine,
@@ -453,7 +454,21 @@ _INSTALL_HASH_FILE = ".paw-install-hash"
 # Files whose contents define the dependency set. If any change, node_modules is
 # stale and must be reinstalled. The lockfile names cover bun's text + binary
 # lockfiles and the npm fallback.
-_INSTALL_INPUT_FILES = ("package.json", "bun.lock", "bun.lockb", "package-lock.json")
+#
+# bunfig.toml is in this list even though it declares no dependency, because it
+# decides HOW they resolve: the release-age floor and ignoreScripts. A node_modules
+# installed without the floor is exactly as stale as one installed from a different
+# package.json, and leaving it out is how introducing the floor would have silently
+# skipped every already-built site — the hash would not move, so install() (which
+# writes it) would never be reached. Including it costs one reinstall per cached
+# build dir, once.
+_INSTALL_INPUT_FILES = (
+    "package.json",
+    "bun.lock",
+    "bun.lockb",
+    "package-lock.json",
+    BUILD_BUNFIG_REL,
+)
 
 # Known workerd SSR-render failure markers (mirrors paw-sites/src/smoke.ts). A
 # LIVE publish fail-gates on these; a preview build tolerates them (the live
@@ -1326,6 +1341,16 @@ class _SubprocessRunner:
         # The deps are already made resolvable by build() (_rewrite_ripple_dep runs
         # before the install decision so the dep-hash reflects the final inputs).
         # This just runs `bun install` on the prepared dir.
+        #
+        # ...behind the same supply-chain floor the Daytona sandbox installs behind.
+        # This used to be the asymmetry: daytona_runner uploaded a bunfig into every
+        # sandbox and this path wrote none, so the LOCAL runner — which is what
+        # dev_server, draft_markup, service and the deployed Coolify image all use —
+        # resolved from the open registry with lifecycle scripts enabled. Written
+        # here rather than in build() because this is the method that spawns the
+        # install: a floor applied anywhere else is one a future caller can route
+        # around by calling install() directly.
+        write_build_bunfig(project_dir)  # the floor, laid at the spawn
         timeout_s = _build_timeout_sec()
         # start_new_session=True: own process group so a wedged install is killable
         # as a group on timeout.
@@ -1849,6 +1874,22 @@ class GeneratorClient:
         # is not a real dir) don't fail on a missing package.json.
         if Path(project_dir, "package.json").is_file():
             _rewrite_ripple_dep(project_dir, _ripple_dep_source())
+            # Lay the supply-chain floor down BEFORE the fingerprint is taken, not
+            # just inside install(). bunfig.toml is one of the fingerprinted install
+            # inputs (it decides how the deps RESOLVE), and the fingerprint is what
+            # decides whether install() runs at all — so a floor written only inside
+            # install() would never reach a build dir whose deps had not changed.
+            # That is the whole cached fleet. Writing it here moves the hash once,
+            # which forces exactly one reinstall per existing dir and nothing after.
+            # install() writes it again at spawn time; the two are idempotent and
+            # guard different things — this one guards the cache decision, that one
+            # guards a caller who reaches install() without coming through build().
+            #
+            # Inside the package.json guard for two reasons that agree: a dir with no
+            # manifest has no install to put a floor under, and the fake-runner tests
+            # hand this a projectDir that was never created on disk (the same reason
+            # _rewrite_ripple_dep is guarded).
+            write_build_bunfig(project_dir)
         # PERF-3 install cache: run `bun install` ONLY when the dependency set
         # changed. Fingerprint the install inputs and compare to the sentinel from
         # the last successful install in this dir. Match → skip (reuse the cached

--- a/ee/pocketpaw_ee/sites/react_paths.py
+++ b/ee/pocketpaw_ee/sites/react_paths.py
@@ -16,8 +16,13 @@
 # writer of a react ``source`` map. ``edit_react_component`` is the second writer,
 # and a second writer with its own copy of the guard is how the guard rots: an edit
 # that could write ``package.json`` would defeat the generator's dependency
-# allowlist and, with it, the supply-chain release-age floor the manifest is what
-# enforces. So the normalization + the reserved set moved HERE and both writers call
+# allowlist. (It would NOT defeat the supply-chain release-age floor, which this
+# comment used to claim: that floor lives in the build lane's ``bunfig.toml``
+# (``sites/bun_supply_chain.py``), written into the project dir by both build
+# runners and outside any author's reach. Corrected 2026-09-12 — the wrong reason
+# for a right guard is still load-bearing, because it is the reason someone reads
+# before deciding whether the guard may be relaxed.)
+# So the normalization + the reserved set moved HERE and both writers call
 # it. ``sites_create`` re-exports the two constants and ``_reserved_react_keys``
 # under their old names, so nothing that imported them from there had to change.
 #
@@ -43,7 +48,15 @@ govern which paths an author (create OR edit) may write:
    ``paw-prerender.mjs`` could remove the pass that fills the prerender outlet,
    turning the site back into a shell that is blank with JavaScript disabled — and
    an author who could overwrite ``package.json`` would be writing the dependency
-   manifest, which is where the supply-chain release-age floor is enforced.
+   manifest, which is what the generator's vetted allowlist checks.
+
+   The release-age floor is NOT enforced here, though this docstring said so until
+   2026-09-12. It lives in the build lane's ``bunfig.toml``
+   (``sites/bun_supply_chain.py``), written into the project dir immediately before
+   ``bun install`` on both the Daytona and the local runner. That distinction
+   matters the moment someone proposes letting an author declare a dependency:
+   the allowlist is the thing this reservation protects, and the floor holds
+   regardless.
 
 2. **Authored files live under ``src/`` or ``public/``.** Everything else at the
    project root belongs to the shell, so a path outside those two prefixes is

--- a/tests/ee/sites/test_generator_client_supply_chain.py
+++ b/tests/ee/sites/test_generator_client_supply_chain.py
@@ -1,0 +1,166 @@
+# tests/ee/sites/test_generator_client_supply_chain.py
+# Created: 2026-09-12 (fix/sites-install-supply-chain-floor) — reproduce-first
+# coverage for "the release-age floor is enforced on one of two build paths".
+#
+# THE BUG. ``daytona_runner`` uploads a ``bunfig.toml`` into every sandbox and
+# displaces any the project emitted, so a Daytona build installs behind a 7-day
+# ``minimumReleaseAge`` with ``ignoreScripts`` on. ``_SubprocessRunner.install``
+# wrote NO bunfig at all — and that is the runner ``dev_server``, ``draft_markup``,
+# ``service`` and the deployed Coolify image all use. ``deploy/coolify/Dockerfile``
+# bakes bun plus the vendored generator and carries no bunfig anywhere, and the
+# protections this workspace relies on live in a developer's home dir (``~/.bunfig.toml``),
+# which a container inherits none of. So a production site build resolved from the
+# open registry with lifecycle scripts ENABLED, as the backend user, in the container
+# holding the app's secrets.
+#
+# That was survivable only because the installed dependency set is a short fixed list
+# nobody outside the generator can influence. The design that lets a site's authoring
+# agent request a package (docs/design/drafts/2026-09-12-sites-npm-dependency-allowlist.md)
+# is what ends that, which is why this is its chunk 0 rather than adjacent cleanup.
+#
+# These tests exercise the REAL ``_SubprocessRunner`` and patch
+# ``asyncio.create_subprocess_exec`` to a fast exit-0 child, so no bun is required.
+# They mirror ``test_daytona_runner``'s bunfig tests deliberately: the same two
+# questions (is a floor present, does a project-supplied one lose) asked of the OTHER
+# runner, so a future reader comparing the two files sees one policy, not two.
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.sites import bun_supply_chain as bsc  # noqa: E402
+from pocketpaw_ee.sites.generator_client import _SubprocessRunner  # noqa: E402
+
+# A child that exits 0 immediately — stands in for a successful `bun install`.
+_OK_ARGV = [sys.executable, "-c", "pass"]
+
+
+def _spawn_observer(tmp_path, observed: dict):
+    """Patch-in for ``create_subprocess_exec`` that snapshots the bunfig state at the
+    exact moment the install would spawn, then runs a trivial exit-0 child instead.
+
+    Snapshotting AT SPAWN is the point: a bunfig written after ``bun install`` has
+    already started is not a floor, it is a file. Asserting on the post-call
+    filesystem would pass for that bug.
+    """
+    real_exec = asyncio.create_subprocess_exec
+
+    async def _fake_exec(*_args, **kwargs):
+        bunfig = tmp_path / bsc.BUILD_BUNFIG_REL
+        observed["present"] = bunfig.is_file()
+        observed["contents"] = bunfig.read_text(encoding="utf-8") if bunfig.is_file() else ""
+        return await real_exec(
+            *_OK_ARGV,
+            stdout=kwargs.get("stdout", asyncio.subprocess.PIPE),
+            stderr=kwargs.get("stderr", asyncio.subprocess.PIPE),
+            cwd=kwargs.get("cwd"),
+            start_new_session=kwargs.get("start_new_session", False),
+        )
+
+    return _fake_exec
+
+
+@pytest.mark.asyncio
+async def test_install_writes_the_supply_chain_bunfig_before_spawning(tmp_path, monkeypatch):
+    """The reproduced bug: the local runner installed with no floor at all.
+
+    THE MUTATION THAT BREAKS THIS: delete the ``_write_build_bunfig`` call from
+    ``install``. The snapshot then reports no bunfig at spawn and this fails — which
+    is precisely the state every Coolify-hosted publish was in before this change.
+    """
+    (tmp_path / "package.json").write_text('{"name":"paw-site-x"}', encoding="utf-8")
+
+    observed: dict = {}
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn_observer(tmp_path, observed))
+
+    ok, msg = await asyncio.wait_for(_SubprocessRunner().install(str(tmp_path)), timeout=10)
+    assert ok is True, msg
+
+    assert observed["present"] is True, (
+        "bun install spawned with no bunfig.toml in the project dir — the local build "
+        "path has no release-age floor and no ignoreScripts"
+    )
+    # Assert the two controls by VALUE, not by "a file exists". A bunfig that omits
+    # either one is the same exposure wearing the right filename.
+    assert "minimumReleaseAge = 604800" in observed["contents"]
+    assert "ignoreScripts = true" in observed["contents"]
+
+
+@pytest.mark.asyncio
+async def test_a_project_supplied_bunfig_is_displaced_so_the_floor_wins(tmp_path, monkeypatch):
+    """A generated project that emits its own bunfig must not be able to lower the floor.
+
+    No generated project emits one today, so this is a guard against a future template
+    change rather than a live hole — the same reason ``daytona_runner`` displaces rather
+    than merges. The hostile file sets both controls to their OFF values, so a merge
+    (or a skip-if-present) fails here while a displace passes.
+    """
+    (tmp_path / "package.json").write_text('{"name":"paw-site-x"}', encoding="utf-8")
+    (tmp_path / bsc.BUILD_BUNFIG_REL).write_text(
+        "[install]\nminimumReleaseAge = 0\nignoreScripts = false\n", encoding="utf-8"
+    )
+
+    observed: dict = {}
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn_observer(tmp_path, observed))
+
+    ok, msg = await asyncio.wait_for(_SubprocessRunner().install(str(tmp_path)), timeout=10)
+    assert ok is True, msg
+
+    assert "minimumReleaseAge = 0" not in observed["contents"], (
+        "the project's own bunfig survived into the install — a template change could "
+        "switch the floor off"
+    )
+    assert "ignoreScripts = false" not in observed["contents"]
+    assert "minimumReleaseAge = 604800" in observed["contents"]
+    assert "ignoreScripts = true" in observed["contents"]
+
+
+def test_the_floor_participates_in_the_install_cache_decision(tmp_path) -> None:
+    """Introducing or changing the floor must invalidate a cached ``node_modules``.
+
+    PERF-3 skips ``bun install`` when the fingerprint of the install inputs is
+    unchanged. A ``node_modules`` installed with no floor is exactly as stale as one
+    installed from a different package.json — but ``bunfig.toml`` declares no
+    dependency, so the obvious input list leaves it out, and then introducing the
+    floor moves no hash, skips the install, and reaches none of the already-built
+    fleet. The fix is silent and total: everything stays green and nothing is floored.
+
+    THE MUTATION THAT BREAKS THIS: drop ``BUILD_BUNFIG_REL`` from
+    ``_INSTALL_INPUT_FILES``. All three hashes below collapse to one and this fails.
+    """
+    from pocketpaw_ee.sites.generator_client import _install_inputs_hash
+
+    (tmp_path / "package.json").write_text('{"name":"paw-site-x"}', encoding="utf-8")
+    unfloored = _install_inputs_hash(str(tmp_path))
+
+    bsc.write_build_bunfig(tmp_path)
+    floored = _install_inputs_hash(str(tmp_path))
+
+    (tmp_path / bsc.BUILD_BUNFIG_REL).write_text(
+        bsc.BUILD_BUNFIG.replace("604800", "60"), encoding="utf-8"
+    )
+    weakened = _install_inputs_hash(str(tmp_path))
+
+    assert floored != unfloored, (
+        "adding the supply-chain floor did not move the install fingerprint — every "
+        "already-built site would keep its unfloored node_modules"
+    )
+    assert weakened != floored, "changing the floor's VALUE did not move the fingerprint"
+
+
+def test_both_runners_enforce_one_policy_not_two() -> None:
+    """The floor is one constant with two call sites, not two constants that agree today.
+
+    ``daytona_runner`` re-exports these under its original ``SANDBOX_*`` names (the same
+    re-export pattern ``sites_create`` uses for ``react_paths``), so nothing that imported
+    them from there had to change. Identity, not equality: two separately-maintained
+    strings that happen to match is the drift this asserts against.
+    """
+    from pocketpaw_ee.sites import daytona_runner as dr
+
+    assert dr.SANDBOX_BUNFIG is bsc.BUILD_BUNFIG
+    assert dr.SANDBOX_BUNFIG_REL is bsc.BUILD_BUNFIG_REL

--- a/tests/mutations/sites_install_supply_chain.json
+++ b/tests/mutations/sites_install_supply_chain.json
@@ -1,0 +1,57 @@
+[
+  {
+    "label": "the local runner spawns bun install with no bunfig - the Coolify build path resolves from the open registry with lifecycle scripts enabled, which is the state this change exists to end",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "        write_build_bunfig(project_dir)  # the floor, laid at the spawn",
+    "replace": "        pass  # floor removed",
+    "tests": [
+      "tests/ee/sites/test_generator_client_supply_chain.py::test_install_writes_the_supply_chain_bunfig_before_spawning"
+    ]
+  },
+  {
+    "label": "the floor respects a project-supplied bunfig instead of displacing it - a template change could switch minimumReleaseAge off and nothing would notice",
+    "file": "ee/pocketpaw_ee/sites/bun_supply_chain.py",
+    "find": "    target.write_text(BUILD_BUNFIG, encoding=\"utf-8\")",
+    "replace": "    target.write_text(target.read_text(encoding=\"utf-8\") if target.is_file() else BUILD_BUNFIG, encoding=\"utf-8\")",
+    "tests": [
+      "tests/ee/sites/test_generator_client_supply_chain.py::test_a_project_supplied_bunfig_is_displaced_so_the_floor_wins"
+    ]
+  },
+  {
+    "label": "bunfig drops out of the install fingerprint - introducing the floor moves no hash, so every already-built site skips the reinstall and keeps its unfloored node_modules while the suite stays green",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "    BUILD_BUNFIG_REL,",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_generator_client_supply_chain.py::test_the_floor_participates_in_the_install_cache_decision"
+    ]
+  },
+  {
+    "label": "daytona re-derives the floor instead of aliasing it - two constants that agree today and drift the first time one is edited",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "SANDBOX_BUNFIG = BUILD_BUNFIG",
+    "replace": "SANDBOX_BUNFIG = \"\".join(list(BUILD_BUNFIG))",
+    "tests": [
+      "tests/ee/sites/test_generator_client_supply_chain.py::test_both_runners_enforce_one_policy_not_two"
+    ]
+  },
+  {
+    "label": "lifecycle scripts are re-enabled in the floor - the file is still written, still named bunfig.toml, and a postinstall runs beside the artifact we are about to deploy",
+    "file": "ee/pocketpaw_ee/sites/bun_supply_chain.py",
+    "find": "ignoreScripts = true",
+    "replace": "ignoreScripts = false",
+    "tests": [
+      "tests/ee/sites/test_generator_client_supply_chain.py::test_install_writes_the_supply_chain_bunfig_before_spawning",
+      "tests/ee/sites/test_generator_client_supply_chain.py::test_a_project_supplied_bunfig_is_displaced_so_the_floor_wins"
+    ]
+  },
+  {
+    "label": "the release-age floor is cut to a minute - a compromised fresh publish of an already-vetted package resolves, which is the exact attack the allowlist cannot catch",
+    "file": "ee/pocketpaw_ee/sites/bun_supply_chain.py",
+    "find": "minimumReleaseAge = 604800",
+    "replace": "minimumReleaseAge = 60",
+    "tests": [
+      "tests/ee/sites/test_generator_client_supply_chain.py::test_install_writes_the_supply_chain_bunfig_before_spawning"
+    ]
+  }
+]

--- a/tests/mutations/sites_supply_chain_floor.json
+++ b/tests/mutations/sites_supply_chain_floor.json
@@ -1,37 +1,47 @@
 [
   {
-    "label": "SL-3: the release-age floor is removed, so a compromised fresh publish of an already-vetted package installs in the build container",
-    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "label": "SL-3: the release-age floor is removed, so a compromised fresh publish of an already-vetted package installs in the build container (the constant moved to bun_supply_chain 2026-09-12; daytona re-exports it, so this mutation still proves the SANDBOX path)",
+    "file": "ee/pocketpaw_ee/sites/bun_supply_chain.py",
     "find": "minimumReleaseAge = 604800",
     "replace": "minimumReleaseAge = 0",
-    "tests": ["tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"]
+    "tests": [
+      "tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"
+    ]
   },
   {
-    "label": "SL-3: lifecycle scripts are re-enabled, so a postinstall runs with the sandbox's network and filesystem next to the artifact about to be deployed",
-    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "label": "SL-3: lifecycle scripts are re-enabled, so a postinstall runs with the sandbox's network and filesystem next to the artifact about to be deployed (the constant moved to bun_supply_chain 2026-09-12; daytona re-exports it, so this mutation still proves the SANDBOX path)",
+    "file": "ee/pocketpaw_ee/sites/bun_supply_chain.py",
     "find": "ignoreScripts = true",
     "replace": "ignoreScripts = false",
-    "tests": ["tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"]
+    "tests": [
+      "tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"
+    ]
   },
   {
-    "label": "SL-3: a project-supplied bunfig is no longer dropped, so the floor's survival depends on the SDK's unspecified duplicate-destination ordering — a guess dressed as a guarantee",
+    "label": "SL-3: a project-supplied bunfig is no longer dropped, so the floor's survival depends on the SDK's unspecified duplicate-destination ordering \u2014 a guess dressed as a guarantee",
     "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
     "find": "            uploads = [u for u in uploads if u[1] != bunfig_dst]",
     "replace": "            pass",
-    "tests": ["tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"]
+    "tests": [
+      "tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"
+    ]
   },
   {
     "label": "SL-3: the floor is never uploaded at all, so the container installs with no release-age gate and scripts enabled",
     "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
     "find": "        uploads.append((SANDBOX_BUNFIG.encode(), bunfig_dst))",
     "replace": "        pass",
-    "tests": ["tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"]
+    "tests": [
+      "tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"
+    ]
   },
   {
     "label": "SL-3: the drop happens silently, so someone whose project bun config appears not to apply has nothing in the log to explain it",
     "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
     "find": "            logger.warning(\n                \"sites: dropped a project-supplied %s in favour of the lane's \"\n                \"supply-chain floor (sandbox %s)\",\n                SANDBOX_BUNFIG_REL,\n                sandbox_id,\n            )",
     "replace": "            pass",
-    "tests": ["tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"]
+    "tests": [
+      "tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"
+    ]
   }
 ]


### PR DESCRIPTION
`daytona_runner` uploads a `bunfig.toml` into every sandbox and displaces any the project emitted, so a Daytona build installs behind a 7-day `minimumReleaseAge` with `ignoreScripts` on. The local subprocess runner wrote none — and that is the runner `dev_server`, `draft_markup`, `service` and the deployed Coolify image all use. The image bakes bun and the vendored generator and carries no bunfig anywhere, and the protections this workspace relies on live in a developer's home dir, which a container inherits none of.

So a production site build resolves from the open registry with lifecycle scripts enabled, as the backend user, in the container that holds the app's secrets. That is survivable today only because the installed dependency set is a short fixed list nobody outside the generator can influence. The design for letting a site's authoring agent request a package is what ends that, so this lands ahead of it.

## What changed

The floor moves to `sites/bun_supply_chain.py` and both runners call it. `daytona_runner` re-exports `SANDBOX_BUNFIG` / `SANDBOX_BUNFIG_REL` under their old names, so nothing that imported them had to change. One constant with two call sites cannot drift; two constants that agree today can. The repointed mutations in `sites_supply_chain_floor` prove that from the other side — breaking the shared constant now fails the *daytona* test class.

`bunfig.toml` joins the fingerprinted install inputs. It declares no dependency, but it decides how they resolve, so a `node_modules` installed without the floor is exactly as stale as one built from a different `package.json`. Leaving it out is how introducing the floor would have silently skipped every already-built site: the hash would not move, `install()` would not run, and the file written inside `install()` would never be reached. The whole cached fleet would stay unfloored with the suite green. It costs one reinstall per cached build dir, once.

That is also why it is written twice — in `build()` before the fingerprint, and in `install()` before the spawn. The first guards the cache decision, the second guards a caller that reaches `install()` without coming through `build()`. A bunfig written after `bun install` has started is not a floor, it is a file.

## The comment that sent this the wrong way

`react_paths.py` justified reserving `package.json` by saying the manifest is where the release-age floor is enforced. It is not, and never was — the floor is the bunfig. The reservation is still right, for the allowlist and the prerender contract, but the wrong reason for a right guard is load-bearing: it is the reason someone reads before deciding whether the guard may be relaxed. It was stale in two places, the module header and docstring rule 1, and both are corrected.

## Line endings

Three of these files had CRLF worktree copies against LF blobs. That made a 40-line change render as 5,000, and it left every multi-line anchor in `static_form_capture` and `fault_ladder` dead on a Windows checkout — a plan with one bad anchor aborts before its first mutation, so it reads as covered while proving nothing. Normalized to LF; all 1,563 anchors across 130 plans now resolve.

## Testing

All six mutations in the new plan are caught, and all five in the repointed one. `tests/ee/sites/` + `tests/cloud/sites/` is 2161 passed, 6 failed.

Those six also fail on `origin/dev` — I checked by reverting these files in place rather than assuming. They are environment, not code: the repo's own `.env` sets `POCKETPAW_SITES_BILLING_ENFORCED=1`, so a test asserting the default is `False` cannot pass locally, and the domain-routing and purchase-authz failures come off the same entitlement config. They should pass on CI, which has no `.env`.

One failure *was* mine and is fixed here: the note about the moved constant named `generator_client`, and `test_fault_ladder_build` text-scans `daytona_runner.py` for that literal to stop a local build fallback being reintroduced. Sharing a supply-chain constant is not a fallback, but the guard reads source text, and a guard that has to reason about intent is worth less than one that does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
