### PR TITLE
Stop sending a max_tokens we picked for a model we've never heard of

### DIFF
--- a/src/pocketpaw/agents/model_limits.py
+++ b/src/pocketpaw/agents/model_limits.py
@@ -35,6 +35,29 @@
 # None means "send no cap", which is exactly today's behaviour — so a model
 # litellm has never heard of, or a deployment without litellm installed, is no
 # worse off than before this file existed.
+#
+# Updated 2026-09-12 (chore/abstain-agent-max-tokens) — **the default is now to
+# send nothing.** The clamp below is what made a single configured number behave
+# per-model, and it only fires for models already in the PINNED metadata. That
+# file trails new releases by design (the resolver's own test says so), so on a
+# gateway fronting 100+ models the clamp silently no-ops on exactly the models
+# just added and every one of them collapses onto the same flat 8192. Measured
+# 2026-09-12: kimi-k3, moonshot/kimi-k3 and moonshotai/kimi-k3 are all unknown to
+# the pinned map, and a kimi run died on
+#
+#   Model token limit (8192) exceeded before any response was generated.
+#
+# because a reasoning model spent the whole 8192 thinking and emitted no content
+# — pydantic_ai/_agent_graph.py raises there on finish_reason == 'length' with no
+# actionable parts. A provider's own default is per-model by construction and
+# needs no maintenance, so ``agent_max_output_tokens`` now defaults to -1.
+#
+# THE 402 IS NOT FIXED, IT IS TRADED. Everything above about OpenRouter's
+# pre-flight reservation is still true and still reachable; it is now opt-out
+# rather than opt-in. An OpenRouter-backed deployment sets
+# ``agent_max_output_tokens`` to 8192 (or its own number) and gets the old
+# behaviour back exactly. Nothing in this module changed — only which branch a
+# deployment lands on when it says nothing.
 
 from __future__ import annotations
 
@@ -48,7 +71,12 @@ logger = logging.getLogger(__name__)
 #: Returned by the settings reader to mean "the operator disabled this".
 _DISABLED = -1
 
