### PR TITLE
An unreachable gateway is a refusal, not a 500

### DIFF
--- a/ee/pocketpaw_ee/cloud/byok/service.py
+++ b/ee/pocketpaw_ee/cloud/byok/service.py
@@ -261,7 +261,17 @@ async def validate_key(
         "content-type": "application/json",
     }
     async with httpx.AsyncClient(timeout=_VALIDATE_TIMEOUT_S) as client:
-        resp = await client.post(_VALIDATE_URL, json=payload, headers=headers)
+        try:
+            resp = await client.post(_VALIDATE_URL, json=payload, headers=headers)
+        except httpx.TransportError as exc:
+            # Same hole as the gateway path below, same answer. This one points
+            # at Anthropic rather than a user-supplied address, so it is far
+            # likelier to be our egress than their key.
+            raise ValidationError(
+                "byok.provider_unreachable",
+                "This server could not reach Anthropic to check the key. Your "
+                "key was not saved and was not rejected — try again shortly.",
+            ) from exc
 
     if resp.status_code in (401, 403):
         raise ValidationError(
@@ -322,7 +332,26 @@ async def _validate_gateway_key(api_key: str, base_url: str, model: str) -> str:
         follow_redirects=False,
         transport=PinnedTransport(target.pinned_ip),
     ) as client:
-        resp = await client.post(f"{base}/chat/completions", json=payload, headers=headers)
+        try:
+            resp = await client.post(f"{base}/chat/completions", json=payload, headers=headers)
+        except httpx.TransportError as exc:
+            # A gateway this server cannot REACH is not a bad key, and it is not
+            # an internal error either. Unguarded, this was a 500 and the panel
+            # said "Internal server error — see server logs for details", which
+            # is both alarming and useless to the person holding a working key.
+            # Seen live on 2026-09-13: the address resolved and the box could
+            # not open a connection to it, so every save failed this way.
+            #
+            # The docstring above says network trouble is not a bad key and
+            # lets the transport error out "so the caller can decide". No
+            # caller decided — the route has no handler, so it reached the
+            # generic 500. Deciding here is what that sentence always meant.
+            raise ValidationError(
+                "byok.gateway_unreachable",
+                f"This server could not reach {base}. The address resolves, so "
+                "check the gateway is up and accepts connections from outside "
+                "your network. Your key was not saved and was not rejected.",
+            ) from exc
 
     if resp.status_code == 401:
         # Measured against api.experientiallabs.ai on 2026-09-09: a base URL

--- a/tests/cloud/byok/test_gateway_unreachable.py
+++ b/tests/cloud/byok/test_gateway_unreachable.py
@@ -1,0 +1,134 @@
+# tests/cloud/byok/test_gateway_unreachable.py — a gateway this server cannot
+# reach is refused clearly, not as a 500.
+#
+# Created 2026-09-13 (fix/byok-gateway-unreachable). Found on the live kiosk an
+# hour into launch day: saving a custom gateway key returned "Internal server
+# error — see server logs for details". The address resolved and passed the
+# egress guard, then httpx could not open a connection, and nothing caught it.
+#
+# The validator's own docstring says network trouble is not a bad key and lets
+# the transport error out "so the caller can decide". No caller decided: the
+# route has no handler, so it reached the generic 500 page. These tests pin the
+# deciding.
+#
+# Mutations: tests/mutations/byok_gateway_unreachable.json.
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.byok import service as byok_service
+
+pytestmark = pytest.mark.asyncio
+
+_KEY = "sk-" + "x" * 40
+_BASE = "https://api.example-gateway.test/v1"
+
+
+class _Boom:
+    """An httpx client whose post always fails at the transport layer."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, *_a, **_k):
+        raise self._exc
+
+
+@pytest.fixture
+def _egress_ok(monkeypatch):
+    """The address resolves and passes the guard — the real failure's shape."""
+
+    async def _ok(base_url):
+        from pocketpaw.security.url_validators import EgressTarget
+
+        base = base_url.rstrip("/")
+        return EgressTarget(
+            url=base, host="api.example-gateway.test", port=443, pinned_ip="93.184.216.34"
+        )
+
+    monkeypatch.setattr(byok_service, "assert_gateway_egress", _ok)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError("connection refused"),
+        httpx.ConnectTimeout("timed out"),
+        httpx.ReadTimeout("read timed out"),
+    ],
+)
+async def test_an_unreachable_gateway_is_a_clear_refusal(_egress_ok, monkeypatch, exc):
+    """Every transport failure names the address instead of 500ing.
+
+    Parametrised because the live failure was a timeout and the first fix only
+    caught ConnectError. httpx.TransportError is the shared base and is what
+    the code catches.
+
+    Mutation that must break this: remove the except.
+    """
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: _Boom(exc))
+
+    with pytest.raises(ValidationError) as err:
+        await byok_service.validate_key(
+            _KEY, provider="openai_compatible", base_url=_BASE, model="some-model"
+        )
+
+    assert err.value.code == "byok.gateway_unreachable"
+    assert _BASE in err.value.message
+
+
+async def test_the_refusal_says_the_key_was_not_judged(_egress_ok, monkeypatch):
+    """The person is holding a key that may be perfectly good. Telling them it
+    was rejected sends them to re-copy something that was never the problem.
+    """
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: _Boom(httpx.ConnectError("nope")))
+
+    with pytest.raises(ValidationError) as err:
+        await byok_service.validate_key(
+            _KEY, provider="openai_compatible", base_url=_BASE, model="m"
+        )
+
+    msg = err.value.message.lower()
+    assert "not saved" in msg and "not rejected" in msg
+
+
+async def test_anthropic_unreachable_is_also_a_refusal(monkeypatch):
+    """The same hole existed on the anthropic path, with its own code: that URL
+    is ours, not the user's, so it points at our egress rather than their key.
+    """
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: _Boom(httpx.ConnectTimeout("t")))
+
+    with pytest.raises(ValidationError) as err:
+        await byok_service.validate_key(_KEY, provider="anthropic")
+
+    assert err.value.code == "byok.provider_unreachable"
+
+
+async def test_a_real_rejection_still_reads_as_a_rejection(_egress_ok, monkeypatch):
+    """The default path. Without this, catching everything as unreachable would
+    tell someone with a revoked key that the gateway is down.
+    """
+
+    class _Rejects(_Boom):
+        def __init__(self):
+            pass
+
+        async def post(self, *_a, **_k):
+            return httpx.Response(401, json={"error": "bad key"})
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: _Rejects())
+
+    with pytest.raises(ValidationError) as err:
+        await byok_service.validate_key(
+            _KEY, provider="openai_compatible", base_url=_BASE, model="m"
+        )
+
+    assert err.value.code in {"byok.key_rejected", "byok.base_url_rejected"}

