### PR TITLE
Carry attached images to the model instead of OCRing them

### DIFF
--- a/src/pocketpaw/agents/backend.py
+++ b/src/pocketpaw/agents/backend.py
@@ -287,6 +287,40 @@ class LeasedClient:
     busy: bool = False
 
 
+@dataclass(frozen=True)
+class ImageAttachment:
+    """One image the user attached to a turn, as bytes the model can see.
+
+    WHY THIS EXISTS. ``run``'s first parameter is ``message: str``, and that one
+    annotation is why an attached image never reached any model. Both SDKs under
+    us take images natively — the Claude Agent SDK as an ``{"type": "image",
+    "source": {"type": "base64", ...}}`` content block in streaming input mode,
+    pydantic-ai as a ``BinaryContent`` entry in a list prompt — but a turn was
+    flattened to a string before it got to either, so the cloud chat path filled
+    the gap by running OCR over the pixels and inlining whatever text came back.
+    A photo of a person or a place OCRs to nothing, which is how "the agent
+    cannot see my image" happened while every test passed.
+
+    Deliberately NOT either SDK's shape. This is the neutral middle the protocol
+    can carry; each backend translates it into its own native form, so a backend
+    that cannot take images simply never declares the parameter and is unaffected
+    (the withhold-when-empty contract below).
+
+    ``data`` is raw bytes, not base64 — the encoding is a property of the wire
+    format each backend targets, and doing it here would mean the pydantic-ai
+    path decodes what the Claude path encoded.
+
+    ``media_type`` must be one both the API and the backend accept: png, jpeg,
+    gif or webp. HEIC is what an iPhone shoots by default and is NOT on that
+    list, so the resolver transcodes before building one of these rather than
+    handing a backend bytes it will reject.
+    """
+
+    data: bytes
+    media_type: str
+    filename: str = ""
+
+
 @runtime_checkable
 class AgentBackend(Protocol):
     """Protocol that all agent backends must implement."""
@@ -312,6 +346,15 @@ class AgentBackend(Protocol):
         # accept it (the Claude SDK backend) let it win over their own model
         # selection; any other backend that grows the kwarg may simply ignore it.
         model_override: str | None = None,
+        # Images the user attached to this turn, passed to the model AS IMAGES.
+        # Rides the withhold-when-empty contract: ``AgentPool.run`` forwards it
+        # ONLY when non-empty, so a backend that cannot take images keeps the
+        # narrower signature and never receives it. Declaring the parameter is
+        # how a backend opts in — the same shape ``model_override`` uses, and
+        # for the same reason: there is no central list of which backends
+        # support what, so the signature IS the capability declaration and a
+        # new backend cannot silently drop images it never mentioned.
+        image_attachments: tuple[ImageAttachment, ...] = (),
         # PA-1 — the assembled system prompt's stable digest. The ONE kwarg here
         # that does not ride the withhold-when-empty contract: it is set on every
         # run, so ``AgentPool.run`` gates it on the backend's SIGNATURE instead

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -749,7 +749,6 @@ def _mcp_result_text(content: object) -> str:
     return ""
 
 
-
 def build_streaming_user_message(message: str, images: "tuple[ImageAttachment, ...]") -> dict:
     """Build the SDK streaming-input message carrying ``images`` alongside the text.
 

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -354,6 +354,7 @@ Uses the official Claude Agent SDK (pip install claude-agent-sdk) which provides
 """
 
 import asyncio
+import base64
 import hashlib
 import logging
 import os
@@ -366,6 +367,7 @@ from pocketpaw.agents.backend import (
     BackendInfo,
     BaseAgentBackend,
     Capability,
+    ImageAttachment,
     LeasedClient,
     SessionHandle,
 )
@@ -745,6 +747,53 @@ def _mcp_result_text(content: object) -> str:
                     parts.append(_t)
         return "\n".join(parts)
     return ""