-#: The cap sent when nothing more specific is known.
+#: The cap sent when an operator opts back in with ``agent_max_output_tokens=0``.
+#
+# No longer the default posture — see the "Updated 2026-09-12" note above for why
+# a fixed number stopped being defensible once the catalog outgrew the pinned
+# metadata. It remains the value a deployment gets by asking for a cap without
+# naming one, and the reasoning for the SIZE is unchanged:
 #
 # NOT the model's advertised ceiling, and this is the whole design decision.
 # The goal is a reservation that covers a real reply, not the largest reply the

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -714,21 +714,27 @@ class Settings(BaseSettings):
         ),
     )
     agent_max_output_tokens: int = Field(
-        default=0,
+        default=-1,
         description=(
-            "Max output tokens an agent run may request. 0 (default) sends "
-            "8192, lowered to the model's documented ceiling when the pinned "
-            "litellm metadata knows it; a positive value replaces the 8192; a "
-            "negative value sends no cap at all. Sending nothing is not "
-            "neutral — OpenRouter prices its pre-flight credit check against "
-            "max_tokens and substitutes the model's own ceiling when none is "
-            "given, so a short reply is refused with a 402 over a reservation "
-            "nobody asked for. The metadata is a clamp rather than the source: "
-            "deepseek-v4-flash advertised 8192 and then 393216 on the same day, "
-            "and sending the larger number would have made that 402 six times "
-            "worse. Distinct from litellm_max_tokens, which only reaches the "
-            "plain-completion provider (chat titles and the like), never an "
-            "agent backend."
+            "Max output tokens an agent run may request. Negative (default) "
+            "sends no cap at all, leaving each provider to apply its own "
+            "per-model default; 0 sends 8192, lowered to the model's documented "
+            "ceiling when the pinned litellm metadata knows it; a positive value "
+            "replaces that 8192. Abstaining is the default because one number "
+            "cannot serve a gateway fronting 100+ models. What made the cap "
+            "per-model was a clamp reading litellm's PINNED metadata, and that "
+            "file trails new releases by design — so the newest models, the ones "
+            "most likely to need a different number, are precisely the ones it "
+            "cannot lower, and they all collapse onto the same flat 8192. A "
+            "provider's own default is per-model by construction and needs no "
+            "maintenance as the catalog grows. The cost is real and is why this "
+            "shipped capped: OpenRouter prices its pre-flight credit check "
+            "against max_tokens and substitutes the model's own ceiling when "
+            "none is given, refusing a short reply with a 402 over a reservation "
+            "nobody asked for. Set 8192, or any positive value, to take the cap "
+            "back on an OpenRouter-backed deployment. Distinct from "
+            "litellm_max_tokens, which only reaches the plain-completion "
+            "provider (chat titles and the like), never an agent backend."
         ),
     )
     pydantic_ai_max_turns: int = Field(

--- a/tests/test_agent_max_output_tokens.py
+++ b/tests/test_agent_max_output_tokens.py
@@ -105,9 +105,12 @@ def test_an_unknown_model_sends_nothing_by_default():
 def test_an_unknown_model_still_gets_the_default_when_a_cap_is_asked_for():
     """Opting in must not depend on the map knowing the model — otherwise the
     OpenRouter 402 comes back on precisely the newest models."""
-    assert resolve_max_output_tokens(
-        "litellm", "no-such-model-xyz", _settings(agent_max_output_tokens=0)
-    ) == DEFAULT_MAX_OUTPUT_TOKENS
+    assert (
+        resolve_max_output_tokens(
+            "litellm", "no-such-model-xyz", _settings(agent_max_output_tokens=0)
+        )
+        == DEFAULT_MAX_OUTPUT_TOKENS
+    )
 
 
 def test_a_smaller_model_ceiling_lowers_the_cap():
@@ -229,7 +232,9 @@ async def test_the_cap_reaches_run_stream_events():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("overrides", [{}, {"agent_max_output_tokens": -1}], ids=["default", "explicit"])
+@pytest.mark.parametrize(
+    "overrides", [{}, {"agent_max_output_tokens": -1}], ids=["default", "explicit"]
+)
 async def test_a_run_sends_no_model_settings_at_all(overrides):
     """The default and the explicit opt-out must both OMIT the key, not send
     ``max_tokens=0`` — which is a request for an empty completion on several

--- a/tests/test_agent_max_output_tokens.py
+++ b/tests/test_agent_max_output_tokens.py
@@ -1,5 +1,16 @@
-# An agent run must send an explicit max_tokens.
+# An agent run sends no max_tokens unless asked to.
 # Created: 2026-08-16 (feat/agent-max-output-tokens).
+# Updated: 2026-09-12 (chore/abstain-agent-max-tokens) — the default INVERTED.
+#
+# The cap is now opt-in. What made one configured number behave per-model was a
+# clamp over litellm's PINNED metadata, and that file trails new releases by
+# design, so on a gateway fronting 100+ models the clamp no-ops on exactly the
+# models just added and they all collapse onto the same flat 8192. kimi-k3 is
+# unknown to the pinned map and a run died on "Model token limit (8192) exceeded
+# before any response was generated" — a reasoning model spending the whole
+# budget thinking. The tests below therefore split in two: the ones that exercise
+# the cap MACHINERY now opt in with ``agent_max_output_tokens=0``, and the ones
+# that pin the DEFAULT POSTURE assert nothing is sent.
 #
 # No agent backend sent one. That is not a neutral omission: OpenRouter prices
 # its PRE-FLIGHT credit check against max_tokens and substitutes the model's own
@@ -43,14 +54,22 @@ def _settings(**overrides) -> Settings:
 # ---------------------------------------------------------------------------
 
 
-def test_a_run_sends_a_cap_by_default():
-    """The whole point: with no configuration, something is sent.
+def test_a_run_sends_no_cap_by_default():
+    """With no configuration, nothing is sent and the provider decides.
 
-    Before this, the answer was None on every model and every backend.
+    Inverted 2026-09-12. A provider's own default is per-model by construction
+    and needs no maintenance as a catalog grows; a number we pick is per-model
+    only for the models litellm's pinned metadata already knows.
     """
-    assert resolve_max_output_tokens("litellm", "deepseek/deepseek-v4-flash", _settings()) == (
-        DEFAULT_MAX_OUTPUT_TOKENS
+    assert resolve_max_output_tokens("litellm", "deepseek/deepseek-v4-flash", _settings()) is None
+
+
+def test_asking_for_a_cap_without_naming_one_sends_the_default():
+    """0 is the opt-in: it means "cap me" without naming a number."""
+    got = resolve_max_output_tokens(
+        "litellm", "deepseek/deepseek-v4-flash", _settings(agent_max_output_tokens=0)
     )
+    assert got == DEFAULT_MAX_OUTPUT_TOKENS
 
 
 def test_an_operator_value_replaces_the_default():
@@ -70,13 +89,25 @@ def test_a_negative_value_opts_out_entirely():
     assert got is None
 
 
-def test_an_unknown_model_still_gets_the_default():
-    """The pinned metadata trails new releases by design, so "not in the map" is
-    ordinary rather than exceptional. It must not mean "send no cap" — that is
-    the broken state, and brand-new models are exactly where it bites."""
-    assert resolve_max_output_tokens("litellm", "no-such-model-xyz", _settings()) == (
-        DEFAULT_MAX_OUTPUT_TOKENS
-    )
+def test_an_unknown_model_sends_nothing_by_default():
+    """The case that inverted the default.
+
+    The pinned metadata trails new releases by design, so "not in the map" is
+    ordinary rather than exceptional — and it is where the clamp goes quiet,
+    leaving a flat number that was never chosen for this model. kimi-k3 is the
+    real one: unknown to the map, and a reasoning model that spent all 8192 on
+    thinking, so the run raised before emitting a single token of output.
+    """
+    for model in ("no-such-model-xyz", "kimi-k3", "moonshotai/kimi-k3"):
+        assert resolve_max_output_tokens("litellm", model, _settings()) is None, model
+
+
+def test_an_unknown_model_still_gets_the_default_when_a_cap_is_asked_for():
+    """Opting in must not depend on the map knowing the model — otherwise the
+    OpenRouter 402 comes back on precisely the newest models."""
+    assert resolve_max_output_tokens(
+        "litellm", "no-such-model-xyz", _settings(agent_max_output_tokens=0)
+    ) == DEFAULT_MAX_OUTPUT_TOKENS
 
 
 def test_a_smaller_model_ceiling_lowers_the_cap():
@@ -90,7 +121,8 @@ def test_a_smaller_model_ceiling_lowers_the_cap():
     if not ceiling or ceiling >= DEFAULT_MAX_OUTPUT_TOKENS:
         pytest.skip("pinned metadata has no smaller-than-default ceiling for gpt-3.5-turbo")
 
-    assert resolve_max_output_tokens("openai", "gpt-3.5-turbo", _settings()) == ceiling
+    got = resolve_max_output_tokens("openai", "gpt-3.5-turbo", _settings(agent_max_output_tokens=0))
+    assert got == ceiling
 
 
 def test_the_model_ceiling_can_never_raise_the_cap():
@@ -105,7 +137,9 @@ def test_the_model_ceiling_can_never_raise_the_cap():
     So a ceiling above the target must be ignored, whatever the metadata says.
     """
     with patch("pocketpaw.agents.model_limits.model_output_ceiling", return_value=393_216):
-        got = resolve_max_output_tokens("litellm", "deepseek/deepseek-v4-flash", _settings())
+        got = resolve_max_output_tokens(
+            "litellm", "deepseek/deepseek-v4-flash", _settings(agent_max_output_tokens=0)
+        )
 
     assert got == DEFAULT_MAX_OUTPUT_TOKENS
     assert got < 393_216
@@ -177,12 +211,16 @@ async def _captured_run_kwargs(backend) -> dict:
 
 @pytest.mark.asyncio
 async def test_the_cap_reaches_run_stream_events():
-    """The number is on the kwargs pydantic-ai receives."""
+    """The number is on the kwargs pydantic-ai receives, when one is asked for.
+
+    Still the test worth having: a resolver returning the right value into a run
+    that never sends it changes nothing about the 402.
+    """
     from pydantic_ai.models.test import TestModel
 
     from pocketpaw.agents.pydantic_ai import PydanticAIBackend
 
-    backend = PydanticAIBackend(_settings())
+    backend = PydanticAIBackend(_settings(agent_max_output_tokens=0))
     with patch.object(backend, "_build_model", return_value=TestModel(custom_output_text="ok")):
         kwargs = await _captured_run_kwargs(backend)
 
@@ -191,14 +229,17 @@ async def test_the_cap_reaches_run_stream_events():
 
 
 @pytest.mark.asyncio
-async def test_opting_out_sends_no_model_settings_at_all():
-    """The escape hatch must omit the key, not send ``max_tokens=0`` — which is
-    a request for an empty completion on several providers."""
+@pytest.mark.parametrize("overrides", [{}, {"agent_max_output_tokens": -1}], ids=["default", "explicit"])
+async def test_a_run_sends_no_model_settings_at_all(overrides):
+    """The default and the explicit opt-out must both OMIT the key, not send
+    ``max_tokens=0`` — which is a request for an empty completion on several
+    providers. The unparametrised half is the new default posture, proven at the
+    surface rather than only in the resolver."""
     from pydantic_ai.models.test import TestModel
 
     from pocketpaw.agents.pydantic_ai import PydanticAIBackend
 
-    backend = PydanticAIBackend(_settings(agent_max_output_tokens=-1))
+    backend = PydanticAIBackend(_settings(**overrides))
     with patch.object(backend, "_build_model", return_value=TestModel(custom_output_text="ok")):
         kwargs = await _captured_run_kwargs(backend)
 


### PR DESCRIPTION
A kimi-k3 run through LiteLLM died on:

```
Model token limit (8192) exceeded before any response was generated.
```

The 8192 was ours. `agent_max_output_tokens` defaulted to 0, which means "send 8192", so every agent run put that number in the request body whatever the model was.

## Why not just raise the number

Because one number doesn't survive a catalog. What made the cap behave per-model was the clamp in `model_limits.py`, which reads litellm's pinned `model_prices_and_context_window_backup.json` and lowers the target to the model's documented ceiling. That only fires for models the pinned file already knows, and it trails new releases by design. The resolver's own test says so in as many words.

Measured 2026-09-12: `kimi-k3`, `moonshot/kimi-k3` and `moonshotai/kimi-k3` are all unknown to it. So on a gateway fronting 100+ models the clamp goes quiet on exactly the models you just added, and they all land on the same flat 8192. The per-model behaviour is real for models we've had a while and absent for the ones most likely to need it.

kimi is what made that fatal rather than just wrong. It's a reasoning model, so it spent the whole 8192 thinking and returned no content at all, which is where pydantic-ai raises on `finish_reason == 'length'` with no actionable parts. A non-reasoning model would have handed back a truncated reply and nobody would have filed anything.

## What changed

`agent_max_output_tokens` now defaults to -1, so we send nothing and each provider applies its own default for its own model. That's per-model by construction and needs no maintenance as the catalog grows.

No resolver logic changed. Only which branch a deployment lands on when it says nothing.

## The trade

The 402 this originally shipped to fix isn't fixed, it's opt-out now. OpenRouter prices its pre-flight credit check against max_tokens and substitutes the model's full ceiling when none is given, refusing a short reply over a reservation nobody asked for. An OpenRouter-backed deployment sets `agent_max_output_tokens` to 8192 and gets the old behaviour back exactly.

I couldn't find a LiteLLM config in the repo to tell what sits behind the gateway here, so that call belongs to whoever runs it.

## Tests

They split in two. The ones exercising the cap machinery now opt in with `agent_max_output_tokens=0`; the ones pinning the default posture assert nothing is sent, both at the resolver and at `run_stream_events`.

13 pass in `tests/test_agent_max_output_tokens.py`, 203 across the adjacent agent suites.

Three failures in `tests/test_openai_compatible_agent.py` are pre-existing and unrelated: a real key from a parent-directory `.env` reaches the worktree where the test expects `not-needed`. The same three fail on pristine `dev` sources, which I checked before blaming them on something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
