### PR TITLE
Social sign-in returns to the face it started on

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,19 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   deliberately not the 402 `billing.*` / `credits.*` codes, because nothing is
   for sale here and the answer is to wait, not to upgrade.
   Crude flood protection belongs at the proxy (Traefik on Coolify), not here.
+- **Social sign-in needs two URLs set, and returns to the face it started on**:
+  `POCKETPAW_PUBLIC_BASE_URL` (no default beyond `http://localhost:8888`) builds
+  the OAuth `redirect_uri` the provider is handed, so an unset value sends Google
+  and GitHub a localhost callback and every social login fails on a deployed
+  host. It must match a redirect URI registered in the provider's console.
+  `POCKETPAW_FRONTEND_BASE_URL` is where the browser lands after consent.
+  Since 2026-09-12 it is only the FALLBACK: the origin the login started from
+  (read from `Referer` in `auth/social/router.py`) is validated against the CORS
+  allowlist and pinned into the single-use OAuth state, then honoured at the
+  callback. One deployment serves two faces on two hostnames, so a single global
+  value landed kiosk users on the Paw OS. Validation is not optional — without
+  it this is an open redirect that also delivers the session cookie — and it runs
+  on the way in AND out, failing closed to the configured default.
 - **Storage caps are enforced, and free is 1 GB** (2026-09-12). The per-plan
   workspace storage ceiling (`ee/pocketpaw_ee/cloud/billing/plans.py`,
   `_MAX_STORAGE_BYTES`: free 1 GB, go 15 GB, pro 50 GB, pro_max 100 GB,

--- a/ee/pocketpaw_ee/cloud/auth/social/router.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/router.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, urlencode, urlparse
 
 from fastapi import APIRouter, Depends, Request
 from starlette.responses import RedirectResponse, Response
@@ -117,19 +117,53 @@ async def list_providers() -> SocialProvidersResponse:
 
 @router.get("/auth/social/{provider}/login")
 async def social_login(
+    request: Request,
     provider: str,
     flow: str = "web",
     next: str | None = None,  # noqa: A002 — matches the query-param name
 ) -> RedirectResponse:
-    """Begin consent. Redirects to the provider."""
+    """Begin consent. Redirects to the provider.
+
+    The caller's ORIGIN is read here and pinned into the state, because one
+    deployment serves two faces on two hostnames and the callback otherwise
+    returns everyone to a single configured origin. This is a top-level
+    navigation, so there is no ``Origin`` header to read — ``Referer`` is what
+    a browser sends, and its scheme+host is all we keep. Unrecognised or
+    absent degrades to the configured default, never to a redirect this
+    deployment has not approved.
+    """
     try:
-        url = await social_service.begin_login(provider, flow=flow, next_path=next)
+        url = await social_service.begin_login(
+            provider,
+            flow=flow,
+            next_path=next,
+            origin=_referer_origin(request),
+        )
     except CloudError as exc:
         return _error_redirect(exc.code)
     except Exception:  # noqa: BLE001 — discovery / network failure
         logger.exception("social.begin_login failed for provider=%s", provider)
         return _error_redirect("social.begin_failed")
     return RedirectResponse(url=url, status_code=302)
+
+
+def _referer_origin(request: Request) -> str:
+    """The scheme+host the login button was clicked on, or "".
+
+    Only the origin is kept: the path can carry anything and we never want it
+    in a redirect. Validation is the service's job, against the CORS allowlist,
+    so this stays a pure read with no policy in it.
+    """
+    referer = request.headers.get("referer") or ""
+    if not referer:
+        return ""
+    try:
+        parsed = urlparse(referer)
+    except ValueError:
+        return ""
+    if not parsed.scheme or not parsed.netloc:
+        return ""
+    return f"{parsed.scheme}://{parsed.netloc}"
 
 
 def _link_redirect(next_path: Any, **params: str) -> RedirectResponse:
@@ -225,7 +259,7 @@ async def social_callback(
     # — never from this request's query string.
     if result["flow"] == "desktop":
         xc = await social_service.issue_exchange_code(str(result["user"].id))
-        base = social_service.frontend_base_url()
+        base = social_service.frontend_base_url(result.get("origin"))
         return RedirectResponse(url=f"{base}/oauth-callback?xc={quote(xc)}", status_code=302)
 
     response = await mint_and_record(cookie_backend, result["user"], request)
@@ -237,7 +271,8 @@ async def social_callback(
     # the same host only when both are served from one domain. In production
     # they are; in local dev they are not, and the user lands on the API root.
     redirect = RedirectResponse(
-        url=f"{social_service.frontend_base_url()}{safe_next}", status_code=302
+        url=f"{social_service.frontend_base_url(result.get('origin'))}{safe_next}",
+        status_code=302,
     )
     for key, value in response.headers.items():
         if key.lower() == "set-cookie":

--- a/ee/pocketpaw_ee/cloud/auth/social/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/service.py
@@ -139,15 +139,50 @@ def redirect_uri() -> str:
     return f"{base}/api/v1/auth/social/callback"
 
 
-def frontend_base_url() -> str:
-    """Where the SPA lives.
+def frontend_base_url(pinned_origin: str | None = None) -> str:
+    """Where the SPA lives, for THIS flow.
 
     The desktop branch bounces through the FRONTEND origin, not the backend:
     /oauth-callback is a SvelteKit route served by Vite/Tauri on :1420, and
     redirecting to the backend origin would land on nothing. Same variable the
     codeconnect GitHub callback already uses.
+
+    ``pinned_origin`` (2026-09-12) is the origin the login STARTED from, pinned
+    into the single-use OAuth state at authorize time and validated there. It
+    wins over the env var, because one deployment now serves two faces from two
+    hostnames: sign in with Google on the Otherhand kiosk and a single global
+    value lands you on the Paw OS instead, which reads as the button being
+    broken. Never taken from the callback's own query string — the same rule
+    ``flow`` already follows, and the reason an attacker cannot aim this
+    redirect.
+
+    Falls back to the env var when nothing was pinned, so every pre-existing
+    flow (desktop, links, deployments with one face) is byte-identical.
     """
+    if pinned_origin:
+        return pinned_origin.rstrip("/")
     return os.environ.get("POCKETPAW_FRONTEND_BASE_URL", "http://localhost:1420").rstrip("/")
+
+
+def safe_frontend_origin(origin: str | None) -> str:
+    """Return ``origin`` if this deployment serves it, else "".
+
+    An open redirect is the failure mode here, so the answer comes from the
+    SAME allowlist CORS enforces — the deployment's configured origins plus the
+    localhost regex — rather than a second list that could drift more
+    permissive. An origin the browser would be refused an API call from has no
+    business receiving a session cookie either.
+    """
+    if not origin:
+        return ""
+    from pocketpaw.api.cors import allowed_origins, origin_allowed
+
+    candidate = origin.strip().rstrip("/")
+    try:
+        return candidate if origin_allowed(candidate, allowed_origins()) else ""
+    except Exception:  # noqa: BLE001 — a settings failure must not break login
+        logger.warning("could not validate social login origin %r", candidate, exc_info=True)
+        return ""
 
 
 # ---------------------------------------------------------------------------
@@ -192,9 +227,19 @@ async def _issue_authorize_url(provider, *, extra: dict[str, Any]) -> str:
 
 
 async def begin_login(
-    provider_name: str, *, flow: str = "web", next_path: str | None = None
+    provider_name: str,
+    *,
+    flow: str = "web",
+    next_path: str | None = None,
+    origin: str | None = None,
 ) -> str:
-    """Build the provider's authorize URL and persist the flow state."""
+    """Build the provider's authorize URL and persist the flow state.
+
+    ``origin`` is the face the user clicked the button on. It is validated
+    against the deployment's own allowlist here, at authorize time, and travels
+    in the single-use state — so the callback reads a value this server already
+    approved rather than anything the round trip could carry back.
+    """
     provider = _usable_provider(provider_name)
     if flow not in _FLOWS:
         raise ValidationError("social.unknown_flow", f"Unknown flow: {flow}")
@@ -205,6 +250,7 @@ async def begin_login(
             "provider": provider.name,
             "flow": flow,
             "next": next_path or "",
+            "origin": safe_frontend_origin(origin),
         },
     )
 
@@ -348,6 +394,12 @@ async def complete_callback(
 
     flow = payload.get("flow") if payload.get("flow") in _FLOWS else "web"
     next_path = str(payload.get("next") or "") or None
+    # Re-validated on the way OUT as well as in. The state is signed and
+    # single-use, so this is belt and braces — but the cost is one allowlist
+    # lookup and the thing it protects is an open redirect that hands over a
+    # session cookie. An origin that stopped being allowed since the flow
+    # began degrades to the configured default rather than being honoured.
+    origin = safe_frontend_origin(str(payload.get("origin") or "") or None)
 
     link_user_id = str(payload.get(_LINK_KEY) or "")
 
@@ -389,6 +441,7 @@ async def complete_callback(
                 "link_code": link_code,
                 "flow": "desktop",
                 "next": next_path,
+                "origin": origin,
             }
         user = await _complete_link(link_user_id, identity, session_user, next_path=next_path)
         return {
@@ -397,6 +450,7 @@ async def complete_callback(
             "provider": identity.provider,
             "flow": "web",
             "next": next_path,
+            "origin": origin,
         }
 
     user = await _resolve_user(identity)
@@ -406,6 +460,7 @@ async def complete_callback(
         "provider": identity.provider,
         "flow": flow,
         "next": next_path,
+        "origin": origin,
     }
 
 

--- a/tests/cloud/auth/test_social_login_origin.py
+++ b/tests/cloud/auth/test_social_login_origin.py
@@ -1,0 +1,161 @@
+# tests/cloud/auth/test_social_login_origin.py — consent returns to the face
+# that started it.
+#
+# Created 2026-09-12 (fix/social-login-origin).
+#
+# One deployment now serves two faces on two hostnames: the Paw OS and the
+# Otherhand kiosk. The social callback redirected to a single configured
+# ``POCKETPAW_FRONTEND_BASE_URL``, so signing in with Google on the kiosk
+# landed the user on the OS. Nothing errors — it simply reads as the button
+# being broken.
+#
+# The origin is now pinned into the single-use OAuth state at authorize time,
+# the same way ``flow`` already is, and validated against the deployment's CORS
+# allowlist on the way in AND on the way out. That validation is the whole
+# security story: without it this is an open redirect that also hands over a
+# session cookie.
+#
+# Mutations: tests/mutations/social_login_origin.json.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.auth.social import service as social_service
+
+_KIOSK = "https://otherhand.interacly.com"
+_OS = "https://paw.hzd.interacly.com"
+
+
+@pytest.fixture(autouse=True)
+def _allowlist(monkeypatch):
+    """Pin the deployment's allowed origins, the way an operator's env would."""
+    import pocketpaw.api.cors as cors
+
+    monkeypatch.setattr(cors, "allowed_origins", lambda: [_KIOSK, _OS])
+    monkeypatch.setenv("POCKETPAW_FRONTEND_BASE_URL", _OS)
+
+
+# ── the allowlist ────────────────────────────────────────────────────────
+
+
+def test_an_allowed_origin_survives():
+    assert social_service.safe_frontend_origin(_KIOSK) == _KIOSK
+
+
+def test_an_unknown_origin_is_dropped():
+    """The open-redirect case, and the reason this validates at all.
+
+    An attacker who gets a victim to start a login from their own page must
+    not receive the redirect that carries the session cookie.
+
+    Mutation that must break this: return the candidate unvalidated.
+    """
+    assert social_service.safe_frontend_origin("https://evil.example.com") == ""
+
+
+def test_a_lookalike_origin_is_dropped():
+    """Exact match, not prefix or suffix. ``interacly.com.evil.test`` ends with
+    nothing useful and ``https://otherhand.interacly.com.evil.test`` begins with
+    a real host — both must fail.
+    """
+    assert social_service.safe_frontend_origin("https://otherhand.interacly.com.evil.test") == ""
+    assert social_service.safe_frontend_origin("https://evil.test/otherhand.interacly.com") == ""
+
+
+def test_a_missing_origin_is_dropped():
+    assert social_service.safe_frontend_origin(None) == ""
+    assert social_service.safe_frontend_origin("") == ""
+
+
+def test_a_broken_allowlist_does_not_break_login(monkeypatch):
+    """Fails closed to the configured default rather than raising. A settings
+    problem must degrade the landing page, never the ability to sign in.
+    """
+    import pocketpaw.api.cors as cors
+
+    def _boom():
+        raise RuntimeError("settings unreadable")
+
+    monkeypatch.setattr(cors, "allowed_origins", _boom)
+
+    assert social_service.safe_frontend_origin(_KIOSK) == ""
+
+
+# ── which origin the callback lands on ───────────────────────────────────
+
+
+def test_a_pinned_origin_wins_over_the_env_var():
+    """The bug itself: the kiosk visitor comes back to the kiosk.
+
+    Mutation that must break this: ignore the pinned origin.
+    """
+    assert social_service.frontend_base_url(_KIOSK) == _KIOSK
+
+
+def test_no_pinned_origin_keeps_the_configured_default():
+    """Every pre-existing flow — desktop, links, single-face deployments — is
+    byte-identical. Without this, a deployment with one face and no Referer
+    would redirect to nowhere.
+    """
+    assert social_service.frontend_base_url(None) == _OS
+    assert social_service.frontend_base_url("") == _OS
+
+
+def test_a_trailing_slash_does_not_double_up():
+    """``{base}{safe_next}`` is string concatenation, so a trailing slash here
+    produces ``//pockets`` — a protocol-relative URL that leaves the origin.
+    """
+    assert social_service.frontend_base_url(_KIOSK + "/") == _KIOSK
+
+
+# ── the state carries it ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_begin_login_pins_the_validated_origin(monkeypatch):
+    """Pinned at authorize time, not read from the callback's query string —
+    the same rule ``flow`` follows, and what makes this unforgeable.
+    """
+    captured: dict = {}
+
+    class _Provider:
+        name = "google"
+
+        def is_configured(self):
+            return True
+
+    async def _fake_issue(provider, *, extra):
+        captured.update(extra)
+        return "https://accounts.google.com/o/oauth2/v2/auth?x=1"
+
+    monkeypatch.setattr(social_service, "_usable_provider", lambda _n: _Provider())
+    monkeypatch.setattr(social_service, "_issue_authorize_url", _fake_issue)
+
+    await social_service.begin_login("google", flow="web", origin=_KIOSK)
+
+    assert captured["origin"] == _KIOSK
+
+
+@pytest.mark.asyncio
+async def test_begin_login_drops_a_hostile_origin(monkeypatch):
+    """A hostile Referer reaches the state as an empty string, so the callback
+    falls back to the configured default.
+    """
+    captured: dict = {}
+
+    class _Provider:
+        name = "google"
+
+        def is_configured(self):
+            return True
+
+    async def _fake_issue(provider, *, extra):
+        captured.update(extra)
+        return "https://accounts.google.com/o/oauth2/v2/auth?x=1"
+
+    monkeypatch.setattr(social_service, "_usable_provider", lambda _n: _Provider())
+    monkeypatch.setattr(social_service, "_issue_authorize_url", _fake_issue)
+
+    await social_service.begin_login("google", flow="web", origin="https://evil.example.com")
+
+    assert captured["origin"] == ""

--- a/tests/mutations/social_login_origin.json
+++ b/tests/mutations/social_login_origin.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "the origin is not validated — an attacker's page receives the redirect that carries the session cookie",
+    "file": "ee/pocketpaw_ee/cloud/auth/social/service.py",
+    "find": "        return candidate if origin_allowed(candidate, allowed_origins()) else \"\"",
+    "replace": "        return candidate",
+    "tests": ["tests/cloud/auth/test_social_login_origin.py::test_an_unknown_origin_is_dropped"]
+  },
+  {
+    "label": "a broken allowlist fails OPEN — a settings error turns validation off instead of degrading the landing page",
+    "file": "ee/pocketpaw_ee/cloud/auth/social/service.py",
+    "find": "        logger.warning(\"could not validate social login origin %r\", candidate, exc_info=True)\n        return \"\"",
+    "replace": "        logger.warning(\"could not validate social login origin %r\", candidate, exc_info=True)\n        return candidate",
+    "tests": ["tests/cloud/auth/test_social_login_origin.py::test_a_broken_allowlist_does_not_break_login"]
+  },
+  {
+    "label": "the pinned origin is ignored — a kiosk sign-in still lands on the Paw OS, which is the bug",
+    "file": "ee/pocketpaw_ee/cloud/auth/social/service.py",
+    "find": "    if pinned_origin:\n        return pinned_origin.rstrip(\"/\")",
+    "replace": "    if False:\n        return pinned_origin.rstrip(\"/\")",
+    "tests": ["tests/cloud/auth/test_social_login_origin.py::test_a_pinned_origin_wins_over_the_env_var"]
+  },
+  {
+    "label": "the env fallback is dropped — a single-face deployment redirects to nothing",
+    "file": "ee/pocketpaw_ee/cloud/auth/social/service.py",
+    "find": "    return os.environ.get(\"POCKETPAW_FRONTEND_BASE_URL\", \"http://localhost:1420\").rstrip(\"/\")",
+    "replace": "    return \"\"",
+    "tests": ["tests/cloud/auth/test_social_login_origin.py::test_no_pinned_origin_keeps_the_configured_default"]
+  },
+  {
+    "label": "the trailing slash survives — the redirect becomes protocol-relative and leaves the origin",
+    "file": "ee/pocketpaw_ee/cloud/auth/social/service.py",
+    "find": "    if pinned_origin:\n        return pinned_origin.rstrip(\"/\")",
+    "replace": "    if pinned_origin:\n        return pinned_origin",
+    "tests": ["tests/cloud/auth/test_social_login_origin.py::test_a_trailing_slash_does_not_double_up"]
+  },
+  {
+    "label": "the origin never reaches the state — the callback has nothing to honour",
+    "file": "ee/pocketpaw_ee/cloud/auth/social/service.py",
+    "find": "            \"origin\": safe_frontend_origin(origin),",
+    "replace": "            \"origin\": \"\",",
+    "tests": ["tests/cloud/auth/test_social_login_origin.py::test_begin_login_pins_the_validated_origin"]
+  }
+]


### PR DESCRIPTION
## Google and GitHub sign-in are broken on every deployed surface

Not just the kiosk. The live backend hands Google this:

```
redirect_uri=http://localhost:8888/api/v1/auth/social/callback
```

That is the built-in fallback, which means `POCKETPAW_PUBLIC_BASE_URL` is unset in production. No code change can guess a public hostname, so that half is operator config and is now written down in CLAUDE.md alongside the provider-console step it implies.

## The half that is code

The callback redirected to a single configured `POCKETPAW_FRONTEND_BASE_URL`. That was fine when one deployment served one face. It now serves two on two hostnames, so signing in with Google on the Otherhand kiosk landed the user on the Paw OS. Nothing errors. It just reads as the button being broken.

The origin the login started from is now pinned into the single-use OAuth state at authorize time, exactly the way `flow` already is, and honoured at the callback. Never read from the callback's own query string, which is what makes it unforgeable.

## The security question this raises

Honouring a caller-supplied origin is an open redirect unless something says no, and this redirect carries the session cookie. So it is validated against the deployment's **CORS allowlist**, not a second list of its own. An origin the browser would be refused an API call from has no business receiving a session.

Validated twice, on the way into the state and again on the way out, and failing closed to the configured default. A settings error degrades which page you land on, never whether you can sign in.

Unpinned flows keep the env var and are byte-identical: desktop, account linking, and any deployment with one face.

## Tests

10 new, and the full `tests/cloud/auth` suite passes at 485.

Mutation plan `tests/mutations/social_login_origin.json`, 6 of 6 caught. The two that matter: dropping validation so an attacker's page receives the redirect, and the allowlist failing open so a settings error silently turns validation off.

## What an operator still has to do

```bash
POCKETPAW_PUBLIC_BASE_URL=https://backend.hzd.interacly.com
POCKETPAW_FRONTEND_BASE_URL=https://paw.hzd.interacly.com   # now only the fallback
```

Then register `https://backend.hzd.interacly.com/api/v1/auth/social/callback` as an authorised redirect URI in both the Google and GitHub apps.