+
+
+
+def build_streaming_user_message(message: str, images: "tuple[ImageAttachment, ...]") -> dict:
+    """Build the SDK streaming-input message carrying ``images`` alongside the text.
+
+    Shape is the one the Agent SDK documents for streaming input mode:
+
+        {"type": "user", "message": {"role": "user", "content": [
+            {"type": "text",  "text": ...},
+            {"type": "image", "source": {"type": "base64",
+                                         "media_type": ..., "data": ...}},
+        ]}}
+
+    STREAMING INPUT IS NOT OPTIONAL HERE. The SDK's single-message mode
+    explicitly does not support image attachments, so a turn carrying images has
+    to go down the persistent-client path; sending it as a plain string is how
+    an image silently becomes no image at all.
+
+    The text block comes FIRST. The API's vision guidance puts the image before
+    the question when there is one image and a question about it, but here the
+    text is the user's turn and the images are what they attached to it — and
+    with several images the model needs the framing before the pile.
+    """
+    content: list[dict] = [{"type": "text", "text": message}]
+    for img in images:
+        content.append(
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": img.media_type,
+                    "data": base64.b64encode(img.data).decode("ascii"),
+                },
+            }
+        )
+    return {"type": "user", "message": {"role": "user", "content": content}}
+
+
+async def stream_one_message(payload: dict):
+    """Yield ``payload`` as the async iterable ``ClaudeSDKClient.query`` wants.
+
+    The SDK takes an async iterable for streaming input; a bare dict is not one,
+    and passing it raises rather than degrading — which is the behaviour we want
+    over silently dropping the images.
+    """
+    yield payload
 
 
 class ClaudeSDKBackend(BaseAgentBackend):

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -889,10 +889,7 @@ class _RunHandle:
         self.stopped = False
 
 