--- a/tests/mutations/byok_gateway_unreachable.json
+++ b/tests/mutations/byok_gateway_unreachable.json
@@ -1,0 +1,47 @@
+[
+  {
+    "label": "the gateway transport error is unguarded again \u2014 saving a key on an unreachable gateway is a 500 saying 'see server logs'",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "            resp = await client.post(f\"{base}/chat/completions\", json=payload, headers=headers)\n        except httpx.TransportError as exc:",
+    "replace": "            resp = await client.post(f\"{base}/chat/completions\", json=payload, headers=headers)\n        except _NeverRaised as exc:",
+    "tests": [
+      "tests/cloud/byok/test_gateway_unreachable.py::test_an_unreachable_gateway_is_a_clear_refusal"
+    ]
+  },
+  {
+    "label": "an unreachable gateway is reported as a rejected key \u2014 the user re-copies a key that was never the problem",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "                \"byok.gateway_unreachable\",",
+    "replace": "                \"byok.key_rejected\",",
+    "tests": [
+      "tests/cloud/byok/test_gateway_unreachable.py::test_an_unreachable_gateway_is_a_clear_refusal"
+    ]
+  },
+  {
+    "label": "the refusal stops saying the key was not judged",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "                \"your network. Your key was not saved and was not rejected.\",",
+    "replace": "                \"your network.\",",
+    "tests": [
+      "tests/cloud/byok/test_gateway_unreachable.py::test_the_refusal_says_the_key_was_not_judged"
+    ]
+  },
+  {
+    "label": "the anthropic path loses its guard \u2014 the same 500 returns for the default provider",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "            resp = await client.post(_VALIDATE_URL, json=payload, headers=headers)\n        except httpx.TransportError as exc:",
+    "replace": "            resp = await client.post(_VALIDATE_URL, json=payload, headers=headers)\n        except _NeverRaised as exc:",
+    "tests": [
+      "tests/cloud/byok/test_gateway_unreachable.py::test_anthropic_unreachable_is_also_a_refusal"
+    ]
+  },
+  {
+    "label": "every failure is called unreachable \u2014 a genuinely revoked key is reported as the gateway being down",
+    "file": "ee/pocketpaw_ee/cloud/byok/service.py",
+    "find": "    if resp.status_code == 401:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/byok/test_gateway_unreachable.py::test_a_real_rejection_still_reads_as_a_rejection"
+    ]
+  }
+]


### PR DESCRIPTION
## What a user saw

Saving a custom gateway key on the live kiosk returned:

> Internal server error — see server logs for details.

Alarming, and useless to someone holding a key that may be perfectly good. It worked locally, which is the tell: the difference is whether this server can open a connection to the gateway.

## What was happening

The address resolved, passed `assert_gateway_egress`, and then `client.post` could not connect. Nothing caught it, so it reached the generic 500.

`validate_key`'s own docstring already says network trouble is not a bad key, and deliberately lets the transport error out "so the caller can decide". No caller decided. The route has no handler. Deciding inside the validator is what that sentence always meant.

## The change

Both network calls were unguarded, so both are guarded now, with different codes because they point at different people:

| code | means |
|---|---|
| `byok.gateway_unreachable` | the address the user typed |
| `byok.provider_unreachable` | our own egress to Anthropic |

The message says the key was **neither saved nor rejected**. Reporting an unreachable gateway as a rejected key sends someone to re-copy a key that was never the problem, and that is the specific wrong turn the wording exists to prevent.

It catches `httpx.TransportError`, not `ConnectError`. The live failure was a timeout and `TransportError` is the shared base, so the test is parametrised over connect, connect-timeout and read-timeout.

## Tests

6 new, and the whole `tests/cloud/byok` suite passes at 70.

Mutation plan `tests/mutations/byok_gateway_unreachable.json`, 5 of 5 caught. The two worth having are the pair that point in opposite directions: reporting an unreachable gateway as a rejected key, and reporting a genuinely revoked key as a gateway outage.

## What this does not fix

Whether the gateway is actually reachable from that box. This turns a confusing 500 into a sentence that names the problem, which is the difference between a user who can act and one who files a bug. If `api.experientiallabs.ai` is genuinely unreachable from the server, that is a separate network question and the new message is what will say so.