-
-def build_multimodal_prompt(
-    message: str, images: tuple[ImageAttachment, ...]
-) -> str | list[Any]:
+def build_multimodal_prompt(message: str, images: tuple[ImageAttachment, ...]) -> str | list[Any]:
     """Build the pydantic-ai prompt carrying ``images`` alongside the text.
 
     pydantic-ai takes multimodal input as a LIST prompt mixing strings with

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -402,7 +402,12 @@ from collections import OrderedDict
 from collections.abc import AsyncIterator, Sequence
 from typing import Any
 
-from pocketpaw.agents.backend import _DEFAULT_IDENTITY, BackendInfo, Capability
+from pocketpaw.agents.backend import (
+    _DEFAULT_IDENTITY,
+    BackendInfo,
+    Capability,
+    ImageAttachment,
+)
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.agents.spend_attribution import end_user_id_for
 from pocketpaw.config import Settings
@@ -882,6 +887,35 @@ class _RunHandle:
 
     def __init__(self) -> None:
         self.stopped = False
+
+
+
+def build_multimodal_prompt(
+    message: str, images: tuple[ImageAttachment, ...]
+) -> str | list[Any]:
+    """Build the pydantic-ai prompt carrying ``images`` alongside the text.
+
+    pydantic-ai takes multimodal input as a LIST prompt mixing strings with
+    content objects — ``agent.run(["what is this?", BinaryContent(...)])``. With
+    no images the prompt stays the bare string, so every existing run is
+    byte-identical and the multimodal path cannot regress a text turn.
+
+    ``BinaryContent``, never ``ImageUrl``. pydantic-ai's own docs warn not to
+    build URL parts from untrusted input: providers fetch cloud-storage URLs
+    (``s3://``, ``gs://``) using OUR credentials, and an attachment URL is
+    user-controlled. We already hold the resolved bytes, so handing over a URL
+    would trade a safe path for an SSRF-shaped one to save a read.
+
+    The import is local: ``pydantic_ai`` is an optional extra, and this module
+    imports on installs that do not have it.
+    """
+    if not images:
+        return message
+    from pydantic_ai import BinaryContent
+
+    parts: list[Any] = [message]
+    parts.extend(BinaryContent(data=img.data, media_type=img.media_type) for img in images)
+    return parts
 
 
 class PydanticAIBackend:

--- a/tests/agents/test_image_attachments_reach_the_model.py
+++ b/tests/agents/test_image_attachments_reach_the_model.py
@@ -78,9 +78,7 @@ class TestClaudeAgentSDKShape:
         msg = claude_sdk.build_streaming_user_message("five", imgs)
         blocks = [b for b in msg["message"]["content"] if b["type"] == "image"]
         assert len(blocks) == 5
-        assert [base64.b64decode(b["source"]["data"]) for b in blocks] == [
-            i.data for i in imgs
-        ]
+        assert [base64.b64decode(b["source"]["data"]) for b in blocks] == [i.data for i in imgs]
 
     @pytest.mark.asyncio
     async def test_the_payload_is_offered_as_an_async_iterable(self) -> None:

--- a/tests/agents/test_image_attachments_reach_the_model.py
+++ b/tests/agents/test_image_attachments_reach_the_model.py
@@ -1,0 +1,127 @@
+# tests/agents/test_image_attachments_reach_the_model.py — an attached image is
+# handed to the model AS AN IMAGE, in each backend's own native shape.
+# Created: 2026-09-12 (fix/chat-image-attachments). New file.
+#
+# Under test: ``claude_sdk.build_streaming_user_message``,
+# ``claude_sdk.stream_one_message`` and ``pydantic_ai.build_multimodal_prompt``.
+#
+# WHY. ``AgentBackend.run``'s first parameter was ``message: str``, and that one
+# annotation is the whole bug: both SDKs underneath take images natively, but a
+# turn was flattened to a string before reaching either. The cloud chat path
+# filled the gap by running OCR over the pixels — which returns nothing for a
+# photo of a person or a place — so "the agent cannot see my image" was true
+# while every test passed.
+#
+# These assert the shapes the VENDOR DOCS specify, because that is the thing we
+# can be wrong about without any error being raised: a malformed content block
+# does not throw, it just quietly stops being an image.
+#
+#   * Claude Agent SDK streaming input:
+#     {"type": "user", "message": {"role": "user", "content": [
+#         {"type": "text", ...},
+#         {"type": "image", "source": {"type": "base64", "media_type", "data"}}]}}
+#     (single-message mode explicitly does NOT support image attachments)
+#   * pydantic-ai: a LIST prompt mixing strings with BinaryContent entries.
+#
+# The no-image cases matter as much as the image ones: a text turn must stay
+# byte-identical, or every existing run pays for the multimodal path.
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from pocketpaw.agents import claude_sdk
+from pocketpaw.agents.backend import ImageAttachment
+
+_PNG = b"\x89PNG\r\n\x1a\n" + b"not really a png, but bytes are bytes" * 3
+_IMG = ImageAttachment(data=_PNG, media_type="image/png", filename="logo.png")
+
+
+class TestClaudeAgentSDKShape:
+    def test_a_text_only_turn_is_left_alone(self) -> None:
+        """No images means the string path, untouched. The multimodal branch must
+        not tax the turns that never had an attachment."""
+        msg = claude_sdk.build_streaming_user_message("just text", ())
+        assert msg["message"]["content"] == [{"type": "text", "text": "just text"}]
+
+    def test_an_image_becomes_a_base64_content_block(self) -> None:
+        """The block the SDK documents — and the bytes must survive the trip."""
+        msg = claude_sdk.build_streaming_user_message("what is this?", (_IMG,))
+
+        assert msg["type"] == "user"
+        assert msg["message"]["role"] == "user"
+        text, image = msg["message"]["content"]
+
+        assert text == {"type": "text", "text": "what is this?"}
+        assert image["type"] == "image"
+        assert image["source"]["type"] == "base64"
+        assert image["source"]["media_type"] == "image/png"
+        # Decodes back to exactly what was attached. A truncated or re-encoded
+        # payload still looks like a valid block and shows the model nothing.
+        assert base64.b64decode(image["source"]["data"]) == _PNG
+
+    def test_the_data_is_base64_text_not_raw_bytes(self) -> None:
+        """``json.dumps`` cannot serialize bytes, and the failure would surface
+        deep in the SDK as a serialization error rather than here."""
+        msg = claude_sdk.build_streaming_user_message("x", (_IMG,))
+        assert isinstance(msg["message"]["content"][1]["source"]["data"], str)
+
+    def test_every_image_in_the_turn_is_carried(self) -> None:
+        """Five attachments must be five blocks — a loop that overwrites instead
+        of appending shows the model only the last one."""
+        imgs = tuple(
+            ImageAttachment(data=bytes([i]) * 8, media_type="image/jpeg", filename=f"{i}.jpg")
+            for i in range(5)
+        )
+        msg = claude_sdk.build_streaming_user_message("five", imgs)
+        blocks = [b for b in msg["message"]["content"] if b["type"] == "image"]
+        assert len(blocks) == 5
+        assert [base64.b64decode(b["source"]["data"]) for b in blocks] == [
+            i.data for i in imgs
+        ]
+
+    @pytest.mark.asyncio
+    async def test_the_payload_is_offered_as_an_async_iterable(self) -> None:
+        """``ClaudeSDKClient.query`` takes an async iterable for streaming input.
+        A bare dict is not one — and streaming input is the ONLY mode that
+        accepts images, so this wrapper is what keeps them attached."""
+        payload = claude_sdk.build_streaming_user_message("hi", (_IMG,))
+        got = [m async for m in claude_sdk.stream_one_message(payload)]
+        assert got == [payload]
+
+
+class TestPydanticAIShape:
+    def test_a_text_only_turn_stays_a_bare_string(self) -> None:
+        """Not a one-element list. The prompt type is what every existing run
+        sends, and widening it for turns with nothing attached is a change with
+        no reason and a blast radius."""
+        from pocketpaw.agents.pydantic_ai import build_multimodal_prompt
+
+        assert build_multimodal_prompt("just text", ()) == "just text"
+
+    def test_an_image_becomes_binarycontent_in_a_list_prompt(self) -> None:
+        """pydantic-ai's documented multimodal shape."""
+        from pydantic_ai import BinaryContent
+
+        from pocketpaw.agents.pydantic_ai import build_multimodal_prompt
+
+        prompt = build_multimodal_prompt("what is this?", (_IMG,))
+
+        assert isinstance(prompt, list)
+        assert prompt[0] == "what is this?"
+        assert isinstance(prompt[1], BinaryContent)
+        assert prompt[1].data == _PNG
+        assert prompt[1].media_type == "image/png"
+
+    def test_it_never_builds_a_url_part_from_an_attachment(self) -> None:
+        """pydantic-ai warns that providers fetch cloud-storage URLs (s3://,
+        gs://) with OUR credentials, so a URL part built from user-controlled
+        input is SSRF-shaped. We hold the bytes; we send the bytes."""
+        from pydantic_ai import ImageUrl
+
+        from pocketpaw.agents.pydantic_ai import build_multimodal_prompt
+
+        prompt = build_multimodal_prompt("x", (_IMG,))
+        assert not any(isinstance(p, ImageUrl) for p in prompt)

--- a/tests/mutations/image_attachments.json
+++ b/tests/mutations/image_attachments.json
@@ -1,0 +1,51 @@
+[
+  {
+    "label": "IMG-1: the image blocks are never appended, so the turn reaches the model as text only — the original bug, restored one layer down",
+    "file": "src/pocketpaw/agents/claude_sdk.py",
+    "find": "    content: list[dict] = [{\"type\": \"text\", \"text\": message}]\n    for img in images:\n        content.append(",
+    "replace": "    content: list[dict] = [{\"type\": \"text\", \"text\": message}]\n    for img in []:\n        content.append(",
+    "tests": ["tests/agents/test_image_attachments_reach_the_model.py"]
+  },
+  {
+    "label": "IMG-2: the loop assigns instead of appending, so only the last of several attachments survives and a five-image turn shows the model one",
+    "file": "src/pocketpaw/agents/claude_sdk.py",
+    "find": "    for img in images:\n        content.append(\n            {\n                \"type\": \"image\",",
+    "replace": "    for img in images:\n        content[1:] = [\n            {\n                \"type\": \"image\",",
+    "tests": ["tests/agents/test_image_attachments_reach_the_model.py"]
+  },
+  {
+    "label": "IMG-3: raw bytes go on the wire instead of base64, which the SDK cannot serialize — and the failure surfaces deep inside the SDK, not here",
+    "file": "src/pocketpaw/agents/claude_sdk.py",
+    "find": "                    \"data\": base64.b64encode(img.data).decode(\"ascii\"),",
+    "replace": "                    \"data\": img.data,",
+    "tests": ["tests/agents/test_image_attachments_reach_the_model.py"]
+  },
+  {
+    "label": "IMG-4: every attachment is declared png regardless of what it is, so a jpeg is decoded as a png and the model is shown nothing",
+    "file": "src/pocketpaw/agents/claude_sdk.py",
+    "find": "                    \"media_type\": img.media_type,",
+    "replace": "                    \"media_type\": \"application/octet-stream\",",
+    "tests": ["tests/agents/test_image_attachments_reach_the_model.py"]
+  },
+  {
+    "label": "IMG-5: the payload is handed over bare instead of as an async iterable, which is the only form streaming input accepts — and streaming is the only mode that carries images",
+    "file": "src/pocketpaw/agents/claude_sdk.py",
+    "find": "async def stream_one_message(payload: dict):",
+    "replace": "async def stream_one_message(payload: dict):\n    return\n    yield payload\n\n\nasync def _unused_stream_one_message(payload: dict):",
+    "tests": ["tests/agents/test_image_attachments_reach_the_model.py"]
+  },
+  {
+    "label": "IMG-6: pydantic-ai is handed a list prompt even with nothing attached, changing the prompt type of every text turn the product already sends",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "    if not images:\n        return message\n    from pydantic_ai import BinaryContent",
+    "replace": "    if False:\n        return message\n    from pydantic_ai import BinaryContent",
+    "tests": ["tests/agents/test_image_attachments_reach_the_model.py"]
+  },
+  {
+    "label": "IMG-7: the pydantic-ai images are dropped from the prompt list, so the model gets the question without the picture it is about",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "    parts.extend(BinaryContent(data=img.data, media_type=img.media_type) for img in images)",
+    "replace": "    parts.extend(BinaryContent(data=img.data, media_type=img.media_type) for img in [])",
+    "tests": ["tests/agents/test_image_attachments_reach_the_model.py"]
+  }
+]


### PR DESCRIPTION
Reported as "I upload an image in the input and the agent can't see it."

## What was wrong

`AgentBackend.run`'s first parameter is `message: str`. That one annotation is the bug. Every turn is flattened to a string before it reaches any SDK, so an attached image has nowhere to go — and the cloud chat path filled the gap by running OCR over the pixels and inlining whatever text came back. A photo of a person or a place OCRs to nothing, so the model was handed `(no text extracted)` and reported the file was empty. Documents worked, which is why this survived: they have text.

Neither SDK has that limitation. Both take images natively:

- **Claude Agent SDK** — [streaming input mode](https://code.claude.com/docs/en/agent-sdk/streaming-vs-single-mode) lists *"Image uploads: attach images directly to messages"*, and states that single-message mode does **not** support direct image attachments. `claude_sdk.py` already builds the streaming `ClaudeSDKClient`; only the string stood in the way.
- **pydantic-ai** — takes a [list prompt](https://pydantic.dev/docs/ai/advanced-features/input/) mixing strings with `BinaryContent`.

## What this adds

`ImageAttachment` (raw bytes + `media_type`) as the neutral middle the protocol carries, plus a translator per backend into its own native shape. Encoding stays at the edges — base64 is a property of the Claude wire format, and doing it centrally would mean the pydantic path decodes what the other encoded.

`image_attachments` rides the withhold-when-empty contract `model_override` already uses. There is no central table of which backend supports what, so the **signature is the capability declaration**: a backend that can't take images keeps the narrower signature, never receives them, and can't silently drop what it never mentioned.

**`BinaryContent`, never `ImageUrl`.** pydantic-ai's docs warn that providers fetch cloud-storage URLs (`s3://`, `gs://`) using *our* credentials, and an attachment URL is user-controlled. We hold the resolved bytes already, so passing a URL would trade a safe path for an SSRF-shaped one to save a read.

## Verification

8 new tests assert the shapes the **vendor docs** specify rather than round-tripping our own helpers — that's the thing we can get wrong with nothing raised, because a malformed content block doesn't throw, it just stops being an image. Bytes are decoded back and compared, so a truncated or re-encoded payload fails rather than looking plausible.

The no-image cases are pinned too: a text turn stays a bare string, so no existing run pays for this path.

233 backend tests green on the rebased base. `ruff check`, `ruff format --check` and the mutation-anchor validator all clean locally.

## Scope

This is the protocol and the two translators. **Not wired to the chat path yet** — pool forwarding and the cloud attachment resolver (image mimes → `ImageAttachment` instead of OCR, plus HEIC→PNG, since the API's media types are png/jpeg/gif/webp and an iPhone shoots HEIC) are the next slice. Nothing in this PR changes runtime behaviour on its own; it makes the path expressible.

A mutation plan for the new gates is owed before these count as protection, per the repo's own rule that a test isn't a gate until a mutation has been seen to break it.

## Separately found, not fixed here

Uploads block for minutes because `uploads/service.py:260` awaits `emit(FileReady(...))` inside the request and `_core/realtime/bus.py:120` awaits local handlers inline. The HTTP response therefore waits on extraction, a comprehension LLM call (30s ceiling) and the KB article compile (300s ceiling). File size is irrelevant — a 20 KB upload takes the same path as a 20 MB one. Worth its own PR to move that work off the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
